### PR TITLE
[FLINK-27036] Exclude final release tags from docker build

### DIFF
--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -24,7 +24,7 @@ on:
       - main
       - 'release-*'
     tags:
-      - 'release-*'
+      - 'release-*-rc*'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
These should be tagged manually from the latest rc instead.