### PR TITLE
[FLINK-26308] Limit RBAC to namespaces watched

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The webhook can be disabled during helm install by passing the `--set webhook.cr
 ### Watching only specific namespaces
 
 The operator supports watching a specific list of namespaces for FlinkDeployment resources. You can enable it by setting the `--set watchNamespaces={flink-test}` parameter.
+When this is enabled role-based access control is only created specifically for these namespaces for the operator and the jobmanagers, otherwise it defaults to cluster scope.
 
 ## User Guide
 ### Create a new Flink deployment

--- a/helm/flink-operator/templates/rbac.yaml
+++ b/helm/flink-operator/templates/rbac.yaml
@@ -16,16 +16,10 @@
 # limitations under the License.
 ################################################################################
 
----
-{{- if .Values.rbac.create }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: flink-operator
-  namespace: {{ .Values.operatorNamespace.name }}
-  labels:
-    {{- include "flink-operator.labels" . | nindent 4 }}
+{{/*
+RBAC rules used to create the (cluster)role based on the operator scope
+*/}}
+{{- define "flink-operator.rbacRules" }}
 rules:
   - apiGroups:
       - flink-operator
@@ -73,6 +67,57 @@ rules:
       - ingresses
     verbs:
       - "*"
+{{- end }}
+---
+{{- if .Values.rbac.create }}
+---
+{{/*
+Namespaced scoped RBAC.
+*/}}
+{{- if .Values.watchNamespaces }}
+{{- range .Values.watchNamespaces }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flink-operator
+  namespace: {{ . }}
+  labels:
+    {{- include "flink-operator.labels" $ | nindent 4 }}
+{{- template "flink-operator.rbacRules" $ }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flink-operator-role-binding
+  namespace: {{ . }}
+  labels:
+    {{- include "flink-operator.labels" $ | nindent 4 }}
+roleRef:
+  kind: Role
+  name: flink-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "flink-operator.serviceAccountName" $ }}
+    namespace: {{ $.Values.operatorNamespace.name }}
+  - kind: ServiceAccount
+    name: {{ template "flink-operator.serviceAccountName" $ }}
+    namespace: {{ . }}
+---
+{{- end }}
+{{ else }}
+{{/*
+Cluster scoped RBAC.
+*/}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flink-operator
+  namespace: {{ .Values.operatorNamespace.name }}
+  labels:
+    {{- include "flink-operator.labels" . | nindent 4 }}
+{{- template "flink-operator.rbacRules" $ }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -89,4 +134,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "flink-operator.serviceAccountName" . }}
     namespace: {{ .Values.operatorNamespace.name }}
+{{- end }}
 {{- end }}

--- a/helm/flink-operator/templates/serviceaccount.yaml
+++ b/helm/flink-operator/templates/serviceaccount.yaml
@@ -29,4 +29,21 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+---
+{{- if .Values.watchNamespaces}}
+{{- range .Values.watchNamespaces }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "flink-operator.serviceAccountName" $ }}
+  namespace: {{ . }}
+  labels:
+    {{- include "flink-operator.labels" $ | nindent 4 }}
+  {{- with $.Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml $ | nindent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}
 {{- end }}

--- a/helm/flink-operator/values.yaml
+++ b/helm/flink-operator/values.yaml
@@ -21,7 +21,8 @@
 operatorNamespace:
   name: default
 
-# List of kubernetes namespaces to watch for FlinkDeployment changes, empty means all namespaces
+# List of kubernetes namespaces to watch for FlinkDeployment changes, empty means all namespaces.
+# When enabled RBAC is only created for said namespaces, otherwise it is done for the cluster scope.
 # watchNamespaces: ["flink"]
 
 image:


### PR DESCRIPTION
Provides the option for the user to switch off creating the cluster scoped RBAC if the `watchNamespaces` value is enabled in the Helm chart. By default it retains the currrent behavior.