### PR TITLE
[FLINK-26655] Improve the observe logic in SessionObserver

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SessionObserver.java
@@ -37,6 +37,9 @@ public class SessionObserver extends BaseObserver {
 
     @Override
     public void observe(FlinkDeployment flinkApp, Context context, Configuration effectiveConfig) {
+        if (!isClusterReady(flinkApp)) {
+            observeJmDeployment(flinkApp, context, effectiveConfig);
+        }
         if (isClusterReady(flinkApp)) {
             // Check if session cluster can serve rest calls following our practice in JobObserver
             try {
@@ -48,8 +51,6 @@ public class SessionObserver extends BaseObserver {
                     observeJmDeployment(flinkApp, context, effectiveConfig);
                 }
             }
-        } else {
-            observeJmDeployment(flinkApp, context, effectiveConfig);
         }
     }
 }


### PR DESCRIPTION
- Adjust the check logic in `SessionObserver#observe()` method using same logic with `JobObserver#observe()` to reduce extra `observe()` call due to https://github.com/apache/flink-kubernetes-operator/pull/62#discussion_r830146506
