### PR TITLE
[FLINK-27235] Publish Flink k8s Operator Helm Charts via Github Actions

### DIFF
--- a/.github/workflows/helm-charts.yaml
+++ b/.github/workflows/helm-charts.yaml
@@ -1,0 +1,35 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.0
+        with:
+          charts_dir: helm
+          charts_repo_url: https://downloads.apache.org/flink/
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_OWNER: "${{github.repository_owner}}"
+          CR_GIT_BASE_URL: "https://api.github.com/"


### PR DESCRIPTION
Hi Flink k8s Operator lovers, 

this PR tends to add the helm releaser workflow (via Github Actions) so that it creates a release package of the operator when any changes are applied into https://github.com/apache/flink-kubernetes-operator/tree/main/helm/flink-kubernetes-operator.

By default, it pushes/stores helm charts into girhub-pages, but there is also an alternative to host them elsewhere, in our case at https://downloads.apache.org/flink/ :  (see here for more details: https://github.com/helm/chart-releaser-action#example-using-custom-config ).

Please, review and do let me know if there is something else needed.

Best regards, 
Gezim

