### PR TITLE
[FLINK-27600] Add minimal jar coping and deleting logs

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -281,11 +281,13 @@ public class FlinkService {
                                     .toSeconds(),
                             TimeUnit.SECONDS);
         } finally {
+            LOG.debug("Deleting the jar file {}", jarFile);
             FileUtils.deleteFileOrDirectory(jarFile);
         }
     }
 
     private void deleteJar(Configuration conf, String jarId) {
+        LOG.debug("Deleting the jar: {}", jarId);
         try (RestClusterClient<String> clusterClient =
                 (RestClusterClient<String>) getClusterClient(conf)) {
             JarDeleteHeaders headers = JarDeleteHeaders.getInstance();


### PR DESCRIPTION
Because we delete the jar after submitting the job, it's better to leave some logs for the end users