### PR TITLE
[FLINK-26640] Make FlinkVersion enum and required

### DIFF
--- a/docs/content/docs/custom-resource/overview.md
+++ b/docs/content/docs/custom-resource/overview.md
@@ -82,6 +82,7 @@ The spec contains all the information the operator need to deploy and manage you
 
 Most deployments will define at least the following fields:
  - `image` : Docker used to run Flink job and task manager processes
+ - `flinkVersion` : Flink version used in the image (`v1_14`, `v1_15`...)
  - `serviceAccount` : Kubernetes service account used by the Flink pods
  - `taskManager, jobManager` : Job and Task manager pod resource specs (cpu, memory, etc.)
  - `flinkConfiguration` : Map of Flink configuration overrides such as HA and checkpointing configs

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -48,7 +48,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | image | java.lang.String | Flink docker image used to start the Job and TaskManager pods. |
 | imagePullPolicy | java.lang.String | Image pull policy of the Flink docker image. |
 | serviceAccount | java.lang.String | Kubernetes service used by the Flink deployment. |
-| flinkVersion | java.lang.String | Flink image version. |
+| flinkVersion | org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion | Flink image version. |
 | ingressDomain | java.lang.String | Ingress domain for the Flink deployment. |
 | flinkConfiguration | java.util.Map<java.lang.String,java.lang.String> | Flink configuration overrides for the Flink deployment. |
 | podTemplate | io.fabric8.kubernetes.api.model.Pod | Base pod template for job and task manager pods. Can be overridden by the jobManager and  taskManager pod templates. |
@@ -56,6 +56,17 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | taskManager | org.apache.flink.kubernetes.operator.crd.spec.TaskManagerSpec | TaskManager specs. |
 | job | org.apache.flink.kubernetes.operator.crd.spec.JobSpec | Job specification for application deployments. Null for session clusters. |
 | logConfiguration | java.util.Map<java.lang.String,java.lang.String> | Log configuration overrides for the Flink deployment. Format logConfigFileName ->  configContent. |
+
+### FlinkVersion
+**Class**: org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion
+
+**Description**: Enumeration for supported Flink versions.
+
+| Value | Docs |
+| ----- | ---- |
+| v1_14 |  |
+| v1_15 |  |
+| v1_16 |  |
 
 ### JobManagerSpec
 **Class**: org.apache.flink.kubernetes.operator.crd.spec.JobManagerSpec

--- a/e2e-tests/data/cr.yaml
+++ b/e2e-tests/data/cr.yaml
@@ -23,7 +23,7 @@ metadata:
   name: flink-example-statemachine
 spec:
   image: flink:1.14.3
-  flinkVersion: 1.14.3
+  flinkVersion: v1_14
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
     high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory

--- a/examples/basic-checkpoint-ha.yaml
+++ b/examples/basic-checkpoint-ha.yaml
@@ -23,7 +23,7 @@ metadata:
   name: basic-checkpoint-ha-example
 spec:
   image: flink:1.14.3
-  flinkVersion: 1.14.3
+  flinkVersion: v1_14
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
     state.savepoints.dir: file:///flink-data/savepoints

--- a/examples/basic-ingress.yaml
+++ b/examples/basic-ingress.yaml
@@ -23,7 +23,7 @@ metadata:
   name: basic-ingress
 spec:
   image: flink:1.14.3
-  flinkVersion: 1.14.3
+  flinkVersion: v1_14
   ingressDomain: flink.k8s.io
   flinkConfiguration:
 #    rest.address: basic-example.flink.k8s.io

--- a/examples/basic-session.yaml
+++ b/examples/basic-session.yaml
@@ -23,7 +23,7 @@ metadata:
   name: basic-session-example
 spec:
   image: flink:1.14.3
-  flinkVersion: 1.14.3
+  flinkVersion: v1_14
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -23,7 +23,7 @@ metadata:
   name: basic-example
 spec:
   image: flink:1.14.3
-  flinkVersion: 1.14.3
+  flinkVersion: v1_14
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink

--- a/examples/custom-logging.yaml
+++ b/examples/custom-logging.yaml
@@ -23,7 +23,7 @@ metadata:
   name: custom-logging-example
 spec:
   image: flink:1.14.3
-  flinkVersion: 1.14.3
+  flinkVersion: v1_14
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -23,7 +23,7 @@ metadata:
   name: pod-template-example
 spec:
   image: flink:1.14.3
