### PR TITLE
[FLINK-26768] Clear errors when observed running job successfully

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/BaseObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/BaseObserver.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
@@ -143,5 +144,14 @@ public abstract class BaseObserver implements Observer {
 
     protected boolean isClusterReady(FlinkDeployment dep) {
         return dep.getStatus().getJobManagerDeploymentStatus() == JobManagerDeploymentStatus.READY;
+    }
+
+    protected void clearErrorsIfJobManagerDeploymentNotInErrorStatus(FlinkDeployment dep) {
+        if (dep.getStatus().getJobManagerDeploymentStatus() != JobManagerDeploymentStatus.ERROR) {
+            final ReconciliationStatus reconciliationStatus =
+                    dep.getStatus().getReconciliationStatus();
+            reconciliationStatus.setSuccess(true);
+            reconciliationStatus.setError(null);
+        }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobObserver.java
@@ -56,6 +56,7 @@ public class JobObserver extends BaseObserver {
                 observeSavepointStatus(flinkApp, effectiveConfig);
             }
         }
+        clearErrorsIfJobManagerDeploymentNotInErrorStatus(flinkApp);
     }
 
     private boolean observeFlinkJobStatus(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SessionObserver.java
@@ -52,5 +52,6 @@ public class SessionObserver extends BaseObserver {
                 }
             }
         }
+        clearErrorsIfJobManagerDeploymentNotInErrorStatus(flinkApp);
     }
 }


### PR DESCRIPTION
I change the `JobReconciler#reconcile()` a bit in this PR. Even though, the spec does not change, we still have a chance to update the reconciliationStatus.