### PR TITLE
[FLINK-26367] Move sanity check in `FlinkService#cancelJob` to `DefaultDeploymentValidator`

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -35,11 +35,9 @@ import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorato
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
-import org.apache.flink.kubernetes.operator.exception.InvalidDeploymentException;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneClientHAServices;
-import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import org.slf4j.Logger;
@@ -153,10 +151,6 @@ public class FlinkService {
                     savepointOpt = Optional.of(savepoint);
                     break;
                 case LAST_STATE:
-                    if (!HighAvailabilityMode.isHighAvailabilityModeActivated(conf)) {
-                        throw new InvalidDeploymentException(
-                                "Job could not be upgraded with last-state while HA disabled");
-                    }
                     final String namespace = conf.getString(KubernetesConfigOptions.NAMESPACE);
                     final String clusterId = clusterClient.getClusterId();
                     FlinkUtils.deleteCluster(namespace, clusterId, kubernetesClient, false);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
 import org.apache.flink.kubernetes.operator.TestingClusterClient;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
-import org.apache.flink.kubernetes.operator.exception.InvalidDeploymentException;
 import org.apache.flink.runtime.messages.Acknowledge;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -44,7 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** @link FlinkService unit tests */
@@ -138,19 +136,6 @@ public class FlinkServiceTest {
                         .inNamespace(TESTING_NAMESPACE)
                         .withName(CLUSTER_ID)
                         .get());
-    }
-
-    @Test
-    public void testCancelJobWithLastStateUpgradeModeWhenHADisabled() {
-        configuration.set(HighAvailabilityOptions.HA_MODE, "None");
-        final TestingClusterClient<String> testingClusterClient =
-                new TestingClusterClient<>(CLUSTER_ID);
-        final FlinkService flinkService = createFlinkService(testingClusterClient);
-
-        final JobID jobID = JobID.generate();
-        assertThrows(
-                InvalidDeploymentException.class,
-                () -> flinkService.cancelJob(jobID, UpgradeMode.LAST_STATE, configuration));
     }
 
     private FlinkService createFlinkService(ClusterClient<String> clusterClient) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DeploymentValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DeploymentValidatorTest.java
@@ -57,6 +57,9 @@ public class DeploymentValidatorTest {
         testError(
                 dep -> dep.getSpec().getJob().setParallelism(-1),
                 "Job parallelism must be larger than 0");
+        testError(
+                dep -> dep.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE),
+                "Job could not be upgraded with last-state while HA disabled");
 
         // Test conf validation
         testSuccess(

--- a/flink-kubernetes-webhook/pom.xml
+++ b/flink-kubernetes-webhook/pom.xml
@@ -39,7 +39,11 @@ under the License.
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.flink</groupId>
-                    <artifactId>*</artifactId>
+                    <artifactId>flink-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-shaded-netty</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
[FLINK-26136](https://issues.apache.org/jira/browse/FLINK-26136) has introduced a unified validator, the validation in `FlinkService#cancelJob` should move to `DefaultDeploymentValidator` for unified validation. 

**The brief change log**
- Removes the validation in `FlinkService#cancelJob` when upgrade mode is `LAST_STATE` and the HA disables.
- Adds the validation for `JobSpec` with whether the upgrade mode is `LAST_STATE` and the HA disables.
- Removes the test case `testCancelJobWithLastStateUpgradeModeWhenHADisabled` for the validation of canceling job in `FlinkServiceTest`.