### PR TITLE
[FLINK-26815] Tests in FlinkConfigBuilderTest are skipped

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilderTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.IngressSpec;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.utils.Constants;
 
@@ -73,7 +74,7 @@ public class FlinkConfigBuilderTest {
                 TestUtils.getTestPod("pod2 hostname", "pod2 api version", new ArrayList<>());
 
         flinkDeployment.getSpec().setPodTemplate(pod0);
-        flinkDeployment.getSpec().getIngress().setTemplate("test.com");
+        flinkDeployment.getSpec().setIngress(IngressSpec.builder().template("test.com").build());
         flinkDeployment.getSpec().getJobManager().setPodTemplate(pod1);
         flinkDeployment.getSpec().getJobManager().setReplicas(2);
         flinkDeployment.getSpec().getTaskManager().setPodTemplate(pod2);

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@ under the License.
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>3.0.0-M4</maven-failsafe-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
 
         <operator.sdk.version>2.1.2</operator.sdk.version>


### PR DESCRIPTION
- hot fix for the NPE caused by [FLINK-26706](https://issues.apache.org/jira/browse/FLINK-26706) Introduce Ingress URL templating
- bumped surfire version see https://issues.apache.org/jira/browse/SUREFIRE-1741
