### PR TITLE
[FLINK-27500] Validation errors should not block reconciliation

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -243,7 +243,8 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 | Value | Docs |
 | ----- | ---- |
-| DEPLOYED | The last reconciledSpec is currently deployed. |
+| DEPLOYED | The lastReconciledSpec is currently deployed. |
+| UPGRADING | The spec is being upgraded. |
 | ROLLING_BACK | In the process of rolling back to the lastStableSpec. |
 | ROLLED_BACK | Rolled back to the lastStableSpec. |
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationState.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationState.java
@@ -19,8 +19,10 @@ package org.apache.flink.kubernetes.operator.crd.status;
 
 /** Current state of the reconciliation. */
 public enum ReconciliationState {
-    /** The last reconciledSpec is currently deployed. */
+    /** The lastReconciledSpec is currently deployed. */
     DEPLOYED,
+    /** The spec is being upgraded. */
+    UPGRADING,
     /** In the process of rolling back to the lastStableSpec. */
     ROLLING_BACK,
     /** Rolled back to the lastStableSpec. */

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test for {@link org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils}. */
@@ -46,19 +45,6 @@ public class ReconciliationUtilsTest {
     FlinkOperatorConfiguration operatorConfiguration =
             FlinkOperatorConfiguration.fromConfiguration(
                     new Configuration(), Collections.emptySet());
-
-    @Test
-    public void testSpecChangedException() {
-        FlinkDeployment previous = TestUtils.buildApplicationCluster();
-        FlinkDeployment current = ReconciliationUtils.clone(previous);
-
-        current.getSpec().setImage("changed-image");
-        assertThrows(
-                UnsupportedOperationException.class,
-                () ->
-                        ReconciliationUtils.toUpdateControl(
-                                operatorConfiguration, previous, current, true));
-    }
 
     @Test
     public void testStatusChanged() {

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9102,6 +9102,7 @@ spec:
                   state:
                     enum:
                     - DEPLOYED
+                    - UPGRADING
                     - ROLLING_BACK
                     - ROLLED_BACK
                     type: string

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -67,6 +67,7 @@ spec:
                   state:
                     enum:
                     - DEPLOYED
+                    - UPGRADING
                     - ROLLING_BACK
                     - ROLLED_BACK
                     type: string


### PR DESCRIPTION
This PR solves the issue detailed in https://issues.apache.org/jira/browse/FLINK-27500 by reconciling using the previous (valid) spec if validation fails for some reason.

This allows rollback/jm-recovery operations to proceed even if an invalid CR was submitted in thea meantime