### PR TITLE
Flink 27211 deployments/finalizers missing for OpenShift Deployment

### DIFF
--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -44,6 +44,7 @@ rules:
       - apps
     resources:
       - deployments
+      - deployments/finalizers
       - replicasets
     verbs:
       - "*"
@@ -87,6 +88,7 @@ rules:
       - apps
     resources:
       - deployments
+      - deployments/finalizers
     verbs:
       - '*'
 {{- end }}


### PR DESCRIPTION
In issue [27211](https://issues.apache.org/jira/browse/FLINK-27211) found a problem where the Flink operator wouldn't deploy on an OpenShift cluster due to missing finalizers in the role and clusterrole.  When the lines are added, then the basic.yaml is able to deploy sucessfully:
```
# oc version
Client Version: 4.8.35
Server Version: 4.8.35
Kubernetes Version: v1.21.8+ee73ea2

# oc get pods
NAME                                         READY   STATUS    RESTARTS   AGE
basic-example-5cc7894895-chxzw               1/1     Running   0          19m
basic-example-taskmanager-1-1                1/1     Running   0          19m
flink-kubernetes-operator-697c4b866b-6jrkt   2/2     Running   0          20m
```