### PR TITLE
[FLINK-27012] Caching maven dependencies to speed up workflows in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,13 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Build with Maven
         run: |
           set -o pipefail; mvn clean install -Pgenerate-docs | tee ./mvn.log; set +o pipefail
@@ -99,6 +106,13 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Build with Maven
         run: |
           set -o pipefail; mvn clean install -DskipTests | tee ./mvn.log; set +o pipefail


### PR DESCRIPTION
Using [cache](https://github.com/marketplace/actions/cache) to speed up workflows.