### PR TITLE
[FLINK-26871] Handle session job spec change

### DIFF
--- a/examples/basic-session-job.yaml
+++ b/examples/basic-session-job.yaml
@@ -17,13 +17,67 @@
 ################################################################################
 
 apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  namespace: default
+  name: basic-session-cluster-with-ha
+spec:
+  image: flink:1.14
+  flinkVersion: v1_14
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "2"
+    state.savepoints.dir: file:///flink-data/savepoints
+    high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
+    high-availability.storageDir: file:///flink-data/ha
+#    kubernetes.rest-service.exposed.type: LoadBalancer
+  jobManager:
+    replicas: 1
+    resource:
+      memory: "2048m"
+      cpu: 1
+  taskManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  podTemplate:
+    spec:
+      serviceAccount: flink
+      containers:
+        - name: flink-main-container
+          volumeMounts:
+            - mountPath: /flink-data
+              name: flink-volume
+      volumes:
+        - name: flink-volume
+          hostPath:
+            # directory location on host
+            path: /tmp/flink
+            # this field is optional
+            type: Directory
+---
+apiVersion: flink.apache.org/v1beta1
 kind: FlinkSessionJob
 metadata:
   namespace: default
-  name: basic-session-job-example
+  name: basic-session-ha-job-example
 spec:
-  clusterId: basic-session-example
+  clusterId: basic-session-cluster-with-ha
   job:
     jarURI: file:///opt/flink/artifacts/TopSpeedWindowing.jar
+    parallelism: 4
+    upgradeMode: savepoint
+    savepointTriggerNonce: 1
+
+---
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  namespace: default
+  name: basic-session-ha-job-example2
+spec:
+  clusterId: basic-session-cluster-with-ha
+  job:
+    jarURI: file:///opt/flink/artifacts/flink-examples-streaming_2.12-1.14.3.jar
     parallelism: 2
     upgradeMode: stateless
