### PR TITLE
[FLINK-26836] Add sanity check for state.savepoints.dir when using savepoint upgrade mode

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultDeploymentValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultDeploymentValidator.java
@@ -142,15 +142,14 @@ public class DefaultDeploymentValidator implements FlinkDeploymentValidator {
             return Optional.of("Jar URI must be defined");
         }
 
+        Configuration configuration = Configuration.fromMap(confMap);
         if (job.getUpgradeMode() == UpgradeMode.LAST_STATE
-                && !HighAvailabilityMode.isHighAvailabilityModeActivated(
-                        Configuration.fromMap(confMap))) {
+                && !HighAvailabilityMode.isHighAvailabilityModeActivated(configuration)) {
             return Optional.of("Job could not be upgraded with last-state while HA disabled");
         }
 
         if (StringUtils.isNullOrWhitespaceOnly(
-                Configuration.fromMap(confMap)
-                        .getString(CheckpointingOptions.SAVEPOINT_DIRECTORY))) {
+                configuration.getString(CheckpointingOptions.SAVEPOINT_DIRECTORY))) {
             if (job.getUpgradeMode() == UpgradeMode.SAVEPOINT) {
                 return Optional.of(
                         String.format(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.controller;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
@@ -266,6 +267,12 @@ public class FlinkDeploymentControllerTest {
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
         appCluster.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
         appCluster.getSpec().getJob().setInitialSavepointPath("s0");
+        appCluster
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(
+                        CheckpointingOptions.SAVEPOINT_DIRECTORY.key(),
+                        "file:///flink-data/savepoints");
 
         testController.reconcile(appCluster, TestUtils.createEmptyContext());
         List<Tuple2<String, JobStatusMessage>> jobs = flinkService.listJobs();
@@ -395,6 +402,12 @@ public class FlinkDeploymentControllerTest {
 
         appCluster = TestUtils.buildApplicationCluster();
         appCluster.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
+        appCluster
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(
+                        CheckpointingOptions.SAVEPOINT_DIRECTORY.key(),
+                        "file:///flink-data/savepoints");
         testUpgradeNotReadyCluster(appCluster, false);
     }
 


### PR DESCRIPTION
Add sanity check for `state.savepoints.dir` when using savepoint upgrade mode and manually triggering endpoint for the running job.

**The brief change log**
- `DefaultDeploymentValidator` adds the check for `state.savepoints.dir` when the upgrade mode is `SAVEPOINT` or `savepointTriggerNonce` isn't null.