### PR TITLE
[FLINK-26620] Mark CRD classes experimental

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/FlinkDeployment.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/FlinkDeployment.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.crd;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 
@@ -29,6 +30,7 @@ import io.fabric8.kubernetes.model.annotation.ShortNames;
 import io.fabric8.kubernetes.model.annotation.Version;
 
 /** Flink deployment object (spec + status). */
+@Experimental
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonDeserialize()
 @Group("flink.apache.org")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/FlinkDeploymentList.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/FlinkDeploymentList.java
@@ -17,7 +17,10 @@
 
 package org.apache.flink.kubernetes.operator.crd;
 
+import org.apache.flink.annotation.Experimental;
+
 import io.fabric8.kubernetes.client.CustomResourceList;
 
 /** Multiple Flink deployments. */
+@Experimental
 public class FlinkDeploymentList extends CustomResourceList<FlinkDeployment> {}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.kubernetes.operator.crd.spec;
 
+import org.apache.flink.annotation.Experimental;
+
 import io.fabric8.kubernetes.api.model.Pod;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +28,7 @@ import lombok.NoArgsConstructor;
 import java.util.Map;
 
 /** Spec that describes a Flink application deployment. */
+@Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobManagerSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobManagerSpec.java
@@ -17,12 +17,15 @@
 
 package org.apache.flink.kubernetes.operator.crd.spec;
 
+import org.apache.flink.annotation.Experimental;
+
 import io.fabric8.kubernetes.api.model.Pod;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** JobManager spec. */
+@Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobSpec.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.kubernetes.operator.crd.spec;
 
+import org.apache.flink.annotation.Experimental;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -24,6 +26,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 /** Flink job spec. */
+@Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/Resource.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/Resource.java
@@ -17,11 +17,14 @@
 
 package org.apache.flink.kubernetes.operator.crd.spec;
 
+import org.apache.flink.annotation.Experimental;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** Resource spec. */
+@Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/TaskManagerSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/TaskManagerSpec.java
@@ -17,12 +17,15 @@
 
 package org.apache.flink.kubernetes.operator.crd.spec;
 
+import org.apache.flink.annotation.Experimental;
+
 import io.fabric8.kubernetes.api.model.Pod;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** TaskManager spec. */
+@Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkDeploymentStatus.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.crd.status;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.kubernetes.operator.observer.JobManagerDeploymentStatus;
 
 import lombok.AllArgsConstructor;
@@ -24,6 +25,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** Current status of the Flink deployment. */
+@Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
@@ -17,12 +17,15 @@
 
 package org.apache.flink.kubernetes.operator.crd.status;
 
+import org.apache.flink.annotation.Experimental;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** Status of an individual job within the Flink deployment. */
+@Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.crd.status;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 
 import lombok.AllArgsConstructor;
@@ -25,6 +26,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** Status of the Flink deployment reconciliation flow. */
+@Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/Savepoint.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/Savepoint.java
@@ -17,11 +17,14 @@
 
 package org.apache.flink.kubernetes.operator.crd.status;
 
+import org.apache.flink.annotation.Experimental;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** Represents information about a finished savepoint. */
+@Experimental
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointInfo.java
@@ -17,12 +17,15 @@
 
 package org.apache.flink.kubernetes.operator.crd.status;
 
+import org.apache.flink.annotation.Experimental;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** Stores savepoint related information. */
+@Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor


### PR DESCRIPTION
We should mark the CRD classes experimental for the first preview release. This is the only API of the operator that we plan to release.

**The brief change log**

- Use `@Experimental` annotation to mark the classes of the `org.apache.flink.kubernetes.operator.crd` package experimental.