### PR TITLE
[FLINK-26892] Observe current status before validating CR changes

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -76,7 +76,9 @@ public class FlinkOperator {
         FlinkDeploymentValidator validator = new DefaultDeploymentValidator();
         ReconcilerFactory reconcilerFactory =
                 new ReconcilerFactory(client, flinkService, operatorConfiguration);
-        ObserverFactory observerFactory = new ObserverFactory(flinkService, operatorConfiguration);
+        ObserverFactory observerFactory =
+                new ObserverFactory(
+                        flinkService, operatorConfiguration, defaultConfig.getFlinkConfig());
 
         controller =
                 new FlinkDeploymentController(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobObserver.java
@@ -21,13 +21,11 @@ package org.apache.flink.kubernetes.operator.observer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
-import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
-import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
@@ -43,48 +41,35 @@ import java.util.concurrent.TimeoutException;
 public class JobObserver extends BaseObserver {
 
     public JobObserver(
-            FlinkService flinkService, FlinkOperatorConfiguration operatorConfiguration) {
-        super(flinkService, operatorConfiguration);
+            FlinkService flinkService,
+            FlinkOperatorConfiguration operatorConfiguration,
+            Configuration flinkConfig) {
+        super(flinkService, operatorConfiguration, flinkConfig);
     }
 
     @Override
-    public void observe(FlinkDeployment flinkApp, Context context, Configuration defaultConfig) {
-        FlinkDeploymentSpec lastReconciledSpec =
-                flinkApp.getStatus().getReconciliationStatus().getLastReconciledSpec();
-        // Nothing has been launched so skip observing
-        if (lastReconciledSpec == null) {
-            return;
+    public void observeIfClusterReady(
+            FlinkDeployment flinkApp, Context context, Configuration lastValidatedConfig) {
+        boolean jobFound = observeFlinkJobStatus(flinkApp, context, lastValidatedConfig);
+        if (jobFound) {
+            observeSavepointStatus(flinkApp, lastValidatedConfig);
         }
-
-        Configuration lastValidatedConfig =
-                FlinkUtils.getEffectiveConfig(
-                        flinkApp.getMetadata(), lastReconciledSpec, defaultConfig);
-        if (!isClusterReady(flinkApp)) {
-            observeJmDeployment(flinkApp, context, lastValidatedConfig);
-        }
-        if (isClusterReady(flinkApp)) {
-            boolean jobFound = observeFlinkJobStatus(flinkApp, context, lastValidatedConfig);
-            if (jobFound) {
-                observeSavepointStatus(flinkApp, lastValidatedConfig);
-            }
-        }
-        clearErrorsIfJobManagerDeploymentNotInErrorStatus(flinkApp);
     }
 
     private boolean observeFlinkJobStatus(
-            FlinkDeployment flinkApp, Context context, Configuration effectiveConfig) {
+            FlinkDeployment flinkApp, Context context, Configuration lastValidatedConfig) {
         logger.info("Observing job status");
         FlinkDeploymentStatus flinkAppStatus = flinkApp.getStatus();
         String previousJobStatus = flinkAppStatus.getJobStatus().getState();
         Collection<JobStatusMessage> clusterJobStatuses;
         try {
-            clusterJobStatuses = flinkService.listJobs(effectiveConfig);
+            clusterJobStatuses = flinkService.listJobs(lastValidatedConfig);
         } catch (Exception e) {
             logger.error("Exception while listing jobs", e);
             flinkAppStatus.getJobStatus().setState(JOB_STATE_UNKNOWN);
             if (e instanceof TimeoutException) {
                 // check for problems with the underlying deployment
-                observeJmDeployment(flinkApp, context, effectiveConfig);
+                observeJmDeployment(flinkApp, context, lastValidatedConfig);
             }
             return false;
         }
@@ -123,7 +108,8 @@ public class JobObserver extends BaseObserver {
         return status.getState();
     }
 
-    private void observeSavepointStatus(FlinkDeployment flinkApp, Configuration effectiveConfig) {
+    private void observeSavepointStatus(
+            FlinkDeployment flinkApp, Configuration lastValidatedConfig) {
         SavepointInfo savepointInfo = flinkApp.getStatus().getJobStatus().getSavepointInfo();
         if (!SavepointUtils.savepointInProgress(flinkApp)) {
             logger.debug("Savepoint not in progress");
@@ -133,7 +119,7 @@ public class JobObserver extends BaseObserver {
 
         SavepointFetchResult savepointFetchResult;
         try {
-            savepointFetchResult = flinkService.fetchSavepointInfo(flinkApp, effectiveConfig);
+            savepointFetchResult = flinkService.fetchSavepointInfo(flinkApp, lastValidatedConfig);
         } catch (Exception e) {
             logger.error("Exception while fetching savepoint info", e);
             return;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/Observer.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/Observer.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.kubernetes.operator.observer;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -30,7 +29,6 @@ public interface Observer {
      *
      * @param flinkApp the target flinkDeployment resource
      * @param context the context with which the operation is executed
-     * @param effectiveConfig the effective config of the flinkApp
      */
-    void observe(FlinkDeployment flinkApp, Context context, Configuration effectiveConfig);
+    void observe(FlinkDeployment flinkApp, Context context);
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/ObserverFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/ObserverFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes.operator.observer;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
@@ -30,13 +31,17 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ObserverFactory {
 
     private final FlinkService flinkService;
-    private final FlinkOperatorConfiguration operatorConfiguration;
+    private final FlinkOperatorConfiguration operatorConfig;
+    private final Configuration flinkConfig;
     private final Map<Mode, Observer> observerMap;
 
     public ObserverFactory(
-            FlinkService flinkService, FlinkOperatorConfiguration operatorConfiguration) {
+            FlinkService flinkService,
+            FlinkOperatorConfiguration operatorConfiguration,
+            Configuration flinkConfig) {
         this.flinkService = flinkService;
-        this.operatorConfiguration = operatorConfiguration;
+        this.operatorConfig = operatorConfiguration;
+        this.flinkConfig = flinkConfig;
         this.observerMap = new ConcurrentHashMap<>();
     }
 
@@ -46,9 +51,9 @@ public class ObserverFactory {
                 mode -> {
                     switch (mode) {
                         case SESSION:
-                            return new SessionObserver(flinkService, operatorConfiguration);
+                            return new SessionObserver(flinkService, operatorConfig, flinkConfig);
                         case APPLICATION:
-                            return new JobObserver(flinkService, operatorConfiguration);
+                            return new JobObserver(flinkService, operatorConfig, flinkConfig);
                         default:
                             throw new UnsupportedOperationException(
                                     String.format("Unsupported running mode: %s", mode));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SessionObserver.java
@@ -21,9 +21,7 @@ package org.apache.flink.kubernetes.operator.observer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
-import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
-import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
@@ -33,37 +31,24 @@ import java.util.concurrent.TimeoutException;
 public class SessionObserver extends BaseObserver {
 
     public SessionObserver(
-            FlinkService flinkService, FlinkOperatorConfiguration operatorConfiguration) {
-        super(flinkService, operatorConfiguration);
+            FlinkService flinkService,
+            FlinkOperatorConfiguration operatorConfiguration,
+            Configuration flinkConfig) {
+        super(flinkService, operatorConfiguration, flinkConfig);
     }
 
     @Override
-    public void observe(FlinkDeployment flinkApp, Context context, Configuration defaultConfig) {
-        FlinkDeploymentSpec lastReconciledSpec =
-                flinkApp.getStatus().getReconciliationStatus().getLastReconciledSpec();
-        // Nothing has been launched so skip observing
-        if (lastReconciledSpec == null) {
-            return;
-        }
-
-        Configuration lastValidatedConfig =
-                FlinkUtils.getEffectiveConfig(
-                        flinkApp.getMetadata(), lastReconciledSpec, defaultConfig);
-        if (!isClusterReady(flinkApp)) {
-            observeJmDeployment(flinkApp, context, lastValidatedConfig);
-        }
-        if (isClusterReady(flinkApp)) {
-            // Check if session cluster can serve rest calls following our practice in JobObserver
-            try {
-                flinkService.listJobs(lastValidatedConfig);
-            } catch (Exception e) {
-                logger.error("REST service in session cluster is bad now", e);
-                if (e instanceof TimeoutException) {
-                    // check for problems with the underlying deployment
-                    observeJmDeployment(flinkApp, context, lastValidatedConfig);
-                }
+    public void observeIfClusterReady(
+            FlinkDeployment flinkApp, Context context, Configuration lastValidatedConfig) {
+        // Check if session cluster can serve rest calls following our practice in JobObserver
+        try {
+            flinkService.listJobs(lastValidatedConfig);
+        } catch (Exception e) {
+            logger.error("REST service in session cluster is bad now", e);
+            if (e instanceof TimeoutException) {
+                // check for problems with the underlying deployment
+                observeJmDeployment(flinkApp, context, lastValidatedConfig);
             }
         }
-        clearErrorsIfJobManagerDeploymentNotInErrorStatus(flinkApp);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -25,6 +25,7 @@ import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
 import org.apache.flink.kubernetes.operator.config.DefaultConfig;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
@@ -33,6 +34,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.Service;
@@ -61,9 +63,14 @@ public class FlinkUtils {
 
     public static Configuration getEffectiveConfig(
             FlinkDeployment flinkApp, Configuration flinkConfig) {
+        return getEffectiveConfig(flinkApp.getMetadata(), flinkApp.getSpec(), flinkConfig);
+    }
+
+    public static Configuration getEffectiveConfig(
+            ObjectMeta meta, FlinkDeploymentSpec spec, Configuration flinkConfig) {
         try {
             final Configuration effectiveConfig =
-                    FlinkConfigBuilder.buildFrom(flinkApp, flinkConfig);
+                    FlinkConfigBuilder.buildFrom(meta, spec, flinkConfig);
             LOG.debug("Effective config: {}", effectiveConfig);
             return effectiveConfig;
         } catch (Exception e) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /** Flink service mock for tests. */
@@ -50,6 +51,7 @@ public class TestingFlinkService extends FlinkService {
     private Set<String> sessions = new HashSet<>();
     private boolean isPortReady = true;
     private PodList podList = new PodList();
+    private Consumer<Configuration> listJobConsumer = conf -> {};
 
     public TestingFlinkService() {
         super(null, null);
@@ -80,6 +82,7 @@ public class TestingFlinkService extends FlinkService {
 
     @Override
     public List<JobStatusMessage> listJobs(Configuration conf) throws Exception {
+        listJobConsumer.accept(conf);
         if (jobs.isEmpty() && !sessions.isEmpty()) {
             throw new Exception("Trying to list a job without submitting it");
         }
@@ -87,6 +90,10 @@ public class TestingFlinkService extends FlinkService {
             throw new TimeoutException("JM port is unavailable");
         }
         return jobs.stream().map(t -> t.f1).collect(Collectors.toList());
+    }
+
+    public void setListJobConsumer(Consumer<Configuration> listJobConsumer) {
+        this.listJobConsumer = listJobConsumer;
     }
 
     public List<Tuple2<String, JobStatusMessage>> listJobs() {


### PR DESCRIPTION
- Adjust current logic in `FlinkDeploymentController` from `validate with new config -> observe with new config -> reconcile with new config `to `observe with latest validated config -> validate new config -> reconcile with new config` to get rid of the case that once a wrong config is applied without webhook, the controller will get stuck on the validation error and lose control of the previous running deployment.
- Refactor `FlinkConfigBuilder` to add support of building config with metadata and deployment spec.
- Add corresponding test.