### PR TITLE
[FLINK-26572] Improve reconcile reschedule configs and defaults

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -26,26 +26,33 @@ import lombok.Value;
 @Value
 public class FlinkOperatorConfiguration {
 
-    int reconcileIntervalInSec;
-
-    int portCheckIntervalInSec;
-
-    int savepointTriggerGracePeriodInSec;
+    int reconcileIntervalSeconds;
+    int progressCheckIntervalSeconds;
+    int restApiReadyDelaySeconds;
+    int savepointTriggerGracePeriodSeconds;
 
     public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
-        int reconcileIntervalInSec =
+        int reconcileIntervalSeconds =
                 operatorConfig.getInteger(
                         OperatorConfigOptions.OPERATOR_RECONCILER_RESCHEDULE_INTERVAL_IN_SEC);
-        int portCheckIntervalInSec =
-                operatorConfig.getInteger(
-                        OperatorConfigOptions.OPERATOR_OBSERVER_PORT_CHECK_INTERVAL_IN_SEC);
 
-        int savepointTriggerGracePeriodInSec =
+        int restApiReadyDelaySeconds =
+                operatorConfig.getInteger(
+                        OperatorConfigOptions.OPERATOR_OBSERVER_REST_READY_DELAY_IN_SEC);
+
+        int progressCheckIntervalSeconds =
+                operatorConfig.getInteger(
+                        OperatorConfigOptions.OPERATOR_OBSERVER_PROGRESS_CHECK_INTERVAL_IN_SEC);
+
+        int savepointTriggerGracePeriodSeconds =
                 operatorConfig.getInteger(
                         OperatorConfigOptions
                                 .OPERATOR_OBSERVER_SAVEPOINT_TRIGGER_GRACE_PERIOD_IN_SEC);
 
         return new FlinkOperatorConfiguration(
-                reconcileIntervalInSec, portCheckIntervalInSec, savepointTriggerGracePeriodInSec);
+                reconcileIntervalSeconds,
+                progressCheckIntervalSeconds,
+                restApiReadyDelaySeconds,
+                savepointTriggerGracePeriodSeconds);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/OperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/OperatorConfigOptions.java
@@ -31,19 +31,25 @@ public class OperatorConfigOptions {
                     .withDescription(
                             "The interval in second for the controller to reschedule the reconcile process");
 
-    public static final ConfigOption<Integer> OPERATOR_OBSERVER_PORT_CHECK_INTERVAL_IN_SEC =
-            ConfigOptions.key("operator.observer.port-check.interval.sec")
+    public static final ConfigOption<Integer> OPERATOR_OBSERVER_REST_READY_DELAY_IN_SEC =
+            ConfigOptions.key("operator.observer.rest-ready.delay.sec")
                     .intType()
                     .defaultValue(10)
                     .withDescription(
-                            "The interval in second for the controller to reschedule the reconcile process to "
-                                    + "wait for deployment to be ready");
+                            "Final delay before deployment is marked ready after port becomes accessible.");
+
+    public static final ConfigOption<Integer> OPERATOR_OBSERVER_PROGRESS_CHECK_INTERVAL_IN_SEC =
+            ConfigOptions.key("operator.observer.progress-check.interval.sec")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "The interval for observing status for in-progress operations such as deployment and savepoints.");
 
     public static final ConfigOption<Integer>
             OPERATOR_OBSERVER_SAVEPOINT_TRIGGER_GRACE_PERIOD_IN_SEC =
                     ConfigOptions.key("operator.observer.savepoint.trigger.grace-period.sec")
                             .intType()
-                            .defaultValue(5)
+                            .defaultValue(10)
                             .withDescription(
                                     "The interval in seconds before a savepoint trigger attempt is marked as unsuccessful");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -45,7 +45,7 @@ public class SavepointUtils {
 
     public static boolean gracePeriodEnded(
             FlinkOperatorConfiguration configuration, SavepointInfo savepointInfo) {
-        int gracePeriod = configuration.getSavepointTriggerGracePeriodInSec();
+        int gracePeriod = configuration.getSavepointTriggerGracePeriodSeconds();
         long triggerTimestamp = savepointInfo.getTriggerTimestamp();
         return (System.currentTimeMillis() - triggerTimestamp)
                 > TimeUnit.SECONDS.toMillis(gracePeriod);


### PR DESCRIPTION
Make config names cleaner and reduce reschedule delays while the job is deploying.