### PR TITLE
[FLINK-26178] Use the same enum for expected and observed jobstate 

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.kubernetes.operator.crd.status;
 
+import org.apache.flink.kubernetes.operator.crd.spec.JobState;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -30,7 +32,7 @@ import lombok.NoArgsConstructor;
 public class JobStatus {
     private String jobName;
     private String jobId;
-    private String state;
+    private JobState state;
     private String updateTime;
     private String savepointLocation;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -95,7 +95,7 @@ public class JobStatusObserver {
         if (newStatus == null) {
             newStatus = createJobStatus(newJob);
         } else {
-            newStatus.setState(newJob.getJobState().name());
+            newStatus.setState(JobState.valueOf(newJob.getJobState().name()));
             newStatus.setJobName(newJob.getJobName());
             newStatus.setJobId(newJob.getJobId().toHexString());
         }
@@ -106,7 +106,7 @@ public class JobStatusObserver {
         JobStatus jobStatus = new JobStatus();
         jobStatus.setJobId(message.getJobId().toHexString());
         jobStatus.setJobName(message.getJobName());
-        jobStatus.setState(message.getJobState().name());
+        jobStatus.setState(JobState.valueOf(message.getJobState().name()));
         return jobStatus;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/JobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/JobReconciler.java
@@ -160,7 +160,7 @@ public class JobReconciler {
                         upgradeMode,
                         effectiveConfig);
         JobStatus jobStatus = flinkApp.getStatus().getJobStatus();
-        jobStatus.setState("suspended");
+        jobStatus.setState(JobState.SUSPENDED);
         savepointOpt.ifPresent(jobStatus::setSavepointLocation);
         return savepointOpt;
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -78,7 +78,7 @@ public class FlinkDeploymentControllerTest {
         JobStatusMessage expectedJobStatus = flinkService.listJobs().get(0).f1;
         assertEquals(expectedJobStatus.getJobId().toHexString(), jobStatus.getJobId());
         assertEquals(expectedJobStatus.getJobName(), jobStatus.getJobName());
-        assertEquals(expectedJobStatus.getJobState().toString(), jobStatus.getState());
+        assertEquals(expectedJobStatus.getJobState().toString(), jobStatus.getState().toString());
 
         // Send in invalid update
         appCluster = TestUtils.clone(appCluster);
@@ -97,7 +97,7 @@ public class FlinkDeploymentControllerTest {
         expectedJobStatus = flinkService.listJobs().get(0).f1;
         assertEquals(expectedJobStatus.getJobId().toHexString(), jobStatus.getJobId());
         assertEquals(expectedJobStatus.getJobName(), jobStatus.getJobName());
-        assertEquals(expectedJobStatus.getJobState().toString(), jobStatus.getState());
+        assertEquals(expectedJobStatus.getJobState().toString(), jobStatus.getState().toString());
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/JobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/JobReconcilerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
@@ -57,7 +58,7 @@ public class JobReconcilerTest {
         JobStatus jobStatus = new JobStatus();
         jobStatus.setJobName(runningJobs.get(0).f1.getJobName());
         jobStatus.setJobId(runningJobs.get(0).f1.getJobId().toHexString());
-        jobStatus.setState("RUNNING");
+        jobStatus.setState(JobState.RUNNING);
 
         deployment.getStatus().setJobStatus(jobStatus);
 

--- a/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9067,6 +9067,9 @@ spec:
                   jobId:
                     type: string
                   state:
+                    enum:
+                    - running
+                    - suspended
                     type: string
                   updateTime:
                     type: string


### PR DESCRIPTION
- Rename the `state` field in `JobStatus` to `jobState` and set its type to `JobState` enum.