### PR TITLE
[FLINK-27261] Disable `web.cancel.enable` for session cluster

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -134,12 +134,10 @@ public class FlinkConfigBuilder {
         // Adapt default rest service type from 1.15+
         setDefaultConf(
                 REST_SERVICE_EXPOSED_TYPE, KubernetesConfigOptions.ServiceExposedType.ClusterIP);
+        // Set 'web.cancel.enable' to false to avoid users accidentally cancelling jobs.
+        setDefaultConf(CANCEL_ENABLE, false);
 
         if (spec.getJob() != null) {
-            // Set 'web.cancel.enable' to false for application deployments to avoid users
-            // accidentally cancelling jobs.
-            setDefaultConf(CANCEL_ENABLE, false);
-
             // With last-state upgrade mode, set the default value of
             // 'execution.checkpointing.interval'
             // to 5 minutes when HA is enabled.

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -55,7 +55,6 @@ import java.util.Collections;
 
 import static org.apache.flink.configuration.DeploymentOptionsInternal.CONF_DIR;
 import static org.apache.flink.configuration.WebOptions.CANCEL_ENABLE;
-import static org.apache.flink.configuration.WebOptions.SUBMIT_ENABLE;
 import static org.apache.flink.kubernetes.configuration.KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE;
 import static org.apache.flink.kubernetes.operator.utils.FlinkUtils.mergePodTemplates;
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
@@ -135,10 +134,6 @@ public class FlinkConfigBuilder {
         // Adapt default rest service type from 1.15+
         setDefaultConf(
                 REST_SERVICE_EXPOSED_TYPE, KubernetesConfigOptions.ServiceExposedType.ClusterIP);
-
-        // Set 'web.submit.enable' to false to disable the web submission.
-        setDefaultConf(SUBMIT_ENABLE, false);
-
         // Set 'web.cancel.enable' to false to avoid users accidentally cancelling jobs.
         setDefaultConf(CANCEL_ENABLE, false);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 
 import static org.apache.flink.configuration.DeploymentOptionsInternal.CONF_DIR;
 import static org.apache.flink.configuration.WebOptions.CANCEL_ENABLE;
+import static org.apache.flink.configuration.WebOptions.SUBMIT_ENABLE;
 import static org.apache.flink.kubernetes.configuration.KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE;
 import static org.apache.flink.kubernetes.operator.utils.FlinkUtils.mergePodTemplates;
 import static org.apache.flink.kubernetes.utils.Constants.CONFIG_FILE_LOG4J_NAME;
@@ -134,6 +135,10 @@ public class FlinkConfigBuilder {
         // Adapt default rest service type from 1.15+
         setDefaultConf(
                 REST_SERVICE_EXPOSED_TYPE, KubernetesConfigOptions.ServiceExposedType.ClusterIP);
+
+        // Set 'web.submit.enable' to false to disable the web submission.
+        setDefaultConf(SUBMIT_ENABLE, false);
+
         // Set 'web.cancel.enable' to false to avoid users accidentally cancelling jobs.
         setDefaultConf(CANCEL_ENABLE, false);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -114,7 +114,6 @@ public class FlinkConfigBuilderTest {
         Assertions.assertEquals(
                 KubernetesConfigOptions.ServiceExposedType.ClusterIP,
                 configuration.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE));
-        Assertions.assertEquals(false, configuration.get(WebOptions.SUBMIT_ENABLE));
         Assertions.assertEquals(false, configuration.get(WebOptions.CANCEL_ENABLE));
 
         FlinkDeployment deployment = ReconciliationUtils.clone(flinkDeployment);
@@ -153,7 +152,6 @@ public class FlinkConfigBuilderTest {
                 new FlinkConfigBuilder(deployment, new Configuration())
                         .applyFlinkConfiguration()
                         .build();
-        Assertions.assertEquals(false, configuration.get(WebOptions.SUBMIT_ENABLE));
         Assertions.assertEquals(false, configuration.get(WebOptions.CANCEL_ENABLE));
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -146,6 +146,13 @@ public class FlinkConfigBuilderTest {
         Assertions.assertEquals(
                 DEFAULT_CHECKPOINTING_INTERVAL,
                 configuration.get(ExecutionCheckpointingOptions.CHECKPOINTING_INTERVAL));
+
+        deployment = TestUtils.buildSessionCluster();
+        configuration =
+                new FlinkConfigBuilder(deployment, new Configuration())
+                        .applyFlinkConfiguration()
+                        .build();
+        Assertions.assertEquals(false, configuration.get(WebOptions.CANCEL_ENABLE));
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -114,6 +114,7 @@ public class FlinkConfigBuilderTest {
         Assertions.assertEquals(
                 KubernetesConfigOptions.ServiceExposedType.ClusterIP,
                 configuration.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE));
+        Assertions.assertEquals(false, configuration.get(WebOptions.SUBMIT_ENABLE));
         Assertions.assertEquals(false, configuration.get(WebOptions.CANCEL_ENABLE));
 
         FlinkDeployment deployment = ReconciliationUtils.clone(flinkDeployment);
@@ -152,6 +153,7 @@ public class FlinkConfigBuilderTest {
                 new FlinkConfigBuilder(deployment, new Configuration())
                         .applyFlinkConfiguration()
                         .build();
+        Assertions.assertEquals(false, configuration.get(WebOptions.SUBMIT_ENABLE));
         Assertions.assertEquals(false, configuration.get(WebOptions.CANCEL_ENABLE));
     }
 


### PR DESCRIPTION
In [FLINK-27154](https://issues.apache.org/jira/browse/FLINK-27154), we disable `web.cancel.enable` for application cluster. We should also do this for session cluster.

**The brief change log**

- Sets `web.cancel.enable` to false at default in `FlinkConfigBuilder` to avoid users accidentally cancelling jobs.