### PR TITLE
[FLINK-26715] Extend e2e ci test matrix with watchNamespaces enabled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,15 @@ jobs:
           stop_minikube
   e2e_ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+          - description: 'Default configuration'
+            namespace: default
+            extraArgs: ''
+          - description: 'WatchNamespaces enabled'
+            namespace: flink
+            extraArgs: '--create-namespace --set "watchNamespaces={default,flink}"'
     name: e2e_ci
     steps:
       - uses: actions/checkout@v2
@@ -111,8 +120,8 @@ jobs:
           docker images
       - name: Start the operator
         run: |
-          helm install flink-operator helm/flink-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-latest
-          kubectl wait --for=condition=Available --timeout=120s deploy/flink-operator
+          helm install flink-operator -n ${{ matrix.config.namespace }} helm/flink-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-latest ${{ matrix.config.extraArgs }}
+          kubectl wait --for=condition=Available --timeout=120s -n ${{ matrix.config.namespace }} deploy/flink-operator
           kubectl get pods
       - name: Run Flink e2e tests
         run: |
@@ -122,7 +131,7 @@ jobs:
           done
       - name: Stop the operator
         run: |
-          helm uninstall flink-operator
+          helm uninstall -n ${{ matrix.config.namespace }} flink-operator
       - name: Stop minikube
         run: |
           source e2e-tests/utils.sh

--- a/e2e-tests/test_kubernetes_application_ha.sh
+++ b/e2e-tests/test_kubernetes_application_ha.sh
@@ -47,6 +47,8 @@ kubectl wait --for=condition=Ready --timeout=${TIMEOUT}s pod/$jm_pod_name || exi
 wait_for_logs $jm_pod_name "Rest endpoint listening at" ${TIMEOUT} || exit 1
 
 wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
+check_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY
+check_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING
 
 job_id=$(kubectl logs $jm_pod_name | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
 
@@ -57,6 +59,8 @@ kubectl exec $jm_pod_name -- /bin/sh -c "kill 1"
 # Check the new JobManager recovering from latest successful checkpoint
 wait_for_logs $jm_pod_name "Restoring job $job_id from Checkpoint" ${TIMEOUT} || exit 1
 wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
+check_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY
+check_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING
 
 echo "Successfully run the Flink Kubernetes application HA test"
 

--- a/e2e-tests/test_last_state_upgrade.sh
+++ b/e2e-tests/test_last_state_upgrade.sh
@@ -51,6 +51,8 @@ retry_times 5 30 "kubectl apply -f e2e-tests/data/cr.yaml" || exit 1
 wait_for_jobmanager_running
 
 wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
+check_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY
+check_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING
 
 job_id=$(kubectl logs $jm_pod_name | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
 
@@ -63,6 +65,8 @@ wait_for_jobmanager_running
 # Check the new JobManager recovering from latest successful checkpoint
 wait_for_logs $jm_pod_name "Restoring job $job_id from Checkpoint" ${TIMEOUT} || exit 1
 wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
+check_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY
+check_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING
 
 echo "Successfully run the last-state upgrade test"
 

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -36,6 +36,20 @@ function wait_for_logs {
   exit 1
 }
 
+function check_status {
+  local resource=$1
+  local status_path=$2
+  local expected_status=$3
+
+  status=$(kubectl get -oyaml $resource | yq $status_path)
+  if [ "$status" == "$expected_status" ]; then
+    echo "Successfully verified that $resource$status_path is in $expected_status state."
+  else
+    echo "Status verification for $resource$status_path failed. It is $status instead of $expected_status."
+    exit 1
+  fi
+}
+
 function retry_times() {
     local retriesNumber=$1
     local backoff=$2


### PR DESCRIPTION
I implemented the additional test as GHA `strategy.matrix`, this seemed the best approach going forward. This provides full separation and parallel execution, but consumes an extra container.

Added additional checks for status messages after the e2e test job completes checkpoints as per @wangyang0918's suggestion. These show up in the logs as follows on successful execution:

```
Log "Completed checkpoint [0-9]+ for job" shows up.
Successfully verified that flinkdep/flink-example-statemachine.status.jobManagerDeploymentStatus is in READY state.
Successfully verified that flinkdep/flink-example-statemachine.status.jobStatus.state is in RUNNING state.
Kill the flink-example-statemachine-7fcf55c88b-qwpl9
Defaulted container "flink-main-container" out of: flink-main-container, artifacts-fetcher (init)
Waiting for log "Restoring job 00000000000000000000000000000000 from Checkpoint"...
Log "Restoring job 00000000000000000000000000000000 from Checkpoint" shows up.
Waiting for log "Completed checkpoint [0-9]+ for job"...
Log "Completed checkpoint [0-9]+ for job" shows up.
Successfully verified that flinkdep/flink-example-statemachine.status.jobManagerDeploymentStatus is in READY state.
Successfully verified that flinkdep/flink-example-statemachine.status.jobStatus.state is in RUNNING state.
Successfully run the Flink Kubernetes application HA test
```

[This](https://github.com/mbalassi/flink-kubernetes-operator/runs/5610713395?check_suite_focus=true) is a negative test where I intentionally tested for an invalid status.