### PR TITLE
[FLINK-26507] Allow session and last-state jobs to reconcile in any state

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobManagerDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobManagerDeploymentStatus.java
@@ -48,6 +48,8 @@ public enum JobManagerDeploymentStatus {
         switch (this) {
             case DEPLOYING:
             case READY:
+            case MISSING:
+            case ERROR:
                 return UpdateControl.updateStatus(flinkDeployment)
                         .rescheduleAfter(
                                 operatorConfiguration.getReconcileIntervalInSec(),
@@ -57,10 +59,8 @@ public enum JobManagerDeploymentStatus {
                         .rescheduleAfter(
                                 operatorConfiguration.getPortCheckIntervalInSec(),
                                 TimeUnit.SECONDS);
-            case MISSING:
-            case ERROR:
             default:
-                return UpdateControl.noUpdate();
+                throw new RuntimeException("Unknown status: " + this);
         }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/Reconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/Reconciler.java
@@ -23,7 +23,6 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
-import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 
 /** The interface of reconciler. */
 public interface Reconciler {
@@ -35,10 +34,8 @@ public interface Reconciler {
      * @param flinkApp the FlinkDeployment resource that has been created or updated
      * @param context the context with which the operation is executed
      * @param effectiveConfig the effective config of the flinkApp
-     * @return UpdateControl to manage updates on the custom resource (usually the status) after
-     *     reconciliation.
      */
-    UpdateControl<FlinkDeployment> reconcile(
+    void reconcile(
             String operatorNamespace,
             FlinkDeployment flinkApp,
             Context context,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -34,7 +34,8 @@ public class ReconciliationUtils {
         reconciliationStatus.setSuccess(true);
         reconciliationStatus.setError(null);
         FlinkDeploymentSpec clonedSpec = clone(flinkApp.getSpec());
-        if (reconciliationStatus.getLastReconciledSpec() != null) {
+        if (reconciliationStatus.getLastReconciledSpec() != null
+                && reconciliationStatus.getLastReconciledSpec().getJob() != null) {
             long oldSavepointTriggerNonce =
                     reconciliationStatus
                             .getLastReconciledSpec()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -177,7 +177,7 @@ public class FlinkUtils {
                                 .withLabels(KubernetesUtils.getJobManagerSelectors(clusterId))
                                 .list();
 
-                if (jmPodList.getItems().isEmpty()) {
+                if (jmPodList == null || jmPodList.getItems().isEmpty()) {
                     jobManagerRunning = false;
                 }
             }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -25,8 +25,13 @@ import java.util.concurrent.TimeUnit;
 
 /** Savepoint utilities. */
 public class SavepointUtils {
+
+    public static boolean savepointInProgress(FlinkDeployment flinkDeployment) {
+        return flinkDeployment.getStatus().getJobStatus().getSavepointInfo().getTriggerId() != null;
+    }
+
     public static boolean shouldTriggerSavepoint(FlinkDeployment flinkDeployment) {
-        if (flinkDeployment.getStatus().getJobStatus().getSavepointInfo().getTriggerId() != null) {
+        if (savepointInProgress(flinkDeployment)) {
             return false;
         }
         return flinkDeployment.getSpec().getJob().getSavepointTriggerNonce()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -89,6 +89,11 @@ public class TestingFlinkService extends FlinkService {
     public Optional<String> cancelJob(JobID jobID, UpgradeMode upgradeMode, Configuration conf)
             throws Exception {
 
+        if (upgradeMode == UpgradeMode.LAST_STATE) {
+            jobs.clear();
+            return Optional.empty();
+        }
+
         if (!jobs.removeIf(js -> js.f1.getJobId().equals(jobID))) {
             throw new Exception("Job not found");
         }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/JobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/JobReconcilerTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
+import org.apache.flink.kubernetes.operator.observer.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
@@ -176,5 +177,6 @@ public class JobReconcilerTest {
         jobStatus.setState("RUNNING");
 
         deployment.getStatus().setJobStatus(jobStatus);
+        deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DeploymentValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DeploymentValidatorTest.java
@@ -33,6 +33,7 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -62,7 +63,10 @@ public class DeploymentValidatorTest {
                 dep -> dep.getSpec().getJob().setParallelism(-1),
                 "Job parallelism must be larger than 0");
         testError(
-                dep -> dep.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE),
+                dep -> {
+                    dep.getSpec().setFlinkConfiguration(new HashMap<>());
+                    dep.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
+                },
                 "Job could not be upgraded with last-state while HA disabled");
 
         // Test conf validation
@@ -93,7 +97,10 @@ public class DeploymentValidatorTest {
                 "Invalid log config key");
 
         testError(
-                dep -> dep.getSpec().getJobManager().setReplicas(2),
+                dep -> {
+                    dep.getSpec().setFlinkConfiguration(new HashMap<>());
+                    dep.getSpec().getJobManager().setReplicas(2);
+                },
                 "High availability should be enabled when starting standby JobManagers.");
         testError(
                 dep -> dep.getSpec().getJobManager().setReplicas(0),


### PR DESCRIPTION
The main goal of this PR is to allow upgrading/suspending clusters even if they are still deploying / failing under certain conditions:
 - Session cluster
 - Job cluster with stateless or last-state upgrade modes
 
 To achieve this, the PR simplifies the observe -> reconcile flow by removing the sketchy isReadyToReconcile logic in between and moving the contained logic to the right places in the reconcilers.
 
 I have also added test cases to validate the upgrade behaviour in cases where the cluster is not ready/running yet for all cluster types.