+    entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -107,7 +107,9 @@ public class FlinkOperator {
     private void registerSessionJobController() {
         Reconciler<FlinkSessionJob> reconciler =
                 new FlinkSessionJobReconciler(client, flinkService, operatorConfiguration);
-        Observer<FlinkSessionJob> observer = new SessionJobObserver();
+        Observer<FlinkSessionJob> observer =
+                new SessionJobObserver(
+                        operatorConfiguration, flinkService, defaultConfig.getFlinkConfig());
         FlinkSessionJobController controller =
                 new FlinkSessionJobController(
                         defaultConfig,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
@@ -29,7 +29,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class JobStatus {
     /** Name of the job. */
     private String jobName;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.observer;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
+import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.runtime.client.JobStatusMessage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeoutException;
+
+import static org.apache.flink.kubernetes.operator.observer.deployment.AbstractDeploymentObserver.JOB_STATE_UNKNOWN;
+
+/** An observer to observe the job status. */
+public abstract class JobStatusObserver<CTX> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JobStatusObserver.class);
+    private final FlinkService flinkService;
+
+    public JobStatusObserver(FlinkService flinkService) {
+        this.flinkService = flinkService;
+    }
+
+    /**
+     * Observe the status of the flink job.
+     *
+     * @param jobStatus The job status to be observed.
+     * @param lastValidatedConfig The last validated config.
+     * @return If job found return true, otherwise return false.
+     */
+    public boolean observe(JobStatus jobStatus, Configuration lastValidatedConfig, CTX ctx) {
+        LOG.info("Observing job status");
+        var previousJobStatus = jobStatus.getState();
+        List<JobStatusMessage> clusterJobStatuses;
+        try {
+            clusterJobStatuses = new ArrayList<>(flinkService.listJobs(lastValidatedConfig));
+        } catch (Exception e) {
+            LOG.error("Exception while listing jobs", e);
+            jobStatus.setState(JOB_STATE_UNKNOWN);
+            if (e instanceof TimeoutException) {
+                onTimeout(ctx);
+            }
+            return false;
+        }
+
+        if (!clusterJobStatuses.isEmpty()) {
+            Optional<String> targetJobStatus = updateJobStatus(jobStatus, clusterJobStatuses);
+            if (targetJobStatus.isEmpty()) {
+                jobStatus.setState(JOB_STATE_UNKNOWN);
+                return false;
+            } else {
+                if (targetJobStatus.get().equals(previousJobStatus)) {
+                    LOG.info("Job status ({}) unchanged", previousJobStatus);
+                } else {
+                    LOG.info(
+                            "Job status successfully updated from {} to {}",
+                            previousJobStatus,
+                            targetJobStatus);
+                }
+            }
+            return true;
+        } else {
+            jobStatus.setState(JOB_STATE_UNKNOWN);
+            LOG.info("No job found on cluster yet");
+            return false;
+        }
+    }
+
+    /** Callback when list jobs timeout. */
+    protected abstract void onTimeout(CTX ctx);
+
+    /**
+     * Find and update previous job status based on the job list from the cluster and return the
+     * target status.
+     *
+     * @param status the target job status to be updated.
+     * @param clusterJobStatuses the candidate cluster jobs.
+     * @return The target status of the job. If no matched job found, {@code Optional.empty()} will
+     *     be returned.
+     */
+    protected abstract Optional<String> updateJobStatus(
+            JobStatus status, List<JobStatusMessage> clusterJobStatuses);
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.observer;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
+import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+/** An observer of savepoint progress. */
+public class SavepointObserver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SavepointObserver.class);
+
+    private final FlinkService flinkService;
+    private final FlinkOperatorConfiguration operatorConfiguration;
+
+    public SavepointObserver(
+            FlinkService flinkService, FlinkOperatorConfiguration operatorConfiguration) {
+        this.flinkService = flinkService;
+        this.operatorConfiguration = operatorConfiguration;
+    }
+
+    /**
+     * Observe the savepoint result based on the current savepoint info.
+     *
+     * @param currentSavepointInfo the current savepoint info.
+     * @param jobID the jobID of the observed job.
+     * @param lastValidatedConfig the last validated config.
+     * @return The observed error, if no error observed, {@code Optional.empty()} will be returned.
+     */
+    public Optional<String> observe(
+            SavepointInfo currentSavepointInfo, String jobID, Configuration lastValidatedConfig) {
+        if (currentSavepointInfo.getTriggerId() == null) {
+            LOG.debug("Savepoint not in progress");
+            return Optional.empty();
+        }
+        LOG.info("Observing savepoint status");
+        SavepointFetchResult savepointFetchResult;
+        try {
+            savepointFetchResult =
+                    flinkService.fetchSavepointInfo(
+                            currentSavepointInfo.getTriggerId(), jobID, lastValidatedConfig);
+        } catch (Exception e) {
+            LOG.error("Exception while fetching savepoint info", e);
+            return Optional.empty();
+        }
+
+        if (!savepointFetchResult.isTriggered()) {
+            String error = savepointFetchResult.getError();
+            if (error != null
+                    || SavepointUtils.gracePeriodEnded(
+                            operatorConfiguration, currentSavepointInfo)) {
+                String errorMsg = error != null ? error : "Savepoint status unknown";
+                LOG.error(errorMsg);
+                currentSavepointInfo.resetTrigger();
+                return Optional.of(errorMsg);
+            }
+            LOG.info("Savepoint operation not running, waiting within grace period...");
+        }
+        if (savepointFetchResult.getSavepoint() == null) {
+            LOG.info("Savepoint is still in progress...");
+            return Optional.empty();
+        }
+        LOG.info("Savepoint status updated with latest completed savepoint info");
+        currentSavepointInfo.updateLastSavepoint(savepointFetchResult.getSavepoint());
+        return Optional.empty();
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/context/ApplicationObserverContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/context/ApplicationObserverContext.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.observer.context;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+
+/** A context for application observer. */
+public class ApplicationObserverContext {
+
+    public final FlinkDeployment flinkApp;
+    public final Context context;
+    public final Configuration lastValidatedConfig;
+
+    public ApplicationObserverContext(
+            FlinkDeployment flinkApp, Context context, Configuration lastValidatedConfig) {
+        this.flinkApp = flinkApp;
+        this.context = context;
+        this.lastValidatedConfig = lastValidatedConfig;
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/context/VoidObserverContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/context/VoidObserverContext.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.observer.context;
+
+/** A empty observer context. */
+public class VoidObserverContext {
+    public static final VoidObserverContext INSTANCE = new VoidObserverContext();
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
@@ -20,128 +20,73 @@ package org.apache.flink.kubernetes.operator.observer.deployment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
-import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
-import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
-import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
+import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
+import org.apache.flink.kubernetes.operator.observer.SavepointObserver;
+import org.apache.flink.kubernetes.operator.observer.context.ApplicationObserverContext;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
-import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
+import java.util.Optional;
 
 /** The observer of {@link org.apache.flink.kubernetes.operator.config.Mode#APPLICATION} cluster. */
 public class ApplicationObserver extends AbstractDeploymentObserver {
+
+    private final SavepointObserver savepointObserver;
+    private final JobStatusObserver<ApplicationObserverContext> jobStatusObserver;
 
     public ApplicationObserver(
             FlinkService flinkService,
             FlinkOperatorConfiguration operatorConfiguration,
             Configuration flinkConfig) {
         super(flinkService, operatorConfiguration, flinkConfig);
+        this.savepointObserver = new SavepointObserver(flinkService, operatorConfiguration);
+        this.jobStatusObserver =
+                new JobStatusObserver<>(flinkService) {
+                    @Override
+                    public void onTimeout(ApplicationObserverContext ctx) {
+                        observeJmDeployment(ctx.flinkApp, ctx.context, ctx.lastValidatedConfig);
+                    }
+
+                    @Override
+                    protected Optional<String> updateJobStatus(
+                            JobStatus status, List<JobStatusMessage> clusterJobStatuses) {
+                        clusterJobStatuses.sort(
+                                (j1, j2) -> Long.compare(j2.getStartTime(), j1.getStartTime()));
+                        JobStatusMessage newJob = clusterJobStatuses.get(0);
+
+                        status.setState(newJob.getJobState().name());
+                        status.setJobName(newJob.getJobName());
+                        status.setJobId(newJob.getJobId().toHexString());
+                        status.setStartTime(String.valueOf(newJob.getStartTime()));
+                        status.setUpdateTime(String.valueOf(System.currentTimeMillis()));
+                        return Optional.of(status.getState());
+                    }
+                };
     }
 
     @Override
     public void observeIfClusterReady(
             FlinkDeployment flinkApp, Context context, Configuration lastValidatedConfig) {
-        boolean jobFound = observeFlinkJobStatus(flinkApp, context, lastValidatedConfig);
+        boolean jobFound =
+                jobStatusObserver.observe(
+                        flinkApp.getStatus().getJobStatus(),
+                        lastValidatedConfig,
+                        new ApplicationObserverContext(flinkApp, context, lastValidatedConfig));
         if (jobFound) {
-            observeSavepointStatus(flinkApp, lastValidatedConfig);
+            savepointObserver
+                    .observe(
+                            flinkApp.getStatus().getJobStatus().getSavepointInfo(),
+                            flinkApp.getStatus().getJobStatus().getJobId(),
+                            lastValidatedConfig)
+                    .ifPresent(
+                            error ->
+                                    ReconciliationUtils.updateForReconciliationError(
+                                            flinkApp, error));
         }
-    }
-
-    private boolean observeFlinkJobStatus(
-            FlinkDeployment flinkApp, Context context, Configuration lastValidatedConfig) {
-        logger.info("Observing job status");
-        FlinkDeploymentStatus flinkAppStatus = flinkApp.getStatus();
-        String previousJobStatus = flinkAppStatus.getJobStatus().getState();
-        Collection<JobStatusMessage> clusterJobStatuses;
-        try {
-            clusterJobStatuses = flinkService.listJobs(lastValidatedConfig);
-        } catch (Exception e) {
-            logger.error("Exception while listing jobs", e);
-            flinkAppStatus.getJobStatus().setState(JOB_STATE_UNKNOWN);
-            if (e instanceof TimeoutException) {
-                // check for problems with the underlying deployment
-                observeJmDeployment(flinkApp, context, lastValidatedConfig);
-            }
-            return false;
-        }
-        if (clusterJobStatuses.isEmpty()) {
-            logger.info("No job found on cluster yet");
-            flinkAppStatus.getJobStatus().setState(JOB_STATE_UNKNOWN);
-            return false;
-        }
-        String targetJobStatus =
-                updateJobStatus(flinkAppStatus.getJobStatus(), new ArrayList<>(clusterJobStatuses));
-        if (targetJobStatus.equals(previousJobStatus)) {
-            logger.info("Job status ({}) unchanged", previousJobStatus);
-        } else {
-            logger.info(
-                    "Job status successfully updated from {} to {}",
-                    previousJobStatus,
-                    targetJobStatus);
-        }
-        return true;
-    }
-
-    /**
-     * Update previous job status based on the job list from the cluster and return the target
-     * status.
-     */
-    private String updateJobStatus(JobStatus status, List<JobStatusMessage> clusterJobStatuses) {
-        Collections.sort(
-                clusterJobStatuses, (j1, j2) -> Long.compare(j2.getStartTime(), j1.getStartTime()));
-        JobStatusMessage newJob = clusterJobStatuses.get(0);
-
-        status.setState(newJob.getJobState().name());
-        status.setJobName(newJob.getJobName());
-        status.setJobId(newJob.getJobId().toHexString());
-        status.setStartTime(String.valueOf(newJob.getStartTime()));
-        status.setUpdateTime(String.valueOf(System.currentTimeMillis()));
-        return status.getState();
-    }
-
-    private void observeSavepointStatus(
-            FlinkDeployment flinkApp, Configuration lastValidatedConfig) {
-        SavepointInfo savepointInfo = flinkApp.getStatus().getJobStatus().getSavepointInfo();
-        if (!SavepointUtils.savepointInProgress(flinkApp)) {
-            logger.debug("Savepoint not in progress");
-            return;
-        }
-        logger.info("Observing savepoint status");
-
-        SavepointFetchResult savepointFetchResult;
-        try {
-            savepointFetchResult = flinkService.fetchSavepointInfo(flinkApp, lastValidatedConfig);
-        } catch (Exception e) {
-            logger.error("Exception while fetching savepoint info", e);
-            return;
-        }
-
-        if (!savepointFetchResult.isTriggered()) {
-            String error = savepointFetchResult.getError();
-            if (error != null
-                    || SavepointUtils.gracePeriodEnded(operatorConfiguration, savepointInfo)) {
-                String errorMsg = error != null ? error : "Savepoint status unknown";
-                logger.error(errorMsg);
-                savepointInfo.resetTrigger();
-                ReconciliationUtils.updateForReconciliationError(flinkApp, errorMsg);
-                return;
-            }
-            logger.info("Savepoint operation not running, waiting within grace period...");
-        }
-        if (savepointFetchResult.getSavepoint() == null) {
-            logger.info("Savepoint is still in progress...");
-            return;
-        }
-        logger.info("Savepoint status updated with latest completed savepoint info");
-        savepointInfo.updateLastSavepoint(savepointFetchResult.getSavepoint());
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -240,6 +240,9 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
 
     private void triggerSavepoint(FlinkDeployment deployment, Configuration effectiveConfig)
             throws Exception {
-        flinkService.triggerSavepoint(deployment, effectiveConfig);
+        flinkService.triggerSavepoint(
+                deployment.getStatus().getJobStatus().getJobId(),
+                deployment.getStatus().getJobStatus().getSavepointInfo(),
+                effectiveConfig);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobHelper.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobHelper.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler.sessionjob;
+
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkSessionJobSpec;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+
+import org.slf4j.Logger;
+
+import java.util.Optional;
+
+/** A tool for session job management condition checker. */
+public class SessionJobHelper {
+
+    private final Logger logger;
+    private final FlinkSessionJob sessionJob;
+    private final FlinkSessionJobSpec lastReconciledSpec;
+
+    public SessionJobHelper(FlinkSessionJob sessionJob, Logger logger) {
+        this.sessionJob = sessionJob;
+        this.lastReconciledSpec =
+                sessionJob.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
+        this.logger = logger;
+    }
+
+    public boolean savepointInProgress() {
+        return sessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId() != null;
+    }
+
+    public boolean shouldTriggerSavepoint() {
+        if (lastReconciledSpec == null) {
+            return false;
+        }
+        if (savepointInProgress()) {
+            return false;
+        }
+        return savepointTriggerNonce() != null
+                && !savepointTriggerNonce()
+                        .equals(lastReconciledSpec.getJob().getSavepointTriggerNonce());
+    }
+
+    private Long savepointTriggerNonce() {
+        return sessionJob.getSpec().getJob().getSavepointTriggerNonce();
+    }
+
+    public boolean specChanged(FlinkSessionJobSpec lastReconciledSpec) {
+        return !sessionJob.getSpec().equals(lastReconciledSpec);
+    }
+
+    public boolean isJobRunning(FlinkDeployment deployment) {
+        FlinkDeploymentStatus status = deployment.getStatus();
+        JobManagerDeploymentStatus deploymentStatus = status.getJobManagerDeploymentStatus();
+        return deploymentStatus == JobManagerDeploymentStatus.READY
+                && org.apache.flink.api.common.JobStatus.RUNNING
+                        .name()
+                        .equals(sessionJob.getStatus().getJobStatus().getState());
+    }
+
+    public boolean sessionClusterReady(Optional<FlinkDeployment> flinkDeploymentOpt) {
+        if (flinkDeploymentOpt.isPresent()) {
+            var flinkdep = flinkDeploymentOpt.get();
+            var jobmanagerDeploymentStatus = flinkdep.getStatus().getJobManagerDeploymentStatus();
+            if (jobmanagerDeploymentStatus != JobManagerDeploymentStatus.READY) {
+                logger.info(
+                        "Session cluster deployment is in {} status, not ready for serve",
+                        jobmanagerDeploymentStatus);
+                return false;
+            } else {
+                return true;
+            }
+        } else {
+            logger.info("Session cluster deployment is not found");
+            return false;
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -279,8 +279,16 @@ public class DefaultValidator implements FlinkResourceValidator {
             FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
 
         return firstPresent(
+                validateJobNotEmpty(sessionJob),
                 validateNotApplicationCluster(session),
                 validateSessionClusterId(sessionJob, session));
+    }
+
+    private Optional<String> validateJobNotEmpty(FlinkSessionJob sessionJob) {
+        if (sessionJob.getSpec().getJob() == null) {
+            return Optional.of("The job spec should not be empty");
+        }
+        return Optional.empty();
     }
 
     private Optional<String> validateSessionClusterId(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -224,6 +224,11 @@ public class TestUtils {
     }
 
     public static Context createContextWithReadyFlinkDeployment() {
+        return createContextWithReadyFlinkDeployment(new HashMap<>());
+    }
+
+    public static Context createContextWithReadyFlinkDeployment(
+            Map<String, String> flinkDepConfig) {
         return new Context() {
             @Override
             public Optional<RetryInfo> getRetryInfo() {
@@ -235,6 +240,7 @@ public class TestUtils {
                     Class<T> expectedType, String eventSourceName) {
                 var session = buildSessionCluster();
                 session.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+                session.getSpec().getFlinkConfiguration().putAll(flinkDepConfig);
                 return Optional.of((T) session);
             }
         };

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.kubernetes.operator.observer;
+package org.apache.flink.kubernetes.operator.observer.deployment;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
@@ -27,8 +27,6 @@ import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
-import org.apache.flink.kubernetes.operator.observer.deployment.AbstractDeploymentObserver;
-import org.apache.flink.kubernetes.operator.observer.deployment.ApplicationObserver;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 
@@ -159,7 +157,10 @@ public class ApplicationObserverTest {
                 JobManagerDeploymentStatus.READY,
                 deployment.getStatus().getJobManagerDeploymentStatus());
 
-        flinkService.triggerSavepoint(deployment, conf);
+        flinkService.triggerSavepoint(
+                deployment.getStatus().getJobStatus().getJobId(),
+                deployment.getStatus().getJobStatus().getSavepointInfo(),
+                conf);
         assertEquals(
                 "trigger_0",
                 deployment.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
@@ -175,7 +176,10 @@ public class ApplicationObserverTest {
         assertNull(deployment.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
         assertNull(deployment.getStatus().getJobStatus().getSavepointInfo().getTriggerTimestamp());
 
-        flinkService.triggerSavepoint(deployment, conf);
+        flinkService.triggerSavepoint(
+                deployment.getStatus().getJobStatus().getJobId(),
+                deployment.getStatus().getJobStatus().getSavepointInfo(),
+                conf);
         assertEquals(
                 "trigger_1",
                 deployment.getStatus().getJobStatus().getSavepointInfo().getTriggerId());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -1,11 +1,10 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -16,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.kubernetes.operator.observer;
+package org.apache.flink.kubernetes.operator.observer.deployment;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
@@ -24,7 +23,7 @@ import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
-import org.apache.flink.kubernetes.operator.observer.deployment.SessionObserver;
+import org.apache.flink.kubernetes.operator.observer.Observer;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.observer.sessionjob;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.config.DefaultConfig;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.reconciler.sessionjob.FlinkSessionJobReconciler;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.apache.flink.kubernetes.operator.observer.deployment.AbstractDeploymentObserver.JOB_STATE_UNKNOWN;
+
+/** Tests for {@link SessionJobObserver}. */
+public class SessionJobObserverTest {
+
+    private final FlinkOperatorConfiguration operatorConfiguration =
+            FlinkOperatorConfiguration.fromConfiguration(new Configuration());
+    private final DefaultConfig defaultConfig =
+            new DefaultConfig(new Configuration(), new Configuration());
+
+    @Test
+    public void testBasicObserve() throws Exception {
+        final var sessionJob = TestUtils.buildSessionJob();
+        final var flinkService = new TestingFlinkService();
+        final var reconciler =
+                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+        final var observer =
+                new SessionJobObserver(
+                        operatorConfiguration, flinkService, defaultConfig.getFlinkConfig());
+        final var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+
+        // observe the brand new job, nothing to do.
+        observer.observe(sessionJob, readyContext);
+
+        // submit job
+        reconciler.reconcile(sessionJob, readyContext, defaultConfig.getFlinkConfig());
+        var jobID = sessionJob.getStatus().getJobStatus().getJobId();
+        Assertions.assertNotNull(jobID);
+        Assertions.assertEquals(
+                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+
+        // observe with empty context will do nothing
+        observer.observe(sessionJob, TestUtils.createEmptyContext());
+        Assertions.assertEquals(
+                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+
+        // observe with ready context
+        observer.observe(sessionJob, readyContext);
+        Assertions.assertEquals(
+                JobStatus.RUNNING.name(), sessionJob.getStatus().getJobStatus().getState());
+
+        flinkService.setPortReady(false);
+        observer.observe(sessionJob, readyContext);
+        Assertions.assertEquals(
+                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+
+        sessionJob.getStatus().getJobStatus().setState(JobStatus.RUNNING.name());
+        // no matched job id, update the state to unknown
+        flinkService.setPortReady(true);
+        sessionJob.getStatus().getJobStatus().setJobId(new JobID().toHexString());
+        observer.observe(sessionJob, readyContext);
+        Assertions.assertEquals(
+                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+        sessionJob.getStatus().getJobStatus().setJobId(jobID);
+
+        // testing multi job
+
+        var sessionJob2 = TestUtils.buildSessionJob();
+        // submit the second job
+        reconciler.reconcile(sessionJob2, readyContext, defaultConfig.getFlinkConfig());
+        var jobID2 = sessionJob2.getStatus().getJobStatus().getJobId();
+        Assertions.assertNotNull(jobID);
+        Assertions.assertNotEquals(jobID, jobID2);
+        Assertions.assertEquals(
+                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+        observer.observe(sessionJob2, readyContext);
+        Assertions.assertEquals(
+                JobStatus.RUNNING.name(), sessionJob2.getStatus().getJobStatus().getState());
+        observer.observe(sessionJob, readyContext);
+        Assertions.assertEquals(
+                JobStatus.RUNNING.name(), sessionJob.getStatus().getJobStatus().getState());
+    }
+
+    @Test
+    public void testObserveWithEffectiveConfig() throws Exception {
+        final var sessionJob = TestUtils.buildSessionJob();
+        final var flinkService = new TestingFlinkService();
+        final var reconciler =
+                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+        final var observer =
+                new SessionJobObserver(
+                        operatorConfiguration, flinkService, defaultConfig.getFlinkConfig());
+        final var readyContext =
+                TestUtils.createContextWithReadyFlinkDeployment(
+                        Map.of(RestOptions.PORT.key(), "8088"));
+
+        // submit job
+        reconciler.reconcile(sessionJob, readyContext, defaultConfig.getFlinkConfig());
+        var jobID = sessionJob.getStatus().getJobStatus().getJobId();
+        Assertions.assertNotNull(jobID);
+        Assertions.assertEquals(
+                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+
+        flinkService.setListJobConsumer(
+                configuration ->
+                        Assertions.assertEquals(8088, configuration.getInteger(RestOptions.PORT)));
+        observer.observe(sessionJob, readyContext);
+        Assertions.assertEquals(
+                JobStatus.RUNNING.name(), sessionJob.getStatus().getJobStatus().getState());
+    }
+
+    @Test
+    public void testObserveSavepoint() throws Exception {
+        final var sessionJob = TestUtils.buildSessionJob();
+        final var flinkService = new TestingFlinkService();
+        final var reconciler =
+                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+        final var observer =
+                new SessionJobObserver(
+                        operatorConfiguration, flinkService, defaultConfig.getFlinkConfig());
+        final var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+
+        // submit job
+        reconciler.reconcile(sessionJob, readyContext, defaultConfig.getFlinkConfig());
+        var jobID = sessionJob.getStatus().getJobStatus().getJobId();
+        Assertions.assertNotNull(jobID);
+        Assertions.assertEquals(
+                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+
+        observer.observe(sessionJob, readyContext);
+        Assertions.assertEquals(
+                JobStatus.RUNNING.name(), sessionJob.getStatus().getJobStatus().getState());
+
+        var savepointInfo = sessionJob.getStatus().getJobStatus().getSavepointInfo();
+        Assertions.assertNull(savepointInfo.getTriggerId());
+        Assertions.assertNull(savepointInfo.getTriggerTimestamp());
+
+        flinkService.triggerSavepoint(jobID, savepointInfo, defaultConfig.getFlinkConfig());
+
+        Assertions.assertEquals("trigger_0", savepointInfo.getTriggerId());
+        observer.observe(sessionJob, readyContext);
+        Assertions.assertEquals("savepoint_0", savepointInfo.getLastSavepoint().getLocation());
+        Assertions.assertNull(savepointInfo.getTriggerId());
+        Assertions.assertNull(savepointInfo.getTriggerTimestamp());
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -353,12 +353,15 @@ public class ApplicationReconcilerTest {
         assertEquals(1, runningJobs.size());
         assertNull(runningJobs.get(0).f0);
 
-        JobStatus jobStatus = new JobStatus();
-        jobStatus.setJobName(runningJobs.get(0).f1.getJobName());
-        jobStatus.setJobId(runningJobs.get(0).f1.getJobId().toHexString());
-        jobStatus.setState("RUNNING");
-
-        deployment.getStatus().setJobStatus(jobStatus);
+        deployment
+                .getStatus()
+                .setJobStatus(
+                        new JobStatus()
+                                .toBuilder()
+                                .jobId(runningJobs.get(0).f1.getJobId().toHexString())
+                                .jobName(runningJobs.get(0).f1.getJobName())
+                                .state("RUNNING")
+                                .build());
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
@@ -17,20 +17,35 @@
 
 package org.apache.flink.kubernetes.operator.reconciler.sessionjob;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.crd.spec.JobState;
+import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
+import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+import static org.apache.flink.kubernetes.operator.observer.deployment.AbstractDeploymentObserver.JOB_STATE_UNKNOWN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for {@link FlinkSessionJobReconciler}. */
 public class FlinkSessionJobReconcilerTest {
 
     private final FlinkOperatorConfiguration operatorConfiguration =
             FlinkOperatorConfiguration.fromConfiguration(new Configuration());
+    private final Configuration defaultConfig = new Configuration();
 
     @Test
     public void testSubmitAndCleanUp() throws Exception {
@@ -39,23 +54,301 @@ public class FlinkSessionJobReconcilerTest {
 
         FlinkSessionJobReconciler reconciler =
                 new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
-        reconciler.reconcile(sessionJob, TestUtils.createEmptyContext(), new Configuration());
-        Assertions.assertEquals(0, flinkService.listJobs().size());
+        // session not found
+        reconciler.reconcile(sessionJob, TestUtils.createEmptyContext(), defaultConfig);
+        assertEquals(0, flinkService.listSessionJobs().size());
+
+        // session not ready
         reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithNotReadyFlinkDeployment(), defaultConfig);
+        assertEquals(0, flinkService.listSessionJobs().size());
+
+        // session ready
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(), defaultConfig);
+        assertEquals(1, flinkService.listSessionJobs().size());
+        verifyAndSetRunningJobsToStatus(
                 sessionJob,
-                TestUtils.createContextWithNotReadyFlinkDeployment(),
-                new Configuration());
-        Assertions.assertEquals(0, flinkService.listJobs().size());
-        reconciler.reconcile(
-                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(), new Configuration());
-        Assertions.assertEquals(1, flinkService.listJobs().size());
+                JobState.RUNNING,
+                JOB_STATE_UNKNOWN,
+                null,
+                flinkService.listSessionJobs());
         // clean up
-        sessionJob
+        reconciler.cleanup(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(), defaultConfig);
+        assertEquals(0, flinkService.listSessionJobs().size());
+    }
+
+    @Test
+    public void testSubmitWithInitialSavepointPath() throws Exception {
+        TestingFlinkService flinkService = new TestingFlinkService();
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+
+        var initSavepointPath = "file:///init-sp";
+        sessionJob.getSpec().getJob().setInitialSavepointPath(initSavepointPath);
+        FlinkSessionJobReconciler reconciler =
+                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(), defaultConfig);
+        verifyAndSetRunningJobsToStatus(
+                sessionJob,
+                JobState.RUNNING,
+                JOB_STATE_UNKNOWN,
+                initSavepointPath,
+                flinkService.listSessionJobs());
+    }
+
+    @Test
+    public void testStatelessUpgrade() throws Exception {
+        TestingFlinkService flinkService = new TestingFlinkService();
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        FlinkSessionJobReconciler reconciler =
+                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+        reconciler.reconcile(sessionJob, readyContext, defaultConfig);
+        assertEquals(1, flinkService.listSessionJobs().size());
+        verifyAndSetRunningJobsToStatus(
+                sessionJob,
+                JobState.RUNNING,
+                JOB_STATE_UNKNOWN,
+                null,
+                flinkService.listSessionJobs());
+
+        var statelessSessionJob = ReconciliationUtils.clone(sessionJob);
+        statelessSessionJob.getSpec().getJob().setUpgradeMode(UpgradeMode.STATELESS);
+        statelessSessionJob.getSpec().getJob().setParallelism(2);
+        // job suspended first
+        reconciler.reconcile(statelessSessionJob, readyContext, defaultConfig);
+        assertTrue(flinkService.listSessionJobs().isEmpty());
+        verifyJobState(statelessSessionJob, JobState.SUSPENDED, JobState.SUSPENDED.name());
+
+        reconciler.reconcile(statelessSessionJob, readyContext, defaultConfig);
+        assertEquals(1, flinkService.listSessionJobs().size());
+        verifyAndSetRunningJobsToStatus(
+                statelessSessionJob,
+                JobState.RUNNING,
+                JOB_STATE_UNKNOWN,
+                null,
+                flinkService.listSessionJobs());
+    }
+
+    @Test
+    public void testSavepointUpgrade() throws Exception {
+        TestingFlinkService flinkService = new TestingFlinkService();
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+        FlinkSessionJobReconciler reconciler =
+                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        reconciler.reconcile(sessionJob, readyContext, defaultConfig);
+        // start the job
+        assertEquals(1, flinkService.listSessionJobs().size());
+
+        // update job spec
+        var statefulSessionJob = ReconciliationUtils.clone(sessionJob);
+        statefulSessionJob.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
+        statefulSessionJob.getSpec().getJob().setParallelism(3);
+        reconciler.reconcile(statefulSessionJob, readyContext, defaultConfig);
+
+        // job suspended first
+        assertTrue(flinkService.listSessionJobs().isEmpty());
+        verifyJobState(statefulSessionJob, JobState.SUSPENDED, JobState.SUSPENDED.name());
+
+        // upgraded
+        reconciler.reconcile(statefulSessionJob, readyContext, defaultConfig);
+        assertEquals(1, flinkService.listSessionJobs().size());
+        verifyAndSetRunningJobsToStatus(
+                statefulSessionJob,
+                JobState.RUNNING,
+                JOB_STATE_UNKNOWN,
+                "savepoint_0",
+                flinkService.listSessionJobs());
+    }
+
+    @Test
+    public void testUseTheEffectiveConfigToSubmit() throws Exception {
+        TestingFlinkService flinkService = new TestingFlinkService();
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+
+        var readyContext =
+                TestUtils.createContextWithReadyFlinkDeployment(Map.of("key", "newValue"));
+        FlinkSessionJobReconciler reconciler =
+                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+        var cfg = new Configuration(defaultConfig);
+        cfg.setString("key", "value");
+        reconciler.reconcile(sessionJob, readyContext, cfg);
+
+        assertEquals(1, flinkService.listSessionJobs().size());
+        var submittedJob =
+                verifyAndReturnTheSubmittedJob(sessionJob, flinkService.listSessionJobs());
+        assertEquals("newValue", submittedJob.effectiveConfig.getString("key", null));
+    }
+
+    @Test
+    public void testTriggerSavepoint() throws Exception {
+        TestingFlinkService flinkService = new TestingFlinkService();
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+        assertNull(sessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        FlinkSessionJobReconciler reconciler =
+                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+        reconciler.reconcile(sessionJob, readyContext, defaultConfig);
+        verifyAndSetRunningJobsToStatus(
+                sessionJob,
+                JobState.RUNNING,
+                JOB_STATE_UNKNOWN,
+                null,
+                flinkService.listSessionJobs());
+
+        assertNull(sessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+
+        // trigger savepoint
+        var sp1SessionJob = ReconciliationUtils.clone(sessionJob);
+
+        // do not trigger savepoint if nonce is null
+        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        assertNull(sessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+
+        sp1SessionJob.getSpec().getJob().setSavepointTriggerNonce(2L);
+        sp1SessionJob
                 .getStatus()
                 .getJobStatus()
-                .setJobId(flinkService.listJobs().get(0).f1.getJobId().toHexString());
-        reconciler.cleanup(
-                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(), new Configuration());
-        Assertions.assertEquals(0, flinkService.listJobs().size());
+                .setState(org.apache.flink.api.common.JobStatus.CREATED.name());
+        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        // do not trigger savepoint if job is not running
+        assertNull(sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+
+        sp1SessionJob
+                .getStatus()
+                .getJobStatus()
+                .setState(org.apache.flink.api.common.JobStatus.RUNNING.name());
+
+        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        assertEquals(
+                "trigger_0",
+                sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+
+        // the last reconcile nonce updated
+        assertEquals(
+                2L,
+                sp1SessionJob
+                        .getStatus()
+                        .getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getSavepointTriggerNonce());
+
+        // don't trigger new savepoint when savepoint is in progress
+        sp1SessionJob.getSpec().getJob().setSavepointTriggerNonce(3L);
+        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        assertEquals(
+                "trigger_0",
+                sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+
+        // don't trigger upgrade when savepoint is in progress
+        assertEquals(
+                1,
+                sp1SessionJob
+                        .getStatus()
+                        .getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getParallelism());
+        sp1SessionJob.getSpec().getJob().setParallelism(100);
+        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        assertEquals(
+                "trigger_0",
+                sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+        // parallelism not changed
+        assertEquals(
+                1,
+                sp1SessionJob
+                        .getStatus()
+                        .getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getParallelism());
+
+        sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
+
+        // running -> suspended
+        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        // suspended -> running
+        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        // parallelism changed
+        assertEquals(
+                100,
+                sp1SessionJob
+                        .getStatus()
+                        .getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getParallelism());
+        verifyAndSetRunningJobsToStatus(
+                sp1SessionJob,
+                JobState.RUNNING,
+                JOB_STATE_UNKNOWN,
+                null,
+                flinkService.listSessionJobs());
+
+        sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
+
+        // don't trigger when nonce is the same
+        sp1SessionJob.getSpec().getJob().setSavepointTriggerNonce(2L);
+        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        assertNull(sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+
+        // trigger when new nonce is defined
+        sp1SessionJob.getSpec().getJob().setSavepointTriggerNonce(3L);
+        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        assertEquals(
+                "trigger_1",
+                sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+        sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
+
+        // don't trigger when nonce is cleared
+        sp1SessionJob.getSpec().getJob().setSavepointTriggerNonce(null);
+        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        assertNull(sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+    }
+
+    private TestingFlinkService.SubmittedJobInfo verifyAndReturnTheSubmittedJob(
+            FlinkSessionJob sessionJob,
+            Map<JobID, TestingFlinkService.SubmittedJobInfo> sessionJobs) {
+        var jobID = JobID.fromHexString(sessionJob.getStatus().getJobStatus().getJobId());
+        var submittedJobInfo = sessionJobs.get(jobID);
+        Assertions.assertNotNull(submittedJobInfo);
+        return submittedJobInfo;
+    }
+
+    private void verifyAndSetRunningJobsToStatus(
+            FlinkSessionJob sessionJob,
+            JobState expectedState,
+            String jobStatusObserved,
+            @Nullable String expectedSavepointPath,
+            Map<JobID, TestingFlinkService.SubmittedJobInfo> sessionJobs) {
+
+        var submittedJobInfo = verifyAndReturnTheSubmittedJob(sessionJob, sessionJobs);
+        assertEquals(expectedSavepointPath, submittedJobInfo.savepointPath);
+
+        verifyJobState(sessionJob, expectedState, jobStatusObserved);
+        JobStatus jobStatus = sessionJob.getStatus().getJobStatus();
+        jobStatus.setJobName(submittedJobInfo.jobStatusMessage.getJobName());
+        jobStatus.setState("RUNNING");
+    }
+
+    private void verifyJobState(
+            FlinkSessionJob sessionJob, JobState expectedState, String jobStatusObserved) {
+        assertEquals(
+                expectedState,
+                sessionJob
+                        .getStatus()
+                        .getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getState());
+
+        assertEquals(jobStatusObserved, sessionJob.getStatus().getJobStatus().getState());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
@@ -175,7 +175,10 @@ public class FlinkServiceTest {
         JobStatus jobStatus = new JobStatus();
         jobStatus.setJobId(jobID.toString());
         flinkDeployment.getStatus().setJobStatus(jobStatus);
-        flinkService.triggerSavepoint(flinkDeployment, configuration);
+        flinkService.triggerSavepoint(
+                flinkDeployment.getStatus().getJobStatus().getJobId(),
+                flinkDeployment.getStatus().getJobStatus().getSavepointInfo(),
+                configuration);
         assertTrue(triggerSavepointFuture.isDone());
         assertEquals(jobID, triggerSavepointFuture.get().f0);
         assertEquals(savepointPath, triggerSavepointFuture.get().f1);

--- a/flink-kubernetes-operator/src/test/resources/log4j2-test.properties
+++ b/flink-kubernetes-operator/src/test/resources/log4j2-test.properties
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+rootLogger.level = OFF
+rootLogger.appenderRef.console.ref = ConsoleAppender
+
+# Log all infos to the console
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %style{%d}{yellow} %style{%-30c{1.}}{cyan} %highlight{[%-5level]%notEmpty{[%X{resource.namespace}/}%notEmpty{%X{resource.name}]} %msg%n%throwable}


### PR DESCRIPTION
This PR is meant to support the upgrade/trigger savepoint for the session job. The brief change as below:

- Complete the `FlinkSessionJobReconciler` to handle spec change
- Complete the `SessionJobObserver` to observe the job status and savepoint result
- Add the `FlinkSessionJobReconcilerTest` and `SessionJobObserverTest` to verify the change.

I have done the basic verification locally to verify the upgrade with `sateless` and `savepoint` and trigger savepoint. But as I test, the `cancel` operation will always cleanup the HA data. So I have not figured out how to support `last_state` mode in session job. So I disable the `last_state` mode now.

An e2e test will be introduce in a following PR to guard the session job functional.