### PR TITLE
[FLINK-27551] Update status manually instead of relying on updatecontrol

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -141,6 +141,8 @@ public class ReconciliationUtils {
 
         STATUS status = current.getStatus();
 
+        // Status update is handled manually independently, we only use UpdateControl to reschedule
+        // reconciliation
         UpdateControl<R> updateControl = UpdateControl.noUpdate();
 
         if (!reschedule) {
@@ -355,6 +357,18 @@ public class ReconciliationUtils {
         }
     }
 
+    /**
+     * Update the resource error status and metrics when the operator encountered an exception
+     * during reconciliation.
+     *
+     * @param client Kubernetes Client used for status updates
+     * @param resource Flink Resource to be updated
+     * @param retryInfo Current RetryInformation
+     * @param e Exception that caused the retry
+     * @param metricManager Metric manager to be updated
+     * @param statusCache Cache containing the latest status updates for this resource type
+     * @return This always returns Empty optional currently, due to the status update logic
+     */
     public static <
                     SPEC extends AbstractFlinkSpec,
                     STATUS extends CommonStatus<SPEC>,
@@ -376,6 +390,8 @@ public class ReconciliationUtils {
                 (e instanceof ReconciliationException) ? e.getCause().toString() : e.toString());
         metricManager.onUpdate(resource);
         OperatorUtils.patchAndCacheStatus(client, resource, statusCache);
+
+        // Status was updated already, no need to return anything
         return Optional.empty();
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/OperatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/OperatorUtils.java
@@ -114,6 +114,7 @@ public class OperatorUtils {
         Class<T> resourceClass = (Class<T>) resource.getClass();
         String namespace = resource.getMetadata().getNamespace();
         String name = resource.getMetadata().getName();
+        resource.getMetadata().setResourceVersion(null);
 
         Exception err = null;
         for (int i = 0; i < 3; i++) {

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ under the License.
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
         <git-commit-id-maven-plugin.version>5.0.0</git-commit-id-maven-plugin.version>
 
-        <operator.sdk.version>2.1.2</operator.sdk.version>
+        <operator.sdk.version>2.1.4</operator.sdk.version>
         <fabric8.version>5.12.1</fabric8.version>
         <lombok.version>1.18.22</lombok.version>
 


### PR DESCRIPTION
This PR reworks how status updates of Flink resources are updated in kubernetes. This is necessary due to https://github.com/java-operator-sdk/java-operator-sdk/issues/1198

Based on offline discussion with the JOSDK team this seems to be the safest short term solution.

The caching of the latest status is necessary to avoid race condition between spec updates and status patches that are made by us.

Tests have been updated with some init logic to enable patching them through the kubernetes client + removed the reliance of mutating status.