### PR TITLE
[FLINK-27425] Default job service account needs access to services to work with Kafka

### DIFF
--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -82,6 +82,7 @@ rules:
     resources:
       - pods
       - configmaps
+      - services
     verbs:
       - '*'
   - apiGroups:


### PR DESCRIPTION
As per https://issues.apache.org/jira/browse/FLINK-27425 this resolves the error, 

```
[ERROR] Could not execute SQL statement. Reason:
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://10.96.0.1/api/v1/namespaces/default/services/basic-example-rest. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "basic-example-rest" is forbidden: User "system:serviceaccount:default:flink" cannot get resource "services" in API group "" in the namespace "default".
```

seen when running a Flink job that uses the Kafka connector against a default install. 