### PR TITLE
[FLINK-26926] Allow users to force upgrade even if savepoint is in progress

### DIFF
--- a/docs/content/docs/operations/configuration.md
+++ b/docs/content/docs/operations/configuration.md
@@ -62,4 +62,7 @@ To learn more about metrics and logging configuration please refer to the dedica
 | kubernetes.operator.observer.flink.client.timeout     |     10s    |  Duration    | The timeout for the observer to wait the flink rest client to return.            |
 | kubernetes.operator.reconciler.flink.cancel.job.timeout     |     1min    |  Duration    | The timeout for the reconciler to wait for flink to cancel job.            |
 | kubernetes.operator.reconciler.flink.cluster.shutdown.timeout     |     60s    |  Duration    | The timeout for the reconciler to wait for flink to shutdown cluster.           |
+| kubernetes.operator.deployment.rollback.enabled     |     false    |  Boolean    | Whether to enable rolling back failed deployment upgrades.          |
+| kubernetes.operator.deployment.readiness.timeout     |     1min    |  Duration    | The timeout for deployments to become ready/stable before being rolled back if rollback is enabled.            |
 | kubernetes.operator.user.artifacts.base.dir     |     /opt/flink/artifacts    |  String |     The base dir to put the session job artifacts.           |
+| kubernetes.operator.job.upgrade.ignore-pending-savepoint     |     false    |  Boolean    | Whether to ignore pending savepoint during job upgrade.          |

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -103,4 +103,10 @@ public class KubernetesOperatorConfigOptions {
                     .stringType()
                     .defaultValue("/opt/flink/artifacts")
                     .withDescription("The base dir to put the session job artifacts.");
+
+    public static final ConfigOption<Boolean> JOB_UPGRADE_IGNORE_PENDING_SAVEPOINT =
+            ConfigOptions.key("kubernetes.operator.job.upgrade.ignore-pending-savepoint")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to ignore pending savepoint during job upgrade.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.reconciler.deployment;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
@@ -89,8 +90,10 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
             return;
         }
 
-        if (SavepointUtils.savepointInProgress(status.getJobStatus())) {
-            LOG.info("Delaying job reconciliation until pending savepoint is completed");
+        if (!effectiveConfig.getBoolean(
+                        KubernetesOperatorConfigOptions.JOB_UPGRADE_IGNORE_PENDING_SAVEPOINT)
+                && SavepointUtils.savepointInProgress(status.getJobStatus())) {
+            LOG.info("Delaying job reconciliation until pending savepoint is completed.");
             return;
         }
 

--- a/helm/flink-kubernetes-operator/conf/flink-conf.yaml
+++ b/helm/flink-kubernetes-operator/conf/flink-conf.yaml
@@ -35,6 +35,10 @@ parallelism.default: 2
 # kubernetes.operator.observer.progress-check.interval: 10 s
 # kubernetes.operator.observer.savepoint.trigger.grace-period: 10 s
 # kubernetes.operator.observer.flink.client.timeout: 10 s
+# kubernetes.operator.deployment.rollback.enabled: false
+# kubernetes.operator.deployment.readiness.timeout: 1min
+# kubernetes.operator.user.artifacts.base.dir: /opt/flink/artifacts
+# kubernetes.operator.job.upgrade.ignore-pending-savepoint: false
 
 # kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory
 # kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE


### PR DESCRIPTION
Currently all upgrades (regardless of upgrade mode) are delayed as long as there is a pending savepoint operation, which should allow users to override this and execute the upgrade (thus potentially cancelling the savepoint) regardless of the savepoint status.

**The brief change log**

- Add the `kubernetes.operator.job.upgrade.ignore-pending-savepoint` option to allow users to force upgrade regardless of the savepoint status.