### PR TITLE
[FLINK-27303][FLINK-27309] Introduce FlinkConfigManager for efficient config management

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -21,6 +21,18 @@
             <td>Whether to enable rolling back failed deployment upgrades.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.dynamic.config.check.interval</h5></td>
+            <td style="word-wrap: break-word;">5 min</td>
+            <td>Duration</td>
+            <td>Time interval for checking config changes.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.dynamic.config.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable on-the-fly config changes through the operator configmap.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.upgrade.ignore-pending-savepoint</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
@@ -66,9 +67,9 @@ public class FlinkOperator {
     private final FlinkConfigManager configManager;
     private final Set<FlinkResourceValidator> validators;
 
-    public FlinkOperator(@Nullable FlinkConfigManager cm) {
+    public FlinkOperator(@Nullable Configuration conf) {
         this.client = new DefaultKubernetesClient();
-        this.configManager = cm != null ? cm : new FlinkConfigManager(client);
+        this.configManager = conf != null ? new FlinkConfigManager(conf) : new FlinkConfigManager();
         this.configurationService =
                 getConfigurationService(configManager.getOperatorConfiguration());
         this.operator = new Operator(client, configurationService);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/artifact/ArtifactManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/artifact/ArtifactManager.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.artifact;
 
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -32,10 +32,10 @@ import java.net.URI;
 public class ArtifactManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(ArtifactManager.class);
-    private final File baseDir;
+    private final FlinkConfigManager configManager;
 
-    public ArtifactManager(FlinkOperatorConfiguration operatorConfiguration) {
-        this.baseDir = new File(operatorConfiguration.getArtifactsBaseDir());
+    public ArtifactManager(FlinkConfigManager configManager) {
+        this.configManager = configManager;
     }
 
     private synchronized void createIfNotExists(File targetDir) {
@@ -65,7 +65,8 @@ public class ArtifactManager {
         return String.join(
                 File.separator,
                 new String[] {
-                    baseDir.getAbsolutePath(),
+                    new File(configManager.getOperatorConfiguration().getArtifactsBaseDir())
+                            .getAbsolutePath(),
                     sessionJob.getMetadata().getNamespace(),
                     sessionJob.getSpec().getDeploymentName(),
                     sessionJob.getMetadata().getName()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -68,29 +68,24 @@ public class FlinkConfigBuilder {
     private final String clusterId;
     private final FlinkDeploymentSpec spec;
     private final Configuration effectiveConfig;
-    private final boolean forDeployment;
 
-    protected FlinkConfigBuilder(
-            FlinkDeployment deployment, Configuration flinkConfig, boolean forDeployment) {
+    protected FlinkConfigBuilder(FlinkDeployment deployment, Configuration flinkConfig) {
         this(
                 deployment.getMetadata().getNamespace(),
                 deployment.getMetadata().getName(),
                 deployment.getSpec(),
-                flinkConfig,
-                forDeployment);
+                flinkConfig);
     }
 
     protected FlinkConfigBuilder(
             String namespace,
             String clusterId,
             FlinkDeploymentSpec spec,
-            Configuration flinkConfig,
-            boolean forDeployment) {
+            Configuration flinkConfig) {
         this.namespace = namespace;
         this.clusterId = clusterId;
         this.spec = spec;
         this.effectiveConfig = new Configuration(flinkConfig);
-        this.forDeployment = forDeployment;
     }
 
     protected FlinkConfigBuilder applyImage() {
@@ -144,7 +139,7 @@ public class FlinkConfigBuilder {
     }
 
     protected FlinkConfigBuilder applyLogConfiguration() throws IOException {
-        if (spec.getLogConfiguration() != null && forDeployment) {
+        if (spec.getLogConfiguration() != null) {
             String confDir =
                     createLogConfigFiles(
                             spec.getLogConfiguration().get(CONFIG_FILE_LOG4J_NAME),
@@ -155,7 +150,7 @@ public class FlinkConfigBuilder {
     }
 
     protected FlinkConfigBuilder applyCommonPodTemplate() throws IOException {
-        if (spec.getPodTemplate() != null && forDeployment) {
+        if (spec.getPodTemplate() != null) {
             effectiveConfig.set(
                     KubernetesConfigOptions.KUBERNETES_POD_TEMPLATE,
                     createTempFile(spec.getPodTemplate()));
@@ -184,13 +179,11 @@ public class FlinkConfigBuilder {
     protected FlinkConfigBuilder applyJobManagerSpec() throws IOException {
         if (spec.getJobManager() != null) {
             setResource(spec.getJobManager().getResource(), effectiveConfig, true);
-            if (forDeployment) {
-                setPodTemplate(
-                        spec.getPodTemplate(),
-                        spec.getJobManager().getPodTemplate(),
-                        effectiveConfig,
-                        true);
-            }
+            setPodTemplate(
+                    spec.getPodTemplate(),
+                    spec.getJobManager().getPodTemplate(),
+                    effectiveConfig,
+                    true);
             if (spec.getJobManager().getReplicas() > 0) {
                 effectiveConfig.set(
                         KubernetesConfigOptions.KUBERNETES_JOBMANAGER_REPLICAS,
@@ -203,13 +196,11 @@ public class FlinkConfigBuilder {
     protected FlinkConfigBuilder applyTaskManagerSpec() throws IOException {
         if (spec.getTaskManager() != null) {
             setResource(spec.getTaskManager().getResource(), effectiveConfig, false);
-            if (forDeployment) {
-                setPodTemplate(
-                        spec.getPodTemplate(),
-                        spec.getTaskManager().getPodTemplate(),
-                        effectiveConfig,
-                        false);
-            }
+            setPodTemplate(
+                    spec.getPodTemplate(),
+                    spec.getTaskManager().getPodTemplate(),
+                    effectiveConfig,
+                    false);
         }
         return this;
     }
@@ -241,13 +232,9 @@ public class FlinkConfigBuilder {
     }
 
     protected static Configuration buildFrom(
-            String namespace,
-            String clusterId,
-            FlinkDeploymentSpec spec,
-            Configuration flinkConfig,
-            boolean deployment)
+            String namespace, String clusterId, FlinkDeploymentSpec spec, Configuration flinkConfig)
             throws IOException, URISyntaxException {
-        return new FlinkConfigBuilder(namespace, clusterId, spec, flinkConfig, deployment)
+        return new FlinkConfigBuilder(namespace, clusterId, spec, flinkConfig)
                 .applyFlinkConfiguration()
                 .applyLogConfiguration()
                 .applyImage()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.config;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+import org.apache.flink.kubernetes.operator.utils.EnvUtils;
+import org.apache.flink.kubernetes.operator.utils.OperatorUtils;
+import org.apache.flink.util.FileUtils;
+
+import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import lombok.SneakyThrows;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_DYNAMIC_CONFIG_CHECK_INTERVAL;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_DYNAMIC_CONFIG_ENABLED;
+
+/** Configuration manager for the Flink operator. */
+public class FlinkConfigManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FlinkConfigManager.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static final String OP_CM_NAME = "flink-operator-config";
+
+    private static final int CACHE_SIZE = 1000;
+
+    private volatile Configuration defaultConfig;
+    private volatile FlinkOperatorConfiguration operatorConfiguration;
+
+    private final Cache<Tuple4<String, String, ObjectNode, Boolean>, Configuration> cache;
+    private Set<String> namespaces = OperatorUtils.getWatchedNamespaces();
+    private ConfigUpdater configUpdater;
+
+    public FlinkConfigManager(KubernetesClient client) {
+        this(readConfiguration(client));
+
+        if (defaultConfig.getBoolean(OPERATOR_DYNAMIC_CONFIG_ENABLED)) {
+            scheduleConfigWatcher(client);
+        }
+    }
+
+    public FlinkConfigManager(Configuration defaultConfig) {
+        this.cache = CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).build();
+        updateDefaultConfig(
+                defaultConfig,
+                FlinkOperatorConfiguration.fromConfiguration(defaultConfig, namespaces));
+    }
+
+    public Configuration getDefaultConfig() {
+        return defaultConfig;
+    }
+
+    @VisibleForTesting
+    public void updateDefaultConfig(
+            Configuration defaultConfig, FlinkOperatorConfiguration operatorConfiguration) {
+        this.defaultConfig = defaultConfig;
+        cache.invalidateAll();
+        this.operatorConfiguration = operatorConfiguration;
+    }
+
+    public FlinkOperatorConfiguration getOperatorConfiguration() {
+        return operatorConfiguration;
+    }
+
+    public Configuration getObserveConfig(FlinkDeployment deployment) {
+        return getConfig(
+                deployment.getMetadata(), ReconciliationUtils.getDeployedSpec(deployment), false);
+    }
+
+    public Configuration getDeployConfig(ObjectMeta objectMeta, FlinkDeploymentSpec spec) {
+        return getConfig(objectMeta, spec, true);
+    }
+
+    @SneakyThrows
+    private Configuration getConfig(
+            ObjectMeta objectMeta, FlinkDeploymentSpec spec, boolean forDeploy) {
+
+        var key =
+                Tuple4.of(
+                        objectMeta.getNamespace(),
+                        objectMeta.getName(),
+                        objectMapper.convertValue(spec, ObjectNode.class),
+                        forDeploy);
+
+        var conf = cache.getIfPresent(key);
+        if (conf == null) {
+            conf = generateConfig(key);
+            cache.put(key, conf);
+        }
+
+        // Always return a copy of the configuration to avoid polluting the cache
+        return conf.clone();
+    }
+
+    private Configuration generateConfig(Tuple4<String, String, ObjectNode, Boolean> key) {
+        try {
+            LOG.info("Generating new {} config", key.f3 ? "deployment" : "observe");
+            return FlinkConfigBuilder.buildFrom(
+                    key.f0,
+                    key.f1,
+                    objectMapper.convertValue(key.f2, FlinkDeploymentSpec.class),
+                    defaultConfig,
+                    key.f3);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load configuration", e);
+        }
+    }
+
+    private void scheduleConfigWatcher(KubernetesClient client) {
+        var checkInterval = defaultConfig.get(OPERATOR_DYNAMIC_CONFIG_CHECK_INTERVAL);
+        var millis = checkInterval.toMillis();
+        configUpdater = new ConfigUpdater(client);
+        Executors.newSingleThreadScheduledExecutor()
+                .scheduleAtFixedRate(configUpdater, millis, millis, TimeUnit.MILLISECONDS);
+        LOG.info("Enabled dynamic config updates, checking config changes every {}", checkInterval);
+    }
+
+    @VisibleForTesting
+    public void setWatchedNamespaces(Set<String> namespaces) {
+        this.namespaces = namespaces;
+        operatorConfiguration =
+                FlinkOperatorConfiguration.fromConfiguration(defaultConfig, namespaces);
+    }
+
+    @VisibleForTesting
+    public Runnable getConfigUpdater() {
+        return configUpdater;
+    }
+
+    private static Configuration readConfiguration(KubernetesClient client) {
+        var operatorNamespace = EnvUtils.getOrDefault(EnvUtils.ENV_OPERATOR_NAMESPACE, "default");
+        var configMap =
+                client.configMaps().inNamespace(operatorNamespace).withName(OP_CM_NAME).get();
+        Map<String, String> data = configMap.getData();
+        Path tmpDir = null;
+        try {
+            tmpDir = Files.createTempDirectory("flink-conf");
+            Files.write(
+                    tmpDir.resolve(GlobalConfiguration.FLINK_CONF_FILENAME),
+                    data.get(GlobalConfiguration.FLINK_CONF_FILENAME)
+                            .getBytes(Charset.defaultCharset()));
+            return GlobalConfiguration.loadConfiguration(tmpDir.toAbsolutePath().toString());
+        } catch (IOException ioe) {
+            throw new RuntimeException("Could not load default config", ioe);
+        } finally {
+            if (tmpDir != null) {
+                FileUtils.deleteDirectoryQuietly(tmpDir.toFile());
+            }
+        }
+    }
+
+    class ConfigUpdater implements Runnable {
+        KubernetesClient kubeClient;
+
+        public ConfigUpdater(KubernetesClient kubeClient) {
+            this.kubeClient = kubeClient;
+        }
+
+        public void run() {
+            try {
+                LOG.debug("Checking for config update changes...");
+                var newConf = readConfiguration(kubeClient);
+                if (!newConf.equals(defaultConfig)) {
+                    LOG.info("Updating default configuration");
+                    updateDefaultConfig(
+                            newConf,
+                            FlinkOperatorConfiguration.fromConfiguration(newConf, namespaces));
+                } else {
+                    LOG.debug("Default configuration did not change, nothing to do...");
+                }
+            } catch (Exception e) {
+                LOG.error("Error while updating operator configuration", e);
+            }
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -33,7 +33,6 @@ import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import lombok.SneakyThrows;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,7 +110,6 @@ public class FlinkConfigManager {
         return getConfig(deployment.getMetadata(), ReconciliationUtils.getDeployedSpec(deployment));
     }
 
-    @SneakyThrows
     private Configuration getConfig(ObjectMeta objectMeta, FlinkDeploymentSpec spec) {
 
         var key =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -20,7 +20,6 @@ package org.apache.flink.kubernetes.operator.config;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
-import org.apache.flink.kubernetes.operator.utils.OperatorUtils;
 
 import lombok.Value;
 
@@ -42,11 +41,6 @@ public class FlinkOperatorConfiguration {
     Duration flinkCancelJobTimeout;
     Duration flinkShutdownClusterTimeout;
     String artifactsBaseDir;
-
-    public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
-        Set<String> watchedNamespaces = OperatorUtils.getWatchedNamespaces();
-        return fromConfiguration(operatorConfig, watchedNamespaces);
-    }
 
     public static FlinkOperatorConfiguration fromConfiguration(
             Configuration operatorConfig, Set<String> watchedNamespaces) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -120,6 +120,6 @@ public class KubernetesOperatorConfigOptions {
     public static final ConfigOption<Duration> OPERATOR_DYNAMIC_CONFIG_CHECK_INTERVAL =
             ConfigOptions.key("kubernetes.operator.dynamic.config.check.interval")
                     .durationType()
-                    .defaultValue(Duration.ofSeconds(30))
+                    .defaultValue(Duration.ofMinutes(5))
                     .withDescription("Time interval for checking config changes.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -109,4 +109,17 @@ public class KubernetesOperatorConfigOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Whether to ignore pending savepoint during job upgrade.");
+
+    public static final ConfigOption<Boolean> OPERATOR_DYNAMIC_CONFIG_ENABLED =
+            ConfigOptions.key("kubernetes.operator.dynamic.config.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to enable on-the-fly config changes through the operator configmap.");
+
+    public static final ConfigOption<Duration> OPERATOR_DYNAMIC_CONFIG_CHECK_INTERVAL =
+            ConfigOptions.key("kubernetes.operator.dynamic.config.check.interval")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    .withDescription("Time interval for checking config changes.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -18,7 +18,7 @@
 package org.apache.flink.kubernetes.operator.observer;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
@@ -34,12 +34,11 @@ public class SavepointObserver {
     private static final Logger LOG = LoggerFactory.getLogger(SavepointObserver.class);
 
     private final FlinkService flinkService;
-    private final FlinkOperatorConfiguration operatorConfiguration;
+    private final FlinkConfigManager configManager;
 
-    public SavepointObserver(
-            FlinkService flinkService, FlinkOperatorConfiguration operatorConfiguration) {
+    public SavepointObserver(FlinkService flinkService, FlinkConfigManager configManager) {
         this.flinkService = flinkService;
-        this.operatorConfiguration = operatorConfiguration;
+        this.configManager = configManager;
     }
 
     /**
@@ -71,7 +70,7 @@ public class SavepointObserver {
             String error = savepointFetchResult.getError();
             if (error != null
                     || SavepointUtils.gracePeriodEnded(
-                            operatorConfiguration, currentSavepointInfo)) {
+                            configManager.getOperatorConfiguration(), currentSavepointInfo)) {
                 String errorMsg = error != null ? error : "Savepoint status unknown";
                 LOG.error(errorMsg);
                 currentSavepointInfo.resetTrigger();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
@@ -18,7 +18,7 @@
 package org.apache.flink.kubernetes.operator.observer.deployment;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
@@ -39,12 +39,9 @@ public class ApplicationObserver extends AbstractDeploymentObserver {
     private final SavepointObserver savepointObserver;
     private final JobStatusObserver<ApplicationObserverContext> jobStatusObserver;
 
-    public ApplicationObserver(
-            FlinkService flinkService,
-            FlinkOperatorConfiguration operatorConfiguration,
-            Configuration flinkConfig) {
-        super(flinkService, operatorConfiguration, flinkConfig);
-        this.savepointObserver = new SavepointObserver(flinkService, operatorConfiguration);
+    public ApplicationObserver(FlinkService flinkService, FlinkConfigManager configManager) {
+        super(flinkService, configManager);
+        this.savepointObserver = new SavepointObserver(flinkService, configManager);
         this.jobStatusObserver =
                 new JobStatusObserver<>(flinkService) {
                     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ObserverFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ObserverFactory.java
@@ -17,8 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.observer.deployment;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.observer.Observer;
@@ -31,17 +30,12 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ObserverFactory {
 
     private final FlinkService flinkService;
-    private final FlinkOperatorConfiguration operatorConfig;
-    private final Configuration flinkConfig;
+    private final FlinkConfigManager configManager;
     private final Map<Mode, Observer<FlinkDeployment>> observerMap;
 
-    public ObserverFactory(
-            FlinkService flinkService,
-            FlinkOperatorConfiguration operatorConfiguration,
-            Configuration flinkConfig) {
+    public ObserverFactory(FlinkService flinkService, FlinkConfigManager configManager) {
         this.flinkService = flinkService;
-        this.operatorConfig = operatorConfiguration;
-        this.flinkConfig = flinkConfig;
+        this.configManager = configManager;
         this.observerMap = new ConcurrentHashMap<>();
     }
 
@@ -51,10 +45,9 @@ public class ObserverFactory {
                 mode -> {
                     switch (mode) {
                         case SESSION:
-                            return new SessionObserver(flinkService, operatorConfig, flinkConfig);
+                            return new SessionObserver(flinkService, configManager);
                         case APPLICATION:
-                            return new ApplicationObserver(
-                                    flinkService, operatorConfig, flinkConfig);
+                            return new ApplicationObserver(flinkService, configManager);
                         default:
                             throw new UnsupportedOperationException(
                                     String.format("Unsupported running mode: %s", mode));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
@@ -18,7 +18,7 @@
 package org.apache.flink.kubernetes.operator.observer.deployment;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
@@ -29,11 +29,8 @@ import java.util.concurrent.TimeoutException;
 /** The observer of the {@link org.apache.flink.kubernetes.operator.config.Mode#SESSION} cluster. */
 public class SessionObserver extends AbstractDeploymentObserver {
 
-    public SessionObserver(
-            FlinkService flinkService,
-            FlinkOperatorConfiguration operatorConfiguration,
-            Configuration flinkConfig) {
-        super(flinkService, operatorConfiguration, flinkConfig);
+    public SessionObserver(FlinkService flinkService, FlinkConfigManager configManager) {
+        super(flinkService, configManager);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
@@ -17,8 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.reconciler.deployment;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.reconciler.Reconciler;
@@ -34,19 +33,16 @@ public class ReconcilerFactory {
 
     private final KubernetesClient kubernetesClient;
     private final FlinkService flinkService;
-    private final FlinkOperatorConfiguration operatorConfiguration;
-    private final Configuration defaultConfig;
+    private final FlinkConfigManager configManager;
     private final Map<Mode, Reconciler<FlinkDeployment>> reconcilerMap;
 
     public ReconcilerFactory(
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
-            FlinkOperatorConfiguration operatorConfiguration,
-            Configuration defaultConfig) {
+            FlinkConfigManager configManager) {
         this.kubernetesClient = kubernetesClient;
         this.flinkService = flinkService;
-        this.operatorConfiguration = operatorConfiguration;
-        this.defaultConfig = defaultConfig;
+        this.configManager = configManager;
         this.reconcilerMap = new ConcurrentHashMap<>();
     }
 
@@ -57,16 +53,10 @@ public class ReconcilerFactory {
                     switch (mode) {
                         case SESSION:
                             return new SessionReconciler(
-                                    kubernetesClient,
-                                    flinkService,
-                                    operatorConfiguration,
-                                    defaultConfig);
+                                    kubernetesClient, flinkService, configManager);
                         case APPLICATION:
                             return new ApplicationReconciler(
-                                    kubernetesClient,
-                                    flinkService,
-                                    operatorConfiguration,
-                                    defaultConfig);
+                                    kubernetesClient, flinkService, configManager);
                         default:
                             throw new UnsupportedOperationException(
                                     String.format("Unsupported running mode: %s", mode));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -22,8 +22,6 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
-import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
-import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
@@ -51,23 +49,6 @@ public class FlinkUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlinkUtils.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    public static Configuration getEffectiveConfig(
-            FlinkDeployment flinkApp, Configuration flinkConfig) {
-        return getEffectiveConfig(flinkApp.getMetadata(), flinkApp.getSpec(), flinkConfig);
-    }
-
-    public static Configuration getEffectiveConfig(
-            ObjectMeta meta, FlinkDeploymentSpec spec, Configuration flinkConfig) {
-        try {
-            final Configuration effectiveConfig =
-                    FlinkConfigBuilder.buildFrom(meta, spec, flinkConfig);
-            LOG.debug("Effective config: {}", effectiveConfig);
-            return effectiveConfig;
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to load configuration", e);
-        }
-    }
 
     public static Pod mergePodTemplates(Pod toPod, Pod fromPod) {
         if (fromPod == null) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
@@ -18,8 +18,8 @@
 package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.validation.DefaultValidator;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
 
@@ -34,13 +34,12 @@ public final class ValidatorUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlinkUtils.class);
 
-    public static Set<FlinkResourceValidator> discoverValidators(Configuration configuration) {
+    public static Set<FlinkResourceValidator> discoverValidators(FlinkConfigManager configManager) {
         Set<FlinkResourceValidator> resourceValidators = new HashSet<>();
-        resourceValidators.add(new DefaultValidator());
-        DefaultValidator defaultValidator = new DefaultValidator();
-        defaultValidator.configure(configuration);
+        DefaultValidator defaultValidator = new DefaultValidator(configManager);
+        defaultValidator.configure(configManager.getDefaultConfig());
         resourceValidators.add(defaultValidator);
-        PluginUtils.createPluginManagerFromRootFolder(configuration)
+        PluginUtils.createPluginManagerFromRootFolder(configManager.getDefaultConfig())
                 .load(FlinkResourceValidator.class)
                 .forEachRemaining(
                         validator -> {
@@ -51,7 +50,7 @@ public final class ValidatorUtils {
                                                     ConfigConstants.ENV_FLINK_PLUGINS_DIR,
                                                     ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS),
                                     validator.getClass().getName());
-                            validator.configure(configuration);
+                            validator.configure(configManager.getDefaultConfig());
                             resourceValidators.add(validator);
                         });
         return resourceValidators;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
@@ -18,7 +18,6 @@
 package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
@@ -68,7 +67,7 @@ public class FlinkOperatorTest {
                                 KubernetesOperatorConfigOptions.OPERATOR_RECONCILER_MAX_PARALLELISM,
                                 p));
 
-        FlinkOperator flinkOperator = new FlinkOperator(new FlinkConfigManager(operatorConfig));
+        FlinkOperator flinkOperator = new FlinkOperator(operatorConfig);
         return flinkOperator.getOperator().getConfigurationService().getExecutorService();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
@@ -67,7 +68,7 @@ public class FlinkOperatorTest {
                                 KubernetesOperatorConfigOptions.OPERATOR_RECONCILER_MAX_PARALLELISM,
                                 p));
 
-        FlinkOperator flinkOperator = new FlinkOperator(operatorConfig);
+        FlinkOperator flinkOperator = new FlinkOperator(new FlinkConfigManager(operatorConfig));
         return flinkOperator.getOperator().getConfigurationService().getExecutorService();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -17,11 +17,10 @@
 
 package org.apache.flink.kubernetes.operator;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.controller.FlinkControllerConfig;
 import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentController;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
@@ -341,22 +340,17 @@ public class TestUtils {
     }
 
     public static FlinkDeploymentController createTestController(
-            FlinkOperatorConfiguration operatorConfiguration,
+            FlinkConfigManager configManager,
             KubernetesClient kubernetesClient,
             TestingFlinkService flinkService) {
-        var defaultConfig = new Configuration();
 
         var controller =
                 new FlinkDeploymentController(
-                        operatorConfiguration,
+                        configManager,
                         kubernetesClient,
-                        ValidatorUtils.discoverValidators(defaultConfig),
-                        new ReconcilerFactory(
-                                kubernetesClient,
-                                flinkService,
-                                operatorConfiguration,
-                                defaultConfig),
-                        new ObserverFactory(flinkService, operatorConfiguration, defaultConfig));
+                        ValidatorUtils.discoverValidators(configManager),
+                        new ReconcilerFactory(kubernetesClient, flinkService, configManager),
+                        new ObserverFactory(flinkService, configManager));
         controller.setControllerConfig(
                 new FlinkControllerConfig(controller, Collections.emptySet()));
         return controller;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -24,7 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
@@ -65,7 +65,7 @@ public class TestingFlinkService extends FlinkService {
     private Consumer<Configuration> listJobConsumer = conf -> {};
 
     public TestingFlinkService() {
-        super(null, FlinkOperatorConfiguration.fromConfiguration(new Configuration()));
+        super(null, new FlinkConfigManager(new Configuration()));
     }
 
     public void clear() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/artifact/ArtifactManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/artifact/ArtifactManagerTest.java
@@ -19,7 +19,7 @@ package org.apache.flink.kubernetes.operator.artifact;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.util.Preconditions;
 
@@ -56,8 +56,7 @@ public class ArtifactManagerTest {
         configuration.setString(
                 KubernetesOperatorConfigOptions.OPERATOR_USER_ARTIFACTS_BASE_DIR,
                 tempDir.toAbsolutePath().toString());
-        artifactManager =
-                new ArtifactManager(FlinkOperatorConfiguration.fromConfiguration(configuration));
+        artifactManager = new ArtifactManager(new FlinkConfigManager(configuration));
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -93,16 +93,14 @@ public class FlinkConfigBuilderTest {
     @Test
     public void testApplyImage() {
         final Configuration configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration(), true)
-                        .applyImage()
-                        .build();
+                new FlinkConfigBuilder(flinkDeployment, new Configuration()).applyImage().build();
         Assert.assertEquals(IMAGE, configuration.get(KubernetesConfigOptions.CONTAINER_IMAGE));
     }
 
     @Test
     public void testApplyImagePolicy() {
         final Configuration configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration(), true)
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyImagePullPolicy()
                         .build();
         Assert.assertEquals(
@@ -113,7 +111,7 @@ public class FlinkConfigBuilderTest {
     @Test
     public void testApplyFlinkConfiguration() {
         Configuration configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration(), true)
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyFlinkConfiguration()
                         .build();
         Assert.assertEquals(2, (int) configuration.get(TaskManagerOptions.NUM_TASK_SLOTS));
@@ -131,7 +129,7 @@ public class FlinkConfigBuilderTest {
                                 KubernetesConfigOptions.ServiceExposedType.LoadBalancer.name()));
 
         configuration =
-                new FlinkConfigBuilder(deployment, new Configuration(), true)
+                new FlinkConfigBuilder(deployment, new Configuration())
                         .applyFlinkConfiguration()
                         .build();
         Assert.assertEquals(
@@ -146,8 +144,7 @@ public class FlinkConfigBuilderTest {
                                         .set(
                                                 HighAvailabilityOptions.HA_MODE,
                                                 KubernetesHaServicesFactory.class
-                                                        .getCanonicalName()),
-                                true)
+                                                        .getCanonicalName()))
                         .applyFlinkConfiguration()
                         .build();
         Assert.assertEquals(
@@ -158,7 +155,7 @@ public class FlinkConfigBuilderTest {
     @Test
     public void testApplyLogConfiguration() throws IOException {
         Configuration configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration(), true)
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyLogConfiguration()
                         .build();
 
@@ -173,7 +170,7 @@ public class FlinkConfigBuilderTest {
     @Test
     public void testApplyCommonPodTemplate() throws Exception {
         Configuration configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration(), true)
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyCommonPodTemplate()
                         .build();
         final Pod jmPod =
@@ -195,7 +192,7 @@ public class FlinkConfigBuilderTest {
     @Test
     public void testApplyIngressDomain() {
         final Configuration configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration(), true)
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyIngressDomain()
                         .build();
         Assert.assertEquals(
@@ -206,7 +203,7 @@ public class FlinkConfigBuilderTest {
     @Test
     public void testApplyServiceAccount() {
         final Configuration configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration(), true)
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyServiceAccount()
                         .build();
         Assert.assertEquals(
@@ -217,7 +214,7 @@ public class FlinkConfigBuilderTest {
     @Test
     public void testApplyJobManagerSpec() throws Exception {
         final Configuration configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration(), true)
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyJobManagerSpec()
                         .build();
         final Pod jmPod =
@@ -243,7 +240,7 @@ public class FlinkConfigBuilderTest {
         deploymentClone.getSpec().setPodTemplate(null);
 
         final Configuration configuration =
-                new FlinkConfigBuilder(deploymentClone, new Configuration(), true)
+                new FlinkConfigBuilder(deploymentClone, new Configuration())
                         .applyTaskManagerSpec()
                         .build();
         final Pod tmPod =
@@ -263,7 +260,7 @@ public class FlinkConfigBuilderTest {
     @Test
     public void testApplyJobOrSessionSpec() throws Exception {
         final Configuration configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration(), true)
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyJobOrSessionSpec()
                         .build();
         Assert.assertEquals(
@@ -280,33 +277,12 @@ public class FlinkConfigBuilderTest {
                         flinkDeployment.getMetadata().getNamespace(),
                         flinkDeployment.getMetadata().getName(),
                         flinkDeployment.getSpec(),
-                        new Configuration(),
-                        true);
+                        new Configuration());
         final String namespace = flinkDeployment.getMetadata().getNamespace();
         final String clusterId = flinkDeployment.getMetadata().getName();
         // Most configs have been tested by previous unit tests, thus we only verify the namespace
         // and clusterId here.
         Assert.assertEquals(namespace, configuration.get(KubernetesConfigOptions.NAMESPACE));
         Assert.assertEquals(clusterId, configuration.get(KubernetesConfigOptions.CLUSTER_ID));
-    }
-
-    @Test
-    public void verifyGenerateForNonDeployment() throws Exception {
-        Configuration configuration =
-                FlinkConfigBuilder.buildFrom(
-                        flinkDeployment.getMetadata().getNamespace(),
-                        flinkDeployment.getMetadata().getName(),
-                        flinkDeployment.getSpec(),
-                        new Configuration(),
-                        false);
-        File log4jFile =
-                new File(
-                        configuration.get(DeploymentOptionsInternal.CONF_DIR),
-                        CONFIG_FILE_LOG4J_NAME);
-        Assert.assertFalse(log4jFile.exists() && log4jFile.isFile() && log4jFile.canRead());
-        Assert.assertFalse(
-                configuration.contains(KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE));
-        Assert.assertFalse(
-                configuration.contains(KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE));
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.config;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/** Test for FlinkConfigManager. */
+@EnableKubernetesMockClient(crud = true)
+public class FlinkConfigManagerTest {
+
+    private KubernetesClient kubernetesClient;
+
+    @BeforeEach
+    public void setup() {
+        Configuration conf = new Configuration();
+        conf.set(KubernetesOperatorConfigOptions.OPERATOR_DYNAMIC_CONFIG_ENABLED, false);
+        updateConfigMap(conf);
+    }
+
+    private void updateConfigMap(Configuration configuration) {
+        ConfigMap cm = new ConfigMap();
+        ObjectMeta objectMeta = new ObjectMeta();
+        objectMeta.setNamespace("default");
+        objectMeta.setName(FlinkConfigManager.OP_CM_NAME);
+        cm.setMetadata(objectMeta);
+        cm.setData(Map.of(GlobalConfiguration.FLINK_CONF_FILENAME, writeAsYaml(configuration)));
+        kubernetesClient
+                .configMaps()
+                .inNamespace("default")
+                .withName(FlinkConfigManager.OP_CM_NAME)
+                .createOrReplace(cm);
+    }
+
+    @Test
+    public void testConfigGeneration() {
+        ConfigOption<String> testConf = ConfigOptions.key("test").stringType().noDefaultValue();
+
+        FlinkConfigManager configManager = new FlinkConfigManager(kubernetesClient);
+        FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        ReconciliationStatus reconciliationStatus =
+                deployment.getStatus().getReconciliationStatus();
+
+        deployment.getSpec().getFlinkConfiguration().put(testConf.key(), "reconciled");
+        reconciliationStatus.serializeAndSetLastReconciledSpec(deployment.getSpec());
+        reconciliationStatus.markReconciledSpecAsStable();
+
+        deployment.getSpec().getFlinkConfiguration().put(testConf.key(), "latest");
+        assertEquals(
+                "latest",
+                configManager
+                        .getDeployConfig(deployment.getMetadata(), deployment.getSpec())
+                        .get(testConf));
+        assertEquals("reconciled", configManager.getObserveConfig(deployment).get(testConf));
+
+        deployment.getSpec().getFlinkConfiguration().put(testConf.key(), "stable");
+        reconciliationStatus.serializeAndSetLastReconciledSpec(deployment.getSpec());
+        reconciliationStatus.markReconciledSpecAsStable();
+
+        deployment.getSpec().getFlinkConfiguration().put(testConf.key(), "rolled-back");
+        reconciliationStatus.serializeAndSetLastReconciledSpec(deployment.getSpec());
+        reconciliationStatus.setState(ReconciliationState.ROLLED_BACK);
+
+        assertEquals("stable", configManager.getObserveConfig(deployment).get(testConf));
+    }
+
+    @Test
+    public void testConfUpdate() {
+        Configuration config = new Configuration();
+        updateConfigMap(config);
+        FlinkConfigManager configManager = new FlinkConfigManager(kubernetesClient);
+        assertFalse(
+                configManager
+                        .getDefaultConfig()
+                        .contains(
+                                KubernetesOperatorConfigOptions
+                                        .OPERATOR_RECONCILER_RESCHEDULE_INTERVAL));
+
+        config.set(
+                KubernetesOperatorConfigOptions.OPERATOR_RECONCILER_RESCHEDULE_INTERVAL,
+                Duration.ofSeconds(15));
+        updateConfigMap(config);
+
+        configManager.getConfigUpdater().run();
+
+        assertEquals(
+                Duration.ofSeconds(15),
+                configManager
+                        .getDefaultConfig()
+                        .get(
+                                KubernetesOperatorConfigOptions
+                                        .OPERATOR_RECONCILER_RESCHEDULE_INTERVAL));
+        assertEquals(
+                Duration.ofSeconds(15),
+                configManager.getOperatorConfiguration().getReconcileInterval());
+    }
+
+    private static String writeAsYaml(Configuration configuration) {
+        StringBuilder stringBuilder = new StringBuilder();
+        configuration.toMap().forEach((k, v) -> stringBuilder.append(k + ": " + v + "\n"));
+        return stringBuilder.toString();
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -21,7 +21,7 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
@@ -51,8 +51,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class RollbackTest {
 
     private final Context context = TestUtils.createContextWithReadyJobManagerDeployment();
-    private final FlinkOperatorConfiguration operatorConfiguration =
-            FlinkOperatorConfiguration.fromConfiguration(new Configuration());
 
     private TestingFlinkService flinkService;
     private FlinkDeploymentController testController;
@@ -64,7 +62,9 @@ public class RollbackTest {
         flinkService = new TestingFlinkService();
         testController =
                 TestUtils.createTestController(
-                        operatorConfiguration, kubernetesClient, flinkService);
+                        new FlinkConfigManager(new Configuration()),
+                        kubernetesClient,
+                        flinkService);
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
@@ -46,8 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /** @link JobStatusObserver unit tests */
 public class ApplicationReconcilerTest {
 
-    private final FlinkOperatorConfiguration operatorConfiguration =
-            FlinkOperatorConfiguration.fromConfiguration(new Configuration());
+    private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
 
     @Test
     public void testUpgrade() throws Exception {
@@ -55,8 +54,7 @@ public class ApplicationReconcilerTest {
         TestingFlinkService flinkService = new TestingFlinkService();
 
         ApplicationReconciler reconciler =
-                new ApplicationReconciler(
-                        null, flinkService, operatorConfiguration, new Configuration());
+                new ApplicationReconciler(null, flinkService, configManager);
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
 
         reconciler.reconcile(deployment, context);
@@ -107,8 +105,7 @@ public class ApplicationReconcilerTest {
         final TestingFlinkService flinkService = new TestingFlinkService();
 
         final ApplicationReconciler reconciler =
-                new ApplicationReconciler(
-                        null, flinkService, operatorConfiguration, new Configuration());
+                new ApplicationReconciler(null, flinkService, configManager);
         final FlinkDeployment deployment = TestUtils.buildApplicationCluster();
 
         reconciler.reconcile(deployment, context);
@@ -151,8 +148,7 @@ public class ApplicationReconcilerTest {
         Context context = TestUtils.createContextWithReadyJobManagerDeployment();
         TestingFlinkService flinkService = new TestingFlinkService();
         ApplicationReconciler reconciler =
-                new ApplicationReconciler(
-                        null, flinkService, operatorConfiguration, new Configuration());
+                new ApplicationReconciler(null, flinkService, configManager);
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
 
         reconciler.reconcile(deployment, context);
@@ -216,8 +212,7 @@ public class ApplicationReconcilerTest {
         final TestingFlinkService flinkService = new TestingFlinkService();
 
         final ApplicationReconciler reconciler =
-                new ApplicationReconciler(
-                        null, flinkService, operatorConfiguration, new Configuration());
+                new ApplicationReconciler(null, flinkService, configManager);
         final FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         deployment.getSpec().getFlinkConfiguration().remove(HighAvailabilityOptions.HA_MODE.key());
 
@@ -265,8 +260,7 @@ public class ApplicationReconcilerTest {
         final TestingFlinkService flinkService = new TestingFlinkService();
 
         final ApplicationReconciler reconciler =
-                new ApplicationReconciler(
-                        null, flinkService, operatorConfiguration, new Configuration());
+                new ApplicationReconciler(null, flinkService, configManager);
         final FlinkDeployment deployment = TestUtils.buildApplicationCluster();
 
         reconciler.reconcile(deployment, context);
@@ -303,8 +297,7 @@ public class ApplicationReconcilerTest {
         TestingFlinkService flinkService = new TestingFlinkService();
 
         ApplicationReconciler reconciler =
-                new ApplicationReconciler(
-                        null, flinkService, operatorConfiguration, new Configuration());
+                new ApplicationReconciler(null, flinkService, configManager);
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
 
         reconciler.reconcile(deployment, context);
@@ -368,8 +361,7 @@ public class ApplicationReconcilerTest {
         Context context = TestUtils.createContextWithReadyJobManagerDeployment();
         TestingFlinkService flinkService = new TestingFlinkService();
         ApplicationReconciler reconciler =
-                new ApplicationReconciler(
-                        null, flinkService, operatorConfiguration, new Configuration());
+                new ApplicationReconciler(null, flinkService, configManager);
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         reconciler.reconcile(deployment, context);
         List<Tuple2<String, JobStatusMessage>> runningJobs = flinkService.listJobs();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.kubernetes.operator.reconciler.deployment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -35,8 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 public class SessionReconcilerTest {
 
-    private final FlinkOperatorConfiguration operatorConfiguration =
-            FlinkOperatorConfiguration.fromConfiguration(new Configuration());
+    private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
 
     @Test
     public void testStartSession() throws Exception {
@@ -51,9 +50,7 @@ public class SessionReconcilerTest {
                     }
                 };
 
-        SessionReconciler reconciler =
-                new SessionReconciler(
-                        null, flinkService, operatorConfiguration, new Configuration());
+        SessionReconciler reconciler = new SessionReconciler(null, flinkService, configManager);
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
         reconciler.reconcile(deployment, context);
         assertEquals(1, count.get());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
@@ -383,8 +383,7 @@ public class FlinkSessionJobReconcilerTest {
                         Map.of(
                                 KubernetesOperatorConfigOptions.JOB_UPGRADE_IGNORE_PENDING_SAVEPOINT
                                         .key(),
-                                "true")),
-                configManager.getOperatorConfiguration());
+                                "true")));
         // Force upgrade when savepoint is in progress.
         reconciler = new FlinkSessionJobReconciler(null, flinkService, configManager);
         spSessionJob.getSpec().getJob().setParallelism(100);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
@@ -27,7 +27,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingClusterClient;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
@@ -186,8 +186,7 @@ public class FlinkServiceTest {
     }
 
     private FlinkService createFlinkService(ClusterClient<String> clusterClient) {
-        return new FlinkService(
-                client, FlinkOperatorConfiguration.fromConfiguration(configuration)) {
+        return new FlinkService(client, new FlinkConfigManager(configuration)) {
             @Override
             protected ClusterClient<String> getClusterClient(Configuration config) {
                 return clusterClient;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.IngressSpec;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
@@ -49,7 +50,8 @@ public class IngressUtilsTest {
     @Test
     public void testIngress() {
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
-        Configuration config = FlinkUtils.getEffectiveConfig(appCluster, new Configuration());
+        Configuration config =
+                new FlinkConfigManager(new Configuration()).getObserveConfig(appCluster);
 
         // no ingress when ingressDomain is empty
         IngressUtils.updateIngressRules(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -33,6 +33,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -42,7 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ReconciliationUtilsTest {
 
     FlinkOperatorConfiguration operatorConfiguration =
-            FlinkOperatorConfiguration.fromConfiguration(new Configuration());
+            FlinkOperatorConfiguration.fromConfiguration(
+                    new Configuration(), Collections.emptySet());
 
     @Test
     public void testSpecChangedException() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.kubernetes.operator.utils;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.validation.DefaultValidator;
 import org.apache.flink.kubernetes.operator.validation.TestValidator;
 
@@ -69,7 +70,8 @@ public class ValidatorUtilsTest {
                             Arrays.asList(
                                     DefaultValidator.class.getName(),
                                     TestValidator.class.getName())),
-                    ValidatorUtils.discoverValidators(new Configuration()).stream()
+                    ValidatorUtils.discoverValidators(new FlinkConfigManager(new Configuration()))
+                            .stream()
                             .map(v -> v.getClass().getName())
                             .collect(Collectors.toSet()));
         } finally {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
 import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
@@ -56,7 +57,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 /** Test deployment validation logic. */
 public class DefaultValidatorTest {
 
-    private final DefaultValidator validator = new DefaultValidator();
+    private final DefaultValidator validator =
+            new DefaultValidator(new FlinkConfigManager(new Configuration()));
 
     @Test
     public void testValidationWithoutDefaultConfig() {
@@ -287,7 +289,8 @@ public class DefaultValidatorTest {
         defaultFlinkConf.set(
                 HighAvailabilityOptions.HA_MODE,
                 KubernetesHaServicesFactory.class.getCanonicalName());
-        final DefaultValidator validatorWithDefaultConfig = new DefaultValidator(defaultFlinkConf);
+        final DefaultValidator validatorWithDefaultConfig =
+                new DefaultValidator(new FlinkConfigManager(defaultFlinkConf));
         testSuccess(
                 dep -> {
                     dep.getSpec().setFlinkConfiguration(new HashMap<>());

--- a/flink-kubernetes-operator/src/test/resources/log4j2-test.properties
+++ b/flink-kubernetes-operator/src/test/resources/log4j2-test.properties
@@ -1,21 +1,3 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-
 ################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
@@ -35,7 +35,6 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedWriteHandler;
 
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +56,7 @@ public class FlinkOperatorWebhook {
 
     public static void main(String[] args) throws Exception {
         EnvUtils.logEnvironmentInfo(LOG, "Flink Kubernetes Webhook", args);
-        FlinkConfigManager configManager = new FlinkConfigManager(new DefaultKubernetesClient());
+        FlinkConfigManager configManager = new FlinkConfigManager();
         AdmissionHandler endpoint =
                 new AdmissionHandler(new FlinkValidator(new DefaultValidator(configManager)));
         ChannelInitializer<SocketChannel> initializer = createChannelInitializer(endpoint);

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.admission;
 
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 import org.apache.flink.kubernetes.operator.validation.DefaultValidator;
 
@@ -34,6 +35,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SupportedCipherSuiteFilter;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedWriteHandler;
 
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,8 +57,9 @@ public class FlinkOperatorWebhook {
 
     public static void main(String[] args) throws Exception {
         EnvUtils.logEnvironmentInfo(LOG, "Flink Kubernetes Webhook", args);
+        FlinkConfigManager configManager = new FlinkConfigManager(new DefaultKubernetesClient());
         AdmissionHandler endpoint =
-                new AdmissionHandler(new FlinkValidator(new DefaultValidator()));
+                new AdmissionHandler(new FlinkValidator(new DefaultValidator(configManager)));
         ChannelInitializer<SocketChannel> initializer = createChannelInitializer(endpoint);
         NioEventLoopGroup bossGroup = new NioEventLoopGroup(1);
         NioEventLoopGroup workerGroup = new NioEventLoopGroup();

--- a/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
+++ b/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.kubernetes.operator.admission;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.validation.DefaultValidator;
@@ -48,7 +50,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class AdmissionHandlerTest {
 
     private final AdmissionHandler admissionHandler =
-            new AdmissionHandler(new FlinkValidator(new DefaultValidator()));
+            new AdmissionHandler(
+                    new FlinkValidator(
+                            new DefaultValidator(new FlinkConfigManager(new Configuration()))));
 
     @Test
     public void testHandleIllegalRequest() {

--- a/helm/flink-kubernetes-operator/conf/log4j-operator.properties
+++ b/helm/flink-kubernetes-operator/conf/log4j-operator.properties
@@ -24,3 +24,7 @@ appender.console.name = ConsoleAppender
 appender.console.type = CONSOLE
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %style{%d}{yellow} %style{%-30c{1.}}{cyan} %highlight{[%-5level]%notEmpty{[%X{resource.namespace}/}%notEmpty{%X{resource.name}]} %msg%n%throwable}
+
+# Do not log config loading
+logger.conf.name = org.apache.flink.configuration.GlobalConfiguration
+logger.conf.level = WARN

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -102,6 +102,12 @@ spec:
               value: -Dlog4j.configurationFile=/opt/flink/conf/log4j-operator.properties
             - name: JVM_ARGS
               value: {{ .Values.jvmArgs.webhook }}
+            - name: FLINK_CONF_DIR
+              value: /opt/flink/conf
+            - name: FLINK_PLUGINS_DIR
+              value: /opt/flink/plugins
+            - name: OPERATOR_NAMESPACE
+              value: {{ .Release.Namespace }}
           volumeMounts:
           - name: keystore
             mountPath: "/certs"


### PR DESCRIPTION
This PR improves/reworks the configuration management of the oprator. Problems with the current approach:
  - Configuration and FlinkOperatorConfigurations are passed around everywhere
  - Every component generates effective configurations on their own (without consistency which can cause problems)
  - Configs are generated again and again creating a large number of temporary files in every reconcile iteration
  - Configuration is completely static and impossible to change without operator restart
  
To try to tackle all these problems at once I have introduced the `FlinkConfigManager` object which is responsible for:
 - Generating configuration for deployment / cluster interactions (observe)
 - The config generation logic is consistently aware of currently deployed spec (this is important due to rollback logic)
 - Caching the generated configs for a given specification to speed things up and avoid extra tmp files
 - Allow modifying default configurations on the fly by watching ConfigMap changes
 
While these changes touch almost all components, it is mostly cosmetic. The core improvements are located in the `FlinkConfigManager` class and which config is requested in the different parts of the reconcile logic.