### PR TITLE
[FLINK-26141] Support last-state upgrade mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,10 @@ jobs:
           kubectl get pods
       - name: Run Flink e2e tests
         run: |
-          ./e2e-tests/test_kubernetes_application_ha.sh
+          ls e2e-tests/test_*.sh | while read script_test;do \
+            echo "Running $script_test"
+            bash $script_test || exit 1
+          done
       - name: Stop the operator
         run: |
           helm uninstall flink-operator

--- a/e2e-tests/data/cr.yaml
+++ b/e2e-tests/data/cr.yaml
@@ -78,6 +78,7 @@ spec:
     jarURI: local:///opt/flink/usrlib/myjob.jar
     entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample
     parallelism: 2
+    upgradeMode: last-state
 
 ---
 apiVersion: v1

--- a/e2e-tests/test_last_state_upgrade.sh
+++ b/e2e-tests/test_last_state_upgrade.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+source "$(dirname "$0")"/utils.sh
+
+CLUSTER_ID="flink-example-statemachine"
+TIMEOUT=300
+
+function cleanup_and_exit() {
+    if [ $TRAPPED_EXIT_CODE != 0 ];then
+      debug_and_show_logs
+    fi
+
+    kubectl delete -f e2e-tests/data/cr.yaml
+    kubectl wait --for=delete pod --timeout=${TIMEOUT}s --selector="app=${CLUSTER_ID}"
+    kubectl delete cm --selector="app=${CLUSTER_ID},configmap-type=high-availability"
+}
+
+function wait_for_jobmanager_running() {
+    retry_times 30 3 "kubectl get deploy/${CLUSTER_ID}" || exit 1
+
+    kubectl wait --for=condition=Available --timeout=${TIMEOUT}s deploy/${CLUSTER_ID} || exit 1
+    jm_pod_name=$(kubectl get pods --selector="app=${CLUSTER_ID},component=jobmanager" -o jsonpath='{..metadata.name}')
+
+    echo "Waiting for jobmanager pod ${jm_pod_name} ready."
+    kubectl wait --for=condition=Ready --timeout=${TIMEOUT}s pod/$jm_pod_name || exit 1
+
+    wait_for_logs $jm_pod_name "Rest endpoint listening at" ${TIMEOUT} || exit 1
+}
+
+on_exit cleanup_and_exit
+
+retry_times 5 30 "kubectl apply -f e2e-tests/data/cr.yaml" || exit 1
+
+wait_for_jobmanager_running
+
+wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
+
+job_id=$(kubectl logs $jm_pod_name | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
+
+# Update the FlinkDeployment and trigger the last state upgrade
+kubectl patch flinkdep ${CLUSTER_ID} --type merge --patch '{"spec":{"jobManager": {"resource": {"cpu": 0.51, "memory": "1024m"} } } }'
+
+kubectl wait --for=delete pod --timeout=${TIMEOUT}s --selector="app=${CLUSTER_ID}"
+wait_for_jobmanager_running
+
+# Check the new JobManager recovering from latest successful checkpoint
+wait_for_logs $jm_pod_name "Restoring job $job_id from Checkpoint" ${TIMEOUT} || exit 1
+wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
+
+echo "Successfully run the last-state upgrade test"
+

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -109,11 +109,19 @@ public class FlinkUtils {
     }
 
     public static void deleteCluster(FlinkDeployment flinkApp, KubernetesClient kubernetesClient) {
+        deleteCluster(
+                flinkApp.getMetadata().getNamespace(),
+                flinkApp.getMetadata().getName(),
+                kubernetesClient);
+    }
+
+    public static void deleteCluster(
+            String namespace, String clusterId, KubernetesClient kubernetesClient) {
         kubernetesClient
                 .apps()
                 .deployments()
-                .inNamespace(flinkApp.getMetadata().getNamespace())
-                .withName(flinkApp.getMetadata().getName())
+                .inNamespace(namespace)
+                .withName(clusterId)
                 .cascading(true)
                 .delete();
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingClusterClient.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingClusterClient.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.util.function.TriFunction;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+/** Testing ClusterClient used implementation. */
+public class TestingClusterClient<T> implements ClusterClient<T> {
+
+    private Function<JobID, CompletableFuture<Acknowledge>> cancelFunction =
+            ignore -> CompletableFuture.completedFuture(Acknowledge.get());
+    private TriFunction<JobID, Boolean, String, CompletableFuture<String>>
+            stopWithSavepointFunction =
+                    (ignore1, ignore2, savepointPath) ->
+                            CompletableFuture.completedFuture(savepointPath);
+
+    private final T clusterId;
+
+    public TestingClusterClient(T clusterId) {
+        this.clusterId = clusterId;
+    }
+
+    public void setCancelFunction(Function<JobID, CompletableFuture<Acknowledge>> cancelFunction) {
+        this.cancelFunction = cancelFunction;
+    }
+
+    public void setStopWithSavepointFunction(
+            TriFunction<JobID, Boolean, String, CompletableFuture<String>>
+                    stopWithSavepointFunction) {
+        this.stopWithSavepointFunction = stopWithSavepointFunction;
+    }
+
+    @Override
+    public T getClusterId() {
+        return clusterId;
+    }
+
+    @Override
+    public Configuration getFlinkConfiguration() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void shutDownCluster() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getWebInterfaceURL() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<Collection<JobStatusMessage>> listJobs() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> disposeSavepoint(String savepointPath) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<JobID> submitJob(@Nonnull JobGraph jobGraph) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<JobStatus> getJobStatus(JobID jobId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<JobResult> requestJobResult(@Nonnull JobID jobId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<Map<String, Object>> getAccumulators(JobID jobID, ClassLoader loader) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> cancel(JobID jobId) {
+        return cancelFunction.apply(jobId);
+    }
+
+    @Override
+    public CompletableFuture<String> cancelWithSavepoint(
+            JobID jobId, @Nullable String savepointDirectory) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<String> stopWithSavepoint(
+            JobID jobId, boolean advanceToEndOfEventTime, @Nullable String savepointDirectory) {
+        return stopWithSavepointFunction.apply(jobId, advanceToEndOfEventTime, savepointDirectory);
+    }
+
+    @Override
+    public CompletableFuture<String> triggerSavepoint(
+            JobID jobId, @Nullable String savepointDirectory) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<CoordinationResponse> sendCoordinationRequest(
+            JobID jobId, OperatorID operatorId, CoordinationRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {}
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.service;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
+import org.apache.flink.kubernetes.operator.TestingClusterClient;
+import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
+import org.apache.flink.kubernetes.operator.exception.InvalidDeploymentException;
+import org.apache.flink.runtime.messages.Acknowledge;
+
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** @link FlinkService unit tests */
+@EnableKubernetesMockClient(crud = true)
+public class FlinkServiceTest {
+    KubernetesClient client;
+    private final Configuration configuration = new Configuration();
+    private static final String CLUSTER_ID = "testing-flink-cluster";
+    private static final String TESTING_NAMESPACE = "test";
+
+    @BeforeEach
+    public void setup() {
+        configuration.set(KubernetesConfigOptions.CLUSTER_ID, CLUSTER_ID);
+        configuration.set(KubernetesConfigOptions.NAMESPACE, TESTING_NAMESPACE);
+    }
+
+    @Test
+    public void testCancelJobWithStatelessUpgradeMode() throws Exception {
+        final TestingClusterClient<String> testingClusterClient =
+                new TestingClusterClient<>(CLUSTER_ID);
+        final CompletableFuture<JobID> cancelFuture = new CompletableFuture<>();
+        testingClusterClient.setCancelFunction(
+                jobID -> {
+                    cancelFuture.complete(jobID);
+                    return CompletableFuture.completedFuture(Acknowledge.get());
+                });
+
+        final FlinkService flinkService = createFlinkService(testingClusterClient);
+
+        final JobID jobID = JobID.generate();
+        Optional<String> result =
+                flinkService.cancelJob(jobID, UpgradeMode.STATELESS, configuration);
+        assertTrue(cancelFuture.isDone());
+        assertEquals(jobID, cancelFuture.get());
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    public void testCancelJobWithSavepointUpgradeMode() throws Exception {
+        final TestingClusterClient<String> testingClusterClient =
+                new TestingClusterClient<>(CLUSTER_ID);
+        final CompletableFuture<Tuple3<JobID, Boolean, String>> stopWithSavepointFuture =
+                new CompletableFuture<>();
+        final String savepointPath = "file:///path/of/svp-1";
+        testingClusterClient.setStopWithSavepointFunction(
+                (jobID, advanceToEndOfEventTime, savepointDir) -> {
+                    stopWithSavepointFuture.complete(
+                            new Tuple3<>(jobID, advanceToEndOfEventTime, savepointDir));
+                    return CompletableFuture.completedFuture(savepointPath);
+                });
+
+        final FlinkService flinkService = createFlinkService(testingClusterClient);
+
+        final JobID jobID = JobID.generate();
+        Optional<String> result =
+                flinkService.cancelJob(jobID, UpgradeMode.SAVEPOINT, configuration);
+        assertTrue(stopWithSavepointFuture.isDone());
+        assertEquals(jobID, stopWithSavepointFuture.get().f0);
+        assertFalse(stopWithSavepointFuture.get().f1);
+        assertNull(stopWithSavepointFuture.get().f2);
+        assertTrue(result.isPresent());
+        assertEquals(savepointPath, result.get());
+    }
+
+    @Test
+    public void testCancelJobWithLastStateUpgradeMode() throws Exception {
+        configuration.set(
+                HighAvailabilityOptions.HA_MODE,
+                KubernetesHaServicesFactory.class.getCanonicalName());
+        final TestingClusterClient<String> testingClusterClient =
+                new TestingClusterClient<>(CLUSTER_ID);
+        final FlinkService flinkService = createFlinkService(testingClusterClient);
+
+        client.apps()
+                .deployments()
+                .inNamespace(TESTING_NAMESPACE)
+                .create(createTestingDeployment());
+        assertNotNull(
+                client.apps()
+                        .deployments()
+                        .inNamespace(TESTING_NAMESPACE)
+                        .withName(CLUSTER_ID)
+                        .get());
+        final JobID jobID = JobID.generate();
+        Optional<String> result =
+                flinkService.cancelJob(jobID, UpgradeMode.LAST_STATE, configuration);
+        assertFalse(result.isPresent());
+        assertNull(
+                client.apps()
+                        .deployments()
+                        .inNamespace(TESTING_NAMESPACE)
+                        .withName(CLUSTER_ID)
+                        .get());
+    }
+
+    @Test
+    public void testCancelJobWithLastStateUpgradeModeWhenHADisabled() {
+        configuration.set(HighAvailabilityOptions.HA_MODE, "None");
+        final TestingClusterClient<String> testingClusterClient =
+                new TestingClusterClient<>(CLUSTER_ID);
+        final FlinkService flinkService = createFlinkService(testingClusterClient);
+
+        final JobID jobID = JobID.generate();
+        assertThrows(
+                InvalidDeploymentException.class,
+                () -> flinkService.cancelJob(jobID, UpgradeMode.LAST_STATE, configuration));
+    }
+
+    private FlinkService createFlinkService(ClusterClient<String> clusterClient) {
+        return new FlinkService((NamespacedKubernetesClient) client) {
+            @Override
+            protected ClusterClient<String> getClusterClient(Configuration config) {
+                return clusterClient;
+            }
+        };
+    }
+
+    private Deployment createTestingDeployment() {
+        return new DeploymentBuilder()
+                .withNewMetadata()
+                .withName(CLUSTER_ID)
+                .withNamespace(TESTING_NAMESPACE)
+                .endMetadata()
+                .withNewSpec()
+                .endSpec()
+                .build();
+    }
+}


### PR DESCRIPTION
This PR tries to support last-state upgrade mode. 

Given that the HA is enabled, if we want to upgrade the job with latest successful checkpoint, we could simply destroy the K8s deployment. All the HA related ConfigMaps will be retained. Then we start the job with same cluster-id and it should recover from the latest retained checkpoint.

[1]. https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/overview/#high-availability-data-lifecycle
[2]. https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/kubernetes_ha/#high-availability-data-clean-up