### PR TITLE
[FLINK-26577] Always trigger a savepoint when upgrade mode changed to last-state

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -17,11 +17,15 @@
 
 package org.apache.flink.kubernetes.operator.reconciler;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
+import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -116,6 +120,29 @@ public class ReconciliationUtils {
                         .rescheduleAfter(current, operatorConfiguration);
 
         return updateControl.rescheduleAfter(rescheduleAfter.toMillis());
+    }
+
+    public static boolean isUpgradeModeChangedToLastStateAndHADisabledPreviously(
+            FlinkDeployment flinkApp) {
+        final FlinkDeploymentSpec lastReconciledSpec =
+                Preconditions.checkNotNull(
+                        flinkApp.getStatus().getReconciliationStatus().getLastReconciledSpec());
+        if (lastReconciledSpec.getJob() == null || flinkApp.getSpec().getJob() == null) {
+            return false;
+        }
+        if (lastReconciledSpec.getFlinkConfiguration() == null
+                || lastReconciledSpec.getFlinkConfiguration().isEmpty()) {
+            return false;
+        }
+        final UpgradeMode previousUpgradeMode = lastReconciledSpec.getJob().getUpgradeMode();
+        final UpgradeMode currentUpgradeMode = flinkApp.getSpec().getJob().getUpgradeMode();
+
+        final Configuration lastReconciledFlinkConfig =
+                Configuration.fromMap(lastReconciledSpec.getFlinkConfiguration());
+
+        return previousUpgradeMode != UpgradeMode.LAST_STATE
+                && currentUpgradeMode == UpgradeMode.LAST_STATE
+                && !HighAvailabilityMode.isHighAvailabilityModeActivated(lastReconciledFlinkConfig);
     }
 
     private static boolean isJobUpgradeInProgress(FlinkDeployment current) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -127,13 +127,6 @@ public class ReconciliationUtils {
         final FlinkDeploymentSpec lastReconciledSpec =
                 Preconditions.checkNotNull(
                         flinkApp.getStatus().getReconciliationStatus().getLastReconciledSpec());
-        if (lastReconciledSpec.getJob() == null || flinkApp.getSpec().getJob() == null) {
-            return false;
-        }
-        if (lastReconciledSpec.getFlinkConfiguration() == null
-                || lastReconciledSpec.getFlinkConfiguration().isEmpty()) {
-            return false;
-        }
         final UpgradeMode previousUpgradeMode = lastReconciledSpec.getJob().getUpgradeMode();
         final UpgradeMode currentUpgradeMode = flinkApp.getSpec().getJob().getUpgradeMode();
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultDeploymentValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultDeploymentValidator.java
@@ -243,19 +243,6 @@ public class DefaultDeploymentValidator implements FlinkDeploymentValidator {
             return Optional.of("Cannot switch from job to session cluster");
         }
 
-        if (StringUtils.isNullOrWhitespaceOnly(
-                        newSpec.getFlinkConfiguration()
-                                .get(CheckpointingOptions.SAVEPOINT_DIRECTORY.key()))
-                && deployment.getStatus().getJobManagerDeploymentStatus()
-                        != JobManagerDeploymentStatus.MISSING
-                && ReconciliationUtils.isUpgradeModeChangedToLastStateAndHADisabledPreviously(
-                        deployment)) {
-            return Optional.of(
-                    String.format(
-                            "Job could not be upgraded to last-state while config key[%s] is not set",
-                            CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
-        }
-
         JobSpec oldJob = oldSpec.getJob();
         JobSpec newJob = newSpec.getJob();
         if (oldJob != null && newJob != null) {
@@ -265,6 +252,19 @@ public class DefaultDeploymentValidator implements FlinkDeploymentValidator {
                     && (deployment.getStatus().getJobStatus().getSavepointInfo().getLastSavepoint()
                             == null)) {
                 return Optional.of("Cannot perform savepoint restore without a valid savepoint");
+            }
+
+            if (StringUtils.isNullOrWhitespaceOnly(
+                            newSpec.getFlinkConfiguration()
+                                    .get(CheckpointingOptions.SAVEPOINT_DIRECTORY.key()))
+                    && deployment.getStatus().getJobManagerDeploymentStatus()
+                            != JobManagerDeploymentStatus.MISSING
+                    && ReconciliationUtils.isUpgradeModeChangedToLastStateAndHADisabledPreviously(
+                            deployment)) {
+                return Optional.of(
+                        String.format(
+                                "Job could not be upgraded to last-state while config key[%s] is not set",
+                                CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
             }
         }
 


### PR DESCRIPTION
> At the moment there are several corner cases which can lead to accidental state loss (or at least weird behaviour) when switching to last-state upgrade mode from other modes.
>
> 2 cases that immediately come to mind:
>
> savepoint to last-state: 
When the new upgrade mode is last-state, the job deployment will simply be deleted. If HA was not enabled previously, the last savepoint might be very far back in time.
>
> stateless to last-state:
If checkpointing and HA is not enabled, the deployment will simply be killed like previously and we might start a job from empty state. Maybe taking a savepoint would be the right approach in this case and continue from there.

After this PR, a savepoint will always be triggered when users change upgrade mode from stateless/savepoint to last-state. This is a safe guard so that we will never lose state.