### PR TITLE
[FLINK-26236] Track and cap retries in ReconciliationStatus

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/FlinkDeployment.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/FlinkDeployment.java
@@ -35,4 +35,10 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Version("v1alpha1")
 @ShortNames({"flinkdep"})
 public class FlinkDeployment extends CustomResource<FlinkDeploymentSpec, FlinkDeploymentStatus>
-        implements Namespaced {}
+        implements Namespaced {
+
+    @Override
+    protected FlinkDeploymentStatus initStatus() {
+        return new FlinkDeploymentStatus();
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/ReconciliationException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/ReconciliationException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.exception;
+
+/** Exception for wrapping reconciliation errors. */
+public class ReconciliationException extends RuntimeException {
+
+    public ReconciliationException(Throwable cause) {
+        super(cause);
+    }
+
+    public ReconciliationException(String msg) {
+        super(msg);
+    }
+
+    public ReconciliationException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -51,7 +51,7 @@ public class FlinkDeploymentControllerTest {
         updateControl = testController.reconcile(appCluster, null);
         assertTrue(updateControl.isUpdateStatus());
         assertEquals(
-                FlinkDeploymentController.OBSERVE_REFRESH_SECONDS * 1000,
+                FlinkDeploymentController.REFRESH_SECONDS * 1000,
                 (long) updateControl.getScheduleDelay().get());
 
         // Validate reconciliation status
@@ -63,7 +63,9 @@ public class FlinkDeploymentControllerTest {
 
         updateControl = testController.reconcile(appCluster, null);
         assertTrue(updateControl.isUpdateStatus());
-        assertFalse(updateControl.getScheduleDelay().isPresent());
+        assertEquals(
+                FlinkDeploymentController.REFRESH_SECONDS * 1000,
+                (long) updateControl.getScheduleDelay().get());
 
         // Validate job status
         JobStatus jobStatus = appCluster.getStatus().getJobStatus();
@@ -77,22 +79,12 @@ public class FlinkDeploymentControllerTest {
         appCluster.getSpec().setJob(null);
         updateControl = testController.reconcile(appCluster, null);
         assertTrue(updateControl.isUpdateStatus());
-        assertEquals(
-                FlinkDeploymentController.RECONCILE_ERROR_REFRESH_SECONDS * 1000,
-                (long) updateControl.getScheduleDelay().get());
+        assertFalse(updateControl.getScheduleDelay().isPresent());
 
         reconciliationStatus = appCluster.getStatus().getReconciliationStatus();
         assertFalse(reconciliationStatus.isSuccess());
-        assertEquals(
-                "Error while reconciling deployment change: Cannot switch from job to session cluster",
-                reconciliationStatus.getError());
+        assertEquals("Cannot switch from job to session cluster", reconciliationStatus.getError());
         assertNotNull(reconciliationStatus.getLastReconciledSpec().getJob());
-
-        updateControl = testController.reconcile(appCluster, null);
-        assertTrue(updateControl.isNoUpdate());
-        assertEquals(
-                FlinkDeploymentController.RECONCILE_ERROR_REFRESH_SECONDS * 1000,
-                (long) updateControl.getScheduleDelay().get());
 
         // Validate job status correct even with error
         jobStatus = appCluster.getStatus().getJobStatus();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class JobStatusObserverTest {
 
     @Test
-    public void observeSessionCluster() {
+    public void observeSessionCluster() throws Exception {
         FlinkService flinkService = new TestingFlinkService();
         JobStatusObserver observer = new JobStatusObserver(flinkService);
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
@@ -50,7 +50,7 @@ public class JobStatusObserverTest {
     }
 
     @Test
-    public void observeApplicationCluster() {
+    public void observeApplicationCluster() throws Exception {
         TestingFlinkService flinkService = new TestingFlinkService();
         JobStatusObserver observer = new JobStatusObserver(flinkService);
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();


### PR DESCRIPTION
- introduce generic error handling 
- distinguish between fatal (e.g. invalid CR) and recoverable errors (e.g. timeout)
- the java-operator-sdk uses exponential backoff strategy to handle recoverable errors (see https://javaoperatorsdk.io/docs/features for further detail)
- fatal errors are handled in the reconcile method itself, with no retry

