### PR TITLE
[FLINK-27435] Savepoint History

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -270,3 +270,4 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | lastSavepoint | org.apache.flink.kubernetes.operator.crd.status.Savepoint | Last completed savepoint by the operator. |
 | triggerId | java.lang.String | Trigger id of a pending savepoint operation. |
 | triggerTimestamp | java.lang.Long | Trigger timestamp of a pending savepoint operation. |
+| savepointHistory | java.util.List<org.apache.flink.kubernetes.operator.crd.status.Savepoint> | List of recent savepoints. |

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -105,6 +105,18 @@
             <td>The interval for the controller to reschedule the reconcile process.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.savepoint.history.max.age</h5></td>
+            <td style="word-wrap: break-word;">86400000 ms</td>
+            <td>Duration</td>
+            <td>Maximum age for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.savepoint.history.max.count</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>Maximum number of savepoint history entries to retain.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.user.artifacts.base.dir</h5></td>
             <td style="word-wrap: break-word;">"/opt/flink/artifacts"</td>
             <td>String</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -41,6 +41,8 @@ public class FlinkOperatorConfiguration {
     Duration flinkCancelJobTimeout;
     Duration flinkShutdownClusterTimeout;
     String artifactsBaseDir;
+    int savepointHistoryMaxCount;
+    Duration savepointHistoryMaxAge;
 
     public static FlinkOperatorConfiguration fromConfiguration(
             Configuration operatorConfig, Set<String> watchedNamespaces) {
@@ -83,6 +85,13 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions.OPERATOR_USER_ARTIFACTS_BASE_DIR);
 
+        int savepointHistoryMaxCount =
+                operatorConfig.get(
+                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT);
+        Duration savepointHistoryMaxAge =
+                operatorConfig.get(
+                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE);
+
         String flinkServiceHostOverride = null;
         if (EnvUtils.get("KUBERNETES_SERVICE_HOST") == null) {
             // not running in k8s, simplify local development
@@ -100,6 +109,8 @@ public class FlinkOperatorConfiguration {
                 watchedNamespaces,
                 flinkCancelJobTimeout,
                 flinkShutdownClusterTimeout,
-                artifactsBaseDir);
+                artifactsBaseDir,
+                savepointHistoryMaxCount,
+                savepointHistoryMaxAge);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -143,6 +143,19 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Whether to enable recovery of missing/deleted jobmanager deployments.");
 
+    public static final ConfigOption<Integer> OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT =
+            ConfigOptions.key("kubernetes.operator.savepoint.history.max.count")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription("Maximum number of savepoint history entries to retain.");
+
+    public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_MAX_AGE =
+            ConfigOptions.key("kubernetes.operator.savepoint.history.max.age")
+                    .durationType()
+                    .defaultValue(Duration.ofHours(24))
+                    .withDescription(
+                            "Maximum age for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.");
+
     public static final ConfigOption<Map<String, String>> JAR_ARTIFACT_HTTP_HEADER =
             ConfigOptions.key("kubernetes.operator.user.artifacts.http.header")
                     .mapType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointInfo.java
@@ -24,6 +24,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /** Stores savepoint related information. */
 @Experimental
 @Data
@@ -40,6 +43,9 @@ public class SavepointInfo {
     /** Trigger timestamp of a pending savepoint operation. */
     private Long triggerTimestamp;
 
+    /** List of recent savepoints. */
+    private List<Savepoint> savepointHistory;
+
     public void setTrigger(String triggerId) {
         this.triggerId = triggerId;
         this.triggerTimestamp = System.currentTimeMillis();
@@ -53,5 +59,23 @@ public class SavepointInfo {
     public void updateLastSavepoint(Savepoint savepoint) {
         lastSavepoint = savepoint;
         resetTrigger();
+    }
+
+    /**
+     * Add the savepoint to the history if it isn't already the most recent savepoint.
+     *
+     * @param newSavepoint
+     */
+    public void addSavepointToHistory(Savepoint newSavepoint) {
+        if (savepointHistory == null) {
+            savepointHistory = new ArrayList<>();
+        }
+        if (!savepointHistory.isEmpty()) {
+            Savepoint recentSp = savepointHistory.get(savepointHistory.size() - 1);
+            if (recentSp.getLocation().equals(newSavepoint.getLocation())) {
+                return;
+            }
+        }
+        savepointHistory.add(newSavepoint);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconciler.java
@@ -201,7 +201,11 @@ public class FlinkSessionJobReconciler implements Reconciler<FlinkSessionJob> {
         JobState stateAfterReconcile = JobState.SUSPENDED;
         jobStatus.setState(stateAfterReconcile.name());
         savepointOpt.ifPresent(
-                location -> jobStatus.getSavepointInfo().setLastSavepoint(Savepoint.of(location)));
+                location -> {
+                    Savepoint sp = Savepoint.of(location);
+                    jobStatus.getSavepointInfo().setLastSavepoint(sp);
+                    jobStatus.getSavepointInfo().addSavepointToHistory(sp);
+                });
         return stateAfterReconcile;
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -76,6 +76,7 @@ public class TestingFlinkService extends FlinkService {
     private boolean deployFailure = false;
     private PodList podList = new PodList();
     private Consumer<Configuration> listJobConsumer = conf -> {};
+    private List<String> disposedSavepoints = new ArrayList<>();
 
     public TestingFlinkService() {
         super(null, new FlinkConfigManager(new Configuration()));
@@ -290,6 +291,15 @@ public class TestingFlinkService extends FlinkService {
     public SavepointFetchResult fetchSavepointInfo(
             String triggerId, String jobId, Configuration conf) {
         return SavepointFetchResult.completed(Savepoint.of("savepoint_" + savepointCounter++));
+    }
+
+    @Override
+    public void disposeSavepoint(String savepointPath, Configuration conf) {
+        disposedSavepoints.add(savepointPath);
+    }
+
+    public List<String> getDisposedSavepoints() {
+        return disposedSavepoints;
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.observer;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.TestingStatusHelper;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+
+/** Tests for {@link SavepointObserver}. */
+public class SavepointObserverTest {
+
+    private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
+    private final TestingFlinkService flinkService = new TestingFlinkService();
+
+    @Test
+    public void testBasicObserve() {
+        SavepointObserver observer =
+                new SavepointObserver(flinkService, configManager, new TestingStatusHelper<>());
+        SavepointInfo spInfo = new SavepointInfo();
+        Assertions.assertNull(spInfo.getSavepointHistory());
+
+        Savepoint sp = new Savepoint(1, "sp1");
+        observer.updateSavepointHistory(spInfo, sp, configManager.getDefaultConfig());
+
+        Assertions.assertNotNull(spInfo.getSavepointHistory());
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp), spInfo.getSavepointHistory());
+    }
+
+    @Test
+    public void testAgeBasedDispose() {
+        Configuration conf = new Configuration();
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                Duration.ofMillis(5));
+
+        SavepointObserver observer =
+                new SavepointObserver(flinkService, configManager, new TestingStatusHelper<>());
+        SavepointInfo spInfo = new SavepointInfo();
+
+        Savepoint sp1 = new Savepoint(1, "sp1");
+        observer.updateSavepointHistory(spInfo, sp1, conf);
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp1), spInfo.getSavepointHistory());
+        Assertions.assertIterableEquals(
+                Collections.emptyList(), flinkService.getDisposedSavepoints());
+
+        Savepoint sp2 = new Savepoint(2, "sp2");
+        observer.updateSavepointHistory(spInfo, sp2, conf);
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp2), spInfo.getSavepointHistory());
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp1.getLocation()), flinkService.getDisposedSavepoints());
+    }
+}

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9133,6 +9133,15 @@ spec:
                         type: string
                       triggerTimestamp:
                         type: integer
