### PR TITLE
[FLINK-27458] Expose allowNonRestoredState flag in JobSpec

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -117,7 +117,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | savepointTriggerNonce | java.lang.Long | Nonce used to manually trigger savepoint for the running job. In order to trigger a  savepoint, change the number to anything other than the current value. |
 | initialSavepointPath | java.lang.String | Savepoint path used by the job the first time it is deployed. Upgrades/redeployments will not  be affected. |
 | upgradeMode | org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode | Upgrade mode of the Flink job. |
-| allowNonRestoredState | boolean | Allow checkpoint state that cannot be mapped to any job vertex in tasks. |
+| allowNonRestoredState | java.lang.Boolean | Allow checkpoint state that cannot be mapped to any job vertex in tasks. |
 
 ### JobState
 **Class**: org.apache.flink.kubernetes.operator.crd.spec.JobState

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -117,6 +117,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | savepointTriggerNonce | java.lang.Long | Nonce used to manually trigger savepoint for the running job. In order to trigger a  savepoint, change the number to anything other than the current value. |
 | initialSavepointPath | java.lang.String | Savepoint path used by the job the first time it is deployed. Upgrades/redeployments will not  be affected. |
 | upgradeMode | org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode | Upgrade mode of the Flink job. |
+| allowNonRestoredState | boolean | Allow checkpoint state that cannot be mapped to any job vertex in tasks. |
 
 ### JobState
 **Class**: org.apache.flink.kubernetes.operator.crd.spec.JobState

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -217,8 +217,10 @@ public class FlinkConfigBuilder {
                 effectiveConfig.set(
                         CoreOptions.DEFAULT_PARALLELISM, spec.getJob().getParallelism());
             }
