### PR TITLE
[hotfix] Disable flink-kubernetes-operator shade step on apache-release profile

### DIFF
--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -294,6 +294,23 @@ under the License.
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>apache-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>shade-flink-operator</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
This fix disables the shade plugin for the flink-kubernetes-operator module when using the apache-release in order to not deploy the fatjar as part of the release process.