### PR TITLE
Use localhost for REST API when running outside k8s

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -54,9 +54,11 @@ public class FlinkOperator {
         DefaultConfigurationService configurationService = DefaultConfigurationService.instance();
         Operator operator = new Operator(client, configurationService);
 
-        FlinkService flinkService = new FlinkService(client);
         FlinkOperatorConfiguration operatorConfiguration =
                 FlinkOperatorConfiguration.fromConfiguration(defaultConfig.getOperatorConfig());
+
+        FlinkService flinkService = new FlinkService(client, operatorConfiguration);
+
         FlinkDeploymentValidator validator = new DefaultDeploymentValidator();
         ReconcilerFactory reconcilerFactory =
                 new ReconcilerFactory(client, flinkService, operatorConfiguration);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.flink.kubernetes.operator.config;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 
 import lombok.Value;
 
@@ -30,6 +31,7 @@ public class FlinkOperatorConfiguration {
     int progressCheckIntervalSeconds;
     int restApiReadyDelaySeconds;
     int savepointTriggerGracePeriodSeconds;
+    String flinkServiceHostOverride;
 
     public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
         int reconcileIntervalSeconds =
@@ -49,10 +51,17 @@ public class FlinkOperatorConfiguration {
                         OperatorConfigOptions
                                 .OPERATOR_OBSERVER_SAVEPOINT_TRIGGER_GRACE_PERIOD_IN_SEC);
 
+        String flinkServiceHostOverride = null;
+        if (EnvUtils.get("KUBERNETES_SERVICE_HOST") == null) {
+            // not running in k8s, simplify local development
+            flinkServiceHostOverride = "localhost";
+        }
+
         return new FlinkOperatorConfiguration(
                 reconcileIntervalSeconds,
                 progressCheckIntervalSeconds,
                 restApiReadyDelaySeconds,
-                savepointTriggerGracePeriodSeconds);
+                savepointTriggerGracePeriodSeconds,
+                flinkServiceHostOverride);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -48,7 +48,7 @@ public class TestingFlinkService extends FlinkService {
     private boolean isPortReady = true;
 
     public TestingFlinkService() {
-        super(null);
+        super(null, null);
     }
 
     public void clear() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -66,7 +66,7 @@ public class FlinkDeploymentControllerTest {
 
     private final Context context = TestUtils.createContextWithReadyJobManagerDeployment();
     private final FlinkOperatorConfiguration operatorConfiguration =
-            new FlinkOperatorConfiguration(1, 2, 3, 4);
+            new FlinkOperatorConfiguration(1, 2, 3, 4, null);
 
     private TestingFlinkService flinkService;
     private FlinkDeploymentController testController;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
@@ -139,7 +139,7 @@ public class FlinkServiceTest {
     }
 
     private FlinkService createFlinkService(ClusterClient<String> clusterClient) {
-        return new FlinkService((NamespacedKubernetesClient) client) {
+        return new FlinkService((NamespacedKubernetesClient) client, null) {
             @Override
             protected ClusterClient<String> getClusterClient(Configuration config) {
                 return clusterClient;


### PR DESCRIPTION
A small improvement to have a good default when running the operator outside of k8s. (I find myself switching back and forth and don't want to rely on local files.) As mentioned in the comment, this can become an operator config if we agree that this is useful.
