### PR TITLE
FLINK-26476 Introduce flink-kubernetes-shaded to avoid overlapping classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,12 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Build with Maven
-        run: mvn clean install
+        run: |
+          mvn clean install | tee ./mvn.log
+          if [[ $(grep -c "overlapping classes" ./mvn.log) -gt 0 ]];then
+            echo "Found overlapping classes, please fix"
+            exit 1
+          fi
       - name: Start minikube
         run: |
           source e2e-tests/utils.sh
@@ -82,7 +87,12 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Build with Maven
-        run: mvn clean install
+        run: |
+          mvn clean install | tee ./mvn.log
+          if [[ $(grep -c "overlapping classes" ./mvn.log) -gt 0 ]];then
+            echo "Found overlapping classes, please fix"
+            exit 1
+          fi
       - name: Start minikube
         run: |
           source e2e-tests/utils.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,14 @@
 FROM maven:3.8.4-openjdk-11 AS build
 
 WORKDIR /app
+ENV SHADED_DIR=flink-kubernetes-shaded
 ENV OPERATOR_DIR=flink-kubernetes-operator
 ENV WEBHOOK_DIR=flink-kubernetes-webhook
 
 RUN mkdir $OPERATOR_DIR $WEBHOOK_DIR
 
 COPY pom.xml .
+COPY $SHADED_DIR/pom.xml ./$SHADED_DIR/
 COPY $WEBHOOK_DIR/pom.xml ./$WEBHOOK_DIR/
 COPY $OPERATOR_DIR/pom.xml ./$OPERATOR_DIR/
 

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -65,8 +65,53 @@ under the License.
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-kubernetes_${scala.version}</artifactId>
-            <version>${flink.version}</version>
+            <artifactId>flink-kubernetes-shaded</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Logging -->
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>${log4j.version}</version>
         </dependency>
 
         <!-- Test -->
@@ -124,6 +169,14 @@ under the License.
                         </goals>
                         <configuration combine.children="append">
                             <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <filters combine.children="append">
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/**/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>*:*</include>

--- a/flink-kubernetes-shaded/pom.xml
+++ b/flink-kubernetes-shaded/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-kubernetes-operator-parent</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-kubernetes-shaded</artifactId>
+    <name>Flink Kubernetes Shaded</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-kubernetes_${scala.version}</artifactId>
+            <version>${flink.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink-operator</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration combine.children="append">
+                            <artifactSet>
+                                <includes combine.children="append">
+                                    <include>*:*</include>
+                                </includes>
+                            </artifactSet>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                            </transformers>
+                            <relocations>
+                                <relocation>
+                                    <pattern>io.fabric8</pattern>
+                                    <shadedPattern>org.apache.flink.kubernetes.shaded.io.fabric8</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@ under the License.
     </licenses>
 
     <modules>
+      <module>flink-kubernetes-shaded</module>
       <module>flink-kubernetes-operator</module>
       <module>flink-kubernetes-webhook</module>
     </modules>
@@ -71,47 +72,6 @@ under the License.
         <spotless.version>2.4.2</spotless.version>
         <it.skip>true</it.skip>
     </properties>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- Logging -->
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-            <version>${log4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>${log4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>${log4j.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <version>${log4j.version}</version>
-        </dependency>
-    </dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
When we compile the flink-kubernetes-operator, we could find the following overlapping classes of fabric8 kubernetes client dependencies. I propose to add a flink-kubernetes-shaded module to fix this in current project. If we are confident enough the shading works well, I will contribute it to the upstream project Flink.

```
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
[WARNING] flink-kubernetes_2.12-1.14.3.jar, kubernetes-model-coordination-5.12.1.jar define 18 overlapping classes:
[WARNING]   - io.fabric8.kubernetes.api.model.coordination.v1.LeaseFluentImpl$SpecNestedImpl
[WARNING]   - io.fabric8.kubernetes.api.model.coordination.v1.LeaseListFluentImpl$ItemsNestedImpl
[WARNING]   - io.fabric8.kubernetes.api.model.coordination.v1.LeaseSpec
[WARNING]   - io.fabric8.kubernetes.api.model.coordination.v1.LeaseFluent$SpecNested
[WARNING]   - io.fabric8.kubernetes.api.model.coordination.v1.LeaseListFluentImpl
[WARNING]   - io.fabric8.kubernetes.api.model.coordination.v1.LeaseSpecBuilder
[WARNING]   - io.fabric8.kubernetes.api.model.coordination.v1.LeaseSpecFluent
[WARNING]   - io.fabric8.kubernetes.api.model.coordination.v1.LeaseFluentImpl$MetadataNestedImpl
[WARNING]   - io.fabric8.kubernetes.api.model.coordination.v1.LeaseFluent
[WARNING]   - io.fabric8.kubernetes.api.model.coordination.v1.LeaseListFluent
[WARNING]   - 8 more...
[WARNING] flink-kubernetes_2.12-1.14.3.jar, kubernetes-client-5.12.1.jar define 476 overlapping classes:
[WARNING]   - io.fabric8.kubernetes.client.internal.CertUtils
[WARNING]   - io.fabric8.kubernetes.client.osgi.ManagedKubernetesClient
[WARNING]   - io.fabric8.kubernetes.client.CustomResource
[WARNING]   - io.fabric8.kubernetes.client.V1beta1ApiextensionAPIGroupDSL
[WARNING]   - io.fabric8.kubernetes.client.internal.PatchUtils$SingletonHolder
[WARNING]   - io.fabric8.kubernetes.client.VersionInfo$1
[WARNING]   - io.fabric8.kubernetes.client.utils.ReplaceValueStream
[WARNING]   - io.fabric8.kubernetes.client.dsl.ApiextensionsAPIGroupDSL
[WARNING]   - io.fabric8.kubernetes.client.dsl.CreateFromServerGettable
[WARNING]   - io.fabric8.kubernetes.client.dsl.Containerable
[WARNING]   - 466 more... 
```