+                      savepointHistory:
+                        items:
+                          properties:
+                            timeStamp:
+                              type: integer
+                            location:
+                              type: string
+                          type: object
+                        type: array
                     type: object
                 type: object
               error:

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -101,6 +101,15 @@ spec:
                         type: string
                       triggerTimestamp:
                         type: integer
+                      savepointHistory:
+                        items:
+                          properties:
+                            timeStamp:
+                              type: integer
+                            location:
+                              type: string
+                          type: object
+                        type: array
                     type: object
                 type: object
               error:


### PR DESCRIPTION
Add savepoint history to status, with age and count based savepoint expiration. Example:
```
Status:
  Job Manager Deployment Status:  READY
  Job Status:
    Job Id:    7cedf7c39c986e583dbebd372be3a8d3
    Job Name:  State machine job
    Savepoint Info:
      Last Savepoint:
        Location:    file:/flink-data/savepoints/savepoint-7cedf7-0fb4b50d72b6
        Time Stamp:  1652671155388
      Savepoint History:
        Location:         file:/flink-data/savepoints/savepoint-7cedf7-ab75503094b5
        Time Stamp:       1652670977699
        Location:         file:/flink-data/savepoints/savepoint-7cedf7-1c12ca67aa68
        Time Stamp:       1652671008035
        Location:         file:/flink-data/savepoints/savepoint-7cedf7-0fb4b50d72b6
        Time Stamp:       1652671124981
      Trigger Id:         20342ead12977c31384dfd83cda82377
      Trigger Timestamp:  1652671114901
    Start Time:           1652670821756
    State:                RUNNING
    Update Time:          1652671155360
  Reconciliation Status:
```