-            if (spec.getJob().isAllowNonRestoredState()) {
-                effectiveConfig.set(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, true);
+            if (spec.getJob().getAllowNonRestoredState() != null) {
+                effectiveConfig.set(
+                        SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE,
+                        spec.getJob().getAllowNonRestoredState());
             }
         } else {
             effectiveConfig.set(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -32,6 +32,7 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.Resource;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
+import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.StringUtils;
@@ -223,6 +224,15 @@ public class FlinkConfigBuilder {
         return this;
     }
 
+    protected FlinkConfigBuilder applyAllowNonRestoredState() {
+        if (spec.getJob() != null) {
+            if (spec.getJob().isAllowNonRestoredState()) {
+                effectiveConfig.set(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, true);
+            }
+        }
+        return this;
+    }
+
     protected Configuration build() {
 
         // Set cluster config
@@ -245,6 +255,7 @@ public class FlinkConfigBuilder {
                 .applyJobManagerSpec()
                 .applyTaskManagerSpec()
                 .applyJobOrSessionSpec()
+                .applyAllowNonRestoredState()
                 .build();
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -217,18 +217,12 @@ public class FlinkConfigBuilder {
                 effectiveConfig.set(
                         CoreOptions.DEFAULT_PARALLELISM, spec.getJob().getParallelism());
             }
-        } else {
-            effectiveConfig.set(
-                    DeploymentOptions.TARGET, KubernetesDeploymentTarget.SESSION.getName());
-        }
-        return this;
-    }
-
-    protected FlinkConfigBuilder applyAllowNonRestoredState() {
-        if (spec.getJob() != null) {
             if (spec.getJob().isAllowNonRestoredState()) {
                 effectiveConfig.set(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, true);
             }
+        } else {
+            effectiveConfig.set(
+                    DeploymentOptions.TARGET, KubernetesDeploymentTarget.SESSION.getName());
         }
         return this;
     }
@@ -255,7 +249,6 @@ public class FlinkConfigBuilder {
                 .applyJobManagerSpec()
                 .applyTaskManagerSpec()
                 .applyJobOrSessionSpec()
-                .applyAllowNonRestoredState()
                 .build();
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobSpec.java
@@ -67,5 +67,5 @@ public class JobSpec {
     @EqualsAndHashCode.Exclude private UpgradeMode upgradeMode = UpgradeMode.STATELESS;
 
     /** Allow checkpoint state that cannot be mapped to any job vertex in tasks. */
-    @EqualsAndHashCode.Exclude private boolean allowNonRestoredState = false;
+    @EqualsAndHashCode.Exclude private Boolean allowNonRestoredState;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobSpec.java
@@ -65,4 +65,7 @@ public class JobSpec {
 
     /** Upgrade mode of the Flink job. */
     @EqualsAndHashCode.Exclude private UpgradeMode upgradeMode = UpgradeMode.STATELESS;
+
+    /** Allow checkpoint state that cannot be mapped to any job vertex in tasks. */
+    @EqualsAndHashCode.Exclude private boolean allowNonRestoredState = false;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -188,7 +188,7 @@ public class FlinkService {
                             job.getArgs() == null ? null : Arrays.asList(job.getArgs()),
                             job.getParallelism() > 0 ? job.getParallelism() : null,
                             jobID,
-                            null,
+                            job.isAllowNonRestoredState(),
                             savepoint);
             LOG.info("Submitting job: {} to session cluster.", jobID.toHexString());
             return clusterClient

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -188,7 +188,7 @@ public class FlinkService {
                             job.getArgs() == null ? null : Arrays.asList(job.getArgs()),
                             job.getParallelism() > 0 ? job.getParallelism() : null,
                             jobID,
-                            job.isAllowNonRestoredState(),
+                            job.getAllowNonRestoredState(),
                             savepoint);
             LOG.info("Submitting job: {} to session cluster.", jobID.toHexString());
             return clusterClient

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -49,6 +49,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -297,6 +298,33 @@ public class FlinkConfigBuilderTest {
         Assertions.assertEquals(SAMPLE_JAR, configuration.get(PipelineOptions.JARS).get(0));
         Assertions.assertEquals(
                 Integer.valueOf(2), configuration.get(CoreOptions.DEFAULT_PARALLELISM));
+    }
+
+    @Test
+    public void testAllowNonRestoredStateInSpecOverrideInFlinkConf() throws URISyntaxException {
+        flinkDeployment.getSpec().getJob().setAllowNonRestoredState(false);
+        flinkDeployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key(), "true");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyJobOrSessionSpec()
+                        .build();
+        Assertions.assertFalse(
+                configuration.getBoolean(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE));
+
+        flinkDeployment.getSpec().getJob().setAllowNonRestoredState(true);
+        flinkDeployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE.key(), "false");
+        configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyJobOrSessionSpec()
+                        .build();
+        Assertions.assertTrue(
+                configuration.getBoolean(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE));
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -36,13 +36,14 @@ import org.apache.flink.kubernetes.operator.crd.spec.IngressSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -88,7 +89,7 @@ public class FlinkConfigBuilderTest {
     public void testApplyImage() {
         final Configuration configuration =
                 new FlinkConfigBuilder(flinkDeployment, new Configuration()).applyImage().build();
-        Assert.assertEquals(IMAGE, configuration.get(KubernetesConfigOptions.CONTAINER_IMAGE));
+        Assertions.assertEquals(IMAGE, configuration.get(KubernetesConfigOptions.CONTAINER_IMAGE));
     }
 
     @Test
@@ -97,7 +98,7 @@ public class FlinkConfigBuilderTest {
                 new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyImagePullPolicy()
                         .build();
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 IMAGE_POLICY,
                 configuration.get(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_POLICY).toString());
     }
@@ -108,11 +109,11 @@ public class FlinkConfigBuilderTest {
                 new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyFlinkConfiguration()
                         .build();
-        Assert.assertEquals(2, (int) configuration.get(TaskManagerOptions.NUM_TASK_SLOTS));
-        Assert.assertEquals(
+        Assertions.assertEquals(2, (int) configuration.get(TaskManagerOptions.NUM_TASK_SLOTS));
+        Assertions.assertEquals(
                 KubernetesConfigOptions.ServiceExposedType.ClusterIP,
                 configuration.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE));
-        Assert.assertEquals(false, configuration.get(WebOptions.CANCEL_ENABLE));
+        Assertions.assertEquals(false, configuration.get(WebOptions.CANCEL_ENABLE));
 
         FlinkDeployment deployment = ReconciliationUtils.clone(flinkDeployment);
         deployment
@@ -126,7 +127,7 @@ public class FlinkConfigBuilderTest {
                 new FlinkConfigBuilder(deployment, new Configuration())
                         .applyFlinkConfiguration()
                         .build();
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 KubernetesConfigOptions.ServiceExposedType.LoadBalancer,
                 configuration.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE));
 
@@ -141,7 +142,7 @@ public class FlinkConfigBuilderTest {
                                                         .getCanonicalName()))
                         .applyFlinkConfiguration()
                         .build();
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 DEFAULT_CHECKPOINTING_INTERVAL,
                 configuration.get(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL));
     }
@@ -157,8 +158,8 @@ public class FlinkConfigBuilderTest {
                 new File(
                         configuration.get(DeploymentOptionsInternal.CONF_DIR),
                         CONFIG_FILE_LOG4J_NAME);
-        Assert.assertTrue(log4jFile.exists() && log4jFile.isFile() && log4jFile.canRead());
-        Assert.assertEquals(CUSTOM_LOG_CONFIG, Files.readString(log4jFile.toPath()));
+        Assertions.assertTrue(log4jFile.exists() && log4jFile.isFile() && log4jFile.canRead());
+        Assertions.assertEquals(CUSTOM_LOG_CONFIG, Files.readString(log4jFile.toPath()));
     }
 
     @Test
@@ -179,8 +180,8 @@ public class FlinkConfigBuilderTest {
                                 configuration.getString(
                                         KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE)),
                         Pod.class);
