### PR TITLE
[FLINK-26216] Make 'replicas' work in JobManager Spec

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
@@ -119,6 +119,11 @@ public class FlinkConfigBuilder {
                         spec.getJobManager().getPodTemplate(),
                         effectiveConfig,
                         true);
+                if (spec.getJobManager().getReplicas() > 0) {
+                    effectiveConfig.set(
+                            KubernetesConfigOptions.KUBERNETES_JOBMANAGER_REPLICAS,
+                            spec.getJobManager().getReplicas());
+                }
             }
         }
         return this;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilderTest.java
@@ -67,6 +67,7 @@ public class FlinkConfigBuilderTest {
         flinkDeployment.getSpec().setPodTemplate(pod0);
         flinkDeployment.getSpec().setIngressDomain("test.com");
         flinkDeployment.getSpec().getJobManager().setPodTemplate(pod1);
+        flinkDeployment.getSpec().getJobManager().setReplicas(2);
         flinkDeployment.getSpec().getTaskManager().setPodTemplate(pod2);
         flinkDeployment.getSpec().getJob().setParallelism(2);
     }
@@ -148,6 +149,9 @@ public class FlinkConfigBuilderTest {
         Assert.assertEquals(
                 Double.valueOf(1), configuration.get(KubernetesConfigOptions.JOB_MANAGER_CPU));
         Assert.assertEquals("pod1 api version", jmPod.getApiVersion());
+        Assert.assertEquals(
+                Integer.valueOf(2),
+                configuration.get(KubernetesConfigOptions.KUBERNETES_JOBMANAGER_REPLICAS));
     }
 
     @Test


### PR DESCRIPTION
- Fix the bug that `replicas` field of `JobManager` spec does not work in the config building process.
- Add corresponding unit test.
