### PR TITLE
[FLINK-26356] Use the common method to construct service name

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -32,6 +32,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.Fabric8FlinkKubeClient;
+import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
@@ -131,8 +132,7 @@ public class FlinkService {
         final String namespace = config.get(KubernetesConfigOptions.NAMESPACE);
         final int port = config.getInteger(RestOptions.PORT);
         final String host =
-                config.getString(
-                        RestOptions.ADDRESS, String.format("%s-rest.%s", clusterId, namespace));
+                ExternalServiceDecorator.getNamespacedExternalServiceName(clusterId, namespace);
         final String restServerAddress = String.format("http://%s:%s", host, port);
         LOG.debug("Creating RestClusterClient({})", restServerAddress);
         return new RestClusterClient<>(


### PR DESCRIPTION
Use the common method to construct service name. 

Besides, the `RestOptions.ADDRESS` is always generated at the server side we can not get it from the client config. 
Since the flink-operator is always deployed with the flink job in the same cluster, we can directly use the `Servicename.Namespace` to talk to Flink job rest server.
I'am not sure whether need to remove the `config.getString(RestOptions.ADDRESS, xx)`