### PR TITLE
[FLINK-27000] Support to set JVM args for operator

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,12 +27,12 @@ if [ "$1" = "help" ]; then
 elif [ "$1" = "operator" ]; then
     echo "Starting Operator"
 
-    exec java -cp /$FLINK_KUBERNETES_SHADED_JAR:/$OPERATOR_JAR $LOG_CONFIG org.apache.flink.kubernetes.operator.FlinkOperator
+    exec java $JVM_ARGS -cp /$FLINK_KUBERNETES_SHADED_JAR:/$OPERATOR_JAR $LOG_CONFIG org.apache.flink.kubernetes.operator.FlinkOperator
 elif [ "$1" = "webhook" ]; then
     echo "Starting Webhook"
 
     # Adds the operator shaded jar on the classpath when the webhook starts
-    exec java -cp /$FLINK_KUBERNETES_SHADED_JAR:/$OPERATOR_JAR:/$WEBHOOK_JAR $LOG_CONFIG org.apache.flink.kubernetes.operator.admission.FlinkOperatorWebhook
+    exec java $JVM_ARGS -cp /$FLINK_KUBERNETES_SHADED_JAR:/$OPERATOR_JAR:/$WEBHOOK_JAR $LOG_CONFIG org.apache.flink.kubernetes.operator.admission.FlinkOperatorWebhook
 fi
 
 args=("${args[@]}")

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -27,12 +27,12 @@ if [ "$1" = "help" ]; then
 elif [ "$1" = "operator" ]; then
     echo "Starting Operator"
 
-    exec java $JVM_ARGS -cp /$FLINK_KUBERNETES_SHADED_JAR:/$OPERATOR_JAR $LOG_CONFIG org.apache.flink.kubernetes.operator.FlinkOperator
+    exec java -cp /$FLINK_KUBERNETES_SHADED_JAR:/$OPERATOR_JAR $LOG_CONFIG $JVM_ARGS org.apache.flink.kubernetes.operator.FlinkOperator
 elif [ "$1" = "webhook" ]; then
     echo "Starting Webhook"
 
     # Adds the operator shaded jar on the classpath when the webhook starts
-    exec java $JVM_ARGS -cp /$FLINK_KUBERNETES_SHADED_JAR:/$OPERATOR_JAR:/$WEBHOOK_JAR $LOG_CONFIG org.apache.flink.kubernetes.operator.admission.FlinkOperatorWebhook
+    exec java -cp /$FLINK_KUBERNETES_SHADED_JAR:/$OPERATOR_JAR:/$WEBHOOK_JAR $LOG_CONFIG $JVM_ARGS org.apache.flink.kubernetes.operator.admission.FlinkOperatorWebhook
 fi
 
 args=("${args[@]}")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -36,6 +36,7 @@ import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.validation.DefaultValidator;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
+import org.apache.flink.runtime.util.EnvironmentInformation;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -65,7 +66,6 @@ public class FlinkOperator {
     }
 
     public FlinkOperator(DefaultConfig defaultConfig) {
-        LOG.info("Starting Flink Kubernetes Operator");
         OperatorMetricUtils.initOperatorMetrics(defaultConfig.getOperatorConfig());
 
         this.defaultConfig = defaultConfig;
@@ -156,6 +156,7 @@ public class FlinkOperator {
     }
 
     public static void main(String... args) {
+        EnvironmentInformation.logEnvironmentInfo(LOG, "Flink Kubernetes Operator", args);
         new FlinkOperator().run();
     }
 }

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.admission;
 
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 import org.apache.flink.kubernetes.operator.validation.DefaultValidator;
+import org.apache.flink.runtime.util.EnvironmentInformation;
 
 import org.apache.flink.shaded.netty4.io.netty.bootstrap.ServerBootstrap;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
@@ -54,7 +55,7 @@ public class FlinkOperatorWebhook {
     private static final int MAX_CONTEXT_LENGTH = 104_857_600;
 
     public static void main(String[] args) throws Exception {
-        LOG.info("Starting Flink Kubernetes Webhook");
+        EnvironmentInformation.logEnvironmentInfo(LOG, "Flink Kubernetes Webhook", args);
         AdmissionHandler endpoint =
                 new AdmissionHandler(new FlinkValidator(new DefaultValidator()));
         ChannelInitializer<SocketChannel> initializer = createChannelInitializer(endpoint);

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -67,6 +67,8 @@ spec:
               value: /opt/flink-operator/conf
             - name: LOG_CONFIG
               value: -Dlog4j.configurationFile=/opt/flink-operator/conf/log4j2.properties
+            - name: JVM_ARGS
+              value: {{ .Values.jvmArgs.operator }}
             - name: FLINK_OPERATOR_WATCH_NAMESPACES
               value: {{ join "," .Values.watchNamespaces  }}
           volumeMounts:
@@ -102,6 +104,8 @@ spec:
               value: "9443"
             - name: LOG_CONFIG
               value: -Dlog4j.configurationFile=/opt/flink-operator/conf/log4j2.properties
+            - name: JVM_ARGS
+              value: {{ .Values.jvmArgs.webhook }}
           volumeMounts:
           - name: keystore
             mountPath: "/certs"

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -95,3 +95,8 @@ metrics:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+
+# Set the jvm start up options for webhook and operator
+jvmArgs:
+  webhook: ""
+  operator: ""


### PR DESCRIPTION
Provide a way to set jvm args and also print the start up options using the flink tools

---

By this we can also easily remote debug in the minikube environment 

```
helm install flink-operator helm/flink-kubernetes-operator  --set image.repository=aitozi/flink-java-operator --set image.tag=latest --set jvmArgs.operator='-agentlib:jdwp=transport=dt_socket\,server=y\,suspend=y\,address=*:5005'

kubectl port-forward {operator-pod} 5005:5005
```