### PR TITLE
[FLINK-26332]Move the operator env to common utils

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -37,8 +37,6 @@ import org.slf4j.LoggerFactory;
 public class FlinkOperator {
     private static final Logger LOG = LoggerFactory.getLogger(FlinkOperator.class);
 
-    public static final String ENV_FLINK_OPERATOR_CONF_DIR = "FLINK_OPERATOR_CONF_DIR";
-
     public static void main(String... args) {
 
         LOG.info("Starting Flink Kubernetes Operator");

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/DefaultConfig.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/DefaultConfig.java
@@ -24,18 +24,18 @@ import org.apache.flink.configuration.Configuration;
 public class DefaultConfig {
 
     private final Configuration operatorConfig;
-    private final Configuration defaultFlinkConfig;
+    private final Configuration flinkConfig;
 
-    public DefaultConfig(Configuration operatorConfig, Configuration defaultFlinkConfig) {
+    public DefaultConfig(Configuration operatorConfig, Configuration flinkConfig) {
         this.operatorConfig = operatorConfig;
-        this.defaultFlinkConfig = defaultFlinkConfig;
+        this.flinkConfig = flinkConfig;
     }
 
     public Configuration getOperatorConfig() {
         return operatorConfig;
     }
 
-    public Configuration getDefaultFlinkConfig() {
-        return defaultFlinkConfig;
+    public Configuration getFlinkConfig() {
+        return flinkConfig;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkControllerConfig.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkControllerConfig.java
@@ -18,10 +18,12 @@
 package org.apache.flink.kubernetes.operator.controller;
 
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 
 import io.javaoperatorsdk.operator.config.runtime.AnnotationConfiguration;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -29,7 +31,6 @@ import java.util.Set;
 /** Custom config for {@link FlinkDeploymentController}. */
 public class FlinkControllerConfig extends AnnotationConfiguration<FlinkDeployment> {
 
-    private static final String ENV_WATCHED_NAMESPACES = "FLINK_OPERATOR_WATCH_NAMESPACES";
     private static final String NAMESPACES_SPLITTER_KEY = ",";
 
     public FlinkControllerConfig(FlinkDeploymentController reconciler) {
@@ -38,17 +39,12 @@ public class FlinkControllerConfig extends AnnotationConfiguration<FlinkDeployme
 
     @Override
     public Set<String> getNamespaces() {
-        String watchedNamespaces = System.getenv(ENV_WATCHED_NAMESPACES);
+        String watchedNamespaces = EnvUtils.get(EnvUtils.ENV_WATCHED_NAMESPACES);
 
         if (StringUtils.isEmpty(watchedNamespaces)) {
             return Collections.emptySet();
+        } else {
+            return new HashSet<>(Arrays.asList(watchedNamespaces.split(NAMESPACES_SPLITTER_KEY)));
         }
-
-        Set<String> namespaces = new HashSet<>();
-        for (String ns : watchedNamespaces.split(NAMESPACES_SPLITTER_KEY)) {
-            namespaces.add(ns);
-        }
-
-        return namespaces;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -88,7 +88,7 @@ public class FlinkDeploymentController
         FlinkUtils.deleteCluster(flinkApp, kubernetesClient);
         IngressUtils.updateIngressRules(
                 flinkApp,
-                FlinkUtils.getEffectiveConfig(flinkApp, defaultConfig.getDefaultFlinkConfig()),
+                FlinkUtils.getEffectiveConfig(flinkApp, defaultConfig.getFlinkConfig()),
                 operatorNamespace,
                 kubernetesClient,
                 true);
@@ -100,7 +100,7 @@ public class FlinkDeploymentController
         LOG.info("Reconciling {}", flinkApp.getMetadata().getName());
 
         Configuration effectiveConfig =
-                FlinkUtils.getEffectiveConfig(flinkApp, defaultConfig.getDefaultFlinkConfig());
+                FlinkUtils.getEffectiveConfig(flinkApp, defaultConfig.getFlinkConfig());
         try {
             boolean successfulObserve = observer.observeFlinkJobStatus(flinkApp, effectiveConfig);
             if (successfulObserve) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/OperatorMetricUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/OperatorMetricUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.metrics;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.MetricRegistryConfiguration;
@@ -30,10 +31,6 @@ import org.apache.flink.runtime.metrics.util.MetricUtils;
 /** Utility class for flink based operator metrics. */
 public class OperatorMetricUtils {
 
-    private static final String ENV_HOSTNAME = "HOSTNAME";
-    private static final String ENV_OPERATOR_NAME = "OPERATOR_NAME";
-    private static final String ENV_OPERATOR_NAMESPACE = "OPERATOR_NAMESPACE";
-
     public static void initOperatorMetrics(Configuration operatorConfig) {
         PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(operatorConfig);
         MetricRegistry metricRegistry = createMetricRegistry(operatorConfig, pluginManager);
@@ -41,9 +38,9 @@ public class OperatorMetricUtils {
                 KubernetesOperatorMetricGroup.create(
                         metricRegistry,
                         operatorConfig,
-                        System.getenv().getOrDefault(ENV_OPERATOR_NAMESPACE, "default"),
-                        System.getenv().getOrDefault(ENV_OPERATOR_NAME, "flink-operator"),
-                        System.getenv().getOrDefault(ENV_HOSTNAME, "localhost"));
+                        EnvUtils.getOrDefault(EnvUtils.ENV_OPERATOR_NAMESPACE, "default"),
+                        EnvUtils.getOrDefault(EnvUtils.ENV_OPERATOR_NAME, "flink-operator"),
+                        EnvUtils.getOrDefault(EnvUtils.ENV_HOSTNAME, "localhost"));
         MetricGroup statusGroup = operatorMetricGroup.addGroup("Status");
         MetricUtils.instantiateStatusMetrics(statusGroup);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EnvUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EnvUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.commons.lang3.StringUtils;
+
+/** Util to get value from environments. */
+public class EnvUtils {
+
+    public static final String ENV_FLINK_OPERATOR_CONF_DIR = "FLINK_OPERATOR_CONF_DIR";
+    public static final String ENV_FLINK_CONF_DIR = "FLINK_CONF_DIR";
+    public static final String ENV_WEBHOOK_KEYSTORE_FILE = "WEBHOOK_KEYSTORE_FILE";
+    public static final String ENV_WEBHOOK_KEYSTORE_PASSWORD = "WEBHOOK_KEYSTORE_PASSWORD";
+    public static final String ENV_WEBHOOK_KEYSTORE_TYPE = "WEBHOOK_KEYSTORE_TYPE";
+    public static final String ENV_WEBHOOK_SERVER_PORT = "WEBHOOK_SERVER_PORT";
+    public static final String ENV_WATCHED_NAMESPACES = "FLINK_OPERATOR_WATCH_NAMESPACES";
+    public static final String ENV_HOSTNAME = "HOSTNAME";
+    public static final String ENV_OPERATOR_NAME = "OPERATOR_NAME";
+    public static final String ENV_OPERATOR_NAMESPACE = "OPERATOR_NAMESPACE";
+
+    /**
+     * Get the value provided by environments.
+     *
+     * @param key the target key
+     * @return the value value provided by environments.
+     */
+    public static String get(String key) {
+        return System.getenv().get(key);
+    }
+
+    /**
+     * Get the value or default value provided by environments.
+     *
+     * @param key the target key
+     * @param defaultValue the default value if key not exists.
+     * @return the value or default value provided by environments.
+     */
+    public static String getOrDefault(String key, String defaultValue) {
+        return System.getenv().getOrDefault(key, defaultValue);
+    }
+
+    /**
+     * Get the value provided by environments.
+     *
+     * @param key the target key
+     * @return the value provided by environments.
+     */
+    public static String getRequired(String key) {
+        String value = System.getenv().get(key);
+        if (StringUtils.isEmpty(value)) {
+            throw new RuntimeException("Environments: " + key + " cannot be empty");
+        }
+        return value;
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
@@ -50,10 +50,10 @@ public class FlinkConfigBuilder {
     private final FlinkDeploymentSpec spec;
     private final Configuration effectiveConfig;
 
-    public FlinkConfigBuilder(FlinkDeployment deploy, Configuration defaultFlinkConfig) {
+    public FlinkConfigBuilder(FlinkDeployment deploy, Configuration flinkConfig) {
         this.deploy = deploy;
         this.spec = this.deploy.getSpec();
-        this.effectiveConfig = defaultFlinkConfig;
+        this.effectiveConfig = flinkConfig;
     }
 
     public FlinkConfigBuilder applyImage() {
@@ -164,9 +164,9 @@ public class FlinkConfigBuilder {
         return effectiveConfig;
     }
 
-    public static Configuration buildFrom(FlinkDeployment dep, Configuration defaultFlinkConf)
+    public static Configuration buildFrom(FlinkDeployment dep, Configuration flinkConfig)
             throws IOException, URISyntaxException {
-        return new FlinkConfigBuilder(dep, defaultFlinkConf)
+        return new FlinkConfigBuilder(dep, flinkConfig)
                 .applyFlinkConfiguration()
                 .applyImage()
                 .applyImagePullPolicy()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -17,10 +17,8 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
-import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
-import org.apache.flink.kubernetes.operator.FlinkOperator;
 import org.apache.flink.kubernetes.operator.config.DefaultConfig;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 
@@ -42,20 +40,18 @@ public class FlinkUtils {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public static DefaultConfig loadDefaultConfig() {
-        // TODO refactor after FLINK-26332
         Configuration operatorConfig =
-                FlinkUtils.loadConfiguration(
-                        System.getenv().get(FlinkOperator.ENV_FLINK_OPERATOR_CONF_DIR));
-        Configuration flinkDefaultConfig =
-                FlinkUtils.loadConfiguration(System.getenv(ConfigConstants.ENV_FLINK_CONF_DIR));
-        return new DefaultConfig(operatorConfig, flinkDefaultConfig);
+                FlinkUtils.loadConfiguration(EnvUtils.get(EnvUtils.ENV_FLINK_OPERATOR_CONF_DIR));
+        Configuration flinkConfig =
+                FlinkUtils.loadConfiguration(EnvUtils.get(EnvUtils.ENV_FLINK_CONF_DIR));
+        return new DefaultConfig(operatorConfig, flinkConfig);
     }
 
     public static Configuration getEffectiveConfig(
-            FlinkDeployment flinkApp, Configuration defaultFlinkConfig) {
+            FlinkDeployment flinkApp, Configuration flinkConfig) {
         try {
             final Configuration effectiveConfig =
-                    FlinkConfigBuilder.buildFrom(flinkApp, defaultFlinkConfig);
+                    FlinkConfigBuilder.buildFrom(flinkApp, flinkConfig);
             LOG.debug("Effective config: {}", effectiveConfig);
             return effectiveConfig;
         } catch (Exception e) {
@@ -64,11 +60,9 @@ public class FlinkUtils {
     }
 
     public static Configuration loadConfiguration(String confDir) {
-        Configuration configuration =
-                confDir != null
-                        ? GlobalConfiguration.loadConfiguration(confDir)
-                        : new Configuration();
-        return configuration;
+        return confDir != null
+                ? GlobalConfiguration.loadConfiguration(confDir)
+                : new Configuration();
     }
 
     public static Pod mergePodTemplates(Pod toPod, Pod fromPod) {


### PR DESCRIPTION
Move the scattered environments variables to the `EnvUtils` and make it clear whether the variable is required