### PR TITLE
[FLINK-27573] Configuring a new random job result store directory

### DIFF
--- a/docs/content/docs/concepts/overview.md
+++ b/docs/content/docs/concepts/overview.md
@@ -66,3 +66,18 @@ Flink Kubernetes Operator aims to capture the responsibilities of a human operat
 | CI/CD                  | Continuous Integration         | full    | via github actions                   |
 |                        | Public Docker repository       | full    | ghcr.io / dockerhub                  |
 |                        | Public Helm repository         | full    | apache release repo                  |
+
+
+# Known issues & limitations
+
+JobResultStore Resource Leak
+
+To mitigate the impact of [FLINK-27569](https://issues.apache.org/jira/browse/FLINK-27569) the operator introduced a workaround [FLINK-27573](https://issues.apache.org/jira/browse/FLINK-27573) by setting `job-result-store.delete-on-commit=false` and a unique value for `job-result-store.storage-path` for every cluster launch. The storage path for older runs must be cleaned up manually, keeping the latest directory always:
+
+```shell
+ls -lth /tmp/flink/ha/job-result-store/basic-checkpoint-ha-example/
+total 0
+drwxr-xr-x 2 9999 9999 40 May 12 09:51 119e0203-c3a9-4121-9a60-d58839576f01 <- must be retained
+drwxr-xr-x 2 9999 9999 60 May 12 09:46 a6031ec7-ab3e-4b30-ba77-6498e58e6b7f
+drwxr-xr-x 2 9999 9999 60 May 11 15:11 b6fb2a9c-d1cd-4e65-a9a1-e825c4b47543
+```

--- a/examples/basic-checkpoint-ha.yaml
+++ b/examples/basic-checkpoint-ha.yaml
@@ -28,6 +28,7 @@ spec:
     state.savepoints.dir: file:///flink-data/savepoints
     high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
     high-availability.storageDir: file:///flink-data/ha
+  serviceAccount: flink
   jobManager:
     resource:
       memory: "2048m"


### PR DESCRIPTION
This is a workaround for  https://issues.apache.org/jira/browse/FLINK-27569 . It creates random job result stores :

```
ls -al /tmp/flink/ha/job-result-store/basic-checkpoint-ha-example/
total 0
drwxr-xr-x 6 9999 9999 120 May 11 15:39 .
drwxr-xr-x 3 9999 9999  60 May 11 14:52 ..
drwxr-xr-x 2 9999 9999  60 May 11 15:32 1e080985-a3a9-4390-8567-134bc1f4c2d1
drwxr-xr-x 2 9999 9999  40 May 11 15:39 a6031ec7-ab3e-4b30-ba77-6498e58e6b7f
drwxr-xr-x 2 9999 9999  60 May 11 15:11 b6fb2a9c-d1cd-4e65-a9a1-e825c4b47543
drwxr-xr-x 2 9999 9999  60 May 11 15:19 e569a5db-abb3-44ac-8169-545eeb46914a
```

It leaks the storage files on every upgrade, that is a know concern.

Verify:
- Run the basic-checkpoint-ha example
- suspend the job
- kill JM -> verify no jobs starts
- resume the job - verify the job restored from checkpoint/savepoint
