### PR TITLE
[FLINK-27609] Tracking flink-version and flink-revision in FlinkDeploymentStatus

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -185,6 +185,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | jobStatus | org.apache.flink.kubernetes.operator.crd.status.JobStatus | Last observed status of the Flink job on Application/Session cluster. |
 | error | java.lang.String | Error information about the FlinkDeployment/FlinkSessionJob. |
+| clusterInfo | java.util.Map<java.lang.String,java.lang.String> | Config information from running clusters. |
 | jobManagerDeploymentStatus | org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus | Last observed status of the JobManager deployment. |
 | reconciliationStatus | org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentReconciliationStatus | Status of the last reconcile operation. |
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkDeploymentStatus.java
@@ -27,6 +27,9 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /** Last observed status of the Flink deployment. */
 @Experimental
 @Data
@@ -36,6 +39,9 @@ import lombok.experimental.SuperBuilder;
 @ToString(callSuper = true)
 @SuperBuilder
 public class FlinkDeploymentStatus extends CommonStatus<FlinkDeploymentSpec> {
+
+    /** Config information from running clusters. */
+    private Map<String, String> clusterInfo = new HashMap<>();
 
     /** Last observed status of the JobManager deployment. */
     private JobManagerDeploymentStatus jobManagerDeploymentStatus =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/CustomDashboardConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/CustomDashboardConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.service;
+
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Custom Response for handling dashboard configs. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@NoArgsConstructor
+public class CustomDashboardConfiguration implements ResponseBody {
+
+    public static final String FIELD_NAME_FLINK_VERSION = "flink-version";
+    public static final String FIELD_NAME_FLINK_REVISION = "flink-revision";
+
+    @JsonProperty(FIELD_NAME_FLINK_VERSION)
+    private String flinkVersion;
+
+    @JsonProperty(FIELD_NAME_FLINK_REVISION)
+    private String flinkRevision;
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/CustomDashboardConfigurationHeaders.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/CustomDashboardConfigurationHeaders.java
@@ -1,0 +1,77 @@
+package org.apache.flink.kubernetes.operator.service;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/** Message headers for the {@link CustomDashboardConfiguration}. */
+public final class CustomDashboardConfigurationHeaders
+        implements MessageHeaders<
+                EmptyRequestBody, CustomDashboardConfiguration, EmptyMessageParameters> {
+
+    public static final CustomDashboardConfigurationHeaders INSTANCE =
+            new CustomDashboardConfigurationHeaders();
+
+    // make the constructor private since we want it to be a singleton
+    private CustomDashboardConfigurationHeaders() {}
+
+    @Override
+    public Class<EmptyRequestBody> getRequestClass() {
+        return EmptyRequestBody.class;
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.GET;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return "/config";
+    }
+
+    @Override
+    public Class<CustomDashboardConfiguration> getResponseClass() {
+        return CustomDashboardConfiguration.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public EmptyMessageParameters getUnresolvedMessageParameters() {
+        return EmptyMessageParameters.getInstance();
+    }
+
+    public static CustomDashboardConfigurationHeaders getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Returns the configuration of the WebUI.";
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -57,6 +57,7 @@ import org.apache.flink.runtime.rest.FileUpload;
 import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationResult;
 import org.apache.flink.runtime.rest.handler.async.TriggerResponse;
+import org.apache.flink.runtime.rest.messages.DashboardConfiguration;
 import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.TriggerId;
@@ -103,6 +104,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -679,6 +682,35 @@ public class FlinkService {
                 (RestClusterClient<String>) getClusterClient(conf)) {
             clusterClient.disposeSavepoint(savepointPath);
         }
+    }
+
+    public Map<String, String> getClusterInfo(Configuration conf) throws Exception {
+        Map<String, String> runtimeVersion = new HashMap<>();
+
+        try (RestClusterClient<String> clusterClient =
+                (RestClusterClient<String>) getClusterClient(conf)) {
+
+            CustomDashboardConfiguration dashboardConfiguration =
+                    clusterClient
+                            .sendRequest(
+                                    CustomDashboardConfigurationHeaders.getInstance(),
+                                    EmptyMessageParameters.getInstance(),
+                                    EmptyRequestBody.getInstance())
+                            .get(
+                                    configManager
+                                            .getOperatorConfiguration()
+                                            .getFlinkClientTimeout()
+                                            .toSeconds(),
+                                    TimeUnit.SECONDS);
+
+            runtimeVersion.put(
+                    DashboardConfiguration.FIELD_NAME_FLINK_VERSION,
+                    dashboardConfiguration.getFlinkVersion());
+            runtimeVersion.put(
+                    DashboardConfiguration.FIELD_NAME_FLINK_REVISION,
+                    dashboardConfiguration.getFlinkRevision());
+        }
+        return runtimeVersion;
     }
 
     public PodList getJmPodList(FlinkDeployment deployment, Configuration conf) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -41,6 +41,7 @@ import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.rest.messages.DashboardConfiguration;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -64,6 +65,12 @@ import java.util.stream.Collectors;
 
 /** Flink service mock for tests. */
 public class TestingFlinkService extends FlinkService {
+
+    public static final Map<String, String> CLUSTER_INFO =
+            Map.of(
+                    DashboardConfiguration.FIELD_NAME_FLINK_VERSION, "15.0.0",
+                    DashboardConfiguration.FIELD_NAME_FLINK_REVISION,
+                            "1234567 @ 1970-01-01T00:00:00+00:00");
 
     private int savepointCounter = 0;
     private int triggerCounter = 0;
@@ -355,5 +362,10 @@ public class TestingFlinkService extends FlinkService {
             this.jobStatusMessage = jobStatusMessage;
             this.effectiveConfig = effectiveConfig;
         }
+    }
+
+    @Override
+    public Map<String, String> getClusterInfo(Configuration conf) throws Exception {
+        return CLUSTER_INFO;
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -90,9 +90,11 @@ public class ApplicationObserverTest {
                 JobManagerDeploymentStatus.DEPLOYED_NOT_READY,
                 deployment.getStatus().getJobManagerDeploymentStatus());
         assertNull(deployment.getStatus().getReconciliationStatus().getLastStableSpec());
+        assertNull(deployment.getStatus().getClusterInfo());
 
         // Stable ready
         observer.observe(deployment, readyContext);
+        assertEquals(TestingFlinkService.CLUSTER_INFO, deployment.getStatus().getClusterInfo());
         assertEquals(
                 JobManagerDeploymentStatus.READY,
                 deployment.getStatus().getJobManagerDeploymentStatus());

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9084,6 +9084,10 @@ spec:
             type: object
           status:
             properties:
+              clusterInfo:
+                additionalProperties:
+                  type: string
+                type: object
               jobManagerDeploymentStatus:
                 enum:
                 - READY


### PR DESCRIPTION
This PR is meant to improve the ability to identify malicious Flink versions (CVE affected, deprecated, etc.) in managed environments. The operator propagates exact versioning information in status:
```
status:
    clusterInfo:
        flink-revision: 3a4c113 @ 2022-04-20T19:50:32+02:00
        flink-version: 1.15.0
```


