### PR TITLE
[FLINK-26135] Introduce ReconciliationStatus and improve error handling in controller flow

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
@@ -17,15 +17,20 @@
 
 package org.apache.flink.kubernetes.operator.crd.status;
 
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
+
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/** Current status of the Flink deployment. */
+/** Status of the Flink deployment reconciliation flow. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class FlinkDeploymentStatus {
-    private JobStatus jobStatus;
-    private ReconciliationStatus reconciliationStatus = new ReconciliationStatus();
+@Builder
+public class ReconciliationStatus {
+    private boolean success;
+    private String error;
+    private FlinkDeploymentSpec lastReconciledSpec;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/InvalidDeploymentException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/InvalidDeploymentException.java
@@ -15,17 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.kubernetes.operator.crd.status;
+package org.apache.flink.kubernetes.operator.exception;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+/** Exception for encountering invalid FlinkDeployment resources. */
+public class InvalidDeploymentException extends Exception {
 
-/** Current status of the Flink deployment. */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class FlinkDeploymentStatus {
-    private JobStatus jobStatus;
-    private ReconciliationStatus reconciliationStatus = new ReconciliationStatus();
+    public InvalidDeploymentException(String msg) {
+        super(msg);
+    }
+
+    public InvalidDeploymentException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.observer;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
@@ -46,12 +47,15 @@ public class JobStatusObserver {
     }
 
     public boolean observeFlinkJobStatus(FlinkDeployment flinkApp, Configuration effectiveConfig) {
-        if (flinkApp.getStatus() == null) {
+        FlinkDeploymentSpec lastReconciledSpec =
+                flinkApp.getStatus().getReconciliationStatus().getLastReconciledSpec();
+
+        if (lastReconciledSpec == null) {
             // This is the first run, nothing to observe
             return true;
         }
 
-        JobSpec jobSpec = flinkApp.getStatus().getSpec().getJob();
+        JobSpec jobSpec = lastReconciledSpec.getJob();
 
         if (jobSpec == null) {
             // This is a session cluster, nothing to observe

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -25,6 +25,7 @@ import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.Resource;
 import org.apache.flink.kubernetes.operator.crd.spec.TaskManagerSpec;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,6 +45,7 @@ public class TestUtils {
 
     public static FlinkDeployment buildSessionCluster() {
         FlinkDeployment deployment = new FlinkDeployment();
+        deployment.setStatus(new FlinkDeploymentStatus());
         deployment.setMetadata(
                 new ObjectMetaBuilder()
                         .withName("test-cluster")

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.controller;
+
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
+import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
+import org.apache.flink.kubernetes.operator.reconciler.JobReconciler;
+import org.apache.flink.kubernetes.operator.reconciler.SessionReconciler;
+import org.apache.flink.runtime.client.JobStatusMessage;
+
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/** @link JobStatusObserver unit tests */
+public class FlinkDeploymentControllerTest {
+
+    private final TestingFlinkService flinkService = new TestingFlinkService();
+
+    @Test
+    public void verifyBasicReconcileLoop() {
+        FlinkDeploymentController testController = createTestController();
+        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
+
+        UpdateControl<FlinkDeployment> updateControl;
+
+        updateControl = testController.reconcile(appCluster, null);
+        assertTrue(updateControl.isUpdateStatus());
+        assertEquals(
+                FlinkDeploymentController.OBSERVE_REFRESH_SECONDS * 1000,
+                (long) updateControl.getScheduleDelay().get());
+
+        // Validate reconciliation status
+        ReconciliationStatus reconciliationStatus =
+                appCluster.getStatus().getReconciliationStatus();
+        assertTrue(reconciliationStatus.isSuccess());
+        assertNull(reconciliationStatus.getError());
+        assertEquals(appCluster.getSpec(), reconciliationStatus.getLastReconciledSpec());
+
+        updateControl = testController.reconcile(appCluster, null);
+        assertTrue(updateControl.isUpdateStatus());
+        assertFalse(updateControl.getScheduleDelay().isPresent());
+
+        // Validate job status
+        JobStatus jobStatus = appCluster.getStatus().getJobStatus();
+        JobStatusMessage expectedJobStatus = flinkService.listJobs().get(0).f1;
+        assertEquals(expectedJobStatus.getJobId().toHexString(), jobStatus.getJobId());
+        assertEquals(expectedJobStatus.getJobName(), jobStatus.getJobName());
+        assertEquals(expectedJobStatus.getJobState().toString(), jobStatus.getState());
+
+        // Send in invalid update
+        appCluster = TestUtils.clone(appCluster);
+        appCluster.getSpec().setJob(null);
+        updateControl = testController.reconcile(appCluster, null);
+        assertTrue(updateControl.isUpdateStatus());
+        assertEquals(
+                FlinkDeploymentController.RECONCILE_ERROR_REFRESH_SECONDS * 1000,
+                (long) updateControl.getScheduleDelay().get());
+
+        reconciliationStatus = appCluster.getStatus().getReconciliationStatus();
+        assertFalse(reconciliationStatus.isSuccess());
+        assertEquals(
+                "Error while reconciling deployment change: Cannot switch from job to session cluster",
+                reconciliationStatus.getError());
+        assertNotNull(reconciliationStatus.getLastReconciledSpec().getJob());
+
+        updateControl = testController.reconcile(appCluster, null);
+        assertTrue(updateControl.isNoUpdate());
+        assertEquals(
+                FlinkDeploymentController.RECONCILE_ERROR_REFRESH_SECONDS * 1000,
+                (long) updateControl.getScheduleDelay().get());
+
+        // Validate job status correct even with error
+        jobStatus = appCluster.getStatus().getJobStatus();
+        expectedJobStatus = flinkService.listJobs().get(0).f1;
+        assertEquals(expectedJobStatus.getJobId().toHexString(), jobStatus.getJobId());
+        assertEquals(expectedJobStatus.getJobName(), jobStatus.getJobName());
+        assertEquals(expectedJobStatus.getJobState().toString(), jobStatus.getState());
+    }
+
+    private FlinkDeploymentController createTestController() {
+        JobStatusObserver observer = new JobStatusObserver(flinkService);
+        JobReconciler jobReconciler = new JobReconciler(null, flinkService);
+        SessionReconciler sessionReconciler = new SessionReconciler(null, flinkService);
+
+        return new FlinkDeploymentController(
+                null, "test", observer, jobReconciler, sessionReconciler);
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
@@ -40,8 +40,10 @@ public class JobStatusObserverTest {
         FlinkService flinkService = new TestingFlinkService();
         JobStatusObserver observer = new JobStatusObserver(flinkService);
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
-        deployment.setStatus(new FlinkDeploymentStatus());
-        deployment.getStatus().setSpec(deployment.getSpec());
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .setLastReconciledSpec(deployment.getSpec());
         assertTrue(
                 observer.observeFlinkJobStatus(
                         deployment, FlinkUtils.getEffectiveConfig(deployment)));
@@ -56,7 +58,10 @@ public class JobStatusObserverTest {
 
         assertTrue(observer.observeFlinkJobStatus(deployment, conf));
         deployment.setStatus(new FlinkDeploymentStatus());
-        deployment.getStatus().setSpec(deployment.getSpec());
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .setLastReconciledSpec(deployment.getSpec());
 
         assertFalse(observer.observeFlinkJobStatus(deployment, conf));
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/JobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/JobReconcilerTest.java
@@ -49,7 +49,10 @@ public class JobReconcilerTest {
         List<Tuple2<String, JobStatusMessage>> runningJobs = flinkService.listJobs();
         assertEquals(1, runningJobs.size());
         assertNull(runningJobs.get(0).f0);
-        deployment.getStatus().setSpec(deployment.getSpec());
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .setLastReconciledSpec(deployment.getSpec());
 
         JobStatus jobStatus = new JobStatus();
         jobStatus.setJobName(runningJobs.get(0).f1.getJobName());


### PR DESCRIPTION
Improvements to flink deployment status handling.

Introduce `ReconciliationStatus` to allow capturing error that do not necessarily affect the running jobs. The PR does not introduce new validation logic for the deployments, that is left as a separate ticket for now

The PR also improves the reonciliation flow to avoid rescheduling reconciliation when not necessary + introduces a controller test to verify the basic flow.

cc @wangyang0918 @tweise 