### PR TITLE
[FLINK-26447] Clean up webhook jar and dependency management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ FROM openjdk:11-jre
 ENV FLINK_HOME=/opt/flink
 ENV OPERATOR_VERSION=1.0-SNAPSHOT
 ENV OPERATOR_JAR=flink-kubernetes-operator-$OPERATOR_VERSION-shaded.jar
-ENV WEBHOOK_JAR=flink-kubernetes-webhook-$OPERATOR_VERSION-shaded.jar
+ENV WEBHOOK_JAR=flink-kubernetes-webhook-$OPERATOR_VERSION.jar
 
 WORKDIR /
 RUN groupadd --system --gid=9999 flink && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,7 +31,8 @@ elif [ "$1" = "operator" ]; then
 elif [ "$1" = "webhook" ]; then
     echo "Starting Webhook"
 
-    exec java -jar $LOG_CONFIG /$WEBHOOK_JAR
+    # Adds the operator shaded jar on the classpath when the webhook starts
+    exec java -cp /$OPERATOR_JAR:/$WEBHOOK_JAR $LOG_CONFIG org.apache.flink.kubernetes.operator.admission.FlinkOperatorWebhook
 fi
 
 args=("${args[@]}")

--- a/flink-kubernetes-webhook/pom.xml
+++ b/flink-kubernetes-webhook/pom.xml
@@ -36,66 +36,6 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-kubernetes-operator</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.flink</groupId>
-                    <artifactId>flink-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.flink</groupId>
-                    <artifactId>flink-shaded-netty</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-core</artifactId>
-            <version>${flink.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-shaded-netty</artifactId>
-            <version>4.1.70.Final-${flink.shaded.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>shade-flink-operator</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration combine.children="append">
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <artifactSet>
-                                <includes combine.children="append">
-                                    <include>*:*</include>
-                                </includes>
-                            </artifactSet>
-                            <transformers combine.children="append">
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>org.apache.flink.kubernetes.operator.admission.FlinkOperatorWebhook</mainClass>
-                                </transformer>
-                                <!-- The service transformer is needed to merge META-INF/services files -->
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <!-- The ApacheNoticeResourceTransformer collects and aggregates NOTICE files -->
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
-                                    <projectName>Apache Flink</projectName>
-                                    <encoding>UTF-8</encoding>
-                                </transformer>
-                            </transformers>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
Currently the webhook module builds it's own shaded jar which includes the operator shaded jar contents as well that is unnecessary and simply adds to the size of the flink operator image. Operator dependencies should be configured in the `provided` scope and the operator shaded jar could be put on the classpath when the webhook starts.

**The brief change log**
- Updates the scope of the dependencies `flink-kubernetes-operator`to `provided` and remove the `flink-core` dependencies in the `pom.xml` of the `flink-kubernetes-webhook` module.
- Adds the classpath option with the path of `OPERATOR_JAR` for webhook starting in `docker-entrypoint.sh`.