### PR TITLE
[FLINK-26140] Support rollback strategies

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -170,6 +170,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | jobStatus | org.apache.flink.kubernetes.operator.crd.status.JobStatus | Last observed status of the Flink job on Application deployments. |
 | jobManagerDeploymentStatus | org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus | Last observed status of the JobManager deployment. |
 | reconciliationStatus | org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus | Status of the last reconcile operation. |
+| error | java.lang.String | Error information about the Flink deployment. |
 
 ### FlinkSessionJobReconciliationStatus
 **Class**: org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobReconciliationStatus
@@ -178,8 +179,6 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
-| success | boolean | True if last reconciliation step was successful. |
-| error | java.lang.String | If success == false, error information about the reconciliation failure. |
 | lastReconciledSpec | java.lang.String | Last reconciled job spec. Used to decide whether further reconciliation steps are necessary. |
 
 ### FlinkSessionJobStatus
@@ -191,6 +190,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | jobStatus | org.apache.flink.kubernetes.operator.crd.status.JobStatus | Last observed status of the job. |
 | reconciliationStatus | org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobReconciliationStatus | Status of the last reconcile operation. |
+| error | java.lang.String | Error information about the session job. |
 
 ### JobManagerDeploymentStatus
 **Class**: org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus
@@ -219,6 +219,17 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | updateTime | java.lang.String | Update time of the job. |
 | savepointInfo | org.apache.flink.kubernetes.operator.crd.status.SavepointInfo | Information about pending and last savepoint for the job. |
 
+### ReconciliationState
+**Class**: org.apache.flink.kubernetes.operator.crd.status.ReconciliationState
+
+**Description**: Current state of the reconciliation.
+
+| Value | Docs |
+| ----- | ---- |
+| DEPLOYED | The last reconciledSpec is currently deployed. |
+| ROLLING_BACK | In the process of rolling back to the lastStableSpec. |
+| ROLLED_BACK | Rolled back to the lastStableSpec. |
+
 ### ReconciliationStatus
 **Class**: org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus
 
@@ -226,9 +237,10 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
-| success | boolean | True if last reconciliation step was successful. |
-| error | java.lang.String | If success == false, error information about the reconciliation failure. |
+| reconciliationTimestamp | long | Epoch timestamp of the last successful reconcile operation. |
 | lastReconciledSpec | java.lang.String | Last reconciled deployment spec. Used to decide whether further reconciliation steps are  necessary. |
