### PR TITLE
[hotfix] Change email/repository notifications to match with Flink Core settings

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,16 @@
+github:
+  enabled_merge_buttons:
+    squash: true
+    merge: false
+    rebase: true
+  labels:
+    - flink
+    - big-data
+    - java
+notifications:
+  commits:      commits@flink.apache.org
+  issues:       issues@flink.apache.org
+  pullrequests: issues@flink.apache.org
+  jobs:         builds@flink.apache.org
+  jira_options: link label
+


### PR DESCRIPTION
Making sure that notification schema is setup like it's currently for Flink core. Details about this file can be found in https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features