### PR TITLE
[FLINK-26432] Cleanly separate validator, observer and reconciler modules

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -21,6 +21,7 @@ import org.apache.flink.kubernetes.operator.config.DefaultConfig;
 import org.apache.flink.kubernetes.operator.controller.FlinkControllerConfig;
 import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentController;
 import org.apache.flink.kubernetes.operator.metrics.OperatorMetricUtils;
+import org.apache.flink.kubernetes.operator.observer.Observer;
 import org.apache.flink.kubernetes.operator.reconciler.JobReconciler;
 import org.apache.flink.kubernetes.operator.reconciler.SessionReconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
@@ -55,6 +56,7 @@ public class FlinkOperator {
 
         FlinkService flinkService = new FlinkService(client);
 
+        Observer observer = new Observer(flinkService);
         JobReconciler jobReconciler = new JobReconciler(client, flinkService);
         SessionReconciler sessionReconciler = new SessionReconciler(client, flinkService);
 
@@ -66,6 +68,7 @@ public class FlinkOperator {
                         client,
                         namespace,
                         validator,
+                        observer,
                         jobReconciler,
                         sessionReconciler);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkDeploymentStatus.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.kubernetes.operator.crd.status;
 
+import org.apache.flink.kubernetes.operator.observer.JobManagerDeploymentStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -26,6 +28,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FlinkDeploymentStatus {
-    private JobStatus jobStatus;
+    private JobStatus jobStatus = new JobStatus();
+    private JobManagerDeploymentStatus jobManagerDeploymentStatus =
+            JobManagerDeploymentStatus.MISSING;
     private ReconciliationStatus reconciliationStatus = new ReconciliationStatus();
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobManagerDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobManagerDeploymentStatus.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.kubernetes.operator.reconciler;
+package org.apache.flink.kubernetes.operator.observer;
 
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 
@@ -44,12 +44,12 @@ public enum JobManagerDeploymentStatus {
     public UpdateControl<FlinkDeployment> toUpdateControl(FlinkDeployment flinkDeployment) {
         switch (this) {
             case DEPLOYING:
+            case READY:
                 return UpdateControl.updateStatus(flinkDeployment)
                         .rescheduleAfter(REFRESH_SECONDS, TimeUnit.SECONDS);
             case DEPLOYED_NOT_READY:
                 return UpdateControl.updateStatus(flinkDeployment)
                         .rescheduleAfter(PORT_READY_DELAY_SECONDS, TimeUnit.SECONDS);
-            case READY:
             case MISSING:
             default:
                 return null;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/BaseReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/BaseReconciler.java
@@ -19,22 +19,17 @@ package org.apache.flink.kubernetes.operator.reconciler;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.observer.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
 
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
-import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.HashSet;
-import java.util.Optional;
 
 /** BaseReconciler with functionality that is common to job and session modes. */
 public abstract class BaseReconciler {
@@ -44,18 +39,12 @@ public abstract class BaseReconciler {
     public static final int REFRESH_SECONDS = 60;
     public static final int PORT_READY_DELAY_SECONDS = 10;
 
-    private final HashSet<String> jobManagerDeployments = new HashSet<>();
-
     protected final KubernetesClient kubernetesClient;
     protected final FlinkService flinkService;
 
     public BaseReconciler(KubernetesClient kubernetesClient, FlinkService flinkService) {
         this.kubernetesClient = kubernetesClient;
         this.flinkService = flinkService;
-    }
-
-    public boolean removeDeployment(FlinkDeployment flinkApp) {
-        return jobManagerDeployments.remove(flinkApp.getMetadata().getUid());
     }
 
     public abstract UpdateControl<FlinkDeployment> reconcile(
@@ -65,70 +54,15 @@ public abstract class BaseReconciler {
             Configuration effectiveConfig)
             throws Exception;
 
-    protected JobManagerDeploymentStatus checkJobManagerDeployment(
-            FlinkDeployment flinkApp, Context context, Configuration effectiveConfig) {
-        if (!jobManagerDeployments.contains(flinkApp.getMetadata().getUid())) {
-            Optional<Deployment> deployment = context.getSecondaryResource(Deployment.class);
-            if (deployment.isPresent()) {
-                DeploymentStatus status = deployment.get().getStatus();
-                DeploymentSpec spec = deployment.get().getSpec();
-                if (status != null
-                        && status.getAvailableReplicas() != null
-                        && spec.getReplicas().intValue() == status.getReplicas()
-                        && spec.getReplicas().intValue() == status.getAvailableReplicas()) {
-                    // typically it takes a few seconds for the REST server to be ready
-                    if (flinkService.isJobManagerPortReady(effectiveConfig)) {
-                        LOG.info(
-                                "JobManager deployment {} in namespace {} is ready",
-                                flinkApp.getMetadata().getName(),
-                                flinkApp.getMetadata().getNamespace());
-                        jobManagerDeployments.add(flinkApp.getMetadata().getUid());
-                        if (flinkApp.getStatus().getJobStatus() != null) {
-                            // pre-existing deployments on operator restart - proceed with
-                            // reconciliation
-                            return JobManagerDeploymentStatus.READY;
-                        }
-                    }
-                    LOG.info(
-                            "JobManager deployment {} in namespace {} port not ready",
-                            flinkApp.getMetadata().getName(),
-                            flinkApp.getMetadata().getNamespace());
-                    return JobManagerDeploymentStatus.DEPLOYED_NOT_READY;
-                }
-                LOG.info(
-                        "JobManager deployment {} in namespace {} not yet ready, status {}",
-                        flinkApp.getMetadata().getName(),
-                        flinkApp.getMetadata().getNamespace(),
-                        status);
-
-                return JobManagerDeploymentStatus.DEPLOYING;
-            }
-            return JobManagerDeploymentStatus.MISSING;
-        }
-        return JobManagerDeploymentStatus.READY;
-    }
-
-    /**
-     * Shuts down the job and deletes all kubernetes resources including k8s HA resources. It will
-     * first perform a graceful shutdown (cancel) before deleting the data if that is unsuccessful
-     * in order to avoid leaking HA metadata to durable storage.
-     *
-     * <p>This feature is limited at the moment to cleaning up native kubernetes HA resources, other
-     * HA providers like ZK need to be cleaned up manually after deletion.
-     */
     public DeleteControl shutdownAndDelete(
-            String operatorNamespace,
-            FlinkDeployment flinkApp,
-            Context context,
-            Configuration effectiveConfig) {
+            String operatorNamespace, FlinkDeployment flinkApp, Configuration effectiveConfig) {
 
-        if (checkJobManagerDeployment(flinkApp, context, effectiveConfig)
-                == JobManagerDeploymentStatus.READY) {
+        if (JobManagerDeploymentStatus.READY
+                == flinkApp.getStatus().getJobManagerDeploymentStatus()) {
             shutdown(flinkApp, effectiveConfig);
         } else {
             FlinkUtils.deleteCluster(flinkApp, kubernetesClient, true);
         }
-        removeDeployment(flinkApp);
         IngressUtils.updateIngressRules(
                 flinkApp, effectiveConfig, operatorNamespace, kubernetesClient, true);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/JobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/JobReconciler.java
@@ -25,7 +25,7 @@ import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
-import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
+import org.apache.flink.kubernetes.operator.observer.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
@@ -48,11 +48,8 @@ public class JobReconciler extends BaseReconciler {
 
     private static final Logger LOG = LoggerFactory.getLogger(JobReconciler.class);
 
-    private final JobStatusObserver observer;
-
     public JobReconciler(KubernetesClient kubernetesClient, FlinkService flinkService) {
         super(kubernetesClient, flinkService);
-        this.observer = new JobStatusObserver(flinkService);
     }
 
     @Override
@@ -72,19 +69,7 @@ public class JobReconciler extends BaseReconciler {
                     Optional.ofNullable(jobSpec.getInitialSavepointPath()));
             IngressUtils.updateIngressRules(
                     flinkApp, effectiveConfig, operatorNamespace, kubernetesClient, false);
-        }
-
-        // wait until the deployment is ready
-        UpdateControl<FlinkDeployment> uc =
-                checkJobManagerDeployment(flinkApp, context, effectiveConfig)
-                        .toUpdateControl(flinkApp);
-        if (uc != null) {
-            return uc;
-        }
-
-        if (!observer.observeFlinkJobStatus(flinkApp, effectiveConfig)) {
-            return UpdateControl.updateStatus(flinkApp)
-                    .rescheduleAfter(REFRESH_SECONDS, TimeUnit.SECONDS);
+            return JobManagerDeploymentStatus.DEPLOYING.toUpdateControl(flinkApp);
         }
 
         // TODO: following assumes that current job is running
@@ -174,15 +159,17 @@ public class JobReconciler extends BaseReconciler {
                         effectiveConfig);
         JobStatus jobStatus = flinkApp.getStatus().getJobStatus();
         jobStatus.setState("suspended");
-        removeDeployment(flinkApp);
+        flinkApp.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
         savepointOpt.ifPresent(jobStatus::setSavepointLocation);
         return savepointOpt;
     }
 
     @Override
     protected void shutdown(FlinkDeployment flinkApp, Configuration effectiveConfig) {
-        if (flinkApp.getStatus().getJobStatus() != null
-                && flinkApp.getStatus().getJobStatus().getJobId() != null) {
+        if (org.apache.flink.api.common.JobStatus.RUNNING
+                .name()
+                .equals(flinkApp.getStatus().getJobStatus().getState())) {
+            LOG.info("Job is running, attempting graceful shutdown.");
             try {
                 flinkService.cancelJob(
                         JobID.fromHexString(flinkApp.getStatus().getJobStatus().getJobId()),

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/JobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/JobReconciler.java
@@ -168,7 +168,7 @@ public class JobReconciler extends BaseReconciler {
     protected void shutdown(FlinkDeployment flinkApp, Configuration effectiveConfig) {
         if (org.apache.flink.api.common.JobStatus.RUNNING
                 .name()
-                .equals(flinkApp.getStatus().getJobStatus().getState())) {
+                .equalsIgnoreCase(flinkApp.getStatus().getJobStatus().getState())) {
             LOG.info("Job is running, attempting graceful shutdown.");
             try {
                 flinkService.cancelJob(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconciler.java
@@ -60,13 +60,6 @@ public class SessionReconciler extends BaseReconciler {
                     flinkApp, effectiveConfig, operatorNamespace, kubernetesClient, false);
         }
 
-        UpdateControl<FlinkDeployment> uc =
-                checkJobManagerDeployment(flinkApp, context, effectiveConfig)
-                        .toUpdateControl(flinkApp);
-        if (uc != null) {
-            return uc;
-        }
-
         boolean specChanged = !flinkApp.getSpec().equals(lastReconciledSpec);
         if (specChanged) {
             upgradeSessionCluster(flinkApp, effectiveConfig);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -33,9 +33,12 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /** Testing utilities. */
 public class TestUtils {
@@ -108,5 +111,19 @@ public class TestUtils {
         pod.setApiVersion(apiVersion);
         pod.setSpec(podSpec);
         return pod;
+    }
+
+    public static Context createEmptyContext() {
+        return new Context() {
+            @Override
+            public Optional<RetryInfo> getRetryInfo() {
+                return Optional.empty();
+            }
+
+            @Override
+            public <T> Optional<T> getSecondaryResource(Class<T> aClass, String s) {
+                return Optional.empty();
+            }
+        };
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -41,6 +41,7 @@ public class TestingFlinkService extends FlinkService {
 
     private List<Tuple2<String, JobStatusMessage>> jobs = new ArrayList<>();
     private Set<String> sessions = new HashSet<>();
+    private boolean isPortReady = true;
 
     public TestingFlinkService() {
         super(null);
@@ -104,6 +105,10 @@ public class TestingFlinkService extends FlinkService {
 
     @Override
     public boolean isJobManagerPortReady(Configuration config) {
-        return true;
+        return isPortReady;
+    }
+
+    public void setPortReady(boolean isPortReady) {
+        this.isPortReady = isPortReady;
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/ObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/ObserverTest.java
@@ -109,7 +109,7 @@ public class ObserverTest {
                 JobManagerDeploymentStatus.DEPLOYED_NOT_READY,
                 deployment.getStatus().getJobManagerDeploymentStatus());
 
-        // Stable rady
+        // Stable ready
         assertTrue(observer.observe(deployment, readyContext, conf));
         assertEquals(
                 JobManagerDeploymentStatus.READY,
@@ -123,5 +123,13 @@ public class ObserverTest {
         assertEquals(
                 deployment.getMetadata().getName(),
                 deployment.getStatus().getJobStatus().getJobName());
+
+        // Test listing failure
+        flinkService.clear();
+        assertFalse(observer.observe(deployment, readyContext, conf));
+        assertEquals(
+                JobManagerDeploymentStatus.READY,
+                deployment.getStatus().getJobManagerDeploymentStatus());
+        assertEquals("UNKNOWN", deployment.getStatus().getJobStatus().getState());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/JobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/JobReconcilerTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
-import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
+import org.apache.flink.kubernetes.operator.observer.Observer;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
@@ -115,7 +115,7 @@ public class JobReconcilerTest {
         final String expectedSavepointPath = "savepoint_0";
         final Context context = JobReconcilerTest.createContextWithReadyJobManagerDeployment();
         final TestingFlinkService flinkService = new TestingFlinkService();
-        JobStatusObserver observer = new JobStatusObserver(flinkService);
+        Observer observer = new Observer(flinkService);
 
         final JobReconciler reconciler = new JobReconciler(null, flinkService);
         final FlinkDeployment deployment = TestUtils.buildApplicationCluster();

--- a/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9073,6 +9073,13 @@ spec:
                   savepointLocation:
                     type: string
                 type: object
+              jobManagerDeploymentStatus:
+                enum:
+                - READY
+                - DEPLOYED_NOT_READY
+                - DEPLOYING
+                - MISSING
+                type: string
               reconciliationStatus:
                 properties:
                   success:


### PR DESCRIPTION
This ticket solves the problem of the lingering configmaps after deleting HA clusters by trying to gracefully shutdown jobs before deleting everything.

It makes the deletion heavier and prone to timeoutexceptions , but this could be improved if we merge https://github.com/apache/flink-kubernetes-operator/pull/21 first then I can improve this based on that.

Also async operations would make this nicer but that is a separate effort tracked in a different ticket.