### PR TITLE
[FLINK-26528] Trigger the updateControl only when the FlinkDeployment…

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.kubernetes.operator.controller;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.DefaultConfig;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
@@ -48,6 +47,7 @@ import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -131,12 +131,12 @@ public class FlinkDeploymentController
             throw new ReconciliationException(e);
         }
 
-        Time rescheduleAfter =
+        Duration rescheduleAfter =
                 flinkApp.getStatus()
                         .getJobManagerDeploymentStatus()
                         .rescheduleAfter(flinkApp, operatorConfiguration);
         return ReconciliationUtils.toUpdateControl(originalCopy, flinkApp)
-                .rescheduleAfter(rescheduleAfter.getSize(), rescheduleAfter.getUnit());
+                .rescheduleAfter(rescheduleAfter.toMillis());
     }
 
     private void handleDeploymentFailed(FlinkDeployment flinkApp, DeploymentFailedException dfe) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
 /** Exception to signal terminal deployment failure. */
 public class DeploymentFailedException extends RuntimeException {
     public static final String COMPONENT_JOBMANAGER = "JobManagerDeployment";
+    private static final long serialVersionUID = -1070179896083579221L;
 
     public final String component;
     public final DeploymentCondition deployCondition;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/ReconciliationException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/ReconciliationException.java
@@ -20,6 +20,8 @@ package org.apache.flink.kubernetes.operator.exception;
 /** Exception for wrapping reconciliation errors. */
 public class ReconciliationException extends RuntimeException {
 
+    private static final long serialVersionUID = 2260638990044248181L;
+
     public ReconciliationException(Throwable cause) {
         super(cause);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobManagerDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobManagerDeploymentStatus.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.observer;
 
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
@@ -45,7 +46,9 @@ public enum JobManagerDeploymentStatus {
     ERROR;
 
     public UpdateControl<FlinkDeployment> toUpdateControl(
-            FlinkDeployment flinkDeployment, FlinkOperatorConfiguration operatorConfiguration) {
+            FlinkDeployment originalCopy,
+            FlinkDeployment flinkDeployment,
+            FlinkOperatorConfiguration operatorConfiguration) {
         int rescheduleAfterSec;
         switch (this) {
             case DEPLOYING:
@@ -67,7 +70,7 @@ public enum JobManagerDeploymentStatus {
             default:
                 throw new RuntimeException("Unknown status: " + this);
         }
-        return UpdateControl.updateStatus(flinkDeployment)
+        return ReconciliationUtils.toUpdateControl(originalCopy, flinkDeployment)
                 .rescheduleAfter(rescheduleAfterSec, TimeUnit.SECONDS);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobManagerDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobManagerDeploymentStatus.java
@@ -17,14 +17,10 @@
 
 package org.apache.flink.kubernetes.operator.observer;
 
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
-import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
-
-import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
-
-import java.util.concurrent.TimeUnit;
 
 /** Status of the Flink JobManager Kubernetes deployment. */
 public enum JobManagerDeploymentStatus {
@@ -45,10 +41,8 @@ public enum JobManagerDeploymentStatus {
     /** Deployment in terminal error, requires spec change for reconciliation to continue. */
     ERROR;
 
-    public UpdateControl<FlinkDeployment> toUpdateControl(
-            FlinkDeployment originalCopy,
-            FlinkDeployment flinkDeployment,
-            FlinkOperatorConfiguration operatorConfiguration) {
+    public Time rescheduleAfter(
+            FlinkDeployment flinkDeployment, FlinkOperatorConfiguration operatorConfiguration) {
         int rescheduleAfterSec;
         switch (this) {
             case DEPLOYING:
@@ -70,7 +64,6 @@ public enum JobManagerDeploymentStatus {
             default:
                 throw new RuntimeException("Unknown status: " + this);
         }
-        return ReconciliationUtils.toUpdateControl(originalCopy, flinkDeployment)
-                .rescheduleAfter(rescheduleAfterSec, TimeUnit.SECONDS);
+        return Time.seconds(rescheduleAfterSec);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobManagerDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobManagerDeploymentStatus.java
@@ -17,10 +17,11 @@
 
 package org.apache.flink.kubernetes.operator.observer;
 
-import org.apache.flink.api.common.time.Time;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
+
+import java.time.Duration;
 
 /** Status of the Flink JobManager Kubernetes deployment. */
 public enum JobManagerDeploymentStatus {
@@ -41,7 +42,7 @@ public enum JobManagerDeploymentStatus {
     /** Deployment in terminal error, requires spec change for reconciliation to continue. */
     ERROR;
 
-    public Time rescheduleAfter(
+    public Duration rescheduleAfter(
             FlinkDeployment flinkDeployment, FlinkOperatorConfiguration operatorConfiguration) {
         int rescheduleAfterSec;
         switch (this) {
@@ -64,6 +65,6 @@ public enum JobManagerDeploymentStatus {
             default:
                 throw new RuntimeException("Unknown status: " + this);
         }
-        return Time.seconds(rescheduleAfterSec);
+        return Duration.ofSeconds(rescheduleAfterSec);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -23,6 +23,9 @@ import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+
+import java.util.Objects;
 
 /** Reconciliation utilities. */
 public class ReconciliationUtils {
@@ -73,5 +76,23 @@ public class ReconciliationUtils {
         } catch (JsonProcessingException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    public static UpdateControl<FlinkDeployment> toUpdateControl(
+            FlinkDeployment originalCopy, FlinkDeployment current) {
+        UpdateControl<FlinkDeployment> updateControl;
+        if (!Objects.equals(originalCopy.getSpec(), current.getSpec())) {
+            throw new UnsupportedOperationException(
+                    "The spec changed during reconcile is not supported.");
+        }
+
+        boolean statusChanged = !Objects.equals(originalCopy.getStatus(), current.getStatus());
+
+        if (statusChanged) {
+            updateControl = UpdateControl.updateStatus(current);
+        } else {
+            updateControl = UpdateControl.noUpdate();
+        }
+        return updateControl;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -83,7 +83,7 @@ public class ReconciliationUtils {
         UpdateControl<FlinkDeployment> updateControl;
         if (!Objects.equals(originalCopy.getSpec(), current.getSpec())) {
             throw new UnsupportedOperationException(
-                    "The spec changed during reconcile is not supported.");
+                    "Detected spec change after reconcile, this probably indicates a bug.");
         }
 
         boolean statusChanged = !Objects.equals(originalCopy.getStatus(), current.getStatus());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -54,12 +54,12 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** @link JobStatusObserver unit tests */
 public class FlinkDeploymentControllerTest {
@@ -192,16 +192,17 @@ public class FlinkDeploymentControllerTest {
         assertNotNull(reconciliationStatus.getError());
 
         // next cycle should not create another event
+        FlinkDeployment previous = ReconciliationUtils.clone(appCluster);
         updateControl =
                 testController.reconcile(
                         appCluster, TestUtils.createContextWithFailedJobManagerDeployment());
         assertEquals(
                 JobManagerDeploymentStatus.ERROR,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
-        assertTrue(updateControl.isUpdateStatus());
+        assertFalse(updateControl.isUpdateStatus());
         assertEquals(
                 JobManagerDeploymentStatus.READY
-                        .toUpdateControl(appCluster, operatorConfiguration)
+                        .toUpdateControl(previous, appCluster, operatorConfiguration)
                         .getScheduleDelay(),
                 updateControl.getScheduleDelay());
     }
@@ -275,11 +276,12 @@ public class FlinkDeploymentControllerTest {
         appCluster = ReconciliationUtils.clone(appCluster);
         appCluster.getSpec().getJob().setParallelism(100);
 
+        FlinkDeployment previous = ReconciliationUtils.clone(appCluster);
         UpdateControl<FlinkDeployment> updateControl =
                 testController.reconcile(appCluster, context);
         assertEquals(
                 JobManagerDeploymentStatus.DEPLOYING
-                        .toUpdateControl(appCluster, operatorConfiguration)
+                        .toUpdateControl(previous, appCluster, operatorConfiguration)
                         .getScheduleDelay(),
                 updateControl.getScheduleDelay());
         testController.reconcile(appCluster, context);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -202,7 +202,7 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 JobManagerDeploymentStatus.READY
                         .rescheduleAfter(appCluster, operatorConfiguration)
-                        .toMilliseconds(),
+                        .toMillis(),
                 updateControl.getScheduleDelay().get());
     }
 
@@ -280,7 +280,7 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 JobManagerDeploymentStatus.DEPLOYING
                         .rescheduleAfter(appCluster, operatorConfiguration)
-                        .toMilliseconds(),
+                        .toMillis(),
                 updateControl.getScheduleDelay().get());
         testController.reconcile(appCluster, context);
         jobs = flinkService.listJobs();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.observer.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test for {@link org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils}. */
+public class ReconciliationUtilsTest {
+
+    @Test
+    public void testSpecChangedException() {
+        FlinkDeployment previous = TestUtils.buildApplicationCluster();
+        FlinkDeployment current =
+                org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils.clone(previous);
+
+        current.getSpec().setImage("changed-image");
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> ReconciliationUtils.toUpdateControl(previous, current));
+    }
+
+    @Test
+    public void testStatusChanged() {
+        FlinkDeployment previous = TestUtils.buildApplicationCluster();
+        FlinkDeployment current =
+                org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils.clone(previous);
+
+        UpdateControl<FlinkDeployment> updateControl =
+                ReconciliationUtils.toUpdateControl(previous, current);
+
+        assertFalse(updateControl.isUpdateResource());
+        assertFalse(updateControl.isUpdateStatus());
+        assertTrue(updateControl.getScheduleDelay().isEmpty());
+
+        // status changed
+        current.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
+        updateControl =
+                ReconciliationUtils.toUpdateControl(previous, current)
+                        .rescheduleAfter(10, TimeUnit.MILLISECONDS);
+        assertFalse(updateControl.isUpdateResource());
+        assertTrue(updateControl.isUpdateStatus());
+        assertEquals(10, updateControl.getScheduleDelay().get());
+    }
+}


### PR DESCRIPTION
… have changed

This PR is meant to eliminate the duplicate status updating for `FlinkDeployment`. To achieve this, we compare the object with the original copy before reconcile. If status changed, the `UpdateControl` will apply, otherwise, It will produce no update.