### PR TITLE
[FLINK-26473] Check for deployment errors when listJobs fails

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -52,6 +52,7 @@ import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerHea
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerRequestBody;
 
+import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
@@ -262,5 +263,16 @@ public class FlinkService {
             LOG.info("Savepoint result: " + savepoint);
             return SavepointFetchResult.completed(savepoint);
         }
+    }
+
+    public PodList getJmPodList(FlinkDeployment deployment, Configuration conf) {
+        final String namespace = conf.getString(KubernetesConfigOptions.NAMESPACE);
+        final String clusterId;
+        try (ClusterClient<String> clusterClient = getClusterClient(conf)) {
+            clusterId = clusterClient.getClusterId();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+        return FlinkUtils.getJmPodList(kubernetesClient, namespace, clusterId);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -170,12 +170,7 @@ public class FlinkUtils {
 
         for (int i = 0; i < 60; i++) {
             if (jobManagerRunning) {
-                PodList jmPodList =
-                        kubernetesClient
-                                .pods()
-                                .inNamespace(namespace)
-                                .withLabels(KubernetesUtils.getJobManagerSelectors(clusterId))
-                                .list();
+                PodList jmPodList = getJmPodList(kubernetesClient, namespace, clusterId);
 
                 if (jmPodList == null || jmPodList.getItems().isEmpty()) {
                     jobManagerRunning = false;
@@ -216,5 +211,14 @@ public class FlinkUtils {
                 kubernetesClient,
                 conf.getString(KubernetesConfigOptions.NAMESPACE),
                 conf.getString(KubernetesConfigOptions.CLUSTER_ID));
+    }
+
+    public static PodList getJmPodList(
+            KubernetesClient kubernetesClient, String namespace, String clusterId) {
+        return kubernetesClient
+                .pods()
+                .inNamespace(namespace)
+                .withLabels(KubernetesUtils.getJobManagerSelectors(clusterId))
+                .list();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -126,6 +126,18 @@ public class TestUtils {
         };
     }
 
+    public static Deployment createDeployment(boolean ready) {
+        DeploymentStatus status = new DeploymentStatus();
+        status.setAvailableReplicas(ready ? 1 : 0);
+        status.setReplicas(1);
+        DeploymentSpec spec = new DeploymentSpec();
+        spec.setReplicas(1);
+        Deployment deployment = new Deployment();
+        deployment.setSpec(spec);
+        deployment.setStatus(status);
+        return deployment;
+    }
+
     public static Context createContextWithReadyJobManagerDeployment() {
         return new Context() {
             @Override
@@ -136,15 +148,22 @@ public class TestUtils {
             @Override
             public <T> Optional<T> getSecondaryResource(
                     Class<T> expectedType, String eventSourceName) {
-                DeploymentStatus status = new DeploymentStatus();
-                status.setAvailableReplicas(1);
-                status.setReplicas(1);
-                DeploymentSpec spec = new DeploymentSpec();
-                spec.setReplicas(1);
-                Deployment deployment = new Deployment();
-                deployment.setSpec(spec);
-                deployment.setStatus(status);
-                return Optional.of((T) deployment);
+                return Optional.of((T) createDeployment(true));
+            }
+        };
+    }
+
+    public static Context createContextWithInProgressDeployment() {
+        return new Context() {
+            @Override
+            public Optional<RetryInfo> getRetryInfo() {
+                return Optional.empty();
+            }
+
+            @Override
+            public <T> Optional<T> getSecondaryResource(
+                    Class<T> expectedType, String eventSourceName) {
+                return Optional.of((T) createDeployment(false));
             }
         };
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -30,6 +30,8 @@ import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 
+import io.fabric8.kubernetes.api.model.PodList;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -46,6 +48,7 @@ public class TestingFlinkService extends FlinkService {
     private List<Tuple2<String, JobStatusMessage>> jobs = new ArrayList<>();
     private Set<String> sessions = new HashSet<>();
     private boolean isPortReady = true;
+    private PodList podList = new PodList();
 
     public TestingFlinkService() {
         super(null, null);
@@ -131,5 +134,14 @@ public class TestingFlinkService extends FlinkService {
 
     public void setPortReady(boolean isPortReady) {
         this.isPortReady = isPortReady;
+    }
+
+    @Override
+    public PodList getJmPodList(FlinkDeployment deployment, Configuration conf) {
+        return podList;
+    }
+
+    public void setJmPodList(PodList podList) {
+        this.podList = podList;
     }
 }


### PR DESCRIPTION
Adds handling for listJobs errors and with that ongoing error checking for the underlying deployment.

Need to add test coverage, this is for early comments.