### PR TITLE
[BP][FLINK-26916] Remove job graph from K8s HA ConfigMaps when submitting a Flink application cluster

### DIFF
--- a/e2e-tests/data/cr.yaml
+++ b/e2e-tests/data/cr.yaml
@@ -24,6 +24,11 @@ metadata:
 spec:
   image: flink:1.14.3
   flinkVersion: v1_14
+  ingress:
+    template: "/{{namespace}}/{{name}}(/|$)(.*)"
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: "/$2"
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
     high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
@@ -92,3 +97,15 @@ spec:
   resources:
     requests:
       storage: 1Gi
+
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+  labels:
+    app.kubernetes.io/component: controller
+  name: nginx
+spec:
+  controller: k8s.io/ingress-nginx

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -102,7 +102,8 @@ function start_minikube {
     if ! retry_times 5 30 start_minikube_if_not_running; then
         echo "Could not start minikube. Aborting..."
         exit 1
-   fi
+    fi
+    minikube addons enable ingress
 }
 
 function start_minikube_if_not_running {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
@@ -18,17 +18,32 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
-import org.junit.Assert;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** FlinkUtilsTest. */
+@EnableKubernetesMockClient(crud = true)
 public class FlinkUtilsTest {
+
+    KubernetesClient kubernetesClient;
 
     @Test
     public void testMergePods() throws Exception {
@@ -48,7 +63,37 @@ public class FlinkUtilsTest {
 
         Pod mergedPod = FlinkUtils.mergePodTemplates(pod1, pod2);
 
-        Assert.assertEquals(pod2.getApiVersion(), mergedPod.getApiVersion());
-        Assert.assertEquals(pod2.getSpec().getContainers(), mergedPod.getSpec().getContainers());
+        assertEquals(pod2.getApiVersion(), mergedPod.getApiVersion());
+        assertEquals(pod2.getSpec().getContainers(), mergedPod.getSpec().getContainers());
+    }
+
+    @Test
+    public void testDeleteJobGraphInKubernetesHA() {
+        final String name = "ha-configmap";
+        final String clusterId = "cluster-id";
+        final Map<String, String> data = new HashMap<>();
+        data.put(Constants.JOB_GRAPH_STORE_KEY_PREFIX + JobID.generate(), "job-graph-data");
+        data.put("leader", "localhost");
+        final ConfigMap kubernetesConfigMap =
+                new ConfigMapBuilder()
+                        .withNewMetadata()
+                        .withName(name)
+                        .withLabels(
+                                KubernetesUtils.getConfigMapLabels(
+                                        clusterId,
+                                        Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY))
+                        .endMetadata()
+                        .withData(data)
+                        .build();
+        kubernetesClient.configMaps().create(kubernetesConfigMap);
+        assertNotNull(kubernetesClient.configMaps().withName(name).get());
+        assertEquals(2, kubernetesClient.configMaps().withName(name).get().getData().size());
+
+        FlinkUtils.deleteJobGraphInKubernetesHA(
+                clusterId, kubernetesClient.getNamespace(), kubernetesClient);
+
+        assertEquals(1, kubernetesClient.configMaps().withName(name).get().getData().size());
+        assertTrue(
+                kubernetesClient.configMaps().withName(name).get().getData().containsKey("leader"));
     }
 }


### PR DESCRIPTION
Backport #133 to release-0.1.