### PR TITLE
[FLINK-26308][FLINK-26471] Separate Flink job role from operator role

### DIFF
--- a/e2e-tests/data/cr.yaml
+++ b/e2e-tests/data/cr.yaml
@@ -30,7 +30,7 @@ spec:
     high-availability.storageDir: file:///opt/flink/volume/flink-ha
     state.checkpoints.dir: file:///opt/flink/volume/flink-cp
     state.savepoints.dir: file:///opt/flink/volume/flink-sp
-  serviceAccount: flink-operator
+  serviceAccount: flink
   podTemplate:
     apiVersion: v1
     kind: Pod

--- a/examples/basic-checkpoint-ha.yaml
+++ b/examples/basic-checkpoint-ha.yaml
@@ -40,7 +40,7 @@ spec:
       cpu: 1
   podTemplate:
     spec:
-      serviceAccount: flink-operator
+      serviceAccount: flink
       containers:
         - name: flink-main-container
           volumeMounts:

--- a/examples/basic-ingress.yaml
+++ b/examples/basic-ingress.yaml
@@ -29,7 +29,7 @@ spec:
 #    rest.address: basic-example.flink.k8s.io
 #    rest.port: "80"
     taskmanager.numberOfTaskSlots: "2"
-  serviceAccount: flink-operator
+  serviceAccount: flink
   jobManager:
     replicas: 1
     resource:

--- a/examples/basic-session.yaml
+++ b/examples/basic-session.yaml
@@ -26,7 +26,7 @@ spec:
   flinkVersion: 1.14.3
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
-  serviceAccount: flink-operator
+  serviceAccount: flink
   jobManager:
     replicas: 1
     resource:

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -26,7 +26,7 @@ spec:
   flinkVersion: 1.14.3
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
-  serviceAccount: flink-operator
+  serviceAccount: flink
   jobManager:
     replicas: 1
     resource:

--- a/examples/custom-logging.yaml
+++ b/examples/custom-logging.yaml
@@ -26,7 +26,7 @@ spec:
   flinkVersion: 1.14.3
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
-  serviceAccount: flink-operator
+  serviceAccount: flink
   jobManager:
     replicas: 1
     resource:

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -32,7 +32,7 @@ spec:
     metadata:
       name: pod-template
     spec:
-      serviceAccount: flink-operator
+      serviceAccount: flink
       containers:
         # Do not change the main container name
         - name: flink-main-container

--- a/helm/flink-operator/templates/_helpers.tpl
+++ b/helm/flink-operator/templates/_helpers.tpl
@@ -68,12 +68,23 @@ app.kubernetes.io/name: {{ include "flink-operator.name" . }}
 {{- end }}
 
 {{/*
-Create the name of the service account to use
+Create the name of the operator service account to use
 */}}
 {{- define "flink-operator.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "flink-operator.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.operatorServiceAccount.create }}
+{{- default (include "flink-operator.fullname" .) .Values.operatorServiceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the job service account to use
+*/}}
+{{- define "flink-operator.jobServiceAccountName" -}}
+{{- if .Values.jobServiceAccount.create }}
+{{- default (include "flink-operator.fullname" .) .Values.jobServiceAccount.name }}
+{{- else }}
+{{- default "default" .Values.jobServiceAccount.name }}
 {{- end }}
 {{- end }}

--- a/helm/flink-operator/templates/rbac.yaml
+++ b/helm/flink-operator/templates/rbac.yaml
@@ -17,7 +17,7 @@
 ################################################################################
 
 {{/*
-RBAC rules used to create the (cluster)role based on the operator scope
+RBAC rules used to create the operator (cluster)role based on the scope
 */}}
 {{- define "flink-operator.rbacRules" }}
 rules:
@@ -68,6 +68,27 @@ rules:
     verbs:
       - "*"
 {{- end }}
