### PR TITLE
[FLINK-27468] Recover missing deployments and other cancel/upgrade improvements for 1.15

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -87,6 +87,12 @@
             <td>The timeout for the reconciler to wait for flink to shutdown cluster.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.reconciler.jm-deployment-recovery.enabled</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Boolean</td>
+            <td>Whether to enable recovery of missing/deleted jobmanager deployments. False by default for Flink 1.14, true for newer Flink version.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.reconciler.max.parallelism</h5></td>
             <td style="word-wrap: break-word;">5</td>
             <td>Integer</td>

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -142,6 +142,13 @@ under the License.
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -88,7 +88,7 @@ public class FlinkOperator {
     private void registerDeploymentController() {
         ReconcilerFactory reconcilerFactory =
                 new ReconcilerFactory(client, flinkService, configManager);
-        ObserverFactory observerFactory = new ObserverFactory(flinkService, configManager);
+        ObserverFactory observerFactory = new ObserverFactory(client, flinkService, configManager);
 
         FlinkDeploymentController controller =
                 new FlinkDeploymentController(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -134,4 +134,11 @@ public class KubernetesOperatorConfigOptions {
                     .intType()
                     .defaultValue(1000)
                     .withDescription("Max config cache size.");
+
+    public static final ConfigOption<Boolean> OPERATOR_RECOVER_JM_DEPLOYMENT_ENABLED =
+            ConfigOptions.key("kubernetes.operator.reconciler.jm-deployment-recovery.enabled")
+                    .booleanType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Whether to enable recovery of missing/deleted jobmanager deployments. False by default for Flink 1.14, true for newer Flink version.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.controller;
 
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
@@ -124,6 +125,7 @@ public class FlinkDeploymentController
     private void handleDeploymentFailed(FlinkDeployment flinkApp, DeploymentFailedException dfe) {
         LOG.error("Flink Deployment failed", dfe);
         flinkApp.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.ERROR);
+        flinkApp.getStatus().getJobStatus().setState(JobStatus.FAILED.name());
         ReconciliationUtils.updateForReconciliationError(flinkApp, dfe.getMessage());
 
         // TODO: avoid repeated event

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
@@ -56,6 +56,15 @@ public class DeploymentFailedException extends RuntimeException {
         this.lastUpdateTime = null;
     }
 
+    public DeploymentFailedException(String component, String type, String error) {
+        super(error);
+        this.component = component;
+        this.type = type;
+        this.reason = error;
+        this.lastTransitionTime = null;
+        this.lastUpdateTime = null;
+    }
+
     public static Event asEvent(DeploymentFailedException dfe, FlinkDeployment flinkApp) {
         EventBuilder evtb =
                 new EventBuilder()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
@@ -24,6 +24,8 @@ import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
 
+import java.time.Instant;
+
 /** Exception to signal terminal deployment failure. */
 public class DeploymentFailedException extends RuntimeException {
     public static final String COMPONENT_JOBMANAGER = "JobManagerDeployment";
@@ -56,13 +58,13 @@ public class DeploymentFailedException extends RuntimeException {
         this.lastUpdateTime = null;
     }
 
-    public DeploymentFailedException(String component, String type, String error) {
-        super(error);
+    public DeploymentFailedException(String message, String component, String type, String reason) {
+        super(message);
         this.component = component;
         this.type = type;
-        this.reason = error;
-        this.lastTransitionTime = null;
-        this.lastUpdateTime = null;
+        this.reason = reason;
+        this.lastTransitionTime = Instant.now().toString();
+        this.lastUpdateTime = lastTransitionTime;
     }
 
     public static Event asEvent(DeploymentFailedException dfe, FlinkDeployment flinkApp) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -30,8 +30,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
-import static org.apache.flink.kubernetes.operator.observer.deployment.AbstractDeploymentObserver.JOB_STATE_UNKNOWN;
-
 /** An observer to observe the job status. */
 public abstract class JobStatusObserver<CTX> {
 
@@ -57,7 +55,7 @@ public abstract class JobStatusObserver<CTX> {
             clusterJobStatuses = new ArrayList<>(flinkService.listJobs(deployedConfig));
         } catch (Exception e) {
             LOG.error("Exception while listing jobs", e);
-            jobStatus.setState(JOB_STATE_UNKNOWN);
+            jobStatus.setState(org.apache.flink.api.common.JobStatus.RECONCILING.name());
             if (e instanceof TimeoutException) {
                 onTimeout(ctx);
             }
@@ -67,7 +65,7 @@ public abstract class JobStatusObserver<CTX> {
         if (!clusterJobStatuses.isEmpty()) {
             Optional<String> targetJobStatus = updateJobStatus(jobStatus, clusterJobStatuses);
             if (targetJobStatus.isEmpty()) {
-                jobStatus.setState(JOB_STATE_UNKNOWN);
+                jobStatus.setState(org.apache.flink.api.common.JobStatus.RECONCILING.name());
                 return false;
             } else {
                 if (targetJobStatus.get().equals(previousJobStatus)) {
@@ -76,12 +74,12 @@ public abstract class JobStatusObserver<CTX> {
                     LOG.info(
                             "Job status successfully updated from {} to {}",
                             previousJobStatus,
-                            targetJobStatus);
+                            targetJobStatus.get());
                 }
             }
             return true;
         } else {
-            jobStatus.setState(JOB_STATE_UNKNOWN);
+            jobStatus.setState(org.apache.flink.api.common.JobStatus.RECONCILING.name());
             LOG.info("No job found on cluster yet");
             return false;
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -29,16 +29,19 @@ import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.observer.Observer;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
 import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import io.fabric8.kubernetes.api.model.apps.DeploymentStatus;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,12 +54,15 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    public static final String JOB_STATE_UNKNOWN = "UNKNOWN";
-
+    protected final KubernetesClient kubernetesClient;
     protected final FlinkService flinkService;
     protected final FlinkConfigManager configManager;
 
-    public AbstractDeploymentObserver(FlinkService flinkService, FlinkConfigManager configManager) {
+    public AbstractDeploymentObserver(
+            KubernetesClient kubernetesClient,
+            FlinkService flinkService,
+            FlinkConfigManager configManager) {
+        this.kubernetesClient = kubernetesClient;
         this.flinkService = flinkService;
         this.configManager = configManager;
     }
@@ -144,8 +150,11 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
             return;
         }
 
-        logger.info("JobManager deployment does not exist");
         deploymentStatus.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
+        if (previousJmStatus != JobManagerDeploymentStatus.MISSING
+                && previousJmStatus != JobManagerDeploymentStatus.ERROR) {
+            onMissingDeployment(flinkApp);
+        }
     }
 
     private Optional<Deployment> getSecondaryResource(FlinkDeployment flinkApp, Context context) {
@@ -209,6 +218,22 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
                 && jobSpec.getState() == JobState.SUSPENDED
                 && lastReconciledSpec != null
                 && lastReconciledSpec.getJob().getState() == JobState.SUSPENDED;
+    }
+
+    private void onMissingDeployment(FlinkDeployment deployment) {
+        String err = "Missing JobManager deployment";
+        logger.error(err);
+        Event event =
+                DeploymentFailedException.asEvent(
+                        new DeploymentFailedException(
+                                DeploymentFailedException.COMPONENT_JOBMANAGER, "Error", err),
+                        deployment);
+        kubernetesClient
+                .v1()
+                .events()
+                .inNamespace(deployment.getMetadata().getNamespace())
+                .create(event);
+        ReconciliationUtils.updateForReconciliationError(deployment, err);
     }
 
     /**

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.observer.deployment;
 
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
@@ -138,6 +139,7 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
                 checkCrashLoopBackoff(flinkApp, effectiveConfig);
             } catch (DeploymentFailedException dfe) {
                 // throw only when not already in error status to allow for spec update
+                deploymentStatus.getJobStatus().setState(JobStatus.FAILED.name());
                 if (!JobManagerDeploymentStatus.ERROR.equals(
                         deploymentStatus.getJobManagerDeploymentStatus())) {
                     throw dfe;
@@ -151,6 +153,8 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
         }
 
         deploymentStatus.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
+        deploymentStatus.getJobStatus().setState(JobStatus.FAILED.name());
+
         if (previousJmStatus != JobManagerDeploymentStatus.MISSING
                 && previousJmStatus != JobManagerDeploymentStatus.ERROR) {
             onMissingDeployment(flinkApp);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -221,7 +221,11 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
     }
 
     private void onMissingDeployment(FlinkDeployment deployment) {
-        String err = "Missing JobManager deployment";
+        String err =
+                "Missing JobManager deployment for "
+                        + deployment.getMetadata().getNamespace()
+                        + "/"
+                        + deployment.getMetadata().getName();
         logger.error(err);
         Event event =
                 DeploymentFailedException.asEvent(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -225,16 +225,15 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
     }
 
     private void onMissingDeployment(FlinkDeployment deployment) {
-        String err =
-                "Missing JobManager deployment for "
-                        + deployment.getMetadata().getNamespace()
-                        + "/"
-                        + deployment.getMetadata().getName();
+        String err = "Missing JobManager deployment";
         logger.error(err);
         Event event =
                 DeploymentFailedException.asEvent(
                         new DeploymentFailedException(
-                                DeploymentFailedException.COMPONENT_JOBMANAGER, "Error", err),
+                                err,
+                                DeploymentFailedException.COMPONENT_JOBMANAGER,
+                                "Error",
+                                "Missing"),
                         deployment);
         kubernetesClient
                 .v1()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
@@ -28,6 +28,7 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import java.util.List;
@@ -39,8 +40,11 @@ public class ApplicationObserver extends AbstractDeploymentObserver {
     private final SavepointObserver savepointObserver;
     private final JobStatusObserver<ApplicationObserverContext> jobStatusObserver;
 
-    public ApplicationObserver(FlinkService flinkService, FlinkConfigManager configManager) {
-        super(flinkService, configManager);
+    public ApplicationObserver(
+            KubernetesClient kubernetesClient,
+            FlinkService flinkService,
+            FlinkConfigManager configManager) {
+        super(kubernetesClient, flinkService, configManager);
         this.savepointObserver = new SavepointObserver(flinkService, configManager);
         this.jobStatusObserver =
                 new JobStatusObserver<>(flinkService) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ObserverFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ObserverFactory.java
@@ -23,17 +23,24 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.observer.Observer;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
+
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** The factory to create the observer based ob the {@link FlinkDeployment} mode. */
 public class ObserverFactory {
 
+    private final KubernetesClient kubernetesClient;
     private final FlinkService flinkService;
     private final FlinkConfigManager configManager;
     private final Map<Mode, Observer<FlinkDeployment>> observerMap;
 
-    public ObserverFactory(FlinkService flinkService, FlinkConfigManager configManager) {
+    public ObserverFactory(
+            KubernetesClient kubernetesClient,
+            FlinkService flinkService,
+            FlinkConfigManager configManager) {
+        this.kubernetesClient = kubernetesClient;
         this.flinkService = flinkService;
         this.configManager = configManager;
         this.observerMap = new ConcurrentHashMap<>();
@@ -45,9 +52,11 @@ public class ObserverFactory {
                 mode -> {
                     switch (mode) {
                         case SESSION:
-                            return new SessionObserver(flinkService, configManager);
+                            return new SessionObserver(
+                                    kubernetesClient, flinkService, configManager);
                         case APPLICATION:
-                            return new ApplicationObserver(flinkService, configManager);
+                            return new ApplicationObserver(
+                                    kubernetesClient, flinkService, configManager);
                         default:
                             throw new UnsupportedOperationException(
                                     String.format("Unsupported running mode: %s", mode));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import java.util.concurrent.TimeoutException;
@@ -29,8 +30,11 @@ import java.util.concurrent.TimeoutException;
 /** The observer of the {@link org.apache.flink.kubernetes.operator.config.Mode#SESSION} cluster. */
 public class SessionObserver extends AbstractDeploymentObserver {
 
-    public SessionObserver(FlinkService flinkService, FlinkConfigManager configManager) {
-        super(flinkService, configManager);
+    public SessionObserver(
+            KubernetesClient kubernetesClient,
+            FlinkService flinkService,
+            FlinkConfigManager configManager) {
+        super(kubernetesClient, flinkService, configManager);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -288,7 +288,8 @@ public class ReconciliationUtils {
         String jobState = status.getJobStatus().getState();
 
         return deploymentStatus == JobManagerDeploymentStatus.READY
-                && org.apache.flink.api.common.JobStatus.valueOf(jobState).isTerminalState();
+                && org.apache.flink.api.common.JobStatus.valueOf(jobState)
+                        .isGloballyTerminalState();
     }
 
     public static boolean isJobRunning(FlinkDeploymentStatus status) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -270,7 +270,13 @@ public class ReconciliationUtils {
                                 : false);
     }
 
-    public static boolean jobManagerMissingForRunningDeployment(FlinkDeploymentStatus status) {
+    public static boolean jmMissingForRunningDeployment(FlinkDeploymentStatus status) {
+        return status.getReconciliationStatus().deserializeLastReconciledSpec().getJob().getState()
+                        == JobState.RUNNING
+                && (status.getJobManagerDeploymentStatus() == JobManagerDeploymentStatus.MISSING);
+    }
+
+    public static boolean jmMissingOrErrorForRunningDep(FlinkDeploymentStatus status) {
         return status.getReconciliationStatus().deserializeLastReconciledSpec().getJob().getState()
                         == JobState.RUNNING
                 && (status.getJobManagerDeploymentStatus() == JobManagerDeploymentStatus.MISSING

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -126,7 +126,7 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
         } else if (ReconciliationUtils.shouldRollBack(reconciliationStatus, deployConfig)) {
             rollbackApplication(flinkApp);
         } else if (ReconciliationUtils.deploymentRecoveryEnabled(deployConfig)
-                && ReconciliationUtils.jobManagerMissingForRunningDeployment(status)) {
+                && ReconciliationUtils.jmMissingForRunningDeployment(status)) {
             recoverJmDeployment(flinkApp);
         } else if (SavepointUtils.shouldTriggerSavepoint(desiredJobSpec, status)
                 && ReconciliationUtils.isJobRunning(status)) {
@@ -195,7 +195,7 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
 
         FlinkDeploymentStatus status = deployment.getStatus();
 
-        if (ReconciliationUtils.jobManagerMissingForRunningDeployment(status)) {
+        if (ReconciliationUtils.jmMissingOrErrorForRunningDep(status)) {
             // JobManager is missing for savepoint upgrade, we cannot roll back
             throw new DeploymentFailedException(
                     DeploymentFailedException.COMPONENT_JOBMANAGER,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -198,9 +198,10 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
         if (ReconciliationUtils.jmMissingOrErrorForRunningDep(status)) {
             // JobManager is missing for savepoint upgrade, we cannot roll back
             throw new DeploymentFailedException(
+                    "Cannot perform savepoint upgrade on missing/failed JobManager deployment",
                     DeploymentFailedException.COMPONENT_JOBMANAGER,
                     "Error",
-                    "Cannot perform savepoint upgrade on missing JobManager deployment.");
+                    "UpgradeFailed");
         }
 
         return ReconciliationUtils.isJobInTerminalState(status)

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconciler.java
@@ -44,8 +44,6 @@ import javax.annotation.Nullable;
 
 import java.util.Optional;
 
-import static org.apache.flink.kubernetes.operator.observer.deployment.AbstractDeploymentObserver.JOB_STATE_UNKNOWN;
-
 /** The reconciler for the {@link FlinkSessionJob}. */
 public class FlinkSessionJobReconciler implements Reconciler<FlinkSessionJob> {
 
@@ -169,7 +167,7 @@ public class FlinkSessionJobReconciler implements Reconciler<FlinkSessionJob> {
                         new JobStatus()
                                 .toBuilder()
                                 .jobId(jobID.toHexString())
-                                .state(JOB_STATE_UNKNOWN)
+                                .state(org.apache.flink.api.common.JobStatus.RECONCILING.name())
                                 .build());
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -20,33 +20,44 @@ package org.apache.flink.kubernetes.operator;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
+import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
 import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
+import org.apache.flink.runtime.messages.Acknowledge;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
 
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -68,6 +79,23 @@ public class TestingFlinkService extends FlinkService {
         super(null, new FlinkConfigManager(new Configuration()));
     }
 
+    public Context getContext() {
+        return new Context() {
+            @Override
+            public Optional<RetryInfo> getRetryInfo() {
+                return Optional.empty();
+            }
+
+            @Override
+            public <T> Optional<T> getSecondaryResource(Class<T> aClass, String s) {
+                if (jobs.isEmpty() && sessions.isEmpty()) {
+                    return Optional.empty();
+                }
+                return Optional.of((T) TestUtils.createDeployment(true));
+            }
+        };
+    }
+
     public void clear() {
         jobs.clear();
         sessions.clear();
@@ -75,7 +103,10 @@ public class TestingFlinkService extends FlinkService {
     }
 
     @Override
-    public void submitApplicationCluster(JobSpec jobSpec, Configuration conf) {
+    public void submitApplicationCluster(JobSpec jobSpec, Configuration conf) throws Exception {
+        if (!jobs.isEmpty()) {
+            throw new Exception("Cannot submit 2 application clusters at the same time");
+        }
         JobID jobID = new JobID();
         JobStatusMessage jobStatusMessage =
                 new JobStatusMessage(
@@ -108,23 +139,11 @@ public class TestingFlinkService extends FlinkService {
     }
 
     @Override
-    public List<JobStatusMessage> listJobs(Configuration conf) throws Exception {
-        listJobConsumer.accept(conf);
-        if (jobs.isEmpty()
-                && !sessions.isEmpty()
-                && conf.get(DeploymentOptions.TARGET)
-                        .equals(KubernetesDeploymentTarget.APPLICATION.getName())) {
-            throw new Exception("Trying to list a job without submitting it");
-        }
+    public Collection<JobStatusMessage> listJobs(Configuration conf) throws Exception {
         if (!isPortReady) {
             throw new TimeoutException("JM port is unavailable");
         }
-        var lists = jobs.stream().map(t -> t.f1).collect(Collectors.toList());
-        lists.addAll(
-                sessionJobs.values().stream()
-                        .map(t -> t.jobStatusMessage)
-                        .collect(Collectors.toList()));
-        return lists;
+        return super.listJobs(conf);
     }
 
     public void setListJobConsumer(Consumer<Configuration> listJobConsumer) {
@@ -135,28 +154,12 @@ public class TestingFlinkService extends FlinkService {
         return new ArrayList<>(jobs);
     }
 
-    public Map<JobID, SubmittedJobInfo> listSessionJobs() {
-        return new HashMap<>(sessionJobs);
+    public long getRunningCount() {
+        return jobs.stream().filter(t -> !t.f1.getJobState().isTerminalState()).count();
     }
 
-    @Override
-    public Optional<String> cancelJob(JobID jobID, UpgradeMode upgradeMode, Configuration conf)
-            throws Exception {
-
-        if (upgradeMode == UpgradeMode.LAST_STATE) {
-            jobs.clear();
-            return Optional.empty();
-        }
-
-        if (!jobs.removeIf(js -> js.f1.getJobId().equals(jobID))) {
-            throw new Exception("Job not found");
-        }
-
-        if (upgradeMode != UpgradeMode.STATELESS) {
-            return Optional.of("savepoint_" + savepointCounter++);
-        } else {
-            return Optional.empty();
-        }
+    public Map<JobID, SubmittedJobInfo> listSessionJobs() {
+        return new HashMap<>(sessionJobs);
     }
 
     @Override
@@ -174,12 +177,6 @@ public class TestingFlinkService extends FlinkService {
     }
 
     @Override
-    public void stopSessionCluster(
-            ObjectMeta objectMeta, Configuration conf, boolean deleteHa, long shutdownTimeout) {
-        sessions.remove(objectMeta.getName());
-    }
-
-    @Override
     public void triggerSavepoint(
             String jobId,
             org.apache.flink.kubernetes.operator.crd.status.SavepointInfo savepointInfo,
@@ -189,8 +186,85 @@ public class TestingFlinkService extends FlinkService {
     }
 
     @Override
+    protected ClusterClient<String> getClusterClient(Configuration config) throws Exception {
+        TestingClusterClient<String> clusterClient = new TestingClusterClient<>(config);
+        FlinkVersion flinkVersion = config.get(FlinkConfigBuilder.FLINK_VERSION);
+        clusterClient.setListJobsFunction(
+                () -> {
+                    listJobConsumer.accept(config);
+                    if (jobs.isEmpty()
+                            && !sessions.isEmpty()
+                            && config.get(DeploymentOptions.TARGET)
+                                    .equals(KubernetesDeploymentTarget.APPLICATION.getName())) {
+                        throw new RuntimeException("Trying to list a job without submitting it");
+                    }
+                    var lists = jobs.stream().map(t -> t.f1).collect(Collectors.toList());
+                    lists.addAll(
+                            sessionJobs.values().stream()
+                                    .map(t -> t.jobStatusMessage)
+                                    .collect(Collectors.toList()));
+                    return CompletableFuture.completedFuture(lists);
+                });
+
+        clusterClient.setStopWithSavepointFunction(
+                (jobID, advanceEventTime, savepointDir) -> {
+                    try {
+                        cancelJob(flinkVersion, jobID);
+                    } catch (Exception e) {
+                        return CompletableFuture.failedFuture(e);
+                    }
+
+                    return CompletableFuture.completedFuture("savepoint_" + savepointCounter++);
+                });
+
+        clusterClient.setCancelFunction(
+                jobID -> {
+                    try {
+                        cancelJob(flinkVersion, jobID);
+                    } catch (Exception e) {
+                        return CompletableFuture.failedFuture(e);
+                    }
+                    return CompletableFuture.completedFuture(Acknowledge.get());
+                });
+        return clusterClient;
+    }
+
+    private void cancelJob(FlinkVersion flinkVersion, JobID jobID) throws Exception {
+        Optional<Tuple2<String, JobStatusMessage>> jobOpt =
+                jobs.stream().filter(js -> js.f1.getJobId().equals(jobID)).findAny();
+
+        if (!jobOpt.isPresent()) {
+            throw new Exception("Job not found");
+        }
+
+        if (flinkVersion.isNewerVersionThan(FlinkVersion.v1_14)) {
+            JobStatusMessage oldStatus = jobOpt.get().f1;
+            jobOpt.get().f1 =
+                    new JobStatusMessage(
+                            oldStatus.getJobId(),
+                            oldStatus.getJobName(),
+                            JobStatus.SUSPENDED,
+                            oldStatus.getStartTime());
+        } else {
+            jobs.removeIf(js -> js.f1.getJobId().equals(jobID));
+        }
+    }
+
+    @Override
+    public void deleteClusterDeployment(
+            ObjectMeta meta, FlinkDeploymentStatus status, boolean deleteHaMeta) {
+        jobs.clear();
+        sessions.remove(meta.getName());
+        status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
+        status.getJobStatus().setState(JobState.SUSPENDED.name());
+    }
+
+    @Override
+    protected void waitForClusterShutdown(Configuration conf) {}
+
+    @Override
     public SavepointFetchResult fetchSavepointInfo(
-            String triggerId, String jobId, Configuration conf) throws Exception {
+            String triggerId, String jobId, Configuration conf) {
         return SavepointFetchResult.completed(Savepoint.of("savepoint_" + savepointCounter++));
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -31,7 +31,6 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
-import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
@@ -243,7 +242,7 @@ public class TestingFlinkService extends FlinkService {
                     new JobStatusMessage(
                             oldStatus.getJobId(),
                             oldStatus.getJobName(),
-                            JobStatus.SUSPENDED,
+                            JobStatus.FINISHED,
                             oldStatus.getStartTime());
         } else {
             jobs.removeIf(js -> js.f1.getJobId().equals(jobID));
@@ -256,7 +255,7 @@ public class TestingFlinkService extends FlinkService {
         jobs.clear();
         sessions.remove(meta.getName());
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
-        status.getJobStatus().setState(JobState.SUSPENDED.name());
+        status.getJobStatus().setState(JobStatus.FINISHED.name());
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -101,7 +101,7 @@ public class DeploymentRecoveryTest {
         } else {
             assertEquals(
                     JobManagerDeploymentStatus.MISSING, status.getJobManagerDeploymentStatus());
-            assertEquals(JobStatus.RECONCILING.name(), status.getJobStatus().getState());
+            assertEquals(JobStatus.FAILED.name(), status.getJobStatus().getState());
         }
 
         // Remove deployment

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.controller;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
+import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/** @link Missing deployment recovery tests */
+@EnableKubernetesMockClient(crud = true)
+public class DeploymentRecoveryTest {
+
+    private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
+
+    private TestingFlinkService flinkService;
+    private Context context;
+    private FlinkDeploymentController testController;
+
+    private KubernetesClient kubernetesClient;
+
+    @BeforeEach
+    public void setup() {
+        flinkService = new TestingFlinkService();
+        context = flinkService.getContext();
+        testController =
+                TestUtils.createTestController(configManager, kubernetesClient, flinkService);
+    }
+
+    @ParameterizedTest
+    @MethodSource("applicationTestParams")
+    public void verifyApplicationJmRecovery(
+            FlinkVersion flinkVersion, UpgradeMode upgradeMode, boolean enabled) {
+        FlinkDeployment appCluster = TestUtils.buildApplicationCluster(flinkVersion);
+        appCluster.getSpec().getJob().setUpgradeMode(upgradeMode);
+        if (enabled) {
+            appCluster
+                    .getSpec()
+                    .getFlinkConfiguration()
+                    .put(
+                            KubernetesOperatorConfigOptions.OPERATOR_RECOVER_JM_DEPLOYMENT_ENABLED
+                                    .key(),
+                            "true");
+        }
+        FlinkDeploymentStatus status = appCluster.getStatus();
+
+        testController.reconcile(appCluster, context);
+        testController.reconcile(appCluster, context);
+        testController.reconcile(appCluster, context);
+
+        assertEquals(JobManagerDeploymentStatus.READY, status.getJobManagerDeploymentStatus());
+
+        // Remove deployment
+        flinkService.setPortReady(false);
+        flinkService.clear();
+        testController.reconcile(appCluster, context);
+        flinkService.setPortReady(true);
+
+        testController.reconcile(appCluster, context);
+        testController.reconcile(appCluster, context);
+        if (flinkVersion != FlinkVersion.v1_14 || enabled) {
+            assertEquals(JobManagerDeploymentStatus.READY, status.getJobManagerDeploymentStatus());
+            assertEquals(JobStatus.RUNNING.name(), status.getJobStatus().getState());
+        } else {
+            assertEquals(
+                    JobManagerDeploymentStatus.MISSING, status.getJobManagerDeploymentStatus());
+            assertEquals(JobStatus.RECONCILING.name(), status.getJobStatus().getState());
+        }
+
+        // Remove deployment
+        flinkService.setPortReady(false);
+        flinkService.clear();
+        // Trigger update
+        appCluster.getSpec().setRestartNonce(123L);
+
+        testController.reconcile(appCluster, context);
+        if (upgradeMode == UpgradeMode.SAVEPOINT) {
+            // If deployment goes missing during an upgrade we should throw an error as savepoint
+            // information cannot be recovered with complete certainty
+            assertEquals(JobManagerDeploymentStatus.ERROR, status.getJobManagerDeploymentStatus());
+        } else {
+            flinkService.setPortReady(true);
+            testController.reconcile(appCluster, context);
+            testController.reconcile(appCluster, context);
+            testController.reconcile(appCluster, context);
+            assertEquals(JobManagerDeploymentStatus.READY, status.getJobManagerDeploymentStatus());
+            assertEquals("RUNNING", status.getJobStatus().getState());
+            assertEquals(
+                    appCluster.getSpec(),
+                    status.getReconciliationStatus().deserializeLastReconciledSpec());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("sessionTestParams")
+    public void verifySessionJmRecovery(FlinkVersion flinkVersion, boolean enabled) {
+        FlinkDeployment appCluster = TestUtils.buildSessionCluster(flinkVersion);
+        if (enabled) {
+            appCluster
+                    .getSpec()
+                    .getFlinkConfiguration()
+                    .put(
+                            KubernetesOperatorConfigOptions.OPERATOR_RECOVER_JM_DEPLOYMENT_ENABLED
+                                    .key(),
+                            "true");
+        }
+        FlinkDeploymentStatus status = appCluster.getStatus();
+
+        testController.reconcile(appCluster, context);
+        testController.reconcile(appCluster, context);
+        testController.reconcile(appCluster, context);
+
+        assertEquals(JobManagerDeploymentStatus.READY, status.getJobManagerDeploymentStatus());
+
+        // Remove deployment
+        flinkService.setPortReady(false);
+        flinkService.clear();
+        testController.reconcile(appCluster, context);
+        flinkService.setPortReady(true);
+
+        if (flinkVersion != FlinkVersion.v1_14 || enabled) {
+            assertEquals(
+                    JobManagerDeploymentStatus.DEPLOYING, status.getJobManagerDeploymentStatus());
+            testController.reconcile(appCluster, context);
+            testController.reconcile(appCluster, context);
+            assertEquals(JobManagerDeploymentStatus.READY, status.getJobManagerDeploymentStatus());
+        } else {
+            assertEquals(
+                    JobManagerDeploymentStatus.MISSING, status.getJobManagerDeploymentStatus());
+            testController.reconcile(appCluster, context);
+            assertEquals(
+                    JobManagerDeploymentStatus.MISSING, status.getJobManagerDeploymentStatus());
+        }
+    }
+
+    private static Stream<Arguments> applicationTestParams() {
+        List<Arguments> args = new ArrayList<>();
+        for (FlinkVersion version : FlinkVersion.values()) {
+            for (UpgradeMode upgradeMode : UpgradeMode.values()) {
+                if (version == FlinkVersion.v1_14) {
+                    args.add(arguments(version, upgradeMode, true));
+                }
+                args.add(arguments(version, upgradeMode, false));
+            }
+        }
+        return args.stream();
+    }
+
+    private static Stream<Arguments> sessionTestParams() {
+        List<Arguments> args = new ArrayList<>();
+        for (FlinkVersion version : FlinkVersion.values()) {
+            args.add(arguments(version, true));
+            args.add(arguments(version, false));
+        }
+        return args.stream();
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -90,7 +90,22 @@ public class DeploymentRecoveryTest {
         // Remove deployment
         flinkService.setPortReady(false);
         flinkService.clear();
+
+        // Make sure we do not try to recover JM deployment errors (only missing)
+        testController.reconcile(
+                appCluster, TestUtils.createContextWithFailedJobManagerDeployment());
+        testController.reconcile(
+                appCluster, TestUtils.createContextWithFailedJobManagerDeployment());
+        assertEquals(JobManagerDeploymentStatus.ERROR, status.getJobManagerDeploymentStatus());
+
         testController.reconcile(appCluster, context);
+        if (flinkVersion != FlinkVersion.v1_14 || enabled) {
+            assertEquals(
+                    JobManagerDeploymentStatus.DEPLOYING, status.getJobManagerDeploymentStatus());
+        } else {
+            assertEquals(
+                    JobManagerDeploymentStatus.MISSING, status.getJobManagerDeploymentStatus());
+        }
         flinkService.setPortReady(true);
 
         testController.reconcile(appCluster, context);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -241,6 +241,9 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 JobManagerDeploymentStatus.ERROR,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
+        assertEquals(
+                org.apache.flink.api.common.JobStatus.FAILED.name(),
+                appCluster.getStatus().getJobStatus().getState());
 
         // Validate status status
         assertNotNull(appCluster.getStatus().getError());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -518,9 +518,13 @@ public class FlinkDeploymentControllerTest {
             testController.reconcile(appCluster, context);
             testController.reconcile(appCluster, context);
             if (appCluster.getSpec().getJob() != null) {
-                assertEquals("RUNNING", appCluster.getStatus().getJobStatus().getState());
+                assertEquals(
+                        org.apache.flink.api.common.JobStatus.RUNNING.name(),
+                        appCluster.getStatus().getJobStatus().getState());
             } else {
-                assertEquals("SUSPENDED", appCluster.getStatus().getJobStatus().getState());
+                assertEquals(
+                        org.apache.flink.api.common.JobStatus.FINISHED.name(),
+                        appCluster.getStatus().getJobStatus().getState());
             }
             assertEquals(
                     JobManagerDeploymentStatus.READY,
@@ -559,7 +563,9 @@ public class FlinkDeploymentControllerTest {
 
             testController.reconcile(appCluster, context);
 
-            assertEquals("RUNNING", appCluster.getStatus().getJobStatus().getState());
+            assertEquals(
+                    org.apache.flink.api.common.JobStatus.RUNNING.name(),
+                    appCluster.getStatus().getJobStatus().getState());
             assertEquals(
                     JobManagerDeploymentStatus.READY,
                     appCluster.getStatus().getJobManagerDeploymentStatus());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -43,9 +43,9 @@ public class ApplicationObserverTest {
     private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
 
     @Test
-    public void observeApplicationCluster() {
+    public void observeApplicationCluster() throws Exception {
         TestingFlinkService flinkService = new TestingFlinkService();
-        ApplicationObserver observer = new ApplicationObserver(flinkService, configManager);
+        ApplicationObserver observer = new ApplicationObserver(null, flinkService, configManager);
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         deployment.setStatus(new FlinkDeploymentStatus());
 
@@ -140,7 +140,7 @@ public class ApplicationObserverTest {
                 JobManagerDeploymentStatus.READY,
                 deployment.getStatus().getJobManagerDeploymentStatus());
         assertEquals(
-                AbstractDeploymentObserver.JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 deployment.getStatus().getJobStatus().getState());
         assertNull(deployment.getStatus().getReconciliationStatus().getLastStableSpec());
     }
@@ -148,7 +148,7 @@ public class ApplicationObserverTest {
     @Test
     public void observeSavepoint() throws Exception {
         TestingFlinkService flinkService = new TestingFlinkService();
-        ApplicationObserver observer = new ApplicationObserver(flinkService, configManager);
+        ApplicationObserver observer = new ApplicationObserver(null, flinkService, configManager);
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         Configuration conf =
                 configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
@@ -218,7 +218,7 @@ public class ApplicationObserverTest {
     @Test
     public void observeListJobsError() {
         TestingFlinkService flinkService = new TestingFlinkService();
-        ApplicationObserver observer = new ApplicationObserver(flinkService, configManager);
+        ApplicationObserver observer = new ApplicationObserver(null, flinkService, configManager);
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         bringToReadyStatus(deployment);
         observer.observe(deployment, readyContext);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -49,7 +49,7 @@ public class SessionObserverTest {
     public void observeSessionCluster() {
         TestingFlinkService flinkService = new TestingFlinkService();
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
-        SessionObserver observer = new SessionObserver(flinkService, configManager);
+        SessionObserver observer = new SessionObserver(null, flinkService, configManager);
         deployment
                 .getStatus()
                 .getReconciliationStatus()
@@ -111,7 +111,7 @@ public class SessionObserverTest {
         k8sDeployment.setStatus(new DeploymentStatus());
 
         AtomicInteger secondaryResourceAccessed = new AtomicInteger(0);
-        Observer observer = new SessionObserver(flinkService, configManager);
+        Observer observer = new SessionObserver(null, flinkService, configManager);
         observer.observe(
                 deployment,
                 new Context() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.apache.flink.kubernetes.operator.observer.deployment.AbstractDeploymentObserver.JOB_STATE_UNKNOWN;
-
 /** Tests for {@link SessionJobObserver}. */
 public class SessionJobObserverTest {
 
@@ -54,12 +52,12 @@ public class SessionJobObserverTest {
         var jobID = sessionJob.getStatus().getJobStatus().getJobId();
         Assertions.assertNotNull(jobID);
         Assertions.assertEquals(
-                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+                JobStatus.RECONCILING.name(), sessionJob.getStatus().getJobStatus().getState());
 
         // observe with empty context will do nothing
         observer.observe(sessionJob, TestUtils.createEmptyContext());
         Assertions.assertEquals(
-                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+                JobStatus.RECONCILING.name(), sessionJob.getStatus().getJobStatus().getState());
 
         // observe with ready context
         observer.observe(sessionJob, readyContext);
@@ -69,7 +67,7 @@ public class SessionJobObserverTest {
         flinkService.setPortReady(false);
         observer.observe(sessionJob, readyContext);
         Assertions.assertEquals(
-                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+                JobStatus.RECONCILING.name(), sessionJob.getStatus().getJobStatus().getState());
 
         sessionJob.getStatus().getJobStatus().setState(JobStatus.RUNNING.name());
         // no matched job id, update the state to unknown
@@ -77,7 +75,7 @@ public class SessionJobObserverTest {
         sessionJob.getStatus().getJobStatus().setJobId(new JobID().toHexString());
         observer.observe(sessionJob, readyContext);
         Assertions.assertEquals(
-                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+                JobStatus.RECONCILING.name(), sessionJob.getStatus().getJobStatus().getState());
         sessionJob.getStatus().getJobStatus().setJobId(jobID);
 
         // testing multi job
@@ -89,7 +87,7 @@ public class SessionJobObserverTest {
         Assertions.assertNotNull(jobID);
         Assertions.assertNotEquals(jobID, jobID2);
         Assertions.assertEquals(
-                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+                JobStatus.RECONCILING.name(), sessionJob.getStatus().getJobStatus().getState());
         observer.observe(sessionJob2, readyContext);
         Assertions.assertEquals(
                 JobStatus.RUNNING.name(), sessionJob2.getStatus().getJobStatus().getState());
@@ -113,7 +111,7 @@ public class SessionJobObserverTest {
         var jobID = sessionJob.getStatus().getJobStatus().getJobId();
         Assertions.assertNotNull(jobID);
         Assertions.assertEquals(
-                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+                JobStatus.RECONCILING.name(), sessionJob.getStatus().getJobStatus().getState());
 
         flinkService.setListJobConsumer(
                 configuration ->
@@ -136,7 +134,7 @@ public class SessionJobObserverTest {
         var jobID = sessionJob.getStatus().getJobStatus().getJobId();
         Assertions.assertNotNull(jobID);
         Assertions.assertEquals(
-                JOB_STATE_UNKNOWN, sessionJob.getStatus().getJobStatus().getState());
+                JobStatus.RECONCILING.name(), sessionJob.getStatus().getJobStatus().getState());
 
         observer.observe(sessionJob, readyContext);
         Assertions.assertEquals(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -392,6 +392,8 @@ public class ApplicationReconcilerTest {
         assertEquals(
                 "trigger_0",
                 spDeployment.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
-        assertEquals(JobState.SUSPENDED.name(), spDeployment.getStatus().getJobStatus().getState());
+        assertEquals(
+                org.apache.flink.api.common.JobStatus.FINISHED.name(),
+                spDeployment.getStatus().getJobStatus().getState());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
@@ -38,7 +38,6 @@ import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.apache.flink.kubernetes.operator.observer.deployment.AbstractDeploymentObserver.JOB_STATE_UNKNOWN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -69,7 +68,7 @@ public class FlinkSessionJobReconcilerTest {
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
                 JobState.RUNNING,
-                JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 null,
                 flinkService.listSessionJobs());
         // clean up
@@ -90,7 +89,7 @@ public class FlinkSessionJobReconcilerTest {
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
                 JobState.RUNNING,
-                JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 null,
                 flinkService.listSessionJobs());
         sessionJob.getSpec().setRestartNonce(2L);
@@ -100,7 +99,7 @@ public class FlinkSessionJobReconcilerTest {
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
                 JobState.RUNNING,
-                JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 null,
                 flinkService.listSessionJobs());
     }
@@ -118,7 +117,7 @@ public class FlinkSessionJobReconcilerTest {
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
                 JobState.RUNNING,
-                JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 initSavepointPath,
                 flinkService.listSessionJobs());
     }
@@ -136,7 +135,7 @@ public class FlinkSessionJobReconcilerTest {
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
                 JobState.RUNNING,
-                JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 null,
                 flinkService.listSessionJobs());
 
@@ -153,7 +152,7 @@ public class FlinkSessionJobReconcilerTest {
         verifyAndSetRunningJobsToStatus(
                 statelessSessionJob,
                 JobState.RUNNING,
-                JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 null,
                 flinkService.listSessionJobs());
     }
@@ -186,7 +185,7 @@ public class FlinkSessionJobReconcilerTest {
         verifyAndSetRunningJobsToStatus(
                 statefulSessionJob,
                 JobState.RUNNING,
-                JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 "savepoint_0",
                 flinkService.listSessionJobs());
     }
@@ -223,7 +222,7 @@ public class FlinkSessionJobReconcilerTest {
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
                 JobState.RUNNING,
-                JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 null,
                 flinkService.listSessionJobs());
 
@@ -315,7 +314,7 @@ public class FlinkSessionJobReconcilerTest {
         verifyAndSetRunningJobsToStatus(
                 sp1SessionJob,
                 JobState.RUNNING,
-                JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 null,
                 flinkService.listSessionJobs());
 
@@ -391,7 +390,7 @@ public class FlinkSessionJobReconcilerTest {
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
                 JobState.RUNNING,
-                JOB_STATE_UNKNOWN,
+                org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 null,
                 flinkService.listSessionJobs());
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -261,6 +261,9 @@ public class DefaultValidatorTest {
         testError(
                 dep -> {
                     dep.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
+                    dep.getSpec()
+                            .getFlinkConfiguration()
+                            .remove(CheckpointingOptions.SAVEPOINT_DIRECTORY.key());
                     dep.setStatus(new FlinkDeploymentStatus());
                     dep.getStatus().setJobStatus(new JobStatus());
 


### PR DESCRIPTION
This PR contains the following features improvements:

- Add general ability to recover MISSING JobManager deployments (that were deleted by the user or otherwise disappeared )
- Improve Job and JobManager deployment state tracking by moving status handling into the methods that actually interact with the clusters/deployments
- Disable application cluster shutdown for 1.15 in case of failures and savepoint suspend operations in order to be able to track job status for terminal states and avoid savepoint upgrade corner cases
- Improve test coverage by adding extra guards in TestingFlinkService and using the FlinkService implementation as much as possible
- Introduce paremerized tests that cover 1.15 cluster shutdown behaviour
- Introduce new config option to enable deployment recovery (disabled by default in 1.14 enabled 1.15 and onward)
- Replace usage of special UNKNOWN string for jobstate with RECONCILING which allows us to map all states to flink jobstatus easily

Follow up work not covered here:
 - Recover last checkpoint/savepoint information from clustery (https://issues.apache.org/jira/browse/FLINK-27495)
 - Add events for terminal job states and record in deployment status for Flink 1.15 (https://issues.apache.org/jira/browse/FLINK-27497)
 - Add E2E tests to cover Flink 1.15 (https://issues.apache.org/jira/browse/FLINK-27498)
 - Bump base Flink dependency to 1.15 and remove some copied code (https://issues.apache.org/jira/browse/FLINK-27499)
 - Consider making JobStatus.state enum (Flink JobStatus) which is now possible