### PR TITLE
[FLINK-26370] Use configurable ThreadPool for Flink cluster communication

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -32,6 +32,7 @@ import java.util.Set;
 public class FlinkOperatorConfiguration {
 
     Duration reconcileInterval;
+    int reconcilerMaxParallelism;
     Duration progressCheckInterval;
     Duration restApiReadyDelay;
     Duration savepointTriggerGracePeriod;
@@ -42,6 +43,10 @@ public class FlinkOperatorConfiguration {
     public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
         Duration reconcileInterval =
                 operatorConfig.get(OperatorConfigOptions.OPERATOR_RECONCILER_RESCHEDULE_INTERVAL);
+
+        int reconcilerMaxParallelism =
+                operatorConfig.getInteger(
+                        OperatorConfigOptions.OPERATOR_RECONCILER_MAX_PARALLELISM);
 
         Duration restApiReadyDelay =
                 operatorConfig.get(OperatorConfigOptions.OPERATOR_OBSERVER_REST_READY_DELAY);
@@ -66,6 +71,7 @@ public class FlinkOperatorConfiguration {
 
         return new FlinkOperatorConfiguration(
                 reconcileInterval,
+                reconcilerMaxParallelism,
                 progressCheckInterval,
                 restApiReadyDelay,
                 savepointTriggerGracePeriod,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/OperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/OperatorConfigOptions.java
@@ -40,6 +40,13 @@ public class OperatorConfigOptions {
                     .withDescription(
                             "Final delay before deployment is marked ready after port becomes accessible.");
 
+    public static final ConfigOption<Integer> OPERATOR_RECONCILER_MAX_PARALLELISM =
+            ConfigOptions.key("operator.reconciler.max.parallelism")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription(
+                            "The maximum number of threads running the reconciliation loop. Use -1 for infinite.");
+
     public static final ConfigOption<Duration> OPERATOR_OBSERVER_PROGRESS_CHECK_INTERVAL =
             ConfigOptions.key("operator.observer.progress-check.interval")
                     .durationType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -53,7 +53,7 @@ import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerMes
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerRequestBody;
 
 import io.fabric8.kubernetes.api.model.PodList;
-import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,12 +74,11 @@ public class FlinkService {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlinkService.class);
 
-    private final NamespacedKubernetesClient kubernetesClient;
+    private final KubernetesClient kubernetesClient;
     private final FlinkOperatorConfiguration operatorConfiguration;
 
     public FlinkService(
-            NamespacedKubernetesClient kubernetesClient,
-            FlinkOperatorConfiguration operatorConfiguration) {
+            KubernetesClient kubernetesClient, FlinkOperatorConfiguration operatorConfiguration) {
         this.kubernetesClient = kubernetesClient;
         this.operatorConfiguration = operatorConfiguration;
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.config.DefaultConfig;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static java.util.Optional.empty;
+
+/** @link FlinkOperator unit tests. */
+public class FlinkOperatorTest {
+
+    @Test
+    public void testExecutorServiceDefaultsToMaxParallelism() {
+        checkExecutorServiceThreadCount(empty(), Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testExecutorServiceUsesReconciliationMaxParallelismFromConfig() {
+        checkExecutorServiceThreadCount(Optional.of(42), 42);
+    }
+
+    @Test
+    public void testExecutorServiceUsesMaxParallelismForMinusOneReconciliationMaxParallelism() {
+        checkExecutorServiceThreadCount(Optional.of(-1), Integer.MAX_VALUE);
+    }
+
+    private void checkExecutorServiceThreadCount(
+            Optional<Integer> parallelism, int expectedThreadCount) {
+        var es = getExecutorForParallelismConfig(parallelism);
+
+        Assertions.assertInstanceOf(ThreadPoolExecutor.class, es);
+
+        ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) es;
+        Assertions.assertEquals(expectedThreadCount, threadPoolExecutor.getMaximumPoolSize());
+    }
+
+    private ExecutorService getExecutorForParallelismConfig(Optional<Integer> parallelism) {
+        var operatorConfig = new Configuration();
+        parallelism.ifPresent(
+                p -> operatorConfig.setInteger("operator.reconciler.max.parallelism", p));
+
+        var flinkConfig = new Configuration();
+        var config = new DefaultConfig(operatorConfig, flinkConfig);
+
+        FlinkOperator flinkOperator = new FlinkOperator(config);
+        return flinkOperator.getOperator().getConfigurationService().getExecutorService();
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -76,6 +76,7 @@ public class FlinkDeploymentControllerTest {
     private final FlinkOperatorConfiguration operatorConfiguration =
             new FlinkOperatorConfiguration(
                     Duration.ofSeconds(1),
+                    -1,
                     Duration.ofSeconds(2),
                     Duration.ofSeconds(3),
                     Duration.ofSeconds(4),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SessionObserverTest.java
@@ -109,6 +109,7 @@ public class SessionObserverTest {
         FlinkOperatorConfiguration allNsConfig =
                 new FlinkOperatorConfiguration(
                         Duration.ofSeconds(1),
+                        -1,
                         Duration.ofSeconds(2),
                         Duration.ofSeconds(3),
                         Duration.ofSeconds(4),
@@ -118,6 +119,7 @@ public class SessionObserverTest {
         FlinkOperatorConfiguration specificNsConfig =
                 new FlinkOperatorConfiguration(
                         Duration.ofSeconds(1),
+                        -1,
                         Duration.ofSeconds(2),
                         Duration.ofSeconds(3),
                         Duration.ofSeconds(4),
@@ -127,6 +129,7 @@ public class SessionObserverTest {
         FlinkOperatorConfiguration multipleNsConfig =
                 new FlinkOperatorConfiguration(
                         Duration.ofSeconds(1),
+                        -1,
                         Duration.ofSeconds(2),
                         Duration.ofSeconds(3),
                         Duration.ofSeconds(4),

--- a/helm/flink-operator/conf/flink-operator-config/flink-conf.yaml
+++ b/helm/flink-operator/conf/flink-operator-config/flink-conf.yaml
@@ -17,6 +17,7 @@
 ################################################################################
 
 # operator.reconciler.reschedule.interval: 60 s
+# operator.reconciler.max.parallelism: -1
 # operator.observer.rest-ready.delay: 10 s
 # operator.observer.progress-check.interval: 10 s
 # operator.observer.savepoint.trigger.grace-period: 10 s


### PR DESCRIPTION
This PR configures the operator sdk to use an unbounded thread pool for its control loop.

Blocking threads in the reconciler loop for a resource will not hold back the reconciliation of other resources anymore.