### PR TITLE
[FLINK-26649] Add startTime in JobStatus

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -135,7 +135,8 @@ under the License.
 | jobName | java.lang.String | Name of the job. |
 | jobId | java.lang.String | Flink JobId of the Job. |
 | state | java.lang.String | Last observed state of the job. |
-| updateTime | java.lang.String | Start time of the job. |
+| startTime | java.lang.String | Start time of the job. |
+| updateTime | java.lang.String | Update time of the job. |
 | savepointInfo | org.apache.flink.kubernetes.operator.crd.status.SavepointInfo | Information about pending and last savepoint for the job. |
 
 ### ReconciliationStatus

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
@@ -41,6 +41,9 @@ public class JobStatus {
     private String state;
 
     /** Start time of the job. */
+    private String startTime;
+
+    /** Update time of the job. */
     private String updateTime;
 
     /** Information about pending and last savepoint for the job. */

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobObserver.java
@@ -87,8 +87,8 @@ public class JobObserver extends BaseObserver {
         status.setState(newJob.getJobState().name());
         status.setJobName(newJob.getJobName());
         status.setJobId(newJob.getJobId().toHexString());
-        // track the start time, changing timestamp would cause busy reconciliation
-        status.setUpdateTime(String.valueOf(newJob.getStartTime()));
+        status.setStartTime(String.valueOf(newJob.getStartTime()));
+        status.setUpdateTime(String.valueOf(System.currentTimeMillis()));
     }
 
     private void observeSavepointStatus(FlinkDeployment flinkApp, Configuration effectiveConfig) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobObserverTest.java
@@ -96,6 +96,11 @@ public class JobObserverTest {
         assertEquals(
                 deployment.getMetadata().getName(),
                 deployment.getStatus().getJobStatus().getJobName());
+        assertEquals(
+                Long.valueOf(deployment.getStatus().getJobStatus().getUpdateTime())
+                        .compareTo(
+                                Long.valueOf(deployment.getStatus().getJobStatus().getStartTime())),
+                1);
 
         // Test listing failure
         flinkService.clear();

--- a/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9074,6 +9074,8 @@ spec:
                     type: string
                   state:
                     type: string
+                  startTime:
+                    type: string
                   updateTime:
                     type: string
                   savepointInfo:


### PR DESCRIPTION
The current `JobStatus.updateTime` actually means the start time, not the last update time. We could introduce a new field `startTime` and make `updateTime` reflect its original intention.

**The brief change log**
- Adds the field `startTime` in `JobStatus` to represent the start time.