### PR TITLE
[FLINK-26816] Verify the java doc is consistent with the code implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,13 @@ jobs:
           distribution: 'adopt'
       - name: Build with Maven
         run: |
-          set -o pipefail; mvn clean install | tee ./mvn.log; set +o pipefail
+          set -o pipefail; mvn clean install -Pgenerate-docs | tee ./mvn.log; set +o pipefail
           if [[ $(grep -c "overlapping classes" ./mvn.log) -gt 0 ]];then
             echo "Found overlapping classes, please fix"
+            exit 1
+          fi
+          if [[ $(git diff HEAD | wc -l) -gt 0 ]];then
+            echo "Please generate the java doc via 'mvn clean install -DskipTests -Pgenerate-docs' again"
             exit 1
           fi
       - name: Start minikube

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -49,7 +49,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | imagePullPolicy | java.lang.String | Image pull policy of the Flink docker image. |
 | serviceAccount | java.lang.String | Kubernetes service used by the Flink deployment. |
 | flinkVersion | org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion | Flink image version. |
-| ingressDomain | java.lang.String | Ingress domain for the Flink deployment. |
+| ingress | org.apache.flink.kubernetes.operator.crd.spec.IngressSpec | Ingress specs. |
 | flinkConfiguration | java.util.Map<java.lang.String,java.lang.String> | Flink configuration overrides for the Flink deployment. |
 | podTemplate | io.fabric8.kubernetes.api.model.Pod | Base pod template for job and task manager pods. Can be overridden by the jobManager and  taskManager pod templates. |
 | jobManager | org.apache.flink.kubernetes.operator.crd.spec.JobManagerSpec | JobManager specs. |
@@ -67,6 +67,17 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | v1_14 |  |
 | v1_15 |  |
 | v1_16 |  |
+
+### IngressSpec
+**Class**: org.apache.flink.kubernetes.operator.crd.spec.IngressSpec
+
+**Description**: Ingress spec.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| template | java.lang.String | Ingress template for the JobManager service. |
+| className | java.lang.String | Ingress className for the Flink deployment. |
+| annotations | java.util.Map<java.lang.String,java.lang.String> | Ingress annotations. |
 
 ### JobManagerSpec
 **Class**: org.apache.flink.kubernetes.operator.crd.spec.JobManagerSpec


### PR DESCRIPTION
We need to verity the java doc is consistent with the code implementation via the CI. Otherwise, it is very easy to forget to re-generate the java doc after some changes. Thanks `git diff` we could make the verification easier :)

A failed case could be found here. https://github.com/wangyang0918/flink-kubernetes-operator/runs/5656298427?check_suite_focus=true

