### PR TITLE
[FLINK-27154] Disable web.cancel.enable for application clusters

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilder.java
@@ -102,9 +102,11 @@ public class FlinkConfigBuilder {
         }
 
         if (spec.getJob() != null) {
-            // Set 'web.cancel.enable' to false for application deployments to avoid users
-            // accidentally cancelling jobs.
-            effectiveConfig.set(CANCEL_ENABLE, false);
+            if (!effectiveConfig.contains(CANCEL_ENABLE)) {
+                // Set 'web.cancel.enable' to false for application deployments to avoid users
+                // accidentally cancelling jobs.
+                effectiveConfig.set(CANCEL_ENABLE, false);
+            }
             // With last-state upgrade mode, set the default value of
             // 'execution.checkpointing.interval'
             // to 5 minutes when HA is enabled.

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkConfigBuilderTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.configuration.WebOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
@@ -117,6 +118,7 @@ public class FlinkConfigBuilderTest {
         Assert.assertEquals(
                 KubernetesConfigOptions.ServiceExposedType.ClusterIP,
                 configuration.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE));
+        Assert.assertEquals(false, configuration.get(WebOptions.CANCEL_ENABLE));
 
         FlinkDeployment deployment = ReconciliationUtils.clone(flinkDeployment);
         deployment


### PR DESCRIPTION
`web.cancel.enable` should be set to false for application deployments to avoid users accidentally cancelling jobs.

**The brief change log**

- `FlinkConfigBuilder` set `web.cancel.enable` to false for application deployments.