### PR TITLE
[FLINK-27572][FLINK-27594] Ensure HA metadata is present before restoring job with last state

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -88,9 +88,9 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.reconciler.jm-deployment-recovery.enabled</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>Whether to enable recovery of missing/deleted jobmanager deployments. False by default for Flink 1.14, true for newer Flink version.</td>
+            <td>Whether to enable recovery of missing/deleted jobmanager deployments.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.reconciler.max.parallelism</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -132,7 +132,12 @@ public class FlinkConfigManager {
     }
 
     public Configuration getObserveConfig(FlinkDeployment deployment) {
-        return getConfig(deployment.getMetadata(), ReconciliationUtils.getDeployedSpec(deployment));
+        var deployedSpec = ReconciliationUtils.getDeployedSpec(deployment);
+        if (deployedSpec == null) {
+            throw new RuntimeException(
+                    "Cannot create observe config before first deployment, this indicates a bug.");
+        }
+        return getConfig(deployment.getMetadata(), deployedSpec);
     }
 
     public Configuration getSessionJobConfig(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -139,9 +139,9 @@ public class KubernetesOperatorConfigOptions {
     public static final ConfigOption<Boolean> OPERATOR_RECOVER_JM_DEPLOYMENT_ENABLED =
             ConfigOptions.key("kubernetes.operator.reconciler.jm-deployment-recovery.enabled")
                     .booleanType()
-                    .noDefaultValue()
+                    .defaultValue(true)
                     .withDescription(
-                            "Whether to enable recovery of missing/deleted jobmanager deployments. False by default for Flink 1.14, true for newer Flink version.");
+                            "Whether to enable recovery of missing/deleted jobmanager deployments.");
 
     public static final ConfigOption<Map<String, String>> JAR_ARTIFACT_HTTP_HEADER =
             ConfigOptions.key("kubernetes.operator.user.artifacts.http.header")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -101,12 +101,14 @@ public class FlinkSessionJobController
             FlinkSessionJob flinkSessionJob, Context context) {
         LOG.info("Starting reconciliation");
         statusHelper.updateStatusFromCache(flinkSessionJob);
+        FlinkSessionJob previousJob = ReconciliationUtils.clone(flinkSessionJob);
+
         observer.observe(flinkSessionJob, context);
         if (!validateSessionJob(flinkSessionJob, context)) {
             metricManager.onUpdate(flinkSessionJob);
             statusHelper.patchAndCacheStatus(flinkSessionJob);
             return ReconciliationUtils.toUpdateControl(
-                    configManager.getOperatorConfiguration(), flinkSessionJob, false);
+                    configManager.getOperatorConfiguration(), flinkSessionJob, previousJob, false);
         }
 
         try {
@@ -117,7 +119,7 @@ public class FlinkSessionJobController
         metricManager.onUpdate(flinkSessionJob);
         statusHelper.patchAndCacheStatus(flinkSessionJob);
         return ReconciliationUtils.toUpdateControl(
-                configManager.getOperatorConfiguration(), flinkSessionJob, true);
+                configManager.getOperatorConfiguration(), flinkSessionJob, previousJob, true);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -139,7 +139,7 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
         try {
             flinkService
                     .getLastCheckpoint(JobID.fromHexString(jobID), deployedConfig)
-                    .ifPresent(savepointInfo::setLastSavepoint);
+                    .ifPresent(savepointInfo::updateLastSavepoint);
         } catch (Exception e) {
             LOG.error("Could not observe latest savepoint information.", e);
             throw new ReconciliationException(e);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -139,7 +139,7 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
                 checkCrashLoopBackoff(flinkApp, effectiveConfig);
             } catch (DeploymentFailedException dfe) {
                 // throw only when not already in error status to allow for spec update
-                deploymentStatus.getJobStatus().setState(JobStatus.FAILED.name());
+                deploymentStatus.getJobStatus().setState(JobStatus.RECONCILING.name());
                 if (!JobManagerDeploymentStatus.ERROR.equals(
                         deploymentStatus.getJobManagerDeploymentStatus())) {
                     throw dfe;
@@ -153,7 +153,7 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
         }
 
         deploymentStatus.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
-        deploymentStatus.getJobStatus().setState(JobStatus.FAILED.name());
+        deploymentStatus.getJobStatus().setState(JobStatus.RECONCILING.name());
 
         if (previousJmStatus != JobManagerDeploymentStatus.MISSING
                 && previousJmStatus != JobManagerDeploymentStatus.ERROR) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -131,6 +131,12 @@ public class DefaultValidator implements FlinkResourceValidator {
                 return Optional.of("Forbidden Flink config key: " + key);
             }
         }
