### PR TITLE
[FLINK-26260] Support watching specific namespaces only

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ The operator is managed helm chart. To install run:
  helm install flink-operator .
 ```
 
+### Validating webhook
+
 In order to use the webhook for FlinkDeployment validation, you must install the cert-manager on the Kubernetes cluster:
 ```
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.yaml
 ```
 
 The webhook can be disabled during helm install by passing the `--set webhook.create=false` parameter or editing the `values.yaml` directly.
+
+### Watching only specific namespaces
+
+The operator supports watching a specific list of namespaces for FlinkDeployment resources. You can enable it by setting the `--set watchNamespaces={flink-test}` parameter.
 
 ## User Guide
 ### Create a new Flink deployment

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkControllerConfig.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkControllerConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.controller;
+
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+
+import io.javaoperatorsdk.operator.config.runtime.AnnotationConfiguration;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** Custom config for {@link FlinkDeploymentController}. */
+public class FlinkControllerConfig extends AnnotationConfiguration<FlinkDeployment> {
+
+    public static final String ENV_WATCHED_NAMESPACES = "FLINK_OPERATOR_WATCH_NAMESPACES";
+
+    public FlinkControllerConfig(FlinkDeploymentController reconciler) {
+        super(reconciler);
+    }
+
+    public Set<String> getNamespaces() {
+        String watchedNamespaces = System.getenv(ENV_WATCHED_NAMESPACES);
+        Set<String> namespaces = new HashSet<>();
+
+        if (StringUtils.isEmpty(watchedNamespaces)) {
+            return namespaces;
+        }
+
+        for (String ns : watchedNamespaces.split(",")) {
+            namespaces.add(ns);
+        }
+
+        return namespaces;
+    }
+}

--- a/helm/flink-operator/templates/flink-operator.yaml
+++ b/helm/flink-operator/templates/flink-operator.yaml
@@ -59,6 +59,8 @@ spec:
               value: /opt/flink-operator/conf
             - name: LOG_CONFIG
               value: -Dlog4j.configurationFile=/opt/flink-operator/conf/log4j2.properties
+            - name: FLINK_OPERATOR_WATCH_NAMESPACES
+              value: {{ join "," .Values.watchNamespaces  }}
           volumeMounts:
             - name: flink-operator-config-volume
               mountPath: /opt/flink-operator/conf

--- a/helm/flink-operator/templates/webhook.yaml
+++ b/helm/flink-operator/templates/webhook.yaml
@@ -81,7 +81,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: {{ .Values.operatorNamespace.name }}/flink-operator-serving-cert
-  name: flink-operator-validating-webhook-configuration
+  name: flink-operator-{{ .Values.operatorNamespace.name }}-webhook-configuration
 webhooks:
 - name: vflinkdeployments.flink.apache.org
   admissionReviewVersions: ["v1"]
@@ -94,10 +94,18 @@ webhooks:
   rules:
   - apiGroups: ["*"]
     apiVersions: ["*"]
+    scope: "Namespaced"
     operations:
     - CREATE
     - UPDATE
     resources:
     - flinkdeployments
   sideEffects: None
+  {{- if .Values.watchNamespaces }}
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: In
+        values: {{ .Values.watchNamespaces }}
+  {{- end }}
   {{- end }}

--- a/helm/flink-operator/values.yaml
+++ b/helm/flink-operator/values.yaml
@@ -21,6 +21,9 @@
 operatorNamespace:
   name: default
 
+# List of kubernetes namespaces to watch for FlinkDeployment changes, empty means all namespaces
+# watchNamespaces: ["flink"]
+
 image:
   repository: flink-operator
   pullPolicy: IfNotPresent


### PR DESCRIPTION
This PR introduces a new config option for watching a list of specific namespaces for FlinkDeployment resources.
The config can be set in the Helm chart as a list and is passed as an env variable to the operator.

It also includes a change to the webhook configuration name to include the operator namespace. This allows us to have multiple webhook configs in the same cluster pointing to different operators (which is necessary if all of them are watching their own namespace)