### PR TITLE
[FLINK-26594] Helm - Replace operatorNamespace with Release Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Kubernetes operator for Apache Flink, implemented in Java. See [FLIP-212](http
 The operator is managed helm chart. To install run:
 ```
  cd helm/flink-operator
- helm install flink-operator .
+ helm install flink-operator . --namespace flink-operator --create-namespace
 ```
 
 ### Validating webhook

--- a/helm/flink-operator/templates/flink-operator.yaml
+++ b/helm/flink-operator/templates/flink-operator.yaml
@@ -20,7 +20,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "flink-operator.name" . }}
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
 spec:
@@ -54,7 +54,7 @@ spec:
           {{- end }}
           env:
             - name: OPERATOR_NAMESPACE
-              value: {{ .Values.operatorNamespace.name }}
+              value: {{ .Release.Namespace }}
             - name: OPERATOR_NAME
               value: {{ include "flink-operator.name" . }}
             - name: FLINK_CONF_DIR
@@ -135,7 +135,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flink-operator-config
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
 data:
@@ -160,7 +160,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: flink-default-config
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
 data:

--- a/helm/flink-operator/templates/ingress.yaml
+++ b/helm/flink-operator/templates/ingress.yaml
@@ -21,7 +21,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "flink-operator.name" . }}
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
 spec:

--- a/helm/flink-operator/templates/rbac.yaml
+++ b/helm/flink-operator/templates/rbac.yaml
@@ -131,7 +131,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "flink-operator.serviceAccountName" $ }}
-    namespace: {{ $.Values.operatorNamespace.name }}
+    namespace: {{ $.Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -161,7 +161,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: flink-operator
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
 {{- template "flink-operator.rbacRules" $ }}
@@ -170,7 +170,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: flink
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
   annotations:
@@ -181,7 +181,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: flink-operator-cluster-role-binding
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
 roleRef:
@@ -191,13 +191,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "flink-operator.serviceAccountName" . }}
-    namespace: {{ .Values.operatorNamespace.name }}
+    namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: flink-role-binding
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
   annotations:
@@ -209,6 +209,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "flink-operator.jobServiceAccountName" . }}
-    namespace: {{ .Values.operatorNamespace.name }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/helm/flink-operator/templates/serviceaccount.yaml
+++ b/helm/flink-operator/templates/serviceaccount.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "flink-operator.serviceAccountName" . }}
-  namespace: {{ Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
   {{- with .Values.operatorServiceAccount.annotations }}

--- a/helm/flink-operator/templates/serviceaccount.yaml
+++ b/helm/flink-operator/templates/serviceaccount.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "flink-operator.serviceAccountName" . }}
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
   {{- with .Values.operatorServiceAccount.annotations }}
@@ -59,7 +59,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "flink-operator.jobServiceAccountName" $ }}
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" $ | nindent 4 }}
   {{- with .Values.jobServiceAccount.annotations }}

--- a/helm/flink-operator/templates/webhook.yaml
+++ b/helm/flink-operator/templates/webhook.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: flink-operator-webhook-service
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 443
@@ -35,7 +35,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: flink-operator-webhook-secret
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
   password: cGFzc3dvcmQxMjM0
@@ -45,11 +45,11 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: flink-operator-serving-cert
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
-  - flink-operator-webhook-service.{{ .Values.operatorNamespace.name }}.svc
-  - flink-operator-webhook-service.{{ .Values.operatorNamespace.name }}.svc.cluster.local
+  - flink-operator-webhook-service.{{ .Release.Namespace }}.svc
+  - flink-operator-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
   keystores:
     pkcs12:
       create: true
@@ -72,7 +72,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: flink-operator-selfsigned-issuer
-  namespace: {{ .Values.operatorNamespace.name }}
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 ---
@@ -80,15 +80,15 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: {{ .Values.operatorNamespace.name }}/flink-operator-serving-cert
-  name: flink-operator-{{ .Values.operatorNamespace.name }}-webhook-configuration
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/flink-operator-serving-cert
+  name: flink-operator-{{ .Release.Namespace }}-webhook-configuration
 webhooks:
 - name: vflinkdeployments.flink.apache.org
   admissionReviewVersions: ["v1"]
   clientConfig:
     service:
       name: flink-operator-webhook-service
-      namespace: {{ .Values.operatorNamespace.name }}
+      namespace: {{ .Release.Namespace }}
       path: /validate
   failurePolicy: Fail
   rules:

--- a/helm/flink-operator/values.yaml
+++ b/helm/flink-operator/values.yaml
@@ -18,9 +18,6 @@
 
 ---
 
-operatorNamespace:
-  name: default
-
 # List of kubernetes namespaces to watch for FlinkDeployment changes, empty means all namespaces.
 # When enabled RBAC is only created for said namespaces, otherwise it is done for the cluster scope.
 # watchNamespaces: ["flink"]


### PR DESCRIPTION
It will be more natural for the end users to customize the namespace with Helm's built-in objects.