-        Assert.assertEquals("container0", jmPod.getSpec().getContainers().get(0).getName());
-        Assert.assertEquals("container0", tmPod.getSpec().getContainers().get(0).getName());
+        Assertions.assertEquals("container0", jmPod.getSpec().getContainers().get(0).getName());
+        Assertions.assertEquals("container0", tmPod.getSpec().getContainers().get(0).getName());
     }
 
     @Test
@@ -189,7 +190,7 @@ public class FlinkConfigBuilderTest {
                 new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyIngressDomain()
                         .build();
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 KubernetesConfigOptions.ServiceExposedType.ClusterIP,
                 configuration.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE));
     }
@@ -200,7 +201,7 @@ public class FlinkConfigBuilderTest {
                 new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyServiceAccount()
                         .build();
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 SERVICE_ACCOUNT,
                 configuration.get(KubernetesConfigOptions.KUBERNETES_SERVICE_ACCOUNT));
     }
@@ -212,14 +213,14 @@ public class FlinkConfigBuilderTest {
                         .applyJobManagerSpec()
                         .build();
 
-        Assert.assertNull(
+        Assertions.assertNull(
                 configuration.getString(KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE));
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 MemorySize.parse("2048m"),
                 configuration.get(JobManagerOptions.TOTAL_PROCESS_MEMORY));
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 Double.valueOf(1), configuration.get(KubernetesConfigOptions.JOB_MANAGER_CPU));
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 Integer.valueOf(2),
                 configuration.get(KubernetesConfigOptions.KUBERNETES_JOBMANAGER_REPLICAS));
 
@@ -240,7 +241,7 @@ public class FlinkConfigBuilderTest {
                                 configuration.getString(
                                         KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE)),
                         Pod.class);
-        Assert.assertEquals("pod1 api version", jmPod.getApiVersion());
+        Assertions.assertEquals("pod1 api version", jmPod.getApiVersion());
     }
 
     @Test
@@ -253,12 +254,12 @@ public class FlinkConfigBuilderTest {
                         .applyTaskManagerSpec()
                         .build();
 
-        Assert.assertNull(
+        Assertions.assertNull(
                 configuration.getString(KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE));
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 MemorySize.parse("2048m"),
                 configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 Double.valueOf(1), configuration.get(KubernetesConfigOptions.TASK_MANAGER_CPU));
 
         deploymentClone
@@ -278,7 +279,7 @@ public class FlinkConfigBuilderTest {
                                 configuration.getString(
                                         KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE)),
                         Pod.class);
