### PR TITLE
[FLINK-27124] Flink Kubernetes operator prints starting logs with wrong version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY $OPERATOR_DIR/pom.xml ./$OPERATOR_DIR/
 COPY $OPERATOR_DIR/src ./$OPERATOR_DIR/src
 COPY $WEBHOOK_DIR/src ./$WEBHOOK_DIR/src
 
+COPY .git ./.git
 COPY tools ./tools
 
 RUN --mount=type=cache,target=/root/.m2 mvn -ntp clean install -DskipTests=$SKIP_TESTS

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -138,6 +138,17 @@ under the License.
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+            </resource>
+            <resource>
+                <directory>src/main/resources-filtered</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
@@ -281,6 +292,35 @@ under the License.
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <!-- Description: https://github.com/git-commit-id/git-commit-id-maven-plugin
+                    Used to show the git ref when starting the Flink Kubernetes operator. -->
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>${git-commit-id-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <skipPoms>false</skipPoms>
+                    <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                    <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+                    <generateGitPropertiesFile>true</generateGitPropertiesFile>
+                    <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties
+                    </generateGitPropertiesFilename>
+                    <includeOnlyProperties>
+                        <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.time$</includeOnlyProperty>
+                    </includeOnlyProperties>
+                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -33,10 +33,10 @@ import org.apache.flink.kubernetes.operator.reconciler.Reconciler;
 import org.apache.flink.kubernetes.operator.reconciler.deployment.ReconcilerFactory;
 import org.apache.flink.kubernetes.operator.reconciler.sessionjob.FlinkSessionJobReconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
-import org.apache.flink.runtime.util.EnvironmentInformation;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -159,7 +159,7 @@ public class FlinkOperator {
     }
 
     public static void main(String... args) {
-        EnvironmentInformation.logEnvironmentInfo(LOG, "Flink Kubernetes Operator", args);
+        EnvUtils.logEnvironmentInfo(LOG, "Flink Kubernetes Operator", args);
         new FlinkOperator().run();
     }
 }

--- a/flink-kubernetes-operator/src/main/resources-filtered/.flink-kubernetes-operator.version.properties
+++ b/flink-kubernetes-operator/src/main/resources-filtered/.flink-kubernetes-operator.version.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project.version=${project.version}
+git.commit.id.abbrev=${git.commit.id.abbrev}
+git.commit.time=${git.commit.time}

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
@@ -19,7 +19,6 @@ package org.apache.flink.kubernetes.operator.admission;
 
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 import org.apache.flink.kubernetes.operator.validation.DefaultValidator;
-import org.apache.flink.runtime.util.EnvironmentInformation;
 
 import org.apache.flink.shaded.netty4.io.netty.bootstrap.ServerBootstrap;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
@@ -55,7 +54,7 @@ public class FlinkOperatorWebhook {
     private static final int MAX_CONTEXT_LENGTH = 104_857_600;
 
     public static void main(String[] args) throws Exception {
-        EnvironmentInformation.logEnvironmentInfo(LOG, "Flink Kubernetes Webhook", args);
+        EnvUtils.logEnvironmentInfo(LOG, "Flink Kubernetes Webhook", args);
         AdmissionHandler endpoint =
                 new AdmissionHandler(new FlinkValidator(new DefaultValidator()));
         ChannelInitializer<SocketChannel> initializer = createChannelInitializer(endpoint);

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@ under the License.
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
+        <git-commit-id-maven-plugin.version>5.0.0</git-commit-id-maven-plugin.version>
 
         <operator.sdk.version>2.1.2</operator.sdk.version>
         <fabric8.version>5.12.1</fabric8.version>
@@ -256,6 +257,7 @@ under the License.
                             <exclude>**/dependency-reduced-pom.xml</exclude>
                             <!-- Administrative files in the main trunk. -->
                             <exclude>**/README.md</exclude>
+                            <exclude>.git/**</exclude>
                             <exclude>.github/**</exclude>
                             <!-- Build files -->
                             <exclude>**/*.iml</exclude>


### PR DESCRIPTION
```
2022-04-07 11:48:01,357 o.a.f.k.o.FlinkOperator       [INFO ]  Starting Flink Kubernetes Operator (Version: 1.14.4, Scala: 2.12, Rev:895c609, Date:2022-02-25T11:57:14+01:00) 
```
The version information in `FlinkOperator` and `FlinkOperatorWebhook` come from Flink binary, not the flink-kubernetes-operator.

**The brief change log**

-` EnvUtils` adds the `logEnvironmentInfo` method to log information about the environment, like project version, code revision, current user, Java version, and JVM parameters.