### PR TITLE
[FLINK-26903] Add correct NOTICE file to flink-kubernetes-operator

### DIFF
--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -61,6 +61,12 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-clients_${scala.version}</artifactId>
             <version>${flink.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-scala_${scala.version}</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,113 @@
+flink-kubernetes-operator
+Copyright 2014-2021 The Apache Software Foundation
+
+This project includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- com.fasterxml.jackson.core:jackson-annotations:2.13.1
+- com.fasterxml.jackson.core:jackson-core:2.13.1
+- com.fasterxml.jackson.core:jackson-databind:2.13.1
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.1
+- com.github.mifmif:generex:1.0.2
+- com.google.auto.service:auto-service-annotations:1.0.1
+- com.google.auto.service:auto-service:1.0.1
+- com.google.auto:auto-common:1.2
+- com.google.code.findbugs:jsr305:1.3.9
+- com.google.errorprone:error_prone_annotations:2.7.1
+- com.google.guava:failureaccess:1.0.1
+- com.google.guava:guava:31.0.1-jre
+- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+- com.google.j2objc:j2objc-annotations:1.3
+- com.squareup.okhttp3:logging-interceptor:3.12.12
+- com.squareup.okhttp3:okhttp:3.12.12
+- com.squareup.okio:okio:1.15.0
+- com.squareup:javapoet:1.13.0
+- commons-cli:commons-cli:1.3.1
+- commons-collections:commons-collections:3.2.2
+- commons-io:commons-io:2.8.0
+- io.fabric8:kubernetes-client:5.12.1
+- io.fabric8:kubernetes-model-admissionregistration:5.12.1
+- io.fabric8:kubernetes-model-apiextensions:5.12.1
+- io.fabric8:kubernetes-model-apps:5.12.1
+- io.fabric8:kubernetes-model-autoscaling:5.12.1
+- io.fabric8:kubernetes-model-batch:5.12.1
+- io.fabric8:kubernetes-model-certificates:5.12.1
+- io.fabric8:kubernetes-model-common:5.12.1
+- io.fabric8:kubernetes-model-coordination:5.12.1
+- io.fabric8:kubernetes-model-core:5.12.1
+- io.fabric8:kubernetes-model-discovery:5.12.1
+- io.fabric8:kubernetes-model-events:5.12.1
+- io.fabric8:kubernetes-model-extensions:5.12.1
+- io.fabric8:kubernetes-model-flowcontrol:5.12.1
+- io.fabric8:kubernetes-model-metrics:5.12.1
+- io.fabric8:kubernetes-model-networking:5.12.1
+- io.fabric8:kubernetes-model-node:5.12.1
+- io.fabric8:kubernetes-model-policy:5.12.1
+- io.fabric8:kubernetes-model-rbac:5.12.1
+- io.fabric8:kubernetes-model-scheduling:5.12.1
+- io.fabric8:kubernetes-model-storageclass:5.12.1
+- io.fabric8:openshift-client:5.12.0
+- io.fabric8:openshift-model-clusterautoscaling:5.12.0
+- io.fabric8:openshift-model-console:5.12.0
+- io.fabric8:openshift-model-hive:5.12.0
+- io.fabric8:openshift-model-installer:5.12.0
+- io.fabric8:openshift-model-machine:5.12.0
+- io.fabric8:openshift-model-machineconfig:5.12.0
+- io.fabric8:openshift-model-miscellaneous:5.12.0
+- io.fabric8:openshift-model-monitoring:5.12.0
+- io.fabric8:openshift-model-operator:5.12.0
+- io.fabric8:openshift-model-operatorhub:5.12.0
+- io.fabric8:openshift-model-storageversionmigrator:5.12.0
+- io.fabric8:openshift-model-tuned:5.12.0
+- io.fabric8:openshift-model-whereabouts:5.12.0
+- io.fabric8:openshift-model:5.12.0
+- io.fabric8:zjsonpatch:0.3.0
+- io.javaoperatorsdk:operator-framework-core:2.1.2
+- io.javaoperatorsdk:operator-framework:2.1.2
+- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-math3:3.5
+- org.apache.flink:flink-annotations:1.14.4
+- org.apache.flink:flink-clients_2.12:1.14.4
+- org.apache.flink:flink-core:1.14.4
+- org.apache.flink:flink-file-sink-common:1.14.4
+- org.apache.flink:flink-hadoop-fs:1.14.4
+- org.apache.flink:flink-java:1.14.4
+- org.apache.flink:flink-metrics-core:1.14.4
+- org.apache.flink:flink-optimizer:1.14.4
+- org.apache.flink:flink-queryable-state-client-java:1.14.4
+- org.apache.flink:flink-rpc-akka-loader:1.14.4
+- org.apache.flink:flink-rpc-core:1.14.4
+- org.apache.flink:flink-runtime:1.14.4
+- org.apache.flink:flink-shaded-asm-7:7.1-14.0
+- org.apache.flink:flink-shaded-force-shading:14.0
+- org.apache.flink:flink-shaded-guava:30.1.1-jre-14.0
+- org.apache.flink:flink-shaded-jackson:2.12.4-14.0
+- org.apache.flink:flink-shaded-netty:4.1.65.Final-14.0
+- org.apache.flink:flink-shaded-zookeeper-3:3.4.14-14.0
+- org.apache.flink:flink-streaming-java_2.12:1.14.4
+- org.apache.logging.log4j:log4j-1.2-api:2.17.1
+- org.apache.logging.log4j:log4j-api:2.17.1
+- org.apache.logging.log4j:log4j-core:2.17.1
+- org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+- org.javassist:javassist:3.24.0-GA
+- org.lz4:lz4-java:1.8.0
+- org.objenesis:objenesis:2.1
+- org.slf4j:slf4j-api:1.7.36
+- org.xerial.snappy:snappy-java:1.1.8.3
+- org.yaml:snakeyaml:1.28
+
+This project bundles the following dependencies under the BSD License.
+See bundled license files for details.
+
+- com.esotericsoftware.kryo:kryo:2.24.0
+- com.esotericsoftware.minlog:minlog:1.2
+- dk.brics.automaton:automaton:1.11-8
+
+This project bundles the following dependencies under the MIT license.
+See bundled license files for details.
+
+- org.checkerframework:checker-qual:3.12.0

--- a/flink-kubernetes-operator/src/main/resources/META-INF/licenses/LICENSE.automaton
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/licenses/LICENSE.automaton
@@ -1,0 +1,24 @@
+Copyright (c) 2001-2017 Anders Moeller
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink-kubernetes-operator/src/main/resources/META-INF/licenses/LICENSE.checker-qual
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/licenses/LICENSE.checker-qual
@@ -1,0 +1,22 @@
+Checker Framework qualifiers
+Copyright 2004-present by the Checker Framework developers
+
+MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/flink-kubernetes-operator/src/main/resources/META-INF/licenses/LICENSE.kryo
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/licenses/LICENSE.kryo
@@ -1,0 +1,10 @@
+Copyright (c) 2008, Nathan Sweet
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/flink-kubernetes-operator/src/main/resources/META-INF/licenses/LICENSE.minlog
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/licenses/LICENSE.minlog
@@ -1,0 +1,10 @@
+Copyright (c) 2008, Nathan Sweet
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    * Neither the name of Esoteric Software nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,10 @@ under the License.
                             <exclude>helm/flink-operator/crds/flinkdeployments.flink.apache.org-v1.yml</exclude>
                             <exclude>helm/flink-operator/crds/flinksessionjobs.flink.apache.org-v1.yml</exclude>
                             <exclude>rio.yml</exclude>
+                            <!-- the licenses that are re-bundled -->
+                            <exclude>**/packaged_licenses/LICENSE.*.txt</exclude>
+                            <exclude>**/licenses/LICENSE*</exclude>
+                            <exclude>**/licenses-binary/LICENSE*</exclude>
                         </excludes>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Given that `flink-kubernetes-shaded` already contains a NOTICE file, and `flink-kubernetes-webhook` does not bundle any dependencies. This PR is trying to add a correct NOTICE file only for the `flink-kubernetes-operator` module.

I have reviewed all the bundled dependencies in the uber jar to make sure they are listed in the NOTICE file with correct license.

cc @gyfora @tweise correct me if I miss anything.