### PR TITLE
[FLINK-27422] Do not create temporary pod template files for JobManager and TaskManager if not configured explicitly

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -272,12 +272,17 @@ public class FlinkConfigBuilder {
             return;
         }
 
-        final ConfigOption<String> podConfigOption =
-                isJM
-                        ? KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE
-                        : KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE;
-        effectiveConfig.setString(
-                podConfigOption, createTempFile(mergePodTemplates(basicPod, appendPod)));
+        // Avoid to create temporary pod template files for JobManager and TaskManager if it is not
+        // configured explicitly via .spec.JobManagerSpec.podTemplate or
+        // .spec.TaskManagerSpec.podTemplate.
+        if (appendPod != null) {
+            final ConfigOption<String> podConfigOption =
+                    isJM
+                            ? KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE
+                            : KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE;
+            effectiveConfig.setString(
+                    podConfigOption, createTempFile(mergePodTemplates(basicPod, appendPod)));
+        }
     }
 
     private static String createLogConfigFiles(String log4jConf, String logbackConf)


### PR DESCRIPTION
It doesn't need to create temporary pod template files for JobManager and TaskManager if it is not configured explicitly via `.spec.JobManagerSpec.podTemplate` or `.spec.TaskManagerSpec.podTemplate`.

**The brief change log**

- `FlinkConfigBuilder#setPodTemplate` adds the check to create temporary pod template files for JobManager and TaskManager when it is configured explicitly via `.spec.JobManagerSpec.podTemplate` or `.spec.TaskManagerSpec.podTemplate`.