### PR TITLE
[FLINK-26605] Check if JM can serve rest api calls every time before reconcile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           export SHELL=/bin/bash
           export DOCKER_BUILDKIT=1
           eval $(minikube -p minikube docker-env)
-          docker build -f ./Dockerfile -t flink-kubernetes-operator:ci-latest .
+          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest .
           docker images
       - name: Start the operator
         run: |
@@ -107,7 +107,7 @@ jobs:
           export SHELL=/bin/bash
           export DOCKER_BUILDKIT=1
           eval $(minikube -p minikube docker-env)
-          docker build -f ./Dockerfile -t flink-kubernetes-operator:ci-latest .
+          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain .
           docker images
       - name: Start the operator
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY $WEBHOOK_DIR/src ./$WEBHOOK_DIR/src
 
 COPY tools ./tools
 
-RUN --mount=type=cache,target=/root/.m2 mvn clean install
+RUN --mount=type=cache,target=/root/.m2 mvn -ntp clean install
 
 # stage
 FROM openjdk:11-jre

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -35,6 +35,7 @@ public class FlinkOperatorConfiguration {
     Duration progressCheckInterval;
     Duration restApiReadyDelay;
     Duration savepointTriggerGracePeriod;
+    Duration flinkClientTimeout;
     String flinkServiceHostOverride;
     Set<String> watchedNamespaces;
 
@@ -52,6 +53,9 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(
                         OperatorConfigOptions.OPERATOR_OBSERVER_SAVEPOINT_TRIGGER_GRACE_PERIOD);
 
+        Duration flinkClientTimeout =
+                operatorConfig.get(OperatorConfigOptions.OPERATOR_OBSERVER_FLINK_CLIENT_TIMEOUT);
+
         String flinkServiceHostOverride = null;
         if (EnvUtils.get("KUBERNETES_SERVICE_HOST") == null) {
             // not running in k8s, simplify local development
@@ -65,6 +69,7 @@ public class FlinkOperatorConfiguration {
                 progressCheckInterval,
                 restApiReadyDelay,
                 savepointTriggerGracePeriod,
+                flinkClientTimeout,
                 flinkServiceHostOverride,
                 watchedNamespaces);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/OperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/OperatorConfigOptions.java
@@ -53,4 +53,11 @@ public class OperatorConfigOptions {
                     .defaultValue(Duration.ofSeconds(10))
                     .withDescription(
                             "The interval before a savepoint trigger attempt is marked as unsuccessful");
+
+    public static final ConfigOption<Duration> OPERATOR_OBSERVER_FLINK_CLIENT_TIMEOUT =
+            ConfigOptions.key("operator.observer.flink.client.timeout.sec")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(10))
+                    .withDescription(
+                            "The timeout for the observer to wait the flink rest client to return.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -138,7 +138,11 @@ public class FlinkService {
 
     public Collection<JobStatusMessage> listJobs(Configuration conf) throws Exception {
         try (ClusterClient<String> clusterClient = getClusterClient(conf)) {
-            return clusterClient.listJobs().get(10, TimeUnit.SECONDS);
+            return clusterClient
+                    .listJobs()
+                    .get(
+                            operatorConfiguration.getFlinkClientTimeout().getSeconds(),
+                            TimeUnit.SECONDS);
         }
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -37,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /** Flink service mock for tests. */
@@ -79,8 +80,11 @@ public class TestingFlinkService extends FlinkService {
 
     @Override
     public List<JobStatusMessage> listJobs(Configuration conf) throws Exception {
-        if (jobs.isEmpty()) {
+        if (jobs.isEmpty() && !sessions.isEmpty()) {
             throw new Exception("Trying to list a job without submitting it");
+        }
+        if (!isPortReady) {
+            throw new TimeoutException("JM port is unavailable");
         }
         return jobs.stream().map(t -> t.f1).collect(Collectors.toList());
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -78,6 +78,7 @@ public class FlinkDeploymentControllerTest {
                     Duration.ofSeconds(2),
                     Duration.ofSeconds(3),
                     Duration.ofSeconds(4),
+                    Duration.ofSeconds(5),
                     null,
                     Collections.emptySet());
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobObserverTest.java
@@ -99,13 +99,28 @@ public class JobObserverTest {
                 deployment.getStatus().getJobStatus().getJobName());
         assertTrue(
                 Long.valueOf(deployment.getStatus().getJobStatus().getUpdateTime())
-                                .compareTo(
-                                        Long.valueOf(
-                                                deployment
-                                                        .getStatus()
-                                                        .getJobStatus()
-                                                        .getStartTime()))
+                        .compareTo(
+                                Long.valueOf(
+                                        deployment
+                                                .getStatus()
+                                                .getJobStatus()
+                                                .getStartTime()))
                         >= 0);
+        // Test job manager is unavailable suddenly
+        flinkService.setPortReady(false);
+        observer.observe(deployment, readyContext, conf);
+        assertEquals(
+                JobManagerDeploymentStatus.DEPLOYING,
+                deployment.getStatus().getJobManagerDeploymentStatus());
+        flinkService.setPortReady(true);
+        observer.observe(deployment, readyContext, conf);
+        assertEquals(
+                JobManagerDeploymentStatus.DEPLOYED_NOT_READY,
+                deployment.getStatus().getJobManagerDeploymentStatus());
+        observer.observe(deployment, readyContext, conf);
+        assertEquals(
+                JobManagerDeploymentStatus.READY,
+                deployment.getStatus().getJobManagerDeploymentStatus());
 
         // Test listing failure
         flinkService.clear();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobObserverTest.java
@@ -99,12 +99,12 @@ public class JobObserverTest {
                 deployment.getStatus().getJobStatus().getJobName());
         assertTrue(
                 Long.valueOf(deployment.getStatus().getJobStatus().getUpdateTime())
-                        .compareTo(
-                                Long.valueOf(
-                                        deployment
-                                                .getStatus()
-                                                .getJobStatus()
-                                                .getStartTime()))
+                                .compareTo(
+                                        Long.valueOf(
+                                                deployment
+                                                        .getStatus()
+                                                        .getJobStatus()
+                                                        .getStartTime()))
                         >= 0);
         // Test job manager is unavailable suddenly
         flinkService.setPortReady(false);
@@ -112,6 +112,7 @@ public class JobObserverTest {
         assertEquals(
                 JobManagerDeploymentStatus.DEPLOYING,
                 deployment.getStatus().getJobManagerDeploymentStatus());
+        // Job manager recovers
         flinkService.setPortReady(true);
         observer.observe(deployment, readyContext, conf);
         assertEquals(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SessionObserverTest.java
@@ -76,6 +76,15 @@ public class SessionObserverTest {
         assertEquals(
                 JobManagerDeploymentStatus.READY,
                 deployment.getStatus().getJobManagerDeploymentStatus());
+
+        observer.observe(
+                deployment,
+                readyContext,
+                FlinkUtils.getEffectiveConfig(deployment, new Configuration()));
+
+        assertEquals(
+                JobManagerDeploymentStatus.READY,
+                deployment.getStatus().getJobManagerDeploymentStatus());
     }
 
     @Test


### PR DESCRIPTION
- Add `isJobManagerServing()` method to use the rest call(i.e. "/jobs/overview") to check if JM can actually serve requests after JM is deployed.
- Add the previous check in the `BaseObserver` logic to be executed every time before reconcile when JM state is `READY`.
- Enhance `SessionObserverTest` and `FlinkDeploymentControllerTest`  to include the case when JM port is ready but the rest service is not available. 