### PR TITLE
[FLINK-26261] Wait for JobManager deployment ready before accessing REST API

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -21,7 +21,6 @@ import org.apache.flink.kubernetes.operator.config.DefaultConfig;
 import org.apache.flink.kubernetes.operator.controller.FlinkControllerConfig;
 import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentController;
 import org.apache.flink.kubernetes.operator.metrics.OperatorMetricUtils;
-import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
 import org.apache.flink.kubernetes.operator.reconciler.JobReconciler;
 import org.apache.flink.kubernetes.operator.reconciler.SessionReconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
@@ -56,7 +55,6 @@ public class FlinkOperator {
 
         FlinkService flinkService = new FlinkService(client);
 
-        JobStatusObserver observer = new JobStatusObserver(flinkService);
         JobReconciler jobReconciler = new JobReconciler(client, flinkService);
         SessionReconciler sessionReconciler = new SessionReconciler(client, flinkService);
 
@@ -68,7 +66,6 @@ public class FlinkOperator {
                         client,
                         namespace,
                         validator,
-                        observer,
                         jobReconciler,
                         sessionReconciler);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -83,10 +83,6 @@ public class JobStatusObserver {
         }
     }
 
-    public boolean isJobManagerReady(Configuration config) {
-        return flinkService.isJobManagerReady(config);
-    }
-
     /** Merge previous job status with the new one from the flink job cluster. */
     private JobStatus mergeJobStatus(
             JobStatus oldStatus, List<JobStatusMessage> clusterJobStatuses) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -83,6 +83,10 @@ public class JobStatusObserver {
         }
     }
 
+    public boolean isJobManagerReady(Configuration config) {
+        return flinkService.isJobManagerReady(config);
+    }
+
     /** Merge previous job status with the new one from the flink job cluster. */
     private JobStatus mergeJobStatus(
             JobStatus oldStatus, List<JobStatusMessage> clusterJobStatuses) {
@@ -98,6 +102,8 @@ public class JobStatusObserver {
             newStatus.setState(newJob.getJobState().name());
             newStatus.setJobName(newJob.getJobName());
             newStatus.setJobId(newJob.getJobId().toHexString());
+            // track the start time, changing timestamp would cause busy reconciliation
+            newStatus.setUpdateTime(String.valueOf(newJob.getStartTime()));
         }
         return newStatus;
     }
@@ -107,6 +113,7 @@ public class JobStatusObserver {
         jobStatus.setJobId(message.getJobId().toHexString());
         jobStatus.setJobName(message.getJobName());
         jobStatus.setState(message.getJobState().name());
+        jobStatus.setUpdateTime(String.valueOf(message.getStartTime()));
         return jobStatus;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/BaseReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/BaseReconciler.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.service.FlinkService;
+
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
+import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/** BaseReconciler with functionality that is common to job and session modes. */
+public abstract class BaseReconciler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseReconciler.class);
+
+    public static final int REFRESH_SECONDS = 60;
+    public static final int PORT_READY_DELAY_SECONDS = 10;
+
+    private final HashSet<String> jobManagerDeployments = new HashSet<>();
+
+    public boolean removeDeployment(FlinkDeployment flinkApp) {
+        return jobManagerDeployments.remove(flinkApp.getMetadata().getUid());
+    }
+
+    public abstract UpdateControl<FlinkDeployment> reconcile(
+            String operatorNamespace,
+            FlinkDeployment flinkApp,
+            Context context,
+            Configuration effectiveConfig)
+            throws Exception;
+
+    protected UpdateControl<FlinkDeployment> checkJobManagerDeployment(
+            FlinkDeployment flinkApp,
+            Context context,
+            Configuration effectiveConfig,
+            FlinkService flinkService) {
+        if (!jobManagerDeployments.contains(flinkApp.getMetadata().getUid())) {
+            Optional<Deployment> deployment = context.getSecondaryResource(Deployment.class);
+            if (deployment.isPresent()) {
+                DeploymentStatus status = deployment.get().getStatus();
+                DeploymentSpec spec = deployment.get().getSpec();
+                if (status != null
+                        && status.getAvailableReplicas() != null
+                        && spec.getReplicas().intValue() == status.getReplicas()
+                        && spec.getReplicas().intValue() == status.getAvailableReplicas()) {
+                    // typically it takes a few seconds for the REST server to be ready
+                    if (flinkService.isJobManagerPortReady(effectiveConfig)) {
+                        LOG.info(
+                                "JobManager deployment {} in namespace {} is ready",
+                                flinkApp.getMetadata().getName(),
+                                flinkApp.getMetadata().getNamespace());
+                        jobManagerDeployments.add(flinkApp.getMetadata().getUid());
+                        if (flinkApp.getStatus().getJobStatus() != null) {
+                            // pre-existing deployments on operator restart - proceed with
+                            // reconciliation
+                            return null;
+                        }
+                    }
+                    LOG.info(
+                            "JobManager deployment {} in namespace {} port not ready",
+                            flinkApp.getMetadata().getName(),
+                            flinkApp.getMetadata().getNamespace());
+                    return UpdateControl.updateStatus(flinkApp)
+                            .rescheduleAfter(PORT_READY_DELAY_SECONDS, TimeUnit.SECONDS);
+                }
+                LOG.info(
+                        "JobManager deployment {} in namespace {} not yet ready, status {}",
+                        flinkApp.getMetadata().getName(),
+                        flinkApp.getMetadata().getNamespace(),
+                        status);
+                // TODO: how frequently do we want here
+                return UpdateControl.updateStatus(flinkApp)
+                        .rescheduleAfter(REFRESH_SECONDS, TimeUnit.SECONDS);
+            }
+        }
+        return null;
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -100,7 +100,7 @@ public class FlinkService {
         LOG.info("Session cluster {} deployed", deployment.getMetadata().getName());
     }
 
-    public boolean isJobManagerReady(Configuration config) {
+    public boolean isJobManagerPortReady(Configuration config) {
         final URI uri;
         try (ClusterClient<String> clusterClient = getClusterClient(config)) {
             uri = URI.create(clusterClient.getWebInterfaceURL());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -100,4 +100,9 @@ public class TestingFlinkService extends FlinkService {
     public void stopSessionCluster(FlinkDeployment deployment, Configuration conf) {
         sessions.remove(deployment.getMetadata().getName());
     }
+
+    @Override
+    public boolean isJobManagerReady(Configuration config) {
+        return true;
+    }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -102,7 +102,7 @@ public class TestingFlinkService extends FlinkService {
     }
 
     @Override
-    public boolean isJobManagerReady(Configuration config) {
+    public boolean isJobManagerPortReady(Configuration config) {
         return true;
     }
 }


### PR DESCRIPTION
First part following resource dependencies in the reconciler logic: Wait for the JM deployment to be ready before trying to access the JM. This will be built upon for improving the error detection/handling later on.