### PR TITLE
[FLINK-26234] Start minikube manually to replace external github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,14 @@ jobs:
       - name: Build with Maven
         run: mvn clean install
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        run: |
+          source e2e-tests/utils.sh
+          start_minikube
       - name: Install cert-manager
         run: |
           kubectl get pods -A
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.yaml
-          kubectl -n cert-manager wait --all=true --for=condition=Ready --timeout=300s pod
+          kubectl -n cert-manager wait --all=true --for=condition=Available --timeout=300s deploy
       - name: Build image
         run: |
           export SHELL=/bin/bash
@@ -65,6 +67,10 @@ jobs:
       - name: Stop the operator
         run: |
           helm uninstall flink-operator
+      - name: Stop minikube
+        run: |
+          source e2e-tests/utils.sh
+          stop_minikube
   e2e_ci:
     runs-on: ubuntu-latest
     name: e2e_ci
@@ -78,12 +84,14 @@ jobs:
       - name: Build with Maven
         run: mvn clean install
       - name: Start minikube
-        uses: medyagh/setup-minikube@master
+        run: |
+          source e2e-tests/utils.sh
+          start_minikube
       - name: Install cert-manager
         run: |
           kubectl get pods -A
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.yaml
-          kubectl -n cert-manager wait --all=true --for=condition=Ready --timeout=300s pod
+          kubectl -n cert-manager wait --all=true --for=condition=Available --timeout=300s deploy
       - name: Build image
         run: |
           export SHELL=/bin/bash
@@ -102,3 +110,7 @@ jobs:
       - name: Stop the operator
         run: |
           helm uninstall flink-operator
+      - name: Stop minikube
+        run: |
+          source e2e-tests/utils.sh
+          stop_minikube


### PR DESCRIPTION
According to the apache requirement, external github actions are not allowed to used in the workflow. So we need to start minikube manually instead of relying on the existing actions.

See https://github.com/apache/flink-kubernetes-operator/actions/runs/1859307064.