### PR TITLE
[FLINK-26996] Break the reconcile after first create session cluster

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconciler.java
@@ -57,13 +57,14 @@ public class SessionReconciler extends BaseReconciler {
             flinkApp.getStatus()
                     .setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
             IngressUtils.updateIngressRules(flinkApp, effectiveConfig, kubernetesClient);
+        } else {
+            boolean specChanged = !flinkApp.getSpec().equals(lastReconciledSpec);
+            if (specChanged) {
+                upgradeSessionCluster(flinkApp, effectiveConfig);
+                IngressUtils.updateIngressRules(flinkApp, effectiveConfig, kubernetesClient);
+            }
         }
 
-        boolean specChanged = !flinkApp.getSpec().equals(lastReconciledSpec);
-        if (specChanged) {
-            upgradeSessionCluster(flinkApp, effectiveConfig);
-            IngressUtils.updateIngressRules(flinkApp, effectiveConfig, kubernetesClient);
-        }
         ReconciliationUtils.updateForSpecReconciliationSuccess(flinkApp, null);
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconciler.java
@@ -57,12 +57,14 @@ public class SessionReconciler extends BaseReconciler {
             flinkApp.getStatus()
                     .setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
             IngressUtils.updateIngressRules(flinkApp, effectiveConfig, kubernetesClient);
-        } else {
-            boolean specChanged = !flinkApp.getSpec().equals(lastReconciledSpec);
-            if (specChanged) {
-                upgradeSessionCluster(flinkApp, effectiveConfig);
-                IngressUtils.updateIngressRules(flinkApp, effectiveConfig, kubernetesClient);
-            }
+            ReconciliationUtils.updateForSpecReconciliationSuccess(flinkApp, null);
+            return;
+        }
+
+        boolean specChanged = !flinkApp.getSpec().equals(lastReconciledSpec);
+        if (specChanged) {
+            upgradeSessionCluster(flinkApp, effectiveConfig);
+            IngressUtils.updateIngressRules(flinkApp, effectiveConfig, kubernetesClient);
         }
 
         ReconciliationUtils.updateForSpecReconciliationSuccess(flinkApp, null);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconcilerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for {@link SessionReconciler}. */
+public class SessionReconcilerTest {
+
+    private final FlinkOperatorConfiguration operatorConfiguration =
+            FlinkOperatorConfiguration.fromConfiguration(new Configuration());
+
+    @Test
+    public void testStartSession() throws Exception {
+        Context context = TestUtils.createEmptyContext();
+        var count = new AtomicInteger();
+        TestingFlinkService flinkService =
+                new TestingFlinkService() {
+                    @Override
+                    public void submitSessionCluster(
+                            FlinkDeployment deployment, Configuration conf) {
+                        super.submitSessionCluster(deployment, conf);
+                        count.addAndGet(1);
+                    }
+                };
+
+        SessionReconciler reconciler =
+                new SessionReconciler(null, flinkService, operatorConfiguration);
+        FlinkDeployment deployment = TestUtils.buildSessionCluster();
+        reconciler.reconcile(deployment, context, new Configuration());
+        assertEquals(count.get(), 1);
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/SessionReconcilerTest.java
@@ -39,7 +39,7 @@ public class SessionReconcilerTest {
     @Test
     public void testStartSession() throws Exception {
         Context context = TestUtils.createEmptyContext();
-        var count = new AtomicInteger();
+        var count = new AtomicInteger(0);
         TestingFlinkService flinkService =
                 new TestingFlinkService() {
                     @Override
@@ -54,6 +54,6 @@ public class SessionReconcilerTest {
                 new SessionReconciler(null, flinkService, operatorConfiguration);
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
         reconciler.reconcile(deployment, context, new Configuration());
-        assertEquals(count.get(), 1);
+        assertEquals(1, count.get());
     }
 }


### PR DESCRIPTION
When I test session cluster, I found that it will always start twice for the session cluster. I think this fix should be included in the release-0.1