### PR TITLE
[FLINK-26830] Transition to SUSPEND before redeploying on job upgrades

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -47,7 +47,6 @@ import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -112,7 +111,8 @@ public class FlinkDeploymentController
         if (validationError.isPresent()) {
             LOG.error("Validation failed: " + validationError.get());
             ReconciliationUtils.updateForReconciliationError(flinkApp, validationError.get());
-            return ReconciliationUtils.toUpdateControl(originalCopy, flinkApp);
+            return ReconciliationUtils.toUpdateControl(
+                    operatorConfiguration, originalCopy, flinkApp, false);
         }
 
         Configuration effectiveConfig =
@@ -127,12 +127,8 @@ public class FlinkDeploymentController
             throw new ReconciliationException(e);
         }
 
-        Duration rescheduleAfter =
-                flinkApp.getStatus()
-                        .getJobManagerDeploymentStatus()
-                        .rescheduleAfter(flinkApp, operatorConfiguration);
-        return ReconciliationUtils.toUpdateControl(originalCopy, flinkApp)
-                .rescheduleAfter(rescheduleAfter.toMillis());
+        return ReconciliationUtils.toUpdateControl(
+                operatorConfiguration, originalCopy, flinkApp, true);
     }
 
     private void handleDeploymentFailed(FlinkDeployment flinkApp, DeploymentFailedException dfe) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconciler.java
@@ -64,7 +64,7 @@ public class SessionReconciler extends BaseReconciler {
             upgradeSessionCluster(flinkApp, effectiveConfig);
             IngressUtils.updateIngressRules(flinkApp, effectiveConfig, kubernetesClient);
         }
-        ReconciliationUtils.updateForSpecReconciliationSuccess(flinkApp);
+        ReconciliationUtils.updateForSpecReconciliationSuccess(flinkApp, null);
     }
 
     private void upgradeSessionCluster(FlinkDeployment flinkApp, Configuration effectiveConfig)

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/JobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/JobReconcilerTest.java
@@ -67,6 +67,11 @@ public class JobReconcilerTest {
         reconciler.reconcile(statelessUpgrade, context, config);
 
         runningJobs = flinkService.listJobs();
+        assertEquals(0, runningJobs.size());
+
+        reconciler.reconcile(statelessUpgrade, context, config);
+
+        runningJobs = flinkService.listJobs();
         assertEquals(1, runningJobs.size());
         assertNull(runningJobs.get(0).f0);
 
@@ -79,6 +84,11 @@ public class JobReconcilerTest {
         FlinkDeployment statefulUpgrade = ReconciliationUtils.clone(deployment);
         statefulUpgrade.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
         statefulUpgrade.getSpec().getFlinkConfiguration().put("new", "conf2");
+
+        reconciler.reconcile(statefulUpgrade, context, new Configuration(config));
+
+        runningJobs = flinkService.listJobs();
+        assertEquals(0, runningJobs.size());
 
         reconciler.reconcile(statefulUpgrade, context, new Configuration(config));
 


### PR DESCRIPTION
Break redeployments into two steps to avoid getting into an inconsistent state if job submission fails.