### PR TITLE
[FLINK-26214] Support cross platform image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           export SHELL=/bin/bash
           export DOCKER_BUILDKIT=1
           eval $(minikube -p minikube docker-env)
-          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest .
+          docker build --progress=plain  --build-arg SKIP_TESTS=false --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest .
           docker images
       - name: Start the operator
         run: |
@@ -101,7 +101,7 @@ jobs:
           distribution: 'adopt'
       - name: Build with Maven
         run: |
-          set -o pipefail; mvn clean install | tee ./mvn.log; set +o pipefail
+          set -o pipefail; mvn clean install -DskipTests | tee ./mvn.log; set +o pipefail
           if [[ $(grep -c "overlapping classes" ./mvn.log) -gt 0 ]];then
             echo "Found overlapping classes, please fix"
             exit 1

--- a/.github/workflows/docker-bake.hcl
+++ b/.github/workflows/docker-bake.hcl
@@ -1,0 +1,29 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+target "docker-metadata-action" {}
+
+target "bake-platform" {
+  inherits = ["docker-metadata-action"]
+  context = "./"
+  dockerfile = "Dockerfile"
+  platforms = [
+    "linux/amd64",
+    "linux/arm64/v8",
+  ]
+}

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Log in to the Container registry
         uses: docker/login-action@v1
         with:
@@ -58,10 +61,11 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v2
+      - name: Build and push Docker images (supported platforms)
+        uses: docker/bake-action@v1.7.0
         with:
-          context: .
+          files: |
+            .github/workflows/docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: bake-platform
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@
 ################################################################################
 # Build
 FROM maven:3.8.4-openjdk-11 AS build
+ARG SKIP_TESTS=true
 
 WORKDIR /app
 ENV SHADED_DIR=flink-kubernetes-shaded
@@ -35,7 +36,7 @@ COPY $WEBHOOK_DIR/src ./$WEBHOOK_DIR/src
 
 COPY tools ./tools
 
-RUN --mount=type=cache,target=/root/.m2 mvn -ntp clean install
+RUN --mount=type=cache,target=/root/.m2 mvn -ntp clean install -DskipTests=$SKIP_TESTS
 
 # stage
 FROM openjdk:11-jre


### PR DESCRIPTION
This enables us to publish docker build for both `amd64` and `arm64`. You can verify this via:

```shell
% docker manifest inspect ghcr.io/mbalassi/flink-operator:149986a
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3055,
         "digest": "sha256:017787b0c5ccf724f676ed73f26c2928a2d9d58c4464e4ba7fb00ca3f2470158",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3055,
         "digest": "sha256:c37a552f048c0431672dc190e735f4a618bd0c42030de4fea9cdc02dbab88fee",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      }
   ]
}
```

While working on this I noticed instability of the maven tests in the docker builds due to growing latency, so I decided to cut down on the number of times we run the tests for a single commit/PR. The docker build does not run the tests after this change by default, but the CI does.