### PR TITLE
[FLINK-27412] Allow flinkVersion v1_13 in flink-kubernetes-operator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,13 @@ jobs:
           - description: 'WatchNamespaces enabled'
             namespace: flink
             extraArgs: '--create-namespace --set "watchNamespaces={default,flink}"'
+        versions:
+          - image: flink:1.13
+            flinkVersion: v1_13
+          - image: flink:1.14
+            flinkVersion: v1_14
+          - image: flink:1.15
+            flinkVersion: v1_15
     name: e2e_ci
     steps:
       - uses: actions/checkout@v2
@@ -143,10 +150,14 @@ jobs:
           kubectl get pods
       - name: Run Flink e2e tests
         run: |
+          sed -i "s/image: flink:.*/image: ${{ matrix.versions.image }}/" e2e-tests/data/*.yaml
+          sed -i "s/flinkVersion: .*/flinkVersion: ${{ matrix.versions.flinkVersion }}/" e2e-tests/data/*.yaml
+          git diff HEAD
           ls e2e-tests/test_*.sh | while read script_test;do \
             echo "Running $script_test"
             bash $script_test || exit 1
           done
+          git reset --hard
       - name: Stop the operator
         run: |
           helm uninstall -n ${{ matrix.config.namespace }} flink-kubernetes-operator

--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -102,7 +102,7 @@ metadata:
   namespace: default
   name: basic-checkpoint-ha-example
 spec:
-  image: flink:1.14.3
+  image: flink:1.14
   flinkVersion: v1_14
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"

--- a/docs/content/docs/custom-resource/overview.md
+++ b/docs/content/docs/custom-resource/overview.md
@@ -111,7 +111,7 @@ metadata:
   namespace: default
   name: basic-example
 spec:
-  image: flink:1.14.3
+  image: flink:1.14
   flinkVersion: v1_14
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"

--- a/docs/content/docs/custom-resource/pod-template.md
+++ b/docs/content/docs/custom-resource/pod-template.md
@@ -49,7 +49,7 @@ metadata:
   namespace: default
   name: pod-template-example
 spec:
-  image: flink:1.14.3
+  image: flink:1.14
   flinkVersion: v1_14
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -76,6 +76,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 | Value | Docs |
 | ----- | ---- |
+| v1_13 |  |
 | v1_14 |  |
 | v1_15 |  |
 | v1_16 |  |

--- a/docs/content/docs/operations/ingress.md
+++ b/docs/content/docs/operations/ingress.md
@@ -35,7 +35,7 @@ metadata:
   namespace: default
   name: advanced-ingress
 spec:
-  image: flink:1.14.3
+  image: flink:1.14
   flinkVersion: v1_14
   ingress:
     template: "flink.k8s.io/{{namespace}}/{{name}}(/|$)(.*)"

--- a/e2e-tests/data/flinkdep-cr.yaml
+++ b/e2e-tests/data/flinkdep-cr.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: default
   name: flink-example-statemachine
 spec:
-  image: flink:1.14.3
+  image: flink:1.14
   flinkVersion: v1_14
   ingress:
     template: "/{{namespace}}/{{name}}(/|$)(.*)"
@@ -47,7 +47,7 @@ spec:
           image: busybox:latest
           imagePullPolicy: IfNotPresent
           # Use wget or other tools to get user jars from remote storage
-          command: [ 'wget', 'https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.3/flink-examples-streaming_2.12-1.14.3.jar', '-O', '/flink-artifact/myjob.jar' ]
+          command: [ 'wget', 'https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.4/flink-examples-streaming_2.12-1.14.4.jar', '-O', '/flink-artifact/myjob.jar' ]
           volumeMounts:
             - mountPath: /flink-artifact
               name: flink-artifact

--- a/e2e-tests/data/sessionjob-cr.yaml
+++ b/e2e-tests/data/sessionjob-cr.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: default
   name: session-cluster-1
 spec:
-  image: flink:1.14.3
+  image: flink:1.14
   flinkVersion: v1_14
   ingress:
     template: "/{{namespace}}/{{name}}(/|$)(.*)"
@@ -76,7 +76,7 @@ metadata:
 spec:
   deploymentName: session-cluster-1
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.3/flink-examples-streaming_2.12-1.14.3.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.4/flink-examples-streaming_2.12-1.14.4.jar
     parallelism: 2
     upgradeMode: savepoint
     entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample

--- a/e2e-tests/test_kubernetes_application_ha.sh
+++ b/e2e-tests/test_kubernetes_application_ha.sh
@@ -34,11 +34,11 @@ wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || e
 wait_for_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
 wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
