### PR TITLE
[FLINK-26804] Improve e2e test status check stability

### DIFF
--- a/e2e-tests/test_kubernetes_application_ha.sh
+++ b/e2e-tests/test_kubernetes_application_ha.sh
@@ -47,8 +47,8 @@ kubectl wait --for=condition=Ready --timeout=${TIMEOUT}s pod/$jm_pod_name || exi
 wait_for_logs $jm_pod_name "Rest endpoint listening at" ${TIMEOUT} || exit 1
 
 wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
-check_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY
-check_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING
+wait_for_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
+wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
 job_id=$(kubectl logs $jm_pod_name | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
 
@@ -59,8 +59,8 @@ kubectl exec $jm_pod_name -- /bin/sh -c "kill 1"
 # Check the new JobManager recovering from latest successful checkpoint
 wait_for_logs $jm_pod_name "Restoring job $job_id from Checkpoint" ${TIMEOUT} || exit 1
 wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
-check_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY
-check_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING
+wait_for_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
+wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
 echo "Successfully run the Flink Kubernetes application HA test"
 

--- a/e2e-tests/test_last_state_upgrade.sh
+++ b/e2e-tests/test_last_state_upgrade.sh
@@ -51,8 +51,8 @@ retry_times 5 30 "kubectl apply -f e2e-tests/data/cr.yaml" || exit 1
 wait_for_jobmanager_running
 
 wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
-check_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY
-check_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING
+wait_for_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
+wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
 job_id=$(kubectl logs $jm_pod_name | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
 
@@ -65,8 +65,8 @@ wait_for_jobmanager_running
 # Check the new JobManager recovering from latest successful checkpoint
 wait_for_logs $jm_pod_name "Restoring job $job_id from Checkpoint" ${TIMEOUT} || exit 1
 wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
-check_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY
-check_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING
+wait_for_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
+wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
 echo "Successfully run the last-state upgrade test"
 


### PR DESCRIPTION
I went with a simple extra wait-time approach as the tools already existed for this.

The meaningful alternative is to add expected whitelisted states, like `DEPLOYED_NOT_READY` instead of `READY` where we do wait and fail otherwise. I felt that this was unnecessarily complex. 

I will retrigger the e2e tests 3 times before merging this to establish confidence that it does solve the issue. 