### PR TITLE
[FLINK-26706] Introduce Ingress URL templating

### DIFF
--- a/examples/advanced-ingress.yaml
+++ b/examples/advanced-ingress.yaml
@@ -20,12 +20,15 @@ apiVersion: flink.apache.org/v1alpha1
 kind: FlinkDeployment
 metadata:
   namespace: default
-  name: basic-ingress
+  name: advanced-ingress
 spec:
   image: flink:1.14.3
   flinkVersion: v1_14
   ingress:
-    template: "{{name}}.{{namespace}}.flink.k8s.io"
+    template: "/{{namespace}}/{{name}}(/|$)(.*)"
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: "/$2"
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkDeploymentSpec.java
@@ -46,8 +46,8 @@ public class FlinkDeploymentSpec {
     /** Flink image version. */
     private FlinkVersion flinkVersion;
 
-    /** Ingress domain for the Flink deployment. */
-    private String ingressDomain;
+    /** Ingress specs. */
+    private IngressSpec ingress;
 
     /** Flink configuration overrides for the Flink deployment. */
     private Map<String, String> flinkConfiguration;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/IngressSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/IngressSpec.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.crd.spec;
+
+import org.apache.flink.annotation.Experimental;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/** Ingress spec. */
+@Experimental
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class IngressSpec {
+
+    /** Ingress template for the JobManager service. */
+    private String template;
+
+    /** Ingress className for the Flink deployment. */
+    private String className;
+
+    /** Ingress annotations. */
+    private Map<String, String> annotations;
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
@@ -113,7 +113,7 @@ public class FlinkConfigBuilder {
 
     public FlinkConfigBuilder applyIngressDomain() {
         // Web UI
-        if (spec.getIngressDomain() != null) {
+        if (spec.getIngress() != null) {
             effectiveConfig.set(
                     REST_SERVICE_EXPOSED_TYPE,
                     KubernetesConfigOptions.ServiceExposedType.ClusterIP);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -52,6 +52,7 @@ import java.util.Optional;
 public class TestUtils {
 
     public static final String TEST_NAMESPACE = "flink-operator-test";
+    public static final String TEST_DEPLOYMENT_NAME = "test-cluster";
     public static final String SERVICE_ACCOUNT = "flink-operator";
     public static final String FLINK_VERSION = "latest";
     public static final String IMAGE = String.format("flink:%s", FLINK_VERSION);
@@ -63,7 +64,7 @@ public class TestUtils {
         deployment.setStatus(new FlinkDeploymentStatus());
         deployment.setMetadata(
                 new ObjectMetaBuilder()
-                        .withName("test-cluster")
+                        .withName(TEST_DEPLOYMENT_NAME)
                         .withNamespace(TEST_NAMESPACE)
                         .build());
         deployment.setSpec(getTestFlinkDeploymentSpec());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilderTest.java
@@ -73,7 +73,7 @@ public class FlinkConfigBuilderTest {
                 TestUtils.getTestPod("pod2 hostname", "pod2 api version", new ArrayList<>());
 
         flinkDeployment.getSpec().setPodTemplate(pod0);
-        flinkDeployment.getSpec().setIngressDomain("test.com");
+        flinkDeployment.getSpec().getIngress().setTemplate("test.com");
         flinkDeployment.getSpec().getJobManager().setPodTemplate(pod1);
         flinkDeployment.getSpec().getJobManager().setReplicas(2);
         flinkDeployment.getSpec().getTaskManager().setPodTemplate(pod2);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.IngressSpec;
+import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
+
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test class for {@link IngressUtils}. */
+@EnableKubernetesMockClient(crud = true)
+public class IngressUtilsTest {
+
+    KubernetesClient client;
+
+    @Test
+    public void testIngress() {
+        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
+        Configuration config = FlinkUtils.getEffectiveConfig(appCluster, new Configuration());
+
+        // no ingress when ingressDomain is empty
+        IngressUtils.updateIngressRules(appCluster, config, client);
+        assertNull(
+                client.network()
+                        .v1()
+                        .ingresses()
+                        .inNamespace(appCluster.getMetadata().getNamespace())
+                        .withName(appCluster.getMetadata().getName())
+                        .get());
+
+        // host based routing
+        IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
+        builder.template("{{name}}.{{namespace}}.example.com");
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(appCluster, config, client);
+        Ingress ingress =
+                client.network()
+                        .v1()
+                        .ingresses()
+                        .inNamespace(appCluster.getMetadata().getNamespace())
+                        .withName(appCluster.getMetadata().getName())
+                        .get();
+
+        List<IngressRule> rules = ingress.getSpec().getRules();
+        assertEquals(1, rules.size());
+        assertEquals(
+                appCluster.getMetadata().getName()
+                        + "."
+                        + appCluster.getMetadata().getNamespace()
+                        + ".example.com",
+                rules.get(0).getHost());
+        assertNull(rules.get(0).getHttp().getPaths().get(0).getPath());
+
+        // path based routing
+        builder.template("/{{namespace}}/{{name}}(/|$)(.*)");
+        builder.className("nginx");
+        builder.annotations(Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(appCluster, config, client);
+        ingress =
+                client.network()
+                        .v1()
+                        .ingresses()
+                        .inNamespace(appCluster.getMetadata().getNamespace())
+                        .withName(appCluster.getMetadata().getName())
+                        .get();
+        rules = ingress.getSpec().getRules();
+        assertEquals(1, rules.size());
+        assertNull(rules.get(0).getHost());
+        assertEquals(1, rules.get(0).getHttp().getPaths().size());
+        assertEquals(
+                "/"
+                        + appCluster.getMetadata().getNamespace()
+                        + "/"
+                        + appCluster.getMetadata().getName()
+                        + "(/|$)(.*)",
+                rules.get(0).getHttp().getPaths().get(0).getPath());
+        assertEquals(
+                Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"),
+                ingress.getMetadata().getAnnotations());
+        assertEquals("nginx", ingress.getSpec().getIngressClassName());
+
+        // host + path based routing
+        builder.template("example.com/{{namespace}}/{{name}}(/|$)(.*)");
+        builder.className("nginx");
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(appCluster, config, client);
+        ingress =
+                client.network()
+                        .v1()
+                        .ingresses()
+                        .inNamespace(appCluster.getMetadata().getNamespace())
+                        .withName(appCluster.getMetadata().getName())
+                        .get();
+        rules = ingress.getSpec().getRules();
+        assertEquals(1, rules.size());
+        assertEquals(1, rules.get(0).getHttp().getPaths().size());
+        assertEquals(
+                "/"
+                        + appCluster.getMetadata().getNamespace()
+                        + "/"
+                        + appCluster.getMetadata().getName()
+                        + "(/|$)(.*)",
+                rules.get(0).getHttp().getPaths().get(0).getPath());
+        assertEquals(
+                Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"),
+                ingress.getMetadata().getAnnotations());
+        assertEquals("nginx", ingress.getSpec().getIngressClassName());
+    }
+
+    @Test
+    public void testIngressUrl() {
+        String template = "flink.k8s.io/{{namespace}}/{{name}}";
+        URL url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
+        assertEquals("flink.k8s.io", url.getHost());
+        assertEquals("/default/basic-ingress", url.getPath());
+
+        template = "/{{namespace}}/{{name}}";
+        url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
+        assertTrue(StringUtils.isBlank(url.getHost()));
+        assertEquals("/default/basic-ingress", url.getPath());
+
+        template = "{{name}}.{{namespace}}.flink.k8s.io";
+        url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
+
+        assertEquals("basic-ingress.default.flink.k8s.io", url.getHost());
+        assertTrue(StringUtils.isBlank(url.getPath()));
+
+        assertThrows(
+                ReconciliationException.class,
+                () -> IngressUtils.getIngressUrl("example.com:port", "basic-ingress", "default"));
+    }
+}

--- a/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -31,8 +31,17 @@ spec:
                 - v1_15
                 - v1_16
                 type: string
-              ingressDomain:
-                type: string
+              ingress:
+                properties:
+                  template:
+                    type: string
+                  className:
+                    type: string
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
               flinkConfiguration:
                 additionalProperties:
                   type: string
@@ -9125,8 +9134,17 @@ spec:
                         - v1_15
                         - v1_16
                         type: string
-                      ingressDomain:
-                        type: string
+                      ingress:
+                        properties:
+                          template:
+                            type: string
+                          className:
+                            type: string
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        type: object
                       flinkConfiguration:
                         additionalProperties:
                           type: string


### PR DESCRIPTION
- users can customise the endpoint address of the Flink UI
- eliminates the need for a wildcard DNS entry `*.example.com`
- enables path and domain based routing with ingress

