### PR TITLE
[FLINK-26257] Enable metrics configuration for Prometheus

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricGroup.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricGroup.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class KubernetesOperatorMetricGroup
         extends AbstractMetricGroup<KubernetesOperatorMetricGroup> {
 
-    private static final String GROUP_NAME = "kubernetes-operator";
+    private static final String GROUP_NAME = "k8soperator";
     private String namespace;
     private String name;
     private String hostname;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
@@ -23,9 +23,8 @@ import org.apache.flink.configuration.ConfigOptions;
 /** Configuration options for metrics. */
 public class KubernetesOperatorMetricOptions {
     public static final ConfigOption<String> SCOPE_NAMING_KUBERNETES_OPERATOR =
-            ConfigOptions.key("metrics.scope.kubernetes-operator")
-                    .stringType()
-                    .defaultValue("<host>.kubernetes-operator.<namespace>.<name>")
+            ConfigOptions.key("metrics.scope.k8soperator")
+                    .defaultValue("<host>.k8soperator.<namespace>.<name>")
                     .withDescription(
                             "Defines the scope format string that is applied to all metrics scoped to the kubernetes operator.");
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricGroupTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricGroupTest.java
@@ -40,10 +40,10 @@ public class KubernetesOperatorMetricGroupTest {
                 KubernetesOperatorMetricGroup.create(
                         registry, configuration, "default", "flink-operator", "localhost");
         assertArrayEquals(
-                new String[] {"localhost", "kubernetes-operator", "default", "flink-operator"},
+                new String[] {"localhost", "k8soperator", "default", "flink-operator"},
                 group.getScopeComponents());
         assertEquals(
-                "localhost.kubernetes-operator.default.flink-operator.test",
+                "localhost.k8soperator.default.flink-operator.test",
                 group.getMetricIdentifier("test"));
 
         assertEquals(

--- a/helm/flink-operator/templates/flink-operator.yaml
+++ b/helm/flink-operator/templates/flink-operator.yaml
@@ -136,7 +136,7 @@ data:
   flink-conf.yaml: |+
     metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory
     metrics.reporter.slf4j.interval: 1 MINUTE
-    # metrics.scope.kubernetes-operator: <host>.kubernetes-operator.<namespace>.<name>
+    # metrics.scope.k8soperator: <host>.k8soperator.<namespace>.<name>
   log4j2.properties: |+
     rootLogger.level = DEBUG
     rootLogger.appenderRef.console.ref = ConsoleAppender

--- a/helm/flink-operator/templates/flink-operator.yaml
+++ b/helm/flink-operator/templates/flink-operator.yaml
@@ -46,6 +46,12 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/docker-entrypoint.sh", "operator"]
+          {{- if .Values.metrics.port }}
+          ports:
+            - containerPort: {{ .Values.metrics.port }}
+              name: metrics
+              protocol: TCP
+          {{- end }}
           env:
             - name: OPERATOR_NAMESPACE
               value: {{ .Values.operatorNamespace.name }}

--- a/helm/flink-operator/values.yaml
+++ b/helm/flink-operator/values.yaml
@@ -52,3 +52,7 @@ webhook:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+
+# (Optional) Exposes metrics port on the container if defined
+metrics:
+  port:


### PR DESCRIPTION
- added documentation on how to enable Prometheus metrics reporter on the operator
- add option for exposing a dedicated port for metrics on the operator container
- minor fix in the operator metric group name that works for Prometheus