### PR TITLE
[FLINK-27129][docs] Hardcoded namespace in FlinkDeployment manifests may fail to deploy

### DIFF
--- a/docs/content/docs/operations/rbac.md
+++ b/docs/content/docs/operations/rbac.md
@@ -26,12 +26,12 @@ under the License.
 
 # Role-based Access Control Model
 
-To be able to deploy the operator itself and Flink jobs, we define two separate Kubernetes 
-[roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole). 
-The former, called `flink-operator` role is used to manage the `flinkdeployments`, to create and manage the 
+To be able to deploy the operator itself and Flink jobs, we define two separate Kubernetes
+[roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole).
+The former, called `flink-operator` role is used to manage the `flinkdeployments`, to create and manage the
 [JobManager](https://nightlies.apache.org/flink/flink-docs-stable/docs/concepts/flink-architecture/#jobmanager) deployment
 for each Flink job and other resources like [services](https://kubernetes.io/docs/concepts/services-networking/service/).
-The latter, called the `flink` role is used by the JobManagers of the jobs to create and manage the 
+The latter, called the `flink` role is used by the JobManagers of the jobs to create and manage the
 [TaskManagers](https://nightlies.apache.org/flink/flink-docs-stable/docs/concepts/flink-architecture/#taskmanagers) and
 [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/) for the job.
 
@@ -39,10 +39,72 @@ The latter, called the `flink` role is used by the JobManagers of the jobs to cr
 
 These service accounts and roles can be created via the operator Helm [chart]({{< ref "docs/operations/helm" >}}).
 By default the `flink-operator` role is cluster scoped (created as a `clusterrole`) and thus allowing a single operator
-instance to be responsible for all Flink deployments in a Kubernetes cluster regardless of the namespace they are
-deployed to. Certain environments are more restrictive and only allow namespaced roles, so we also support this option
+instance to be responsible for all Flink deployments (jobs) in a Kubernetes cluster regardless of the namespace they are
+deployed to (with the additional [instruction](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/docs/operations/rbac/#cluster-scoped-flink-operator-with-jobs-running-in-other-namespaces) below). Certain environments are more restrictive and only allow namespaced roles, so we also support this option
 via [watchNamespaces]({{< ref "docs/operations/helm" >}}#watching-only-specific-namespaces).
 
-The `flink` role is always namespaced, by default it is created in the namespace of the operator. When 
+The `flink` role is always namespaced, by default it is created in the namespace of the operator. When
 [watchNamespaces]({{< ref "docs/operations/helm" >}}#watching-only-specific-namespaces) is enabled it is created for all
-watched namespaces individually. 
+watched namespaces individually.
+
+## Cluster Scoped Flink Operator With Jobs Running in Other Namespaces
+The steps described in the [quick-start](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/docs/try-flink-kubernetes-operator/quick-start/#deploying-the-operator) let users install Flink operator and run Flink jobs in the default namespace. To run Flink jobs in another namespace, users are responsible for creating a flink service account in that namespace. This is when users deploy cluster scoped Flink operator without using the `--set watchNamespaces={namespaces}` option and wish to create Flink jobs in other namespaces later.
+
+For each additional namespace that runs the Flink jobs, users need to do the following:
+1. Switch to the namespace by running:
+    ```sh
+    kubectl config set-context --current --namespace=CHANGEIT
+    ```
+2. Create the service account, role, and role binding in the namespace using the commands below:
+    ``` sh
+    kubectl apply -f - <<EOF
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/name: flink-kubernetes-operator
+        app.kubernetes.io/version: 0.1.0
+      name: flink
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/name: flink-kubernetes-operator
+        app.kubernetes.io/version: 0.1.0
+      name: flink
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - configmaps
+      verbs:
+      - '*'
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      verbs:
+      - '*'
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/name: flink-kubernetes-operator
+        app.kubernetes.io/version: 0.1.0
+      name: flink-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: flink
+    subjects:
+    - kind: ServiceAccount
+      name: flink
+    EOF
+    ```
+3. Optionally create an example Flink job in the namespace. Run the command from the root of the cloned flink-kuberntes-operator repo:
+    ```sh
+    kubectl -f example/basic.yaml
+    ```

--- a/examples/advanced-ingress.yaml
+++ b/examples/advanced-ingress.yaml
@@ -19,7 +19,6 @@
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
-  namespace: default
   name: advanced-ingress
 spec:
   image: flink:1.14

--- a/examples/basic-checkpoint-ha.yaml
+++ b/examples/basic-checkpoint-ha.yaml
@@ -19,7 +19,6 @@
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
-  namespace: default
   name: basic-checkpoint-ha-example
 spec:
   image: flink:1.14

--- a/examples/basic-ingress.yaml
+++ b/examples/basic-ingress.yaml
@@ -19,7 +19,6 @@
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
-  namespace: default
   name: basic-ingress
 spec:
   image: flink:1.14

--- a/examples/basic-session-job.yaml
+++ b/examples/basic-session-job.yaml
@@ -19,7 +19,6 @@
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
-  namespace: default
   name: basic-session-cluster-with-ha
 spec:
   image: flink:1.14
@@ -58,7 +57,6 @@ spec:
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkSessionJob
 metadata:
-  namespace: default
   name: basic-session-ha-job-example
 spec:
   deploymentName: basic-session-cluster-with-ha
@@ -72,7 +70,6 @@ spec:
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkSessionJob
 metadata:
-  namespace: default
   name: basic-session-ha-job-example2
 spec:
   deploymentName: basic-session-cluster-with-ha

--- a/examples/basic-session.yaml
+++ b/examples/basic-session.yaml
@@ -19,7 +19,6 @@
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
-  namespace: default
   name: basic-session-example
 spec:
   image: flink:1.14

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -19,7 +19,6 @@
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
-  namespace: default
   name: basic-example
 spec:
   image: flink:1.14

--- a/examples/custom-logging.yaml
+++ b/examples/custom-logging.yaml
@@ -19,7 +19,6 @@
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
-  namespace: default
   name: custom-logging-example
 spec:
   image: flink:1.14

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -19,7 +19,6 @@
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
-  namespace: default
   name: pod-template-example
 spec:
   image: flink:1.14


### PR DESCRIPTION
Remove hardcode default namespace from the flinkdeployment examples.
Document the step to create flinkdeployment in other namespaces when watchNamespaces not used.

Signed-off-by: ted chang <htchang@us.ibm.com>