-        Assert.assertEquals("pod2 api version", tmPod.getApiVersion());
+        Assertions.assertEquals("pod2 api version", tmPod.getApiVersion());
     }
 
     @Test
@@ -287,11 +288,23 @@ public class FlinkConfigBuilderTest {
                 new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyJobOrSessionSpec()
                         .build();
-        Assert.assertEquals(
+        Assertions.assertEquals(
                 KubernetesDeploymentTarget.APPLICATION.getName(),
                 configuration.get(DeploymentOptions.TARGET));
-        Assert.assertEquals(SAMPLE_JAR, configuration.get(PipelineOptions.JARS).get(0));
-        Assert.assertEquals(Integer.valueOf(2), configuration.get(CoreOptions.DEFAULT_PARALLELISM));
+        Assertions.assertEquals(SAMPLE_JAR, configuration.get(PipelineOptions.JARS).get(0));
+        Assertions.assertEquals(
+                Integer.valueOf(2), configuration.get(CoreOptions.DEFAULT_PARALLELISM));
+    }
+
+    @Test
+    public void testApplyAllowNonRestoredState() {
+        flinkDeployment.getSpec().getJob().setAllowNonRestoredState(true);
+        final Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyAllowNonRestoredState()
+                        .build();
+        Assertions.assertTrue(
+                configuration.getBoolean(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE));
     }
 
     @Test
@@ -306,7 +319,7 @@ public class FlinkConfigBuilderTest {
         final String clusterId = flinkDeployment.getMetadata().getName();
         // Most configs have been tested by previous unit tests, thus we only verify the namespace
         // and clusterId here.
-        Assert.assertEquals(namespace, configuration.get(KubernetesConfigOptions.NAMESPACE));
-        Assert.assertEquals(clusterId, configuration.get(KubernetesConfigOptions.CLUSTER_ID));
+        Assertions.assertEquals(namespace, configuration.get(KubernetesConfigOptions.NAMESPACE));
+        Assertions.assertEquals(clusterId, configuration.get(KubernetesConfigOptions.CLUSTER_ID));
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -284,27 +284,19 @@ public class FlinkConfigBuilderTest {
 
     @Test
     public void testApplyJobOrSessionSpec() throws Exception {
+        flinkDeployment.getSpec().getJob().setAllowNonRestoredState(true);
         final Configuration configuration =
                 new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyJobOrSessionSpec()
                         .build();
+        Assertions.assertTrue(
+                configuration.getBoolean(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE));
         Assertions.assertEquals(
                 KubernetesDeploymentTarget.APPLICATION.getName(),
                 configuration.get(DeploymentOptions.TARGET));
         Assertions.assertEquals(SAMPLE_JAR, configuration.get(PipelineOptions.JARS).get(0));
         Assertions.assertEquals(
                 Integer.valueOf(2), configuration.get(CoreOptions.DEFAULT_PARALLELISM));
-    }
-
-    @Test
-    public void testApplyAllowNonRestoredState() {
-        flinkDeployment.getSpec().getJob().setAllowNonRestoredState(true);
-        final Configuration configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration())
-                        .applyAllowNonRestoredState()
-                        .build();
-        Assertions.assertTrue(
-                configuration.getBoolean(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE));
     }
 
     @Test

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9075,6 +9075,8 @@ spec:
                     - last-state
                     - stateless
                     type: string
+                  allowNonRestoredState:
+                    type: boolean
                 type: object
               restartNonce:
                 type: integer

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -48,6 +48,8 @@ spec:
                     - last-state
                     - stateless
                     type: string
+                  allowNonRestoredState:
+                    type: boolean
                 type: object
               restartNonce:
                 type: integer


### PR DESCRIPTION
This PR introduces the `allowNonRestoredState` in `JobSpec` to let the session job can enable/disable it individually.