### PR TITLE
[FLINK-27310] Fix FlinkOperatorITCase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,12 @@ jobs:
       - name: Tests in flink-kubernetes-operator
         run: |
           cd flink-kubernetes-operator
-          mvn integration-test -Dit.skip=false
+          mvn verify -Dit.skip=false
           cd ..
       - name: Tests in flink-kubernetes-webhook
         run: |
           cd flink-kubernetes-webhook
-          mvn integration-test -Dit.skip=false
+          mvn verify -Dit.skip=false
           cd ..
       - name: Stop the operator
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ buildNumber.properties
 
 .idea
 *.iml
+*.DS_Store

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
@@ -114,6 +114,7 @@ public class FlinkOperatorITCase {
         resource.setCpu(1);
         JobManagerSpec jm = new JobManagerSpec();
         jm.setResource(resource);
+        jm.setReplicas(1);
         spec.setJobManager(jm);
         TaskManagerSpec tm = new TaskManagerSpec();
         tm.setResource(resource);

--- a/flink-kubernetes-operator/src/test/resources/log4j2-test.properties
+++ b/flink-kubernetes-operator/src/test/resources/log4j2-test.properties
@@ -34,7 +34,7 @@
 # limitations under the License.
 ################################################################################
 
-rootLogger.level = OFF
+rootLogger.level = INFO
 rootLogger.appenderRef.console.ref = ConsoleAppender
 
 # Log all infos to the console

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@ under the License.
                     <execution>
                         <goals>
                             <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
- Fix FlinkOperatorITCase that not sets JM replica correctly.
- Due to the [doc of failsafe plugin](https://maven.apache.org/surefire/maven-failsafe-plugin/), use the `mvn verify` to replace `mvn integration-test` so the `post-integration-test` phase can be executed and as a result, if the IT fails, the maven build will fail.