### PR TITLE
[FLINK-26893] Validate checkpoint config with last-state upgrade mode

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
@@ -30,6 +30,8 @@ import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.Resource;
+import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
+import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.util.StringUtils;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -41,6 +43,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.time.Duration;
 import java.util.Collections;
 
 import static org.apache.flink.configuration.DeploymentOptionsInternal.CONF_DIR;
@@ -93,6 +96,17 @@ public class FlinkConfigBuilder {
             effectiveConfig.set(
                     REST_SERVICE_EXPOSED_TYPE,
                     KubernetesConfigOptions.ServiceExposedType.ClusterIP);
+        }
+
+        // With last-state upgrade mode, set the default value of 'execution.checkpointing.interval'
+        // to 5 minutes when HA is enabled.
+        if (spec.getJob() != null
+                && spec.getJob().getUpgradeMode() == UpgradeMode.LAST_STATE
+                && FlinkUtils.isKubernetesHAActivated(effectiveConfig)
+                && !effectiveConfig.contains(
+                        ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL)) {
+            effectiveConfig.set(
+                    ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofMinutes(5));
         }
         return this;
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
@@ -102,7 +102,6 @@ public class FlinkConfigBuilder {
         // to 5 minutes when HA is enabled.
         if (spec.getJob() != null
                 && spec.getJob().getUpgradeMode() == UpgradeMode.LAST_STATE
-                && FlinkUtils.isKubernetesHAActivated(effectiveConfig)
                 && !effectiveConfig.contains(
                         ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL)) {
             effectiveConfig.set(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
@@ -58,6 +58,8 @@ public class FlinkConfigBuilder {
     private final FlinkDeploymentSpec spec;
     private final Configuration effectiveConfig;
 
+    public static final Duration DEFAULT_CHECKPOINTING_INTERVAL = Duration.ofMinutes(5);
+
     public FlinkConfigBuilder(FlinkDeployment deploy, Configuration flinkConfig) {
         this(deploy.getMetadata(), deploy.getSpec(), flinkConfig);
     }
@@ -105,7 +107,8 @@ public class FlinkConfigBuilder {
                 && !effectiveConfig.contains(
                         ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL)) {
             effectiveConfig.set(
-                    ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL, Duration.ofMinutes(5));
+                    ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL,
+                    DEFAULT_CHECKPOINTING_INTERVAL);
         }
         return this;
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilderTest.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
@@ -57,6 +56,7 @@ import static org.apache.flink.kubernetes.operator.TestUtils.IMAGE;
 import static org.apache.flink.kubernetes.operator.TestUtils.IMAGE_POLICY;
 import static org.apache.flink.kubernetes.operator.TestUtils.SAMPLE_JAR;
 import static org.apache.flink.kubernetes.operator.TestUtils.SERVICE_ACCOUNT;
+import static org.apache.flink.kubernetes.operator.utils.FlinkConfigBuilder.DEFAULT_CHECKPOINTING_INTERVAL;
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
 
 /** FlinkConfigBuilderTest. */
@@ -146,7 +146,7 @@ public class FlinkConfigBuilderTest {
                         .applyFlinkConfiguration()
                         .build();
         Assert.assertEquals(
-                Duration.ofMinutes(5),
+                DEFAULT_CHECKPOINTING_INTERVAL,
                 configuration.get(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL));
     }
 


### PR DESCRIPTION
When last-state upgrade mode is selected, the validation whether checkpointing is turned on (in addition to the HA settings) should be considered.

**The brief change log**
- `DefaultDeploymentValidator` adds the validation whether checkpointing is turned on when upgrade mode is `LAST_STATE`.