-  flinkVersion: 1.14.3
+  flinkVersion: v1_14
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
   podTemplate:

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
@@ -44,7 +44,7 @@ public class FlinkDeploymentSpec {
     private String serviceAccount;
 
     /** Flink image version. */
-    private String flinkVersion;
+    private FlinkVersion flinkVersion = FlinkVersion.v1_14;
 
     /** Ingress domain for the Flink deployment. */
     private String ingressDomain;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
@@ -44,7 +44,7 @@ public class FlinkDeploymentSpec {
     private String serviceAccount;
 
     /** Flink image version. */
-    private FlinkVersion flinkVersion = FlinkVersion.v1_14;
+    private FlinkVersion flinkVersion;
 
     /** Ingress domain for the Flink deployment. */
     private String ingressDomain;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkVersion.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkVersion.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.crd.spec;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Enumeration for Flink versions. This is copied from flink-annotations. Should be removed once we
+ * upgrade to flink-1.15+.
+ */
+@Experimental
+public enum FlinkVersion {
+
+    // NOTE: the version strings must not change,
+    // as they are used to locate snapshot file paths.
+    // The definition order (enum ordinal) matters for performing version arithmetic.
+    v1_3("1.3"),
+    v1_4("1.4"),
+    v1_5("1.5"),
+    v1_6("1.6"),
+    v1_7("1.7"),
+    v1_8("1.8"),
+    v1_9("1.9"),
+    v1_10("1.10"),
+    v1_11("1.11"),
+    v1_12("1.12"),
+    v1_13("1.13"),
+    v1_14("1.14"),
+    v1_15("1.15"),
+    v1_16("1.16");
+
+    private final String versionStr;
+
+    FlinkVersion(String versionStr) {
+        this.versionStr = versionStr;
+    }
+
+    @Override
+    public String toString() {
+        return versionStr;
+    }
+
+    public boolean isNewerVersionThan(FlinkVersion otherVersion) {
+        return this.ordinal() > otherVersion.ordinal();
+    }
+
+    /** Returns all versions within the defined range, inclusive both start and end. */
+    public static Set<FlinkVersion> rangeOf(FlinkVersion start, FlinkVersion end) {
+        return Stream.of(FlinkVersion.values())
+                .filter(v -> v.ordinal() >= start.ordinal() && v.ordinal() <= end.ordinal())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static final Map<String, FlinkVersion> CODE_MAP =
+            Arrays.stream(values())
+                    .collect(Collectors.toMap(v -> v.versionStr, Function.identity()));
+
+    public static Optional<FlinkVersion> byCode(String code) {
+        return Optional.ofNullable(CODE_MAP.get(code));
+    }
+
+    /** Returns the current version. */
+    public static FlinkVersion current() {
+        return values()[values().length - 1];
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkVersion.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkVersion.java
@@ -20,50 +20,17 @@ package org.apache.flink.kubernetes.operator.crd.spec;
 
 import org.apache.flink.annotation.Experimental;
 
-import java.util.Arrays;
 import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/**
- * Enumeration for Flink versions. This is copied from flink-annotations. Should be removed once we
- * upgrade to flink-1.15+.
- */
+/** Enumeration for supported Flink versions. */
 @Experimental
 public enum FlinkVersion {
-
-    // NOTE: the version strings must not change,
-    // as they are used to locate snapshot file paths.
-    // The definition order (enum ordinal) matters for performing version arithmetic.
-    v1_3("1.3"),
-    v1_4("1.4"),
-    v1_5("1.5"),
-    v1_6("1.6"),
-    v1_7("1.7"),
-    v1_8("1.8"),
-    v1_9("1.9"),
-    v1_10("1.10"),
-    v1_11("1.11"),
-    v1_12("1.12"),
-    v1_13("1.13"),
-    v1_14("1.14"),
-    v1_15("1.15"),
-    v1_16("1.16");
-
-    private final String versionStr;
-
-    FlinkVersion(String versionStr) {
-        this.versionStr = versionStr;
-    }
-
-    @Override
-    public String toString() {
-        return versionStr;
-    }
+    v1_14,
+    v1_15,
+    v1_16;
 
     public boolean isNewerVersionThan(FlinkVersion otherVersion) {
         return this.ordinal() > otherVersion.ordinal();
@@ -74,14 +41,6 @@ public enum FlinkVersion {
         return Stream.of(FlinkVersion.values())
                 .filter(v -> v.ordinal() >= start.ordinal() && v.ordinal() <= end.ordinal())
                 .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-    private static final Map<String, FlinkVersion> CODE_MAP =
-            Arrays.stream(values())
-                    .collect(Collectors.toMap(v -> v.versionStr, Function.identity()));
-
-    public static Optional<FlinkVersion> byCode(String code) {
-        return Optional.ofNullable(CODE_MAP.get(code));
     }
 
     /** Returns the current version. */

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultDeploymentValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultDeploymentValidator.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.JobManagerSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
@@ -50,6 +51,7 @@ public class DefaultDeploymentValidator implements FlinkDeploymentValidator {
     public Optional<String> validate(FlinkDeployment deployment) {
         FlinkDeploymentSpec spec = deployment.getSpec();
         return firstPresent(
+                validateFlinkVersion(spec.getFlinkVersion()),
                 validateFlinkConfig(spec.getFlinkConfiguration()),
                 validateLogConfig(spec.getLogConfiguration()),
                 validateJobSpec(spec.getJob(), spec.getFlinkConfiguration()),
@@ -63,6 +65,16 @@ public class DefaultDeploymentValidator implements FlinkDeploymentValidator {
             if (opt.isPresent()) {
                 return opt;
             }
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> validateFlinkVersion(FlinkVersion version) {
+        if (version == null) {
+            return Optional.of("Flink Version must be defined.");
+        }
+        if (!version.isNewerVersionThan(FlinkVersion.v1_13)) {
+            return Optional.of("Only Flink versions 1.14 and above are supported.");
         }
         return Optional.empty();
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultDeploymentValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultDeploymentValidator.java
@@ -73,9 +73,6 @@ public class DefaultDeploymentValidator implements FlinkDeploymentValidator {
         if (version == null) {
             return Optional.of("Flink Version must be defined.");
         }
-        if (!version.isNewerVersionThan(FlinkVersion.v1_13)) {
-            return Optional.of("Only Flink versions 1.14 and above are supported.");
-        }
         return Optional.empty();
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.JobManagerSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.Resource;
 import org.apache.flink.kubernetes.operator.crd.spec.TaskManagerSpec;
@@ -106,7 +107,7 @@ public class FlinkOperatorITCase {
                         .build());
         FlinkDeploymentSpec spec = new FlinkDeploymentSpec();
         spec.setImage(IMAGE);
-        spec.setFlinkVersion(FLINK_VERSION);
+        spec.setFlinkVersion(FlinkVersion.v1_14);
         spec.setServiceAccount(SERVICE_ACCOUNT);
         Resource resource = new Resource();
         resource.setMemory("2048m");

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.JobManagerSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
@@ -95,7 +96,7 @@ public class TestUtils {
                 .image(IMAGE)
                 .imagePullPolicy(IMAGE_POLICY)
                 .serviceAccount(SERVICE_ACCOUNT)
-                .flinkVersion(FLINK_VERSION)
+                .flinkVersion(FlinkVersion.v1_14)
                 .flinkConfiguration(conf)
                 .jobManager(new JobManagerSpec(new Resource(1, "2048m"), 1, null))
                 .taskManager(new TaskManagerSpec(new Resource(1, "2048m"), null))

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DeploymentValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DeploymentValidatorTest.java
@@ -196,10 +196,6 @@ public class DeploymentValidatorTest {
 
         testError(dep -> dep.getSpec().setFlinkVersion(null), "Flink Version must be defined.");
 
-        testError(
-                dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_13),
-                "Only Flink versions 1.14 and above are supported.");
-
         testSuccess(dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_15));
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DeploymentValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DeploymentValidatorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.validation;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
@@ -192,6 +193,14 @@ public class DeploymentValidatorTest {
                     dep.getStatus().getReconciliationStatus().getLastReconciledSpec().setJob(null);
                 },
                 "Cannot switch from session to job cluster");
+
+        testError(dep -> dep.getSpec().setFlinkVersion(null), "Flink Version must be defined.");
+
+        testError(
+                dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_13),
+                "Only Flink versions 1.14 and above are supported.");
+
+        testSuccess(dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_15));
     }
 
     private void testSuccess(Consumer<FlinkDeployment> deploymentModifier) {

--- a/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -26,6 +26,22 @@ spec:
               serviceAccount:
                 type: string
               flinkVersion:
+                enum:
+                - v1_3
+                - v1_4
+                - v1_5
+                - v1_6
+                - v1_7
+                - v1_8
+                - v1_9
+                - v1_10
+                - v1_11
+                - v1_12
+                - v1_13
+                - v1_14
+                - v1_15
+                - v1_16
+                - versionStr
                 type: string
               ingressDomain:
                 type: string
@@ -9114,6 +9130,22 @@ spec:
                       serviceAccount:
                         type: string
                       flinkVersion:
+                        enum:
+                        - v1_3
+                        - v1_4
+                        - v1_5
+                        - v1_6
+                        - v1_7
+                        - v1_8
+                        - v1_9
+                        - v1_10
+                        - v1_11
+                        - v1_12
+                        - v1_13
+                        - v1_14
+                        - v1_15
+                        - v1_16
+                        - versionStr
                         type: string
                       ingressDomain:
                         type: string

--- a/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -27,21 +27,9 @@ spec:
                 type: string
               flinkVersion:
                 enum:
-                - v1_3
-                - v1_4
-                - v1_5
-                - v1_6
-                - v1_7
-                - v1_8
-                - v1_9
-                - v1_10
-                - v1_11
-                - v1_12
-                - v1_13
                 - v1_14
                 - v1_15
                 - v1_16
-                - versionStr
                 type: string
               ingressDomain:
                 type: string
@@ -9131,21 +9119,9 @@ spec:
                         type: string
                       flinkVersion:
                         enum:
-                        - v1_3
-                        - v1_4
-                        - v1_5
-                        - v1_6
-                        - v1_7
-                        - v1_8
-                        - v1_9
-                        - v1_10
-                        - v1_11
-                        - v1_12
-                        - v1_13
                         - v1_14
                         - v1_15
                         - v1_16
-                        - versionStr
                         type: string
                       ingressDomain:
                         type: string


### PR DESCRIPTION
This PR changes the FlinkVersion from string to enum.

I simply copied the FlinkVersion enum from flink master so that we can adapt this directly once we bump the flink dep to at least 1.15.