+| lastStableSpec | java.lang.String | Last stable deployment spec according to the specified stability condition. If a rollback  strategy is defined this will be the target to roll back to. |
+| state | org.apache.flink.kubernetes.operator.crd.status.ReconciliationState | Deployment state of the last reconciled spec. |
 
 ### Savepoint
 **Class**: org.apache.flink.kubernetes.operator.crd.status.Savepoint

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -82,14 +82,17 @@ public class FlinkOperator {
 
     private void registerDeploymentController() {
         ReconcilerFactory reconcilerFactory =
-                new ReconcilerFactory(client, flinkService, operatorConfiguration);
+                new ReconcilerFactory(
+                        client,
+                        flinkService,
+                        operatorConfiguration,
+                        defaultConfig.getFlinkConfig());
         ObserverFactory observerFactory =
                 new ObserverFactory(
                         flinkService, operatorConfiguration, defaultConfig.getFlinkConfig());
 
         FlinkDeploymentController controller =
                 new FlinkDeploymentController(
-                        defaultConfig,
                         operatorConfiguration,
                         client,
                         validators,
@@ -106,18 +109,17 @@ public class FlinkOperator {
 
     private void registerSessionJobController() {
         Reconciler<FlinkSessionJob> reconciler =
-                new FlinkSessionJobReconciler(client, flinkService, operatorConfiguration);
+                new FlinkSessionJobReconciler(
+                        client,
+                        flinkService,
+                        operatorConfiguration,
+                        defaultConfig.getFlinkConfig());
         Observer<FlinkSessionJob> observer =
                 new SessionJobObserver(
                         operatorConfiguration, flinkService, defaultConfig.getFlinkConfig());
         FlinkSessionJobController controller =
                 new FlinkSessionJobController(
-                        defaultConfig,
-                        operatorConfiguration,
-                        client,
-                        validators,
-                        reconciler,
-                        observer);
+                        operatorConfiguration, client, validators, reconciler, observer);
 
         FlinkControllerConfig<FlinkSessionJob> controllerConfig =
                 new FlinkControllerConfig<>(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/OperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/OperatorConfigOptions.java
@@ -83,4 +83,18 @@ public class OperatorConfigOptions {
                     .defaultValue(Duration.ofSeconds(60))
                     .withDescription(
                             "The timeout for the reconciler to wait for flink to shutdown cluster.");
+
+    public static final ConfigOption<Boolean> DEPLOYMENT_ROLLBACK_ENABLED =
+            ConfigOptions.key("kubernetes.operator.deployment.rollback.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to enable rolling back failed deployment upgrades.");
+
+    public static final ConfigOption<Duration> DEPLOYMENT_READINESS_TIMEOUT =
+            ConfigOptions.key("kubernetes.operator.deployment.readiness.timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(1))
+                    .withDescription(
+                            "The timeout for deployments to become ready/stable "
+                                    + "before being rolled back if rollback is enabled.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.kubernetes.operator.controller;
 
-import org.apache.flink.kubernetes.operator.config.DefaultConfig;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
@@ -73,19 +72,16 @@ public class FlinkSessionJobController
     private final Set<FlinkResourceValidator> validators;
     private final Reconciler<FlinkSessionJob> reconciler;
     private final Observer<FlinkSessionJob> observer;
-    private final DefaultConfig defaultConfig;
     private final FlinkOperatorConfiguration operatorConfiguration;
     private Map<String, SharedIndexInformer<FlinkSessionJob>> informers;
     private FlinkControllerConfig<FlinkSessionJob> controllerConfig;
 
     public FlinkSessionJobController(
-            DefaultConfig defaultConfig,
             FlinkOperatorConfiguration operatorConfiguration,
             KubernetesClient kubernetesClient,
             Set<FlinkResourceValidator> validators,
             Reconciler<FlinkSessionJob> reconciler,
             Observer<FlinkSessionJob> observer) {
-        this.defaultConfig = defaultConfig;
         this.operatorConfiguration = operatorConfiguration;
         this.kubernetesClient = kubernetesClient;
         this.validators = validators;
@@ -114,7 +110,7 @@ public class FlinkSessionJobController
 
         try {
             // TODO refactor the reconciler interface to return UpdateControl directly
-            reconciler.reconcile(flinkSessionJob, context, defaultConfig.getFlinkConfig());
+            reconciler.reconcile(flinkSessionJob, context);
         } catch (Exception e) {
             throw new ReconciliationException(e);
         }
@@ -127,7 +123,7 @@ public class FlinkSessionJobController
     public DeleteControl cleanup(FlinkSessionJob sessionJob, Context context) {
         LOG.info("Deleting FlinkSessionJob");
 
-        return reconciler.cleanup(sessionJob, context, defaultConfig.getFlinkConfig());
+        return reconciler.cleanup(sessionJob, context);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkSessionJobReconciliationStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkSessionJobReconciliationStatus.java
@@ -35,12 +35,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class FlinkSessionJobReconciliationStatus {
 
-    /** True if last reconciliation step was successful. */
-    private boolean success;
-
-    /** If success == false, error information about the reconciliation failure. */
-    private String error;
-
     /**
      * Last reconciled job spec. Used to decide whether further reconciliation steps are necessary.
      */

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkSessionJobStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkSessionJobStatus.java
@@ -36,4 +36,7 @@ public class FlinkSessionJobStatus {
     /** Status of the last reconcile operation. */
     private FlinkSessionJobReconciliationStatus reconciliationStatus =
             new FlinkSessionJobReconciliationStatus();
+
+    /** Error information about the session job. */
+    private String error;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobManagerDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobManagerDeploymentStatus.java
@@ -51,7 +51,8 @@ public enum JobManagerDeploymentStatus {
                 break;
             case READY:
                 rescheduleAfter =
-                        SavepointUtils.savepointInProgress(flinkDeployment)
+                        SavepointUtils.savepointInProgress(
+                                        flinkDeployment.getStatus().getJobStatus())
                                 ? operatorConfiguration.getProgressCheckInterval()
                                 : operatorConfiguration.getReconcileInterval();
                 break;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationState.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationState.java
@@ -17,28 +17,12 @@
 
 package org.apache.flink.kubernetes.operator.crd.status;
 
-import org.apache.flink.annotation.Experimental;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-/** Last observed status of the Flink deployment. */
-@Experimental
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class FlinkDeploymentStatus {
-    /** Last observed status of the Flink job on Application deployments. */
-    private JobStatus jobStatus = new JobStatus();
-
-    /** Last observed status of the JobManager deployment. */
-    private JobManagerDeploymentStatus jobManagerDeploymentStatus =
-            JobManagerDeploymentStatus.MISSING;
-
-    /** Status of the last reconcile operation. */
-    private ReconciliationStatus reconciliationStatus = new ReconciliationStatus();
-
-    /** Error information about the Flink deployment. */
-    private String error;
+/** Current state of the reconciliation. */
+public enum ReconciliationState {
+    /** The last reconciledSpec is currently deployed. */
+    DEPLOYED,
+    /** In the process of rolling back to the lastStableSpec. */
+    ROLLING_BACK,
+    /** Rolled back to the lastStableSpec. */
+    ROLLED_BACK;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -46,15 +46,15 @@ public abstract class JobStatusObserver<CTX> {
      * Observe the status of the flink job.
      *
      * @param jobStatus The job status to be observed.
-     * @param lastValidatedConfig The last validated config.
+     * @param deployedConfig Deployed job config.
      * @return If job found return true, otherwise return false.
      */
-    public boolean observe(JobStatus jobStatus, Configuration lastValidatedConfig, CTX ctx) {
+    public boolean observe(JobStatus jobStatus, Configuration deployedConfig, CTX ctx) {
         LOG.info("Observing job status");
         var previousJobStatus = jobStatus.getState();
         List<JobStatusMessage> clusterJobStatuses;
         try {
-            clusterJobStatuses = new ArrayList<>(flinkService.listJobs(lastValidatedConfig));
+            clusterJobStatuses = new ArrayList<>(flinkService.listJobs(deployedConfig));
         } catch (Exception e) {
             LOG.error("Exception while listing jobs", e);
             jobStatus.setState(JOB_STATE_UNKNOWN);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -47,11 +47,11 @@ public class SavepointObserver {
      *
      * @param currentSavepointInfo the current savepoint info.
      * @param jobID the jobID of the observed job.
-     * @param lastValidatedConfig the last validated config.
+     * @param deployedConfig Deployed job config.
      * @return The observed error, if no error observed, {@code Optional.empty()} will be returned.
      */
     public Optional<String> observe(
-            SavepointInfo currentSavepointInfo, String jobID, Configuration lastValidatedConfig) {
+            SavepointInfo currentSavepointInfo, String jobID, Configuration deployedConfig) {
         if (currentSavepointInfo.getTriggerId() == null) {
             LOG.debug("Savepoint not in progress");
             return Optional.empty();
@@ -61,7 +61,7 @@ public class SavepointObserver {
         try {
             savepointFetchResult =
                     flinkService.fetchSavepointInfo(
-                            currentSavepointInfo.getTriggerId(), jobID, lastValidatedConfig);
+                            currentSavepointInfo.getTriggerId(), jobID, deployedConfig);
         } catch (Exception e) {
             LOG.error("Exception while fetching savepoint info", e);
             return Optional.empty();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/context/ApplicationObserverContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/context/ApplicationObserverContext.java
@@ -27,12 +27,12 @@ public class ApplicationObserverContext {
 
     public final FlinkDeployment flinkApp;
     public final Context context;
-    public final Configuration lastValidatedConfig;
+    public final Configuration deployedConfig;
 
     public ApplicationObserverContext(
-            FlinkDeployment flinkApp, Context context, Configuration lastValidatedConfig) {
+            FlinkDeployment flinkApp, Context context, Configuration deployedConfig) {
         this.flinkApp = flinkApp;
         this.context = context;
-        this.lastValidatedConfig = lastValidatedConfig;
+        this.deployedConfig = deployedConfig;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
@@ -37,17 +37,19 @@ public class SessionObserver extends AbstractDeploymentObserver {
     }
 
     @Override
-    public void observeIfClusterReady(
-            FlinkDeployment flinkApp, Context context, Configuration lastValidatedConfig) {
+    public boolean observeFlinkCluster(
+            FlinkDeployment flinkApp, Context context, Configuration deployedConfig) {
         // Check if session cluster can serve rest calls following our practice in JobObserver
         try {
-            flinkService.listJobs(lastValidatedConfig);
+            flinkService.listJobs(deployedConfig);
+            return true;
         } catch (Exception e) {
             logger.error("REST service in session cluster is bad now", e);
             if (e instanceof TimeoutException) {
                 // check for problems with the underlying deployment
-                observeJmDeployment(flinkApp, context, lastValidatedConfig);
+                observeJmDeployment(flinkApp, context, deployedConfig);
             }
+            return false;
         }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
@@ -28,7 +28,6 @@ import org.apache.flink.kubernetes.operator.observer.context.VoidObserverContext
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.sessionjob.SessionJobHelper;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
-import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.OperatorUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.util.Preconditions;
@@ -113,19 +112,19 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
             return;
         }
 
-        Configuration lastValidatedConfig =
-                FlinkUtils.getEffectiveConfig(flinkDepOpt.get(), this.defaultConfig);
+        Configuration deployedConfig =
+                ReconciliationUtils.getDeployedConfig(flinkDepOpt.get(), defaultConfig);
         var jobFound =
                 jobStatusObserver.observe(
                         flinkSessionJob.getStatus().getJobStatus(),
-                        lastValidatedConfig,
+                        deployedConfig,
                         VoidObserverContext.INSTANCE);
         if (jobFound) {
             savepointObserver
                     .observe(
                             flinkSessionJob.getStatus().getJobStatus().getSavepointInfo(),
                             flinkSessionJob.getStatus().getJobStatus().getJobId(),
-                            lastValidatedConfig)
+                            deployedConfig)
                     .ifPresent(
                             error ->
                                     ReconciliationUtils.updateForReconciliationError(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/Reconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/Reconciler.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.kubernetes.operator.reconciler;
 
-import org.apache.flink.configuration.Configuration;
-
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
 
@@ -35,9 +33,8 @@ public interface Reconciler<CR> {
      *
      * @param cr the custom resource that has been created or updated
      * @param context the context with which the operation is executed
-     * @param effectiveConfig the effective config of the target resource
      */
-    void reconcile(CR cr, Context context, Configuration effectiveConfig) throws Exception;
+    void reconcile(CR cr, Context context) throws Exception;
 
     /**
      * This is called when receiving the delete event of custom resource. This method is meant to
@@ -45,8 +42,7 @@ public interface Reconciler<CR> {
      *
      * @param cr the custom resource that has been deleted
      * @param context the context with which the operation is executed
-     * @param effectiveConfig the effective config of the flinkApp
      * @return DeleteControl to manage the deletion behavior
      */
-    DeleteControl cleanup(CR cr, Context context, Configuration effectiveConfig);
+    DeleteControl cleanup(CR cr, Context context);
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.reconciler;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.OperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.CrdConstants;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
@@ -27,6 +28,8 @@ import org.apache.flink.kubernetes.operator.crd.spec.FlinkSessionJobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobReconciliationStatus;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.util.Preconditions;
@@ -41,6 +44,7 @@ import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Objects;
 
 /** Reconciliation utilities. */
@@ -51,8 +55,7 @@ public class ReconciliationUtils {
     public static void updateForSpecReconciliationSuccess(
             FlinkDeployment flinkApp, JobState stateAfterReconcile) {
         ReconciliationStatus reconciliationStatus = flinkApp.getStatus().getReconciliationStatus();
-        reconciliationStatus.setSuccess(true);
-        reconciliationStatus.setError(null);
+        flinkApp.getStatus().setError(null);
         FlinkDeploymentSpec clonedSpec = clone(flinkApp.getSpec());
         FlinkDeploymentSpec lastReconciledSpec =
                 reconciliationStatus.deserializeLastReconciledSpec();
@@ -62,32 +65,31 @@ public class ReconciliationUtils {
             clonedSpec.getJob().setState(stateAfterReconcile);
         }
         reconciliationStatus.serializeAndSetLastReconciledSpec(clonedSpec);
+        reconciliationStatus.setReconciliationTimestamp(System.currentTimeMillis());
+        reconciliationStatus.setState(ReconciliationState.DEPLOYED);
     }
 
     public static void updateSavepointReconciliationSuccess(FlinkDeployment flinkApp) {
         ReconciliationStatus reconciliationStatus = flinkApp.getStatus().getReconciliationStatus();
-        reconciliationStatus.setSuccess(true);
-        reconciliationStatus.setError(null);
+        flinkApp.getStatus().setError(null);
         FlinkDeploymentSpec lastReconciledSpec =
                 reconciliationStatus.deserializeLastReconciledSpec();
         lastReconciledSpec
                 .getJob()
                 .setSavepointTriggerNonce(flinkApp.getSpec().getJob().getSavepointTriggerNonce());
         reconciliationStatus.serializeAndSetLastReconciledSpec(lastReconciledSpec);
+        reconciliationStatus.setReconciliationTimestamp(System.currentTimeMillis());
     }
 
     public static void updateForReconciliationError(FlinkDeployment flinkApp, String err) {
-        ReconciliationStatus reconciliationStatus = flinkApp.getStatus().getReconciliationStatus();
-        reconciliationStatus.setSuccess(false);
-        reconciliationStatus.setError(err);
+        flinkApp.getStatus().setError(err);
     }
 
     public static void updateForSpecReconciliationSuccess(
             FlinkSessionJob sessionJob, JobState stateAfterReconcile) {
         FlinkSessionJobReconciliationStatus reconciliationStatus =
                 sessionJob.getStatus().getReconciliationStatus();
-        reconciliationStatus.setSuccess(true);
-        reconciliationStatus.setError(null);
+        sessionJob.getStatus().setError(null);
         FlinkSessionJobSpec clonedSpec = clone(sessionJob.getSpec());
         if (reconciliationStatus.getLastReconciledSpec() != null) {
             var lastReconciledSpec = reconciliationStatus.deserializeLastReconciledSpec();
@@ -99,11 +101,11 @@ public class ReconciliationUtils {
     }
 
     public static void updateSavepointReconciliationSuccess(FlinkSessionJob flinkSessionJob) {
-        FlinkSessionJobReconciliationStatus reconciliationStatus =
-                flinkSessionJob.getStatus().getReconciliationStatus();
+        FlinkSessionJobStatus status = flinkSessionJob.getStatus();
+        status.setError(null);
+
+        FlinkSessionJobReconciliationStatus reconciliationStatus = status.getReconciliationStatus();
         var lastReconciledSpec = reconciliationStatus.deserializeLastReconciledSpec();
-        reconciliationStatus.setSuccess(true);
-        reconciliationStatus.setError(null);
         lastReconciledSpec
                 .getJob()
                 .setSavepointTriggerNonce(
@@ -112,10 +114,7 @@ public class ReconciliationUtils {
     }
 
     public static void updateForReconciliationError(FlinkSessionJob flinkSessionJob, String err) {
-        FlinkSessionJobReconciliationStatus reconciliationStatus =
-                flinkSessionJob.getStatus().getReconciliationStatus();
-        reconciliationStatus.setSuccess(false);
-        reconciliationStatus.setError(err);
+        flinkSessionJob.getStatus().setError(err);
     }
 
     public static <T> T clone(T object) {
@@ -175,32 +174,52 @@ public class ReconciliationUtils {
     }
 
     public static boolean isUpgradeModeChangedToLastStateAndHADisabledPreviously(
-            FlinkDeployment flinkApp) {
-        final FlinkDeploymentSpec lastReconciledSpec =
-                Preconditions.checkNotNull(
-                        flinkApp.getStatus()
-                                .getReconciliationStatus()
-                                .deserializeLastReconciledSpec());
-        final UpgradeMode previousUpgradeMode = lastReconciledSpec.getJob().getUpgradeMode();
-        final UpgradeMode currentUpgradeMode = flinkApp.getSpec().getJob().getUpgradeMode();
+            FlinkDeployment flinkApp, Configuration defaultConf) {
 
-        final Configuration lastReconciledFlinkConfig =
-                Configuration.fromMap(lastReconciledSpec.getFlinkConfiguration());
+        FlinkDeploymentSpec deployedSpec = getDeployedSpec(flinkApp);
+        UpgradeMode previousUpgradeMode = deployedSpec.getJob().getUpgradeMode();
+        UpgradeMode currentUpgradeMode = flinkApp.getSpec().getJob().getUpgradeMode();
 
         return previousUpgradeMode != UpgradeMode.LAST_STATE
                 && currentUpgradeMode == UpgradeMode.LAST_STATE
-                && !FlinkUtils.isKubernetesHAActivated(lastReconciledFlinkConfig);
+                && !FlinkUtils.isKubernetesHAActivated(getDeployedConfig(flinkApp, defaultConf));
+    }
+
+    public static FlinkDeploymentSpec getDeployedSpec(FlinkDeployment deployment) {
+        ReconciliationStatus reconciliationStatus =
+                deployment.getStatus().getReconciliationStatus();
+
+        if (reconciliationStatus.getState() == ReconciliationState.DEPLOYED) {
+            return reconciliationStatus.deserializeLastReconciledSpec();
+        } else {
+            return reconciliationStatus.deserializeLastStableSpec();
+        }
+    }
+
+    public static Configuration getDeployedConfig(
+            FlinkDeployment deployment, Configuration defaultConf) {
+        return FlinkUtils.getEffectiveConfig(
+                deployment.getMetadata(), getDeployedSpec(deployment), defaultConf);
     }
 
     private static boolean isJobUpgradeInProgress(FlinkDeployment current) {
         ReconciliationStatus reconciliationStatus = current.getStatus().getReconciliationStatus();
 
-        if (reconciliationStatus == null || current.getSpec().getJob() == null) {
+        if (reconciliationStatus == null) {
+            return false;
+        }
+
+        if (reconciliationStatus.getState() == ReconciliationState.ROLLING_BACK) {
+            return true;
+        }
+
+        if (current.getSpec().getJob() == null
+                || reconciliationStatus.getLastReconciledSpec() == null) {
             return false;
         }
 
         return current.getSpec().getJob().getState() == JobState.RUNNING
-                && reconciliationStatus.isSuccess()
+                && current.getStatus().getError() == null
                 && reconciliationStatus.deserializeLastReconciledSpec().getJob().getState()
                         == JobState.SUSPENDED;
     }
@@ -228,5 +247,24 @@ public class ReconciliationUtils {
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Could not serialize spec, this indicates a bug...", e);
         }
+    }
+
+    public static boolean shouldRollBack(
+            ReconciliationStatus reconciliationStatus, Configuration configuration) {
+        if (reconciliationStatus.getState() == ReconciliationState.ROLLING_BACK) {
+            return true;
+        }
+
+        if (!configuration.get(OperatorConfigOptions.DEPLOYMENT_ROLLBACK_ENABLED)
+                || reconciliationStatus.getState() == ReconciliationState.ROLLED_BACK
+                || reconciliationStatus.isLastReconciledSpecStable()) {
+            return false;
+        }
+
+        Duration readinessTimeout =
+                configuration.get(OperatorConfigOptions.DEPLOYMENT_READINESS_TIMEOUT);
+        return Instant.now()
+                .minus(readinessTimeout)
+                .isAfter(Instant.ofEpochMilli(reconciliationStatus.getReconciliationTimestamp()));
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractDeploymentReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractDeploymentReconciler.java
@@ -35,19 +35,23 @@ public abstract class AbstractDeploymentReconciler implements Reconciler<FlinkDe
     protected final FlinkOperatorConfiguration operatorConfiguration;
     protected final KubernetesClient kubernetesClient;
     protected final FlinkService flinkService;
+    protected final Configuration defaultConfig;
 
     public AbstractDeploymentReconciler(
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
-            FlinkOperatorConfiguration operatorConfiguration) {
+            FlinkOperatorConfiguration operatorConfiguration,
+            Configuration defaultConfig) {
+
         this.kubernetesClient = kubernetesClient;
         this.flinkService = flinkService;
         this.operatorConfiguration = operatorConfiguration;
+        this.defaultConfig = defaultConfig;
     }
 
     @Override
-    public DeleteControl cleanup(
-            FlinkDeployment flinkApp, Context context, Configuration effectiveConfig) {
+    public DeleteControl cleanup(FlinkDeployment flinkApp, Context context) {
+        Configuration effectiveConfig = FlinkUtils.getEffectiveConfig(flinkApp, defaultConfig);
         return shutdownAndDelete(flinkApp, effectiveConfig);
     }
 
@@ -59,7 +63,7 @@ public abstract class AbstractDeploymentReconciler implements Reconciler<FlinkDe
             shutdown(flinkApp, effectiveConfig);
         } else {
             FlinkUtils.deleteCluster(
-                    flinkApp,
+                    flinkApp.getMetadata(),
                     kubernetesClient,
                     true,
                     operatorConfiguration.getFlinkShutdownClusterTimeout().toSeconds());

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -135,19 +135,11 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
     private void rollbackApplication(FlinkDeployment flinkApp) throws Exception {
         ReconciliationStatus reconciliationStatus = flinkApp.getStatus().getReconciliationStatus();
 
-        if (reconciliationStatus.getState() != ReconciliationState.ROLLING_BACK) {
-            LOG.warn("Preparing to roll back to last stable spec.");
-            if (flinkApp.getStatus().getError() == null) {
-                flinkApp.getStatus()
-                        .setError(
-                                "Deployment is not ready within the configured timeout, rolling back.");
-            }
-            reconciliationStatus.setState(ReconciliationState.ROLLING_BACK);
+        if (initiateRollBack(flinkApp.getStatus())) {
             return;
         }
 
         LOG.warn("Executing rollback operation");
-
         FlinkDeploymentSpec rollbackSpec = reconciliationStatus.deserializeLastStableSpec();
         Configuration rollbackConfig =
                 FlinkUtils.getEffectiveConfig(flinkApp.getMetadata(), rollbackSpec, defaultConfig);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -28,6 +28,8 @@ import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
@@ -37,6 +39,7 @@ import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.util.Preconditions;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.slf4j.Logger;
@@ -57,41 +60,48 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
     public ApplicationReconciler(
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
-            FlinkOperatorConfiguration operatorConfiguration) {
-        super(kubernetesClient, flinkService, operatorConfiguration);
+            FlinkOperatorConfiguration operatorConfiguration,
+            Configuration defaultConfig) {
+        super(kubernetesClient, flinkService, operatorConfiguration, defaultConfig);
     }
 
     @Override
-    public void reconcile(FlinkDeployment flinkApp, Context context, Configuration effectiveConfig)
-            throws Exception {
-
+    public void reconcile(FlinkDeployment flinkApp, Context context) throws Exception {
+        ObjectMeta deployMeta = flinkApp.getMetadata();
+        Configuration effectiveConfig = FlinkUtils.getEffectiveConfig(flinkApp, defaultConfig);
+        FlinkDeploymentStatus status = flinkApp.getStatus();
+        ReconciliationStatus reconciliationStatus = status.getReconciliationStatus();
         FlinkDeploymentSpec lastReconciledSpec =
-                flinkApp.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
-        JobSpec jobSpec = flinkApp.getSpec().getJob();
+                reconciliationStatus.deserializeLastReconciledSpec();
+        FlinkDeploymentSpec currentDeploySpec = flinkApp.getSpec();
+
+        JobSpec currentJobSpec = currentDeploySpec.getJob();
         if (lastReconciledSpec == null) {
             deployFlinkJob(
-                    flinkApp,
+                    currentJobSpec,
+                    status,
                     effectiveConfig,
-                    Optional.ofNullable(jobSpec.getInitialSavepointPath()));
-            IngressUtils.updateIngressRules(flinkApp, effectiveConfig, kubernetesClient);
+                    Optional.ofNullable(currentJobSpec.getInitialSavepointPath()));
+            IngressUtils.updateIngressRules(
+                    deployMeta, currentDeploySpec, effectiveConfig, kubernetesClient);
             ReconciliationUtils.updateForSpecReconciliationSuccess(flinkApp, JobState.RUNNING);
             return;
         }
 
-        if (SavepointUtils.savepointInProgress(flinkApp)) {
+        if (SavepointUtils.savepointInProgress(status.getJobStatus())) {
             LOG.info("Delaying job reconciliation until pending savepoint is completed");
             return;
         }
 
-        boolean specChanged = !flinkApp.getSpec().equals(lastReconciledSpec);
+        boolean specChanged = !currentDeploySpec.equals(lastReconciledSpec);
         if (specChanged) {
             if (!inUpgradeableState(flinkApp)) {
                 LOG.info("Waiting for upgradeable state");
                 return;
             }
             JobState currentJobState = lastReconciledSpec.getJob().getState();
-            JobState desiredJobState = jobSpec.getState();
-            UpgradeMode upgradeMode = jobSpec.getUpgradeMode();
+            JobState desiredJobState = currentJobSpec.getState();
+            UpgradeMode upgradeMode = currentJobSpec.getUpgradeMode();
             JobState stateAfterReconcile = currentJobState;
             if (currentJobState == JobState.RUNNING) {
                 if (desiredJobState == JobState.RUNNING) {
@@ -102,36 +112,86 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
             }
             if (currentJobState == JobState.SUSPENDED && desiredJobState == JobState.RUNNING) {
                 if (upgradeMode == UpgradeMode.STATELESS) {
-                    deployFlinkJob(flinkApp, effectiveConfig, Optional.empty());
-                } else if (upgradeMode == UpgradeMode.LAST_STATE
-                        || upgradeMode == UpgradeMode.SAVEPOINT) {
-                    restoreFromLastSavepoint(flinkApp, effectiveConfig);
+                    deployFlinkJob(currentJobSpec, status, effectiveConfig, Optional.empty());
+                } else {
+                    restoreFromLastSavepoint(currentJobSpec, status, effectiveConfig);
                 }
                 stateAfterReconcile = JobState.RUNNING;
             }
-            IngressUtils.updateIngressRules(flinkApp, effectiveConfig, kubernetesClient);
+            IngressUtils.updateIngressRules(
+                    deployMeta, currentDeploySpec, effectiveConfig, kubernetesClient);
             ReconciliationUtils.updateForSpecReconciliationSuccess(flinkApp, stateAfterReconcile);
-        } else if (SavepointUtils.shouldTriggerSavepoint(flinkApp) && isJobRunning(flinkApp)) {
+        } else if (ReconciliationUtils.shouldRollBack(reconciliationStatus, effectiveConfig)) {
+            rollbackApplication(flinkApp);
+        } else if (SavepointUtils.shouldTriggerSavepoint(currentJobSpec, status)
+                && isJobRunning(status)) {
             triggerSavepoint(flinkApp, effectiveConfig);
             ReconciliationUtils.updateSavepointReconciliationSuccess(flinkApp);
+        } else {
+            LOG.info("Deployment is fully reconciled, nothing to do.");
         }
+    }
+
+    private void rollbackApplication(FlinkDeployment flinkApp) throws Exception {
+        ReconciliationStatus reconciliationStatus = flinkApp.getStatus().getReconciliationStatus();
+
+        if (reconciliationStatus.getState() != ReconciliationState.ROLLING_BACK) {
+            LOG.warn("Preparing to roll back to last stable spec.");
+            if (flinkApp.getStatus().getError() == null) {
+                flinkApp.getStatus()
+                        .setError(
+                                "Deployment is not ready within the configured timeout, rolling back.");
+            }
+            reconciliationStatus.setState(ReconciliationState.ROLLING_BACK);
+            return;
+        }
+
+        LOG.warn("Executing rollback operation");
+
+        FlinkDeploymentSpec rollbackSpec = reconciliationStatus.deserializeLastStableSpec();
+        Configuration rollbackConfig =
+                FlinkUtils.getEffectiveConfig(flinkApp.getMetadata(), rollbackSpec, defaultConfig);
+
+        UpgradeMode upgradeMode = flinkApp.getSpec().getJob().getUpgradeMode();
+
+        suspendJob(
+                flinkApp,
+                upgradeMode == UpgradeMode.STATELESS
+                        ? UpgradeMode.STATELESS
+                        : UpgradeMode.LAST_STATE,
+                rollbackConfig);
+        deployFlinkJob(
+                rollbackSpec.getJob(),
+                flinkApp.getStatus(),
+                rollbackConfig,
+                upgradeMode == UpgradeMode.STATELESS
+                        ? Optional.empty()
+                        : Optional.ofNullable(
+                                        flinkApp.getStatus()
+                                                .getJobStatus()
+                                                .getSavepointInfo()
+                                                .getLastSavepoint())
+                                .map(Savepoint::getLocation));
+        IngressUtils.updateIngressRules(
+                flinkApp.getMetadata(), rollbackSpec, rollbackConfig, kubernetesClient);
+        reconciliationStatus.setState(ReconciliationState.ROLLED_BACK);
     }
 
     private boolean inUpgradeableState(FlinkDeployment deployment) {
         if (deployment.getSpec().getJob().getUpgradeMode() != UpgradeMode.SAVEPOINT
                 && !ReconciliationUtils.isUpgradeModeChangedToLastStateAndHADisabledPreviously(
-                        deployment)) {
+                        deployment, defaultConfig)) {
             // Only savepoint upgrade mode or changed from stateless/savepoint to last-state while
             // HA disabled previously need a running job
             return true;
         }
-        return deployment.getStatus().getJobManagerDeploymentStatus()
-                        == JobManagerDeploymentStatus.MISSING
-                || isJobRunning(deployment);
+
+        FlinkDeploymentStatus status = deployment.getStatus();
+        return status.getJobManagerDeploymentStatus() == JobManagerDeploymentStatus.MISSING
+                || isJobRunning(status);
     }
 
-    private boolean isJobRunning(FlinkDeployment deployment) {
-        FlinkDeploymentStatus status = deployment.getStatus();
+    private boolean isJobRunning(FlinkDeploymentStatus status) {
         JobManagerDeploymentStatus deploymentStatus = status.getJobManagerDeploymentStatus();
         return deploymentStatus == JobManagerDeploymentStatus.READY
                 && org.apache.flink.api.common.JobStatus.RUNNING
@@ -140,26 +200,30 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
     }
 
     private void deployFlinkJob(
-            FlinkDeployment flinkApp, Configuration effectiveConfig, Optional<String> savepoint)
+            JobSpec jobSpec,
+            FlinkDeploymentStatus status,
+            Configuration effectiveConfig,
+            Optional<String> savepoint)
             throws Exception {
         if (savepoint.isPresent()) {
             effectiveConfig.set(SavepointConfigOptions.SAVEPOINT_PATH, savepoint.get());
         } else {
             effectiveConfig.removeConfig(SavepointConfigOptions.SAVEPOINT_PATH);
         }
-        flinkService.submitApplicationCluster(flinkApp, effectiveConfig);
-        flinkApp.getStatus().getJobStatus().setState(JOB_STATE_UNKNOWN);
-        flinkApp.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
+        flinkService.submitApplicationCluster(jobSpec, effectiveConfig);
+        status.getJobStatus().setState(JOB_STATE_UNKNOWN);
+        status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
     }
 
-    private void restoreFromLastSavepoint(FlinkDeployment flinkApp, Configuration effectiveConfig)
+    private void restoreFromLastSavepoint(
+            JobSpec jobSpec, FlinkDeploymentStatus status, Configuration effectiveConfig)
             throws Exception {
-        JobStatus jobStatus = flinkApp.getStatus().getJobStatus();
+        JobStatus jobStatus = status.getJobStatus();
         Optional<String> savepointOpt =
                 Optional.ofNullable(jobStatus.getSavepointInfo().getLastSavepoint())
                         .flatMap(s -> Optional.ofNullable(s.getLocation()));
 
-        deployFlinkJob(flinkApp, effectiveConfig, savepointOpt);
+        deployFlinkJob(jobSpec, status, effectiveConfig, savepointOpt);
     }
 
     private void printCancelLogs(UpgradeMode upgradeMode) {
@@ -182,10 +246,12 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
             FlinkDeployment flinkApp, UpgradeMode upgradeMode, Configuration effectiveConfig)
             throws Exception {
         final String jobIdString = flinkApp.getStatus().getJobStatus().getJobId();
+
         // Always trigger a savepoint when upgrade mode changes from stateless/savepoint to
         // last-state and HA is disabled previously. This is a safeguard to ensure the state is
         // never lost.
-        if (ReconciliationUtils.isUpgradeModeChangedToLastStateAndHADisabledPreviously(flinkApp)) {
+        if (ReconciliationUtils.isUpgradeModeChangedToLastStateAndHADisabledPreviously(
+                flinkApp, defaultConfig)) {
             return flinkService.cancelJob(
                     JobID.fromHexString(Preconditions.checkNotNull(jobIdString)),
                     UpgradeMode.SAVEPOINT,
@@ -218,7 +284,7 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
 
     @Override
     protected void shutdown(FlinkDeployment flinkApp, Configuration effectiveConfig) {
-        if (isJobRunning(flinkApp)) {
+        if (isJobRunning(flinkApp.getStatus())) {
             LOG.info("Job is running, attempting graceful shutdown.");
             try {
                 flinkService.cancelJob(
@@ -232,7 +298,7 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
         }
 
         FlinkUtils.deleteCluster(
-                flinkApp,
+                flinkApp.getMetadata(),
                 kubernetesClient,
                 true,
                 operatorConfiguration.getFlinkShutdownClusterTimeout().toSeconds());

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.reconciler.deployment;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
@@ -34,15 +35,18 @@ public class ReconcilerFactory {
     private final KubernetesClient kubernetesClient;
     private final FlinkService flinkService;
     private final FlinkOperatorConfiguration operatorConfiguration;
+    private final Configuration defaultConfig;
     private final Map<Mode, Reconciler<FlinkDeployment>> reconcilerMap;
 
     public ReconcilerFactory(
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
-            FlinkOperatorConfiguration operatorConfiguration) {
+            FlinkOperatorConfiguration operatorConfiguration,
+            Configuration defaultConfig) {
         this.kubernetesClient = kubernetesClient;
         this.flinkService = flinkService;
         this.operatorConfiguration = operatorConfiguration;
+        this.defaultConfig = defaultConfig;
         this.reconcilerMap = new ConcurrentHashMap<>();
     }
 
@@ -53,10 +57,16 @@ public class ReconcilerFactory {
                     switch (mode) {
                         case SESSION:
                             return new SessionReconciler(
-                                    kubernetesClient, flinkService, operatorConfiguration);
+                                    kubernetesClient,
+                                    flinkService,
+                                    operatorConfiguration,
+                                    defaultConfig);
                         case APPLICATION:
                             return new ApplicationReconciler(
-                                    kubernetesClient, flinkService, operatorConfiguration);
+                                    kubernetesClient,
+                                    flinkService,
+                                    operatorConfiguration,
+                                    defaultConfig);
                         default:
                             throw new UnsupportedOperationException(
                                     String.format("Unsupported running mode: %s", mode));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconciler.java
@@ -52,22 +52,23 @@ public class FlinkSessionJobReconciler implements Reconciler<FlinkSessionJob> {
     private static final Logger LOG = LoggerFactory.getLogger(FlinkSessionJobReconciler.class);
 
     private final FlinkOperatorConfiguration operatorConfiguration;
+    private final Configuration defaultConfig;
     private final KubernetesClient kubernetesClient;
     private final FlinkService flinkService;
 
     public FlinkSessionJobReconciler(
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
-            FlinkOperatorConfiguration operatorConfiguration) {
+            FlinkOperatorConfiguration operatorConfiguration,
+            Configuration defaultConfig) {
         this.kubernetesClient = kubernetesClient;
         this.flinkService = flinkService;
         this.operatorConfiguration = operatorConfiguration;
+        this.defaultConfig = defaultConfig;
     }
 
     @Override
-    public void reconcile(
-            FlinkSessionJob flinkSessionJob, Context context, Configuration defaultConfig)
-            throws Exception {
+    public void reconcile(FlinkSessionJob flinkSessionJob, Context context) throws Exception {
 
         SessionJobHelper helper = new SessionJobHelper(flinkSessionJob, LOG);
         FlinkSessionJobSpec lastReconciledSpec =
@@ -136,8 +137,7 @@ public class FlinkSessionJobReconciler implements Reconciler<FlinkSessionJob> {
     }
 
     @Override
-    public DeleteControl cleanup(
-            FlinkSessionJob sessionJob, Context context, Configuration defaultConfig) {
+    public DeleteControl cleanup(FlinkSessionJob sessionJob, Context context) {
         Optional<FlinkDeployment> flinkDepOptional =
                 OperatorUtils.getSecondaryResource(sessionJob, context, operatorConfiguration);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -70,6 +70,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.lang3.ObjectUtils;
@@ -140,8 +141,7 @@ public class FlinkService {
         LOG.info("Application cluster successfully deployed");
     }
 
-    public void submitSessionCluster(FlinkDeployment deployment, Configuration conf)
-            throws Exception {
+    public void submitSessionCluster(Configuration conf) throws Exception {
         LOG.info("Deploying session cluster");
         final ClusterClientServiceLoader clusterClientServiceLoader =
                 new DefaultClusterClientServiceLoader();
@@ -382,12 +382,8 @@ public class FlinkService {
     }
 
     public void stopSessionCluster(
-            FlinkDeployment deployment,
-            Configuration conf,
-            boolean deleteHaData,
-            long shutdownTimeout) {
-        FlinkUtils.deleteCluster(
-                deployment.getMetadata(), kubernetesClient, deleteHaData, shutdownTimeout);
+            ObjectMeta objectMeta, Configuration conf, boolean deleteHaData, long shutdownTimeout) {
+        FlinkUtils.deleteCluster(objectMeta, kubernetesClient, deleteHaData, shutdownTimeout);
         FlinkUtils.waitForClusterShutdown(kubernetesClient, conf, shutdownTimeout);
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -115,8 +115,7 @@ public class FlinkService {
                         4, new ExecutorThreadFactory("Flink-RestClusterClient-IO"));
     }
 
-    public void submitApplicationCluster(FlinkDeployment deployment, Configuration conf)
-            throws Exception {
+    public void submitApplicationCluster(JobSpec jobSpec, Configuration conf) throws Exception {
         if (FlinkUtils.isKubernetesHAActivated(conf)) {
             final String clusterId =
                     Preconditions.checkNotNull(conf.get(KubernetesConfigOptions.CLUSTER_ID));
@@ -132,7 +131,6 @@ public class FlinkService {
         final ApplicationDeployer deployer =
                 new ApplicationClusterDeployer(clusterClientServiceLoader);
 
-        JobSpec jobSpec = deployment.getSpec().getJob();
         final ApplicationConfiguration applicationConfiguration =
                 new ApplicationConfiguration(
                         jobSpec.getArgs() != null ? jobSpec.getArgs() : new String[0],
@@ -388,7 +386,8 @@ public class FlinkService {
             Configuration conf,
             boolean deleteHaData,
             long shutdownTimeout) {
-        FlinkUtils.deleteCluster(deployment, kubernetesClient, deleteHaData, shutdownTimeout);
+        FlinkUtils.deleteCluster(
+                deployment.getMetadata(), kubernetesClient, deleteHaData, shutdownTimeout);
         FlinkUtils.waitForClusterShutdown(kubernetesClient, conf, shutdownTimeout);
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -128,13 +128,13 @@ public class FlinkUtils {
     }
 
     public static void deleteCluster(
-            FlinkDeployment flinkApp,
+            ObjectMeta meta,
             KubernetesClient kubernetesClient,
             boolean deleteHaConfigmaps,
             long shutdownTimeout) {
         deleteCluster(
-                flinkApp.getMetadata().getNamespace(),
-                flinkApp.getMetadata().getName(),
+                meta.getNamespace(),
+                meta.getName(),
                 kubernetesClient,
                 deleteHaConfigmaps,
                 shutdownTimeout);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -18,7 +18,9 @@
 package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
-import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
 
 import java.time.Duration;
@@ -26,23 +28,18 @@ import java.time.Duration;
 /** Savepoint utilities. */
 public class SavepointUtils {
 
-    public static boolean savepointInProgress(FlinkDeployment flinkDeployment) {
-        return flinkDeployment.getStatus().getJobStatus().getSavepointInfo().getTriggerId() != null;
+    public static boolean savepointInProgress(JobStatus jobStatus) {
+        return jobStatus.getSavepointInfo().getTriggerId() != null;
     }
 
-    public static boolean shouldTriggerSavepoint(FlinkDeployment flinkDeployment) {
-        if (savepointInProgress(flinkDeployment)) {
+    public static boolean shouldTriggerSavepoint(JobSpec jobSpec, FlinkDeploymentStatus status) {
+        if (savepointInProgress(status.getJobStatus())) {
             return false;
         }
-        return flinkDeployment.getSpec().getJob().getSavepointTriggerNonce() != null
-                && !flinkDeployment
-                        .getSpec()
-                        .getJob()
-                        .getSavepointTriggerNonce()
+        return jobSpec.getSavepointTriggerNonce() != null
+                && !jobSpec.getSavepointTriggerNonce()
                         .equals(
-                                flinkDeployment
-                                        .getStatus()
-                                        .getReconciliationStatus()
+                                status.getReconciliationStatus()
                                         .deserializeLastReconciledSpec()
                                         .getJob()
                                         .getSavepointTriggerNonce());

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -35,6 +35,7 @@ import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
 import org.apache.flink.kubernetes.utils.Constants;
@@ -54,6 +55,9 @@ public class DefaultValidator implements FlinkResourceValidator {
 
     private static final Set<String> ALLOWED_LOG_CONF_KEYS =
             Set.of(Constants.CONFIG_FILE_LOG4J_NAME, Constants.CONFIG_FILE_LOGBACK_NAME);
+
+    private static Configuration defaultFlinkConf =
+            FlinkUtils.loadConfiguration(EnvUtils.get(EnvUtils.ENV_FLINK_CONF_DIR));
 
     @Override
     public Optional<String> validateDeployment(FlinkDeployment deployment) {
@@ -261,7 +265,7 @@ public class DefaultValidator implements FlinkResourceValidator {
                     && deployment.getStatus().getJobManagerDeploymentStatus()
                             != JobManagerDeploymentStatus.MISSING
                     && ReconciliationUtils.isUpgradeModeChangedToLastStateAndHADisabledPreviously(
-                            deployment)) {
+                            deployment, defaultFlinkConf)) {
                 return Optional.of(
                         String.format(
                                 "Job could not be upgraded to last-state while config key[%s] is not set",

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -21,8 +21,10 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
 import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
@@ -69,12 +71,12 @@ public class TestingFlinkService extends FlinkService {
     }
 
     @Override
-    public void submitApplicationCluster(FlinkDeployment deployment, Configuration conf) {
+    public void submitApplicationCluster(JobSpec jobSpec, Configuration conf) {
         JobID jobID = new JobID();
         JobStatusMessage jobStatusMessage =
                 new JobStatusMessage(
                         jobID,
-                        deployment.getMetadata().getName(),
+                        conf.getString(KubernetesConfigOptions.CLUSTER_ID),
                         JobStatus.RUNNING,
                         System.currentTimeMillis());
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -21,7 +21,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
@@ -32,6 +34,7 @@ import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
 
 import javax.annotation.Nullable;
@@ -84,8 +87,8 @@ public class TestingFlinkService extends FlinkService {
     }
 
     @Override
-    public void submitSessionCluster(FlinkDeployment deployment, Configuration conf) {
-        sessions.add(deployment.getMetadata().getName());
+    public void submitSessionCluster(Configuration conf) {
+        sessions.add(conf.get(KubernetesConfigOptions.CLUSTER_ID));
     }
 
     @Override
@@ -106,7 +109,10 @@ public class TestingFlinkService extends FlinkService {
     @Override
     public List<JobStatusMessage> listJobs(Configuration conf) throws Exception {
         listJobConsumer.accept(conf);
-        if (jobs.isEmpty() && !sessions.isEmpty()) {
+        if (jobs.isEmpty()
+                && !sessions.isEmpty()
+                && conf.get(DeploymentOptions.TARGET)
+                        .equals(KubernetesDeploymentTarget.APPLICATION.getName())) {
             throw new Exception("Trying to list a job without submitting it");
         }
         if (!isPortReady) {
@@ -168,11 +174,8 @@ public class TestingFlinkService extends FlinkService {
 
     @Override
     public void stopSessionCluster(
-            FlinkDeployment deployment,
-            Configuration conf,
-            boolean deleteHa,
-            long shutdownTimeout) {
-        sessions.remove(deployment.getMetadata().getName());
+            ObjectMeta objectMeta, Configuration conf, boolean deleteHa, long shutdownTimeout) {
+        sessions.remove(objectMeta.getName());
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.controller;
+
+import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.OperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.JobState;
+import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
+import org.apache.flink.util.function.ThrowingRunnable;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** @link RollBack logic tests */
+public class RollbackTest {
+
+    private final Context context = TestUtils.createContextWithReadyJobManagerDeployment();
+    private final FlinkOperatorConfiguration operatorConfiguration =
+            FlinkOperatorConfiguration.fromConfiguration(new Configuration());
+
+    private TestingFlinkService flinkService;
+    private FlinkDeploymentController testController;
+
+    private KubernetesClient kubernetesClient;
+
+    @BeforeEach
+    public void setup() {
+        flinkService = new TestingFlinkService();
+        testController =
+                TestUtils.createTestController(
+                        operatorConfiguration, kubernetesClient, flinkService);
+    }
+
+    @Test
+    public void testRollbackWithSavepoint() throws Exception {
+        var dep = TestUtils.buildApplicationCluster();
+        dep.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
+        var flinkConfiguration = dep.getSpec().getFlinkConfiguration();
+        flinkConfiguration.put(CheckpointingOptions.SAVEPOINT_DIRECTORY.key(), "sd");
+        var jobStatus = dep.getStatus().getJobStatus();
+        var reconStatus = dep.getStatus().getReconciliationStatus();
+
+        List<String> savepoints = new ArrayList<>();
+        testRollback(
+                dep,
+                () -> {
+                    dep.getSpec().getJob().setParallelism(9999);
+                    testController.reconcile(dep, context);
+                    savepoints.add(jobStatus.getSavepointInfo().getLastSavepoint().getLocation());
+                    assertEquals(
+                            JobState.SUSPENDED,
+                            reconStatus.deserializeLastReconciledSpec().getJob().getState());
+                    testController.reconcile(dep, TestUtils.createEmptyContext());
+
+                    // Trigger rollback by delaying the recovery
+                    Thread.sleep(500);
+                    testController.reconcile(dep, context);
+                },
+                () -> {
+                    assertEquals(1, flinkService.listJobs().size());
+                    // Make sure we rolled back using the savepoint taken during upgrade
+                    assertEquals(savepoints.get(0), flinkService.listJobs().get(0).f0);
+                    dep.getSpec().setRestartNonce(10L);
+                    testController.reconcile(dep, context);
+                });
+    }
+
+    @Test
+    public void testRollbackWithLastState() throws Exception {
+        var dep = TestUtils.buildApplicationCluster();
+        dep.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
+        var reconStatus = dep.getStatus().getReconciliationStatus();
+
+        testRollback(
+                dep,
+                () -> {
+                    dep.getSpec().getJob().setParallelism(9999);
+                    testController.reconcile(dep, context);
+                    assertEquals(
+                            JobState.SUSPENDED,
+                            reconStatus.deserializeLastReconciledSpec().getJob().getState());
+                    testController.reconcile(dep, TestUtils.createEmptyContext());
+
+                    // Trigger rollback by delaying the recovery
+                    Thread.sleep(500);
+                    testController.reconcile(dep, context);
+                },
+                () -> {
+                    assertEquals(1, flinkService.listJobs().size());
+                    dep.getSpec().setRestartNonce(10L);
+                    testController.reconcile(dep, context);
+                });
+    }
+
+    @Test
+    public void testRollbackFailureWithLastState() throws Exception {
+        var dep = TestUtils.buildApplicationCluster();
+        dep.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
+        var reconStatus = dep.getStatus().getReconciliationStatus();
+
+        testRollback(
+                dep,
+                () -> {
+                    dep.getSpec().getJob().setParallelism(9999);
+                    testController.reconcile(dep, context);
+                    assertEquals(
+                            JobState.SUSPENDED,
+                            reconStatus.deserializeLastReconciledSpec().getJob().getState());
+                    testController.reconcile(dep, TestUtils.createEmptyContext());
+
+                    // Trigger rollback by delaying the recovery
+                    Thread.sleep(500);
+                    testController.reconcile(dep, context);
+                },
+                () -> {
+                    assertEquals(1, flinkService.listJobs().size());
+
+                    // Remove job to simulate rollback failure
+                    flinkService.clear();
+                    flinkService.setPortReady(false);
+
+                    dep.getSpec().setRestartNonce(10L);
+                    testController.reconcile(dep, context);
+                    flinkService.setPortReady(true);
+                });
+    }
+
+    public void testRollback(
+            FlinkDeployment deployment,
+            ThrowingRunnable<Exception> triggerRollback,
+            ThrowingRunnable<Exception> validateAndRecover)
+            throws Exception {
+
+        var flinkConfiguration = deployment.getSpec().getFlinkConfiguration();
+        flinkConfiguration.put(OperatorConfigOptions.DEPLOYMENT_ROLLBACK_ENABLED.key(), "true");
+        flinkConfiguration.put(OperatorConfigOptions.DEPLOYMENT_READINESS_TIMEOUT.key(), "100");
+
+        testController.reconcile(deployment, TestUtils.createEmptyContext());
+
+        // Validate reconciliation status
+        var reconciliationStatus = deployment.getStatus().getReconciliationStatus();
+
+        testController.reconcile(deployment, context);
+        testController.reconcile(deployment, context);
+
+        // Validate stable job
+        var jobStatus = deployment.getStatus().getJobStatus();
+        assertTrue(reconciliationStatus.isLastReconciledSpecStable());
+
+        triggerRollback.run();
+
+        assertFalse(reconciliationStatus.isLastReconciledSpecStable());
+        assertEquals(ReconciliationState.ROLLING_BACK, reconciliationStatus.getState());
+        assertEquals(
+                "Deployment is not ready within the configured timeout, rolling back.",
+                deployment.getStatus().getError());
+
+        testController.reconcile(deployment, context);
+        assertEquals(ReconciliationState.ROLLED_BACK, reconciliationStatus.getState());
+
+        testController.reconcile(deployment, context);
+        testController.reconcile(deployment, context);
+
+        assertEquals("RUNNING", jobStatus.getState());
+        assertEquals(ReconciliationState.ROLLED_BACK, reconciliationStatus.getState());
+        assertFalse(reconciliationStatus.isLastReconciledSpecStable());
+        assertEquals(1, flinkService.listJobs().size());
+
+        validateAndRecover.run();
+        // Test update
+        testController.reconcile(deployment, TestUtils.createEmptyContext());
+        assertEquals(deployment.getSpec(), reconciliationStatus.deserializeLastReconciledSpec());
+        testController.reconcile(deployment, context);
+        testController.reconcile(deployment, context);
+        assertTrue(reconciliationStatus.isLastReconciledSpecStable());
+        assertEquals(ReconciliationState.DEPLOYED, reconciliationStatus.getState());
+        assertNull(deployment.getStatus().getError());
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -119,7 +119,7 @@ public class RollbackTest {
                     testController.reconcile(dep, TestUtils.createEmptyContext());
 
                     // Trigger rollback by delaying the recovery
-                    Thread.sleep(500);
+                    Thread.sleep(200);
                     testController.reconcile(dep, context);
                 },
                 () -> {
@@ -147,7 +147,7 @@ public class RollbackTest {
                     testController.reconcile(dep, TestUtils.createEmptyContext());
 
                     // Trigger rollback by delaying the recovery
-                    Thread.sleep(500);
+                    Thread.sleep(200);
                     testController.reconcile(dep, context);
                 },
                 () -> {
@@ -181,7 +181,7 @@ public class RollbackTest {
                     testController.reconcile(dep, TestUtils.createEmptyContext());
 
                     // Trigger rollback by delaying the recovery
-                    Thread.sleep(500);
+                    Thread.sleep(200);
                     dep.getStatus()
                             .getJobStatus()
                             .getSavepointInfo()
@@ -265,5 +265,28 @@ public class RollbackTest {
         assertTrue(reconciliationStatus.isLastReconciledSpecStable());
         assertEquals(ReconciliationState.DEPLOYED, reconciliationStatus.getState());
         assertNull(deployment.getStatus().getError());
+
+        if (deployment.getSpec().getJob() != null) {
+            deployment.getSpec().getJob().setState(JobState.SUSPENDED);
+            testController.reconcile(deployment, context);
+            Thread.sleep(500);
+            testController.reconcile(deployment, TestUtils.createEmptyContext());
+            testController.reconcile(deployment, context);
+            testController.reconcile(deployment, context);
+            assertTrue(reconciliationStatus.isLastReconciledSpecStable());
+            assertEquals(ReconciliationState.DEPLOYED, reconciliationStatus.getState());
+            assertNull(deployment.getStatus().getError());
+
+            deployment.getSpec().getJob().setState(JobState.RUNNING);
+            testController.reconcile(deployment, context);
+            // Make sure we do not roll back to suspended state
+            Thread.sleep(200);
+            testController.reconcile(deployment, TestUtils.createEmptyContext());
+            testController.reconcile(deployment, context);
+            testController.reconcile(deployment, context);
+            assertTrue(reconciliationStatus.isLastReconciledSpecStable());
+            assertEquals(ReconciliationState.DEPLOYED, reconciliationStatus.getState());
+            assertNull(deployment.getStatus().getError());
+        }
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.observer.Observer;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
-import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
@@ -55,13 +54,13 @@ public class SessionObserverTest {
                         flinkService,
                         FlinkOperatorConfiguration.fromConfiguration(new Configuration()),
                         flinkConf);
-        Configuration conf = FlinkUtils.getEffectiveConfig(deployment, flinkConf);
         deployment
                 .getStatus()
                 .getReconciliationStatus()
                 .serializeAndSetLastReconciledSpec(deployment.getSpec());
 
         observer.observe(deployment, readyContext);
+        assertNull(deployment.getStatus().getReconciliationStatus().getLastStableSpec());
 
         assertEquals(
                 JobManagerDeploymentStatus.DEPLOYED_NOT_READY,
@@ -72,6 +71,10 @@ public class SessionObserverTest {
         assertEquals(
                 JobManagerDeploymentStatus.READY,
                 deployment.getStatus().getJobManagerDeploymentStatus());
+        assertEquals(
+                deployment.getStatus().getReconciliationStatus().getLastReconciledSpec(),
+                deployment.getStatus().getReconciliationStatus().getLastStableSpec());
+
         // Observe again, the JM should be READY
         observer.observe(deployment, readyContext);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -47,7 +47,8 @@ public class SessionJobObserverTest {
         final var sessionJob = TestUtils.buildSessionJob();
         final var flinkService = new TestingFlinkService();
         final var reconciler =
-                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+                new FlinkSessionJobReconciler(
+                        null, flinkService, operatorConfiguration, new Configuration());
         final var observer =
                 new SessionJobObserver(
                         operatorConfiguration, flinkService, defaultConfig.getFlinkConfig());
@@ -57,7 +58,7 @@ public class SessionJobObserverTest {
         observer.observe(sessionJob, readyContext);
 
         // submit job
-        reconciler.reconcile(sessionJob, readyContext, defaultConfig.getFlinkConfig());
+        reconciler.reconcile(sessionJob, readyContext);
         var jobID = sessionJob.getStatus().getJobStatus().getJobId();
         Assertions.assertNotNull(jobID);
         Assertions.assertEquals(
@@ -91,7 +92,7 @@ public class SessionJobObserverTest {
 
         var sessionJob2 = TestUtils.buildSessionJob();
         // submit the second job
-        reconciler.reconcile(sessionJob2, readyContext, defaultConfig.getFlinkConfig());
+        reconciler.reconcile(sessionJob2, readyContext);
         var jobID2 = sessionJob2.getStatus().getJobStatus().getJobId();
         Assertions.assertNotNull(jobID);
         Assertions.assertNotEquals(jobID, jobID2);
@@ -110,7 +111,8 @@ public class SessionJobObserverTest {
         final var sessionJob = TestUtils.buildSessionJob();
         final var flinkService = new TestingFlinkService();
         final var reconciler =
-                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+                new FlinkSessionJobReconciler(
+                        null, flinkService, operatorConfiguration, new Configuration());
         final var observer =
                 new SessionJobObserver(
                         operatorConfiguration, flinkService, defaultConfig.getFlinkConfig());
@@ -119,7 +121,7 @@ public class SessionJobObserverTest {
                         Map.of(RestOptions.PORT.key(), "8088"));
 
         // submit job
-        reconciler.reconcile(sessionJob, readyContext, defaultConfig.getFlinkConfig());
+        reconciler.reconcile(sessionJob, readyContext);
         var jobID = sessionJob.getStatus().getJobStatus().getJobId();
         Assertions.assertNotNull(jobID);
         Assertions.assertEquals(
@@ -138,14 +140,15 @@ public class SessionJobObserverTest {
         final var sessionJob = TestUtils.buildSessionJob();
         final var flinkService = new TestingFlinkService();
         final var reconciler =
-                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+                new FlinkSessionJobReconciler(
+                        null, flinkService, operatorConfiguration, new Configuration());
         final var observer =
                 new SessionJobObserver(
                         operatorConfiguration, flinkService, defaultConfig.getFlinkConfig());
         final var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
 
         // submit job
-        reconciler.reconcile(sessionJob, readyContext, defaultConfig.getFlinkConfig());
+        reconciler.reconcile(sessionJob, readyContext);
         var jobID = sessionJob.getStatus().getJobStatus().getJobId();
         Assertions.assertNotNull(jobID);
         Assertions.assertEquals(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -45,9 +45,8 @@ public class SessionReconcilerTest {
         TestingFlinkService flinkService =
                 new TestingFlinkService() {
                     @Override
-                    public void submitSessionCluster(
-                            FlinkDeployment deployment, Configuration conf) {
-                        super.submitSessionCluster(deployment, conf);
+                    public void submitSessionCluster(Configuration conf) {
+                        super.submitSessionCluster(conf);
                         count.addAndGet(1);
                     }
                 };

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -53,9 +53,10 @@ public class SessionReconcilerTest {
                 };
 
         SessionReconciler reconciler =
-                new SessionReconciler(null, flinkService, operatorConfiguration);
+                new SessionReconciler(
+                        null, flinkService, operatorConfiguration, new Configuration());
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
-        reconciler.reconcile(deployment, context, new Configuration());
+        reconciler.reconcile(deployment, context);
         assertEquals(1, count.get());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
@@ -53,19 +53,18 @@ public class FlinkSessionJobReconcilerTest {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
         FlinkSessionJobReconciler reconciler =
-                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+                new FlinkSessionJobReconciler(
+                        null, flinkService, operatorConfiguration, defaultConfig);
         // session not found
-        reconciler.reconcile(sessionJob, TestUtils.createEmptyContext(), defaultConfig);
+        reconciler.reconcile(sessionJob, TestUtils.createEmptyContext());
         assertEquals(0, flinkService.listSessionJobs().size());
 
         // session not ready
-        reconciler.reconcile(
-                sessionJob, TestUtils.createContextWithNotReadyFlinkDeployment(), defaultConfig);
+        reconciler.reconcile(sessionJob, TestUtils.createContextWithNotReadyFlinkDeployment());
         assertEquals(0, flinkService.listSessionJobs().size());
 
         // session ready
-        reconciler.reconcile(
-                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(), defaultConfig);
+        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
         assertEquals(1, flinkService.listSessionJobs().size());
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
@@ -74,8 +73,7 @@ public class FlinkSessionJobReconcilerTest {
                 null,
                 flinkService.listSessionJobs());
         // clean up
-        reconciler.cleanup(
-                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(), defaultConfig);
+        reconciler.cleanup(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
         assertEquals(0, flinkService.listSessionJobs().size());
     }
 
@@ -87,9 +85,9 @@ public class FlinkSessionJobReconcilerTest {
         var initSavepointPath = "file:///init-sp";
         sessionJob.getSpec().getJob().setInitialSavepointPath(initSavepointPath);
         FlinkSessionJobReconciler reconciler =
-                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
-        reconciler.reconcile(
-                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(), defaultConfig);
+                new FlinkSessionJobReconciler(
+                        null, flinkService, operatorConfiguration, defaultConfig);
+        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
                 JobState.RUNNING,
@@ -105,8 +103,9 @@ public class FlinkSessionJobReconcilerTest {
 
         var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
         FlinkSessionJobReconciler reconciler =
-                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
-        reconciler.reconcile(sessionJob, readyContext, defaultConfig);
+                new FlinkSessionJobReconciler(
+                        null, flinkService, operatorConfiguration, defaultConfig);
+        reconciler.reconcile(sessionJob, readyContext);
         assertEquals(1, flinkService.listSessionJobs().size());
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
@@ -119,11 +118,11 @@ public class FlinkSessionJobReconcilerTest {
         statelessSessionJob.getSpec().getJob().setUpgradeMode(UpgradeMode.STATELESS);
         statelessSessionJob.getSpec().getJob().setParallelism(2);
         // job suspended first
-        reconciler.reconcile(statelessSessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(statelessSessionJob, readyContext);
         assertTrue(flinkService.listSessionJobs().isEmpty());
         verifyJobState(statelessSessionJob, JobState.SUSPENDED, JobState.SUSPENDED.name());
 
-        reconciler.reconcile(statelessSessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(statelessSessionJob, readyContext);
         assertEquals(1, flinkService.listSessionJobs().size());
         verifyAndSetRunningJobsToStatus(
                 statelessSessionJob,
@@ -138,10 +137,11 @@ public class FlinkSessionJobReconcilerTest {
         TestingFlinkService flinkService = new TestingFlinkService();
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
         FlinkSessionJobReconciler reconciler =
-                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
+                new FlinkSessionJobReconciler(
+                        null, flinkService, operatorConfiguration, defaultConfig);
 
         var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
-        reconciler.reconcile(sessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sessionJob, readyContext);
         // start the job
         assertEquals(1, flinkService.listSessionJobs().size());
 
@@ -149,14 +149,14 @@ public class FlinkSessionJobReconcilerTest {
         var statefulSessionJob = ReconciliationUtils.clone(sessionJob);
         statefulSessionJob.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
         statefulSessionJob.getSpec().getJob().setParallelism(3);
-        reconciler.reconcile(statefulSessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(statefulSessionJob, readyContext);
 
         // job suspended first
         assertTrue(flinkService.listSessionJobs().isEmpty());
         verifyJobState(statefulSessionJob, JobState.SUSPENDED, JobState.SUSPENDED.name());
 
         // upgraded
-        reconciler.reconcile(statefulSessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(statefulSessionJob, readyContext);
         assertEquals(1, flinkService.listSessionJobs().size());
         verifyAndSetRunningJobsToStatus(
                 statefulSessionJob,
@@ -173,11 +173,12 @@ public class FlinkSessionJobReconcilerTest {
 
         var readyContext =
                 TestUtils.createContextWithReadyFlinkDeployment(Map.of("key", "newValue"));
+
         FlinkSessionJobReconciler reconciler =
-                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
-        var cfg = new Configuration(defaultConfig);
-        cfg.setString("key", "value");
-        reconciler.reconcile(sessionJob, readyContext, cfg);
+                new FlinkSessionJobReconciler(
+                        null, flinkService, operatorConfiguration, defaultConfig);
+
+        reconciler.reconcile(sessionJob, readyContext);
 
         assertEquals(1, flinkService.listSessionJobs().size());
         var submittedJob =
@@ -192,8 +193,9 @@ public class FlinkSessionJobReconcilerTest {
         assertNull(sessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
         var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
         FlinkSessionJobReconciler reconciler =
-                new FlinkSessionJobReconciler(null, flinkService, operatorConfiguration);
-        reconciler.reconcile(sessionJob, readyContext, defaultConfig);
+                new FlinkSessionJobReconciler(
+                        null, flinkService, operatorConfiguration, defaultConfig);
+        reconciler.reconcile(sessionJob, readyContext);
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
                 JobState.RUNNING,
@@ -207,7 +209,7 @@ public class FlinkSessionJobReconcilerTest {
         var sp1SessionJob = ReconciliationUtils.clone(sessionJob);
 
         // do not trigger savepoint if nonce is null
-        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sp1SessionJob, readyContext);
         assertNull(sessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
 
         sp1SessionJob.getSpec().getJob().setSavepointTriggerNonce(2L);
@@ -215,7 +217,7 @@ public class FlinkSessionJobReconcilerTest {
                 .getStatus()
                 .getJobStatus()
                 .setState(org.apache.flink.api.common.JobStatus.CREATED.name());
-        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sp1SessionJob, readyContext);
         // do not trigger savepoint if job is not running
         assertNull(sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
 
@@ -224,7 +226,7 @@ public class FlinkSessionJobReconcilerTest {
                 .getJobStatus()
                 .setState(org.apache.flink.api.common.JobStatus.RUNNING.name());
 
-        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sp1SessionJob, readyContext);
         assertEquals(
                 "trigger_0",
                 sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
@@ -241,7 +243,7 @@ public class FlinkSessionJobReconcilerTest {
 
         // don't trigger new savepoint when savepoint is in progress
         sp1SessionJob.getSpec().getJob().setSavepointTriggerNonce(3L);
-        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sp1SessionJob, readyContext);
         assertEquals(
                 "trigger_0",
                 sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
@@ -256,7 +258,7 @@ public class FlinkSessionJobReconcilerTest {
                         .getJob()
                         .getParallelism());
         sp1SessionJob.getSpec().getJob().setParallelism(100);
-        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sp1SessionJob, readyContext);
         assertEquals(
                 "trigger_0",
                 sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
@@ -273,9 +275,9 @@ public class FlinkSessionJobReconcilerTest {
         sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
 
         // running -> suspended
-        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sp1SessionJob, readyContext);
         // suspended -> running
-        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sp1SessionJob, readyContext);
         // parallelism changed
         assertEquals(
                 100,
@@ -296,12 +298,12 @@ public class FlinkSessionJobReconcilerTest {
 
         // don't trigger when nonce is the same
         sp1SessionJob.getSpec().getJob().setSavepointTriggerNonce(2L);
-        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sp1SessionJob, readyContext);
         assertNull(sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
 
         // trigger when new nonce is defined
         sp1SessionJob.getSpec().getJob().setSavepointTriggerNonce(3L);
-        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sp1SessionJob, readyContext);
         assertEquals(
                 "trigger_1",
                 sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
@@ -309,7 +311,7 @@ public class FlinkSessionJobReconcilerTest {
 
         // don't trigger when nonce is cleared
         sp1SessionJob.getSpec().getJob().setSavepointTriggerNonce(null);
-        reconciler.reconcile(sp1SessionJob, readyContext, defaultConfig);
+        reconciler.reconcile(sp1SessionJob, readyContext);
         assertNull(sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
@@ -52,7 +52,8 @@ public class IngressUtilsTest {
         Configuration config = FlinkUtils.getEffectiveConfig(appCluster, new Configuration());
 
         // no ingress when ingressDomain is empty
-        IngressUtils.updateIngressRules(appCluster, config, client);
+        IngressUtils.updateIngressRules(
+                appCluster.getMetadata(), appCluster.getSpec(), config, client);
         assertNull(
                 client.network()
                         .v1()
@@ -65,7 +66,8 @@ public class IngressUtilsTest {
         IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
         builder.template("{{name}}.{{namespace}}.example.com");
         appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(appCluster, config, client);
+        IngressUtils.updateIngressRules(
+                appCluster.getMetadata(), appCluster.getSpec(), config, client);
         Ingress ingress =
                 client.network()
                         .v1()
@@ -89,7 +91,8 @@ public class IngressUtilsTest {
         builder.className("nginx");
         builder.annotations(Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"));
         appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(appCluster, config, client);
+        IngressUtils.updateIngressRules(
+                appCluster.getMetadata(), appCluster.getSpec(), config, client);
         ingress =
                 client.network()
                         .v1()
@@ -117,7 +120,8 @@ public class IngressUtilsTest {
         builder.template("example.com/{{namespace}}/{{name}}(/|$)(.*)");
         builder.className("nginx");
         appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(appCluster, config, client);
+        IngressUtils.updateIngressRules(
+                appCluster.getMetadata(), appCluster.getSpec(), config, client);
         ingress =
                 client.network()
                         .v1()

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9118,13 +9118,21 @@ spec:
                 type: string
               reconciliationStatus:
                 properties:
-                  success:
-                    type: boolean
-                  error:
-                    type: string
+                  reconciliationTimestamp:
+                    type: integer
                   lastReconciledSpec:
                     type: string
+                  lastStableSpec:
+                    type: string
+                  state:
+                    enum:
+                    - DEPLOYED
+                    - ROLLING_BACK
+                    - ROLLED_BACK
+                    type: string
                 type: object
+              error:
+                type: string
             type: object
         type: object
     served: true

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -81,13 +81,11 @@ spec:
                 type: object
               reconciliationStatus:
                 properties:
-                  success:
-                    type: boolean
-                  error:
-                    type: string
                   lastReconciledSpec:
                     type: string
                 type: object
+              error:
+                type: string
             type: object
         type: object
     served: true


### PR DESCRIPTION
This PR is designed to lay the groundwork for upgrade rollback strategies. It contains the following changes, improvements and new features on a high level:

**CRD**
 - Remove `error` & `success` fields from `ReconciliationStatus` and move `error` to the top level `FlinkDeploymentStatus/FlinkSessionJobStatus` class (the success flag has been removed completely)
 - Move configuration management from Controller to Reconciler
 - Introduce `reconciliationTimestamp`, `lastStableSpec` and `state` fields in `ReconciliationStatus`
 
**Configuration**
```
kubernetes.operator.upgrade.rollback.enabled: true
kubernetes.operator.upgrade.readiness.timeout: 60s
```
 
**Stable deployments and roll-back logic:**
The rollback logic relies on tracking the last stable / running deployment spec (in addition to the lastReconciledSpec). The observer decides (in the future based on the cunfigured settings) when a job is stable and updates the lastStableSpec accordingly.

If rollback is enabled, the readiness timeout defines the maximum time a new deployment can take to get into a stable / running state before it is rolled back.

**Future improvements that are not part of this PR:**
 - Allow custom stability conditions such as successful checkpoints etc.
 - Roll back before end of readiness timeout on fatal errors
 - Support rolling back sessionjob deployments
 