+
+{{/*
+RBAC rules used to create the job (cluster)role based on the scope
+*/}}
+{{- define "flink-operator.jobRbacRules" }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - configmaps
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - '*'
+{{- end }}
+
 ---
 {{- if .Values.rbac.create }}
 ---
@@ -86,6 +107,17 @@ metadata:
 {{- template "flink-operator.rbacRules" $ }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flink
+  namespace: {{ . }}
+  labels:
+    {{- include "flink-operator.labels" $ | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
+{{- template "flink-operator.jobRbacRules" $ }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flink-operator-role-binding
@@ -98,10 +130,25 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: {{ template "flink-operator.serviceAccountName" $ }}
+    name: {{ include "flink-operator.serviceAccountName" $ }}
     namespace: {{ $.Values.operatorNamespace.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flink-role-binding
+  namespace: {{ . }}
+  labels:
+    {{- include "flink-operator.labels" $ | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
+roleRef:
+  kind: Role
+  name: flink
+  apiGroup: rbac.authorization.k8s.io
+subjects:
   - kind: ServiceAccount
-    name: {{ template "flink-operator.serviceAccountName" $ }}
+    name: {{ include "flink-operator.jobServiceAccountName" $ }}
     namespace: {{ . }}
 ---
 {{- end }}
@@ -120,6 +167,17 @@ metadata:
 {{- template "flink-operator.rbacRules" $ }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: flink
+  namespace: {{ .Values.operatorNamespace.name }}
+  labels:
+    {{- include "flink-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
+{{- template "flink-operator.jobRbacRules" $ }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flink-operator-cluster-role-binding
@@ -132,7 +190,25 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
-    name: {{ template "flink-operator.serviceAccountName" . }}
+    name: {{ include "flink-operator.serviceAccountName" . }}
+    namespace: {{ .Values.operatorNamespace.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flink-role-binding
+  namespace: {{ .Values.operatorNamespace.name }}
+  labels:
+    {{- include "flink-operator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
+roleRef:
+  kind: Role
+  name: flink
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "flink-operator.jobServiceAccountName" . }}
     namespace: {{ .Values.operatorNamespace.name }}
 {{- end }}
 {{- end }}

--- a/helm/flink-operator/templates/serviceaccount.yaml
+++ b/helm/flink-operator/templates/serviceaccount.yaml
@@ -17,7 +17,7 @@
 ################################################################################
 
 ---
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.operatorServiceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -25,25 +25,46 @@ metadata:
   namespace: {{ .Values.operatorNamespace.name }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- with .Values.operatorServiceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 ---
+{{- if .Values.jobServiceAccount.create -}}
+{{/*
+Create job service accounts for all watched namespaces.
+*/}}
 {{- if .Values.watchNamespaces}}
 {{- range .Values.watchNamespaces }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "flink-operator.serviceAccountName" $ }}
+  name: {{ include "flink-operator.jobServiceAccountName" $ }}
   namespace: {{ . }}
   labels:
     {{- include "flink-operator.labels" $ | nindent 4 }}
-  {{- with $.Values.serviceAccount.annotations }}
+  {{- with $.Values.jobServiceAccount.annotations }}
   annotations:
-    {{- toYaml $ | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 ---
 {{- end }}
+{{/*
+Create the job servife account for the operator namespace, it is to be added for other namespaces manually
+(or via specifying them in watchNamespaces).
+*/}}
+{{- else}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "flink-operator.jobServiceAccountName" $ }}
+  namespace: {{ .Values.operatorNamespace.name }}
+  labels:
+    {{- include "flink-operator.labels" $ | nindent 4 }}
+  {{- with .Values.jobServiceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/flink-operator/templates/webhook.yaml
+++ b/helm/flink-operator/templates/webhook.yaml
@@ -106,6 +106,6 @@ webhooks:
     matchExpressions:
       - key: kubernetes.io/metadata.name
         operator: In
-        values: {{ .Values.watchNamespaces }}
+        values: [{{- range .Values.watchNamespaces }}{{ . | quote }},{{- end}}]
   {{- end }}
   {{- end }}

--- a/helm/flink-operator/values.yaml
+++ b/helm/flink-operator/values.yaml
@@ -36,10 +36,16 @@ rbac:
 ingress:
   create: false
 
-serviceAccount:
+operatorServiceAccount:
   create: true
   annotations: {}
   name: "flink-operator"
+
+jobServiceAccount:
+  create: true
+  annotations:
+    "helm.sh/resource-policy": keep
+  name: "flink"
 
 webhook:
   create: true


### PR DESCRIPTION
This separates the Flink job role from the operator role, which fixes two issues:
1. That when the `operatorNamespace` is the same as one of the `watchNamespaces` the install fails due to attempted duplicated role creation which I introduced in #35.
2. That deleting the operator role affected jobs described in FLINK-26471.

@wangyang0918 has raised another issue with #35 [here](https://github.com/apache/flink-kubernetes-operator/pull/35#issuecomment-1058750206), that prior to 1.15 when using `watchNamespaces` unless the user explicitly sets 
```
kubernetes.rest-service.exposed.type: ClusterIP
```
I would like to avoid overwriting the default Flink behavior in the operator, my suggestion is to present a warning to the user in the admission control validation and we might a line to the Readme / docs anyway.

Also while testing this change I have discovered that the webhook fails when we have multiple entries in `watchNamespaces`. I will fix these two issues in a separate PR early next week.