### PR TITLE
[FLINK-27289]Do some optimizations for "FlinkService#stopSessionCluster"

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -94,6 +94,10 @@ public class SessionReconciler extends AbstractDeploymentReconciler {
                 effectiveConfig,
                 false,
                 operatorConfiguration.getFlinkShutdownClusterTimeout().toSeconds());
+        FlinkUtils.waitForClusterShutdown(
+                kubernetesClient,
+                effectiveConfig,
+                operatorConfiguration.getFlinkShutdownClusterTimeout().toSeconds());
         flinkService.submitSessionCluster(effectiveConfig);
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
         IngressUtils.updateIngressRules(objectMeta, deploySpec, effectiveConfig, kubernetesClient);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -404,7 +404,6 @@ public class FlinkService {
     public void stopSessionCluster(
             ObjectMeta objectMeta, Configuration conf, boolean deleteHaData, long shutdownTimeout) {
         FlinkUtils.deleteCluster(objectMeta, kubernetesClient, deleteHaData, shutdownTimeout);
-        FlinkUtils.waitForClusterShutdown(kubernetesClient, conf, shutdownTimeout);
     }
 
     public void triggerSavepoint(


### PR DESCRIPTION
In the "FlinkService#stopSessionCluster" method, if 'deleteHaData=true', the 'FlinkUtils#waitForClusterShutdown' method will be called twice.
So we should only execute 'FlinkUtils#waitForClusterShutdown' again with 'deleteHaData=false',This will reduce two visits to the kubernetes cluster