+
+        if (conf.get(KubernetesOperatorConfigOptions.DEPLOYMENT_ROLLBACK_ENABLED)
+                && !FlinkUtils.isKubernetesHAActivated(conf)) {
+            return Optional.of("Kubernetes HA must be enabled for rollback support.");
+        }
+
         return Optional.empty();
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -24,8 +24,10 @@ import org.apache.flink.configuration.DeploymentOptionsInternal;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.utils.Constants;
 
 import io.fabric8.kubernetes.api.model.Pod;
@@ -99,6 +101,8 @@ public class FlinkConfigManagerTest {
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         deployment.getSpec().setLogConfiguration(Map.of(Constants.CONFIG_FILE_LOG4J_NAME, "test"));
         deployment.getSpec().setPodTemplate(new Pod());
+
+        ReconciliationUtils.updateForSpecReconciliationSuccess(deployment, JobState.RUNNING);
         Configuration deployConfig = configManager.getObserveConfig(deployment);
         assertFalse(
                 deployConfig.contains(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -65,7 +65,7 @@ public class ApplicationObserverTest {
                 .getReconciliationStatus()
                 .serializeAndSetLastReconciledSpec(deployment.getSpec());
         deployment.getStatus().setJobStatus(new JobStatus());
-        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf);
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
 
         // Validate port check logic
         flinkService.setPortReady(false);
@@ -159,7 +159,7 @@ public class ApplicationObserverTest {
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         Configuration conf =
                 configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
-        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf);
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
         bringToReadyStatus(deployment);
         observer.observe(deployment, readyContext);
         assertEquals(
@@ -217,6 +217,8 @@ public class ApplicationObserverTest {
                         jobTuple.f1.getJobName(),
                         org.apache.flink.api.common.JobStatus.FAILED,
                         jobTuple.f1.getStartTime());
+        deployment.getStatus().getJobStatus().getSavepointInfo().setTriggerId("test");
+        deployment.getStatus().getJobStatus().getSavepointInfo().setTriggerTimestamp(123L);
 
         observer.observe(deployment, readyContext);
         assertEquals(
@@ -230,6 +232,8 @@ public class ApplicationObserverTest {
                         .getSavepointInfo()
                         .getLastSavepoint()
                         .getLocation());
+        assertNull(deployment.getStatus().getJobStatus().getSavepointInfo().getTriggerTimestamp());
+        assertNull(deployment.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
     }
 
     private void bringToReadyStatus(FlinkDeployment deployment) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
@@ -51,7 +51,8 @@ public class IngressUtilsTest {
     public void testIngress() {
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
         Configuration config =
-                new FlinkConfigManager(new Configuration()).getObserveConfig(appCluster);
+                new FlinkConfigManager(new Configuration())
+                        .getDeployConfig(appCluster.getMetadata(), appCluster.getSpec());
 
         // no ingress when ingressDomain is empty
         IngressUtils.updateIngressRules(

--- a/flink-kubernetes-operator/src/test/resources/log4j2-test.properties
+++ b/flink-kubernetes-operator/src/test/resources/log4j2-test.properties
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-rootLogger.level = INFO
+rootLogger.level = DEBUG
 rootLogger.appenderRef.console.ref = ConsoleAppender
 
 # Log all infos to the console

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -89,6 +89,8 @@ defaultConfiguration:
   log4j-operator.properties: |+
     # Flink Operator Logging Overrides
     # rootLogger.level = DEBUG
+    # logger.operator.name= org.apache.flink.kubernetes.operator
+    # logger.operator.level = DEBUG
   log4j-console.properties: |+
     # Flink Deployment Logging Overrides
     # rootLogger.level = DEBUG


### PR DESCRIPTION
**This PR contains the following improvements/fixes for a number of loosely connected blocker issues:**

1. Eliminate bug that causes 0 delay infinite reconcile loop with the UpdateControl management logic
2. Ensure HA metadata is available when we are relying on it during stateful upgrades
3. Make JM deployment recovery condititional on availablity of HA metadata
4. Trigger fatal error when upgrade progress is stuck
5. Clean up and improve stateful upgrade conditions with added detailed debug logging
6. Greately simplify code around suspend/cancellation and restore operation in the reconciler
7. Make sure finished jobs are marked as stable to avoid rollback loop for short jobs