### PR TITLE
[Flink 27329] Add default value of replica of JM pod and not declare it in example yamls

### DIFF
--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -110,7 +110,6 @@ spec:
     high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
     high-availability.storageDir: file:///flink-data/ha
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/docs/content/docs/custom-resource/overview.md
+++ b/docs/content/docs/custom-resource/overview.md
@@ -117,7 +117,6 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/docs/content/docs/custom-resource/pod-template.md
+++ b/docs/content/docs/custom-resource/pod-template.md
@@ -77,7 +77,6 @@ spec:
         - name: flink-logs
           emptyDir: { }
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -137,7 +137,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
-| cpu | double | Amount of CPU allocated to the pod. |
+| cpu | java.lang.Double | Amount of CPU allocated to the pod. |
 | memory | java.lang.String | Amount of memory allocated to the pod. Example: 1024m, 1g |
 
 ### TaskManagerSpec

--- a/e2e-tests/data/flinkdep-cr.yaml
+++ b/e2e-tests/data/flinkdep-cr.yaml
@@ -71,7 +71,6 @@ spec:
           persistentVolumeClaim:
             claimName: flink-example-statemachine
   jobManager:
-    replicas: 1
     resource:
       memory: "1024m"
       cpu: 0.5

--- a/e2e-tests/data/sessionjob-cr.yaml
+++ b/e2e-tests/data/sessionjob-cr.yaml
@@ -58,7 +58,6 @@ spec:
           persistentVolumeClaim:
             claimName: session-cluster-1-pvc
   jobManager:
-    replicas: 1
     resource:
       memory: "1024m"
       cpu: 0.5

--- a/examples/advanced-ingress.yaml
+++ b/examples/advanced-ingress.yaml
@@ -32,7 +32,6 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/examples/basic-checkpoint-ha.yaml
+++ b/examples/basic-checkpoint-ha.yaml
@@ -29,7 +29,6 @@ spec:
     high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
     high-availability.storageDir: file:///flink-data/ha
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/examples/basic-ingress.yaml
+++ b/examples/basic-ingress.yaml
@@ -29,7 +29,6 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/examples/basic-session-job.yaml
+++ b/examples/basic-session-job.yaml
@@ -24,7 +24,6 @@ spec:
   image: flink:1.14
   flinkVersion: v1_14
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/examples/basic-session.yaml
+++ b/examples/basic-session.yaml
@@ -27,7 +27,6 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -27,7 +27,6 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/examples/custom-logging.yaml
+++ b/examples/custom-logging.yaml
@@ -27,7 +27,6 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -49,7 +49,6 @@ spec:
         - name: flink-logs
           emptyDir: { }
   jobManager:
-    replicas: 1
     resource:
       memory: "2048m"
       cpu: 1

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -292,8 +292,12 @@ public class FlinkConfigBuilder {
                     isJM
                             ? KubernetesConfigOptions.JOB_MANAGER_CPU
                             : KubernetesConfigOptions.TASK_MANAGER_CPU;
-            effectiveConfig.setString(memoryConfigOption.key(), resource.getMemory());
-            effectiveConfig.setDouble(cpuConfigOption.key(), resource.getCpu());
+            if (resource.getMemory() != null) {
+                effectiveConfig.setString(memoryConfigOption.key(), resource.getMemory());
+            }
+            if (resource.getCpu() != null) {
+                effectiveConfig.setDouble(cpuConfigOption.key(), resource.getCpu());
+            }
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobManagerSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobManagerSpec.java
@@ -34,7 +34,7 @@ public class JobManagerSpec {
     private Resource resource;
 
     /** Number of JobManager replicas. Must be 1 for non-HA deployments. */
-    private int replicas;
+    private int replicas = 1;
 
     /** JobManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. */
     private Pod podTemplate;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/Resource.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/Resource.java
@@ -30,7 +30,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Resource {
     /** Amount of CPU allocated to the pod. */
-    private double cpu;
+    private Double cpu;
 
     /** Amount of memory allocated to the pod. Example: 1024m, 1g */
     private String memory;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -81,7 +81,8 @@ public class DefaultValidator implements FlinkResourceValidator {
                 validateJobSpec(spec.getJob(), effectiveConfig),
                 validateJmSpec(spec.getJobManager(), effectiveConfig),
                 validateTmSpec(spec.getTaskManager()),
-                validateSpecChange(deployment, effectiveConfig));
+                validateSpecChange(deployment, effectiveConfig),
+                validateServiceAccount(spec.getServiceAccount()));
     }
 
     private static Optional<String> firstPresent(Optional<String>... errOpts) {
@@ -383,6 +384,14 @@ public class DefaultValidator implements FlinkResourceValidator {
             return Optional.of("Cannot perform savepoint restore without a valid savepoint");
         }
 
+        return Optional.empty();
+    }
+
+    private Optional<String> validateServiceAccount(String serviceAccount) {
+        if (serviceAccount == null) {
+            return Optional.of(
+                    "spec.serviceAccount must be defined. If you use helm, its value should be the same with the name of jobServiceAccount.");
+        }
         return Optional.empty();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
@@ -111,7 +111,7 @@ public class FlinkOperatorITCase {
         spec.setServiceAccount(SERVICE_ACCOUNT);
         Resource resource = new Resource();
         resource.setMemory("2048m");
-        resource.setCpu(1);
+        resource.setCpu(1.0);
         JobManagerSpec jm = new JobManagerSpec();
         jm.setResource(resource);
         jm.setReplicas(1);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -152,8 +152,8 @@ public class TestUtils {
                 .serviceAccount(SERVICE_ACCOUNT)
                 .flinkVersion(version)
                 .flinkConfiguration(conf)
-                .jobManager(new JobManagerSpec(new Resource(1, "2048m"), 1, null))
-                .taskManager(new TaskManagerSpec(new Resource(1, "2048m"), null))
+                .jobManager(new JobManagerSpec(new Resource(1.0, "2048m"), 1, null))
+                .taskManager(new TaskManagerSpec(new Resource(1.0, "2048m"), null))
                 .build();
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -285,6 +285,12 @@ public class DefaultValidatorTest {
         testError(dep -> dep.getSpec().setFlinkVersion(null), "Flink Version must be defined.");
 
         testSuccess(dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_15));
+
+        testError(
+                dep -> dep.getSpec().setServiceAccount(null),
+                "spec.serviceAccount must be defined. If you use helm, its value should be the same with the name of jobServiceAccount.");
+
+        testSuccess(dep -> dep.getSpec().setServiceAccount("flink"));
     }
 
     @Test


### PR DESCRIPTION

1. Revisit default values in org.apache.flink.kubernetes.operator.crd.spec (details is [here])(https://issues.apache.org/jira/browse/FLINK-27329?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel)
2. Set default value of `crd.spec.Resource#cpu` to `1.0`
3. Set default value of  `crd.spec.FlinkDeploymentSpec#serviceAccount` to `flink`
4. Set default value of  `crd.spec.JobManagerSpec#replicas` to 1 and remove its usage in examples.