### PR TITLE
[FLINK-26832] Output more status info for JobObserver and BaseObserver

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/BaseObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/BaseObserver.java
@@ -63,7 +63,8 @@ public abstract class BaseObserver implements Observer {
         JobManagerDeploymentStatus previousJmStatus =
                 deploymentStatus.getJobManagerDeploymentStatus();
 
-        logger.info("Observing JobManager deployment status");
+        logger.info(
+                "Observing JobManager deployment. Previous status: {}", previousJmStatus.name());
 
         if (JobManagerDeploymentStatus.DEPLOYED_NOT_READY == previousJmStatus) {
             deploymentStatus.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);


### PR DESCRIPTION
- Make logger output current and next status in JobObserver/BaseObserver to help developers/users track status from k8s log