### PR TITLE
[FLINK-26538] Add ability to restart flink deployment

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -55,6 +55,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | jobManager | org.apache.flink.kubernetes.operator.crd.spec.JobManagerSpec | JobManager specs. |
 | taskManager | org.apache.flink.kubernetes.operator.crd.spec.TaskManagerSpec | TaskManager specs. |
 | job | org.apache.flink.kubernetes.operator.crd.spec.JobSpec | Job specification for application deployments. Null for session clusters. |
+| restartNonce | java.lang.Long | Nonce used to manually trigger restart for the cluster. In order to trigger restart, change  the number to anything other than the current value. |
 | logConfiguration | java.util.Map<java.lang.String,java.lang.String> | Log configuration overrides for the Flink deployment. Format logConfigFileName ->  configContent. |
 
 ### FlinkSessionJobSpec

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
@@ -68,6 +68,12 @@ public class FlinkDeploymentSpec {
     private JobSpec job;
 
     /**
+     * Nonce used to manually trigger restart for the cluster. In order to trigger restart, change
+     * the number to anything other than the current value.
+     */
+    private Long restartNonce;
+
+    /**
      * Log configuration overrides for the Flink deployment. Format logConfigFileName ->
      * configContent.
      */

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -58,6 +58,8 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
@@ -161,8 +163,8 @@ public class FlinkService {
                 config, clusterId, (c, e) -> new StandaloneClientHAServices(restServerAddress));
     }
 
-    public Optional<String> cancelJob(JobID jobID, UpgradeMode upgradeMode, Configuration conf)
-            throws Exception {
+    public Optional<String> cancelJob(
+            @Nullable JobID jobID, UpgradeMode upgradeMode, Configuration conf) throws Exception {
         Optional<String> savepointOpt = Optional.empty();
         try (ClusterClient<String> clusterClient = getClusterClient(conf)) {
             switch (upgradeMode) {

--- a/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9072,6 +9072,8 @@ spec:
                     - stateless
                     type: string
                 type: object
+              restartNonce:
+                type: integer
               logConfiguration:
                 additionalProperties:
                   type: string
@@ -18175,6 +18177,8 @@ spec:
                             - stateless
                             type: string
                         type: object
+                      restartNonce:
+                        type: integer
                       logConfiguration:
                         additionalProperties:
                           type: string


### PR DESCRIPTION
This PR is meant to add ability to restart deployment with one-shot command. 

**Brief change**

- Add `restartNonce` in the `FlinkDeployment#spec`
- JobReconciler will react to the `restartNonce` change by restarting the flink deployment.
