### PR TITLE
[hotfix] Make flink-kubernetes-shaded dep provided

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ ENV FLINK_HOME=/opt/flink
 ENV OPERATOR_VERSION=1.0-SNAPSHOT
 ENV OPERATOR_JAR=flink-kubernetes-operator-$OPERATOR_VERSION-shaded.jar
 ENV WEBHOOK_JAR=flink-kubernetes-webhook-$OPERATOR_VERSION.jar
+ENV FLINK_KUBERNETES_SHADED_JAR=flink-kubernetes-shaded-$OPERATOR_VERSION.jar
 
 WORKDIR /
 RUN groupadd --system --gid=9999 flink && \
@@ -50,6 +51,7 @@ RUN groupadd --system --gid=9999 flink && \
 
 COPY --from=build /app/flink-kubernetes-operator/target/$OPERATOR_JAR .
 COPY --from=build /app/flink-kubernetes-webhook/target/$WEBHOOK_JAR .
+COPY --from=build /app/flink-kubernetes-shaded/target/$FLINK_KUBERNETES_SHADED_JAR .
 COPY --from=build /app/flink-kubernetes-operator/target/plugins $FLINK_HOME/plugins
 COPY docker-entrypoint.sh /
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,12 +27,12 @@ if [ "$1" = "help" ]; then
 elif [ "$1" = "operator" ]; then
     echo "Starting Operator"
 
-    exec java -jar $LOG_CONFIG /$OPERATOR_JAR
+    exec java -cp /$FLINK_KUBERNETES_SHADED_JAR:/$OPERATOR_JAR $LOG_CONFIG org.apache.flink.kubernetes.operator.FlinkOperator
 elif [ "$1" = "webhook" ]; then
     echo "Starting Webhook"
 
     # Adds the operator shaded jar on the classpath when the webhook starts
-    exec java -cp /$OPERATOR_JAR:/$WEBHOOK_JAR $LOG_CONFIG org.apache.flink.kubernetes.operator.admission.FlinkOperatorWebhook
+    exec java -cp /$FLINK_KUBERNETES_SHADED_JAR:/$OPERATOR_JAR:/$WEBHOOK_JAR $LOG_CONFIG org.apache.flink.kubernetes.operator.admission.FlinkOperatorWebhook
 fi
 
 args=("${args[@]}")

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -67,12 +67,7 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-kubernetes-shaded</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Solves a problem where we had a compile dependency on a fatjar which does not really work in many cases.