### PR TITLE
[FLINK-26554] Upgrade Operator SDK to avoid cleanup race condition

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -31,6 +31,8 @@ import org.apache.flink.kubernetes.operator.validation.FlinkDeploymentValidator;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
+import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.ConfigurationServiceOverrider;
 import io.javaoperatorsdk.operator.config.runtime.DefaultConfigurationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +53,11 @@ public class FlinkOperator {
             namespace = "default";
         }
 
-        DefaultConfigurationService configurationService = DefaultConfigurationService.instance();
+        ConfigurationService configurationService =
+                new ConfigurationServiceOverrider(DefaultConfigurationService.instance())
+                        .checkingCRDAndValidateLocalModel(false)
+                        .build();
+
         Operator operator = new Operator(client, configurationService);
 
         FlinkOperatorConfiguration operatorConfiguration =

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ under the License.
         <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
 
-        <operator.sdk.version>2.1.1</operator.sdk.version>
+        <operator.sdk.version>2.1.2</operator.sdk.version>
         <fabric8.version>5.12.1</fabric8.version>
         <lombok.version>1.18.22</lombok.version>
 


### PR DESCRIPTION
Upgrade the SDK version thus eliminating some annoying exception logs on cleanup caused by a race condition.