-job_id=$(kubectl logs $jm_pod_name | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
+job_id=$(kubectl logs $jm_pod_name -c flink-main-container | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
 
 # Kill the JobManager
 echo "Kill the $jm_pod_name"
-kubectl exec $jm_pod_name -- /bin/sh -c "kill 1"
+kubectl exec $jm_pod_name -c flink-main-container -- /bin/sh -c "kill 1"
 
 # Check the new JobManager recovering from latest successful checkpoint
 wait_for_logs $jm_pod_name "Restoring job $job_id from Checkpoint" ${TIMEOUT} || exit 1

--- a/e2e-tests/test_last_state_upgrade.sh
+++ b/e2e-tests/test_last_state_upgrade.sh
@@ -35,7 +35,7 @@ wait_for_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymen
 wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 assert_available_slots 0 $CLUSTER_ID
 
-job_id=$(kubectl logs $jm_pod_name | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
+job_id=$(kubectl logs $jm_pod_name -c flink-main-container | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
 
 # Update the FlinkDeployment and trigger the last state upgrade
 kubectl patch flinkdep ${CLUSTER_ID} --type merge --patch '{"spec":{"job": {"parallelism": 1 } } }'

--- a/e2e-tests/test_sessionjob_ha.sh
+++ b/e2e-tests/test_sessionjob_ha.sh
@@ -35,11 +35,11 @@ wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || e
 wait_for_status $SESSION_CLUSTER_IDENTIFIER '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
 wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
-job_id=$(kubectl logs $jm_pod_name | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
+job_id=$(kubectl logs $jm_pod_name -c flink-main-container | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
 
 # Kill the JobManager
 echo "Kill the $jm_pod_name"
-kubectl exec $jm_pod_name -- /bin/sh -c "kill 1"
+kubectl exec $jm_pod_name -c flink-main-container -- /bin/sh -c "kill 1"
 
 # Check the new JobManager recovering from latest successful checkpoint
 wait_for_logs $jm_pod_name "Restoring job $job_id from Checkpoint" ${TIMEOUT} || exit 1

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -25,7 +25,7 @@ function wait_for_logs {
   # wait or timeout until the log shows up
   echo "Waiting for log \"$2\"..."
   for i in $(seq 1 ${timeout}); do
-    if kubectl logs $jm_pod_name | grep -E "${successful_response_regex}" >/dev/null; then
+    if kubectl logs $jm_pod_name -c flink-main-container | grep -E "${successful_response_regex}" >/dev/null; then
       echo "Log \"$2\" shows up."
       return
     fi

--- a/examples/basic-session-job.yaml
+++ b/examples/basic-session-job.yaml
@@ -41,7 +41,7 @@ metadata:
 spec:
   deploymentName: basic-session-cluster
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.3/flink-examples-streaming_2.12-1.14.3-TopSpeedWindowing.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.4/flink-examples-streaming_2.12-1.14.4-TopSpeedWindowing.jar
     parallelism: 4
     upgradeMode: stateless
 
@@ -53,7 +53,7 @@ metadata:
 spec:
   deploymentName: basic-session-cluster
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.3/flink-examples-streaming_2.12-1.14.3.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.4/flink-examples-streaming_2.12-1.14.4.jar
     parallelism: 2
     upgradeMode: stateless
     entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkVersion.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkVersion.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 /** Enumeration for supported Flink versions. */
 @Experimental
 public enum FlinkVersion {
+    v1_13,
     v1_14,
     v1_15,
     v1_16;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
@@ -50,7 +50,7 @@ public class FlinkOperatorITCase {
     private static final String TEST_NAMESPACE = "flink-operator-test";
     private static final String SERVICE_ACCOUNT = "flink-operator";
     private static final String CLUSTER_ROLE_BINDING = "flink-operator-cluster-role-binding";
-    private static final String FLINK_VERSION = "1.14.3";
+    private static final String FLINK_VERSION = "1.14.4";
     private static final String IMAGE = String.format("flink:%s", FLINK_VERSION);
     private static final Logger LOG = LoggerFactory.getLogger(FlinkOperatorITCase.class);
     private KubernetesClient client;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -99,7 +99,7 @@ public class DeploymentRecoveryTest {
         assertEquals(JobManagerDeploymentStatus.ERROR, status.getJobManagerDeploymentStatus());
 
         testController.reconcile(appCluster, context);
-        if (flinkVersion != FlinkVersion.v1_14 || enabled) {
+        if (flinkVersion.isNewerVersionThan(FlinkVersion.v1_14) || enabled) {
             assertEquals(
                     JobManagerDeploymentStatus.DEPLOYING, status.getJobManagerDeploymentStatus());
         } else {
@@ -110,7 +110,7 @@ public class DeploymentRecoveryTest {
 
         testController.reconcile(appCluster, context);
         testController.reconcile(appCluster, context);
-        if (flinkVersion != FlinkVersion.v1_14 || enabled) {
+        if (flinkVersion.isNewerVersionThan(FlinkVersion.v1_14) || enabled) {
             assertEquals(JobManagerDeploymentStatus.READY, status.getJobManagerDeploymentStatus());
             assertEquals(JobStatus.RUNNING.name(), status.getJobStatus().getState());
         } else {
@@ -170,7 +170,7 @@ public class DeploymentRecoveryTest {
         testController.reconcile(appCluster, context);
         flinkService.setPortReady(true);
 
-        if (flinkVersion != FlinkVersion.v1_14 || enabled) {
+        if (flinkVersion.isNewerVersionThan(FlinkVersion.v1_14) || enabled) {
             assertEquals(
                     JobManagerDeploymentStatus.DEPLOYING, status.getJobManagerDeploymentStatus());
             testController.reconcile(appCluster, context);
@@ -189,9 +189,7 @@ public class DeploymentRecoveryTest {
         List<Arguments> args = new ArrayList<>();
         for (FlinkVersion version : FlinkVersion.values()) {
             for (UpgradeMode upgradeMode : UpgradeMode.values()) {
-                if (version == FlinkVersion.v1_14) {
-                    args.add(arguments(version, upgradeMode, true));
-                }
+                args.add(arguments(version, upgradeMode, true));
                 args.add(arguments(version, upgradeMode, false));
             }
         }

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -27,6 +27,7 @@ spec:
                 type: string
               flinkVersion:
                 enum:
+                - v1_13
                 - v1_14
                 - v1_15
                 - v1_16


### PR DESCRIPTION
The core k8s related features:

- native k8s integration for session cluster, 1.10
- native k8s integration for application cluster, 1.11
- Flink K8s HA, 1.12
- pod template, 1.13

Hence required the minimum version could be set to 1.13 which allows more users to have a try on flink-kubernetes-operator. The e2e tests should be updated to cover all the supported versions.

**The brief change log**

- Add the `tests.sh` to cover all the supported versions for e2e tests.