### PR TITLE
[hotfix] Do not use nulls in status for savepoint trigger and cluster info

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointInfo.java
@@ -38,10 +38,10 @@ public class SavepointInfo {
     private Savepoint lastSavepoint;
 
     /** Trigger id of a pending savepoint operation. */
-    private String triggerId;
+    private String triggerId = "";
 
     /** Trigger timestamp of a pending savepoint operation. */
-    private Long triggerTimestamp;
+    private Long triggerTimestamp = 0L;
 
     /** List of recent savepoints. */
     private List<Savepoint> savepointHistory = new ArrayList<>();
@@ -52,8 +52,8 @@ public class SavepointInfo {
     }
 
     public void resetTrigger() {
-        this.triggerId = null;
-        this.triggerTimestamp = null;
+        this.triggerId = "";
+        this.triggerTimestamp = 0L;
     }
 
     public void updateLastSavepoint(Savepoint savepoint) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -32,6 +32,7 @@ import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusHelper;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,7 +102,7 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
      */
     private Optional<String> observeTriggeredSavepointProgress(
             SavepointInfo currentSavepointInfo, String jobID, Configuration deployedConfig) {
-        if (currentSavepointInfo.getTriggerId() == null) {
+        if (StringUtils.isEmpty(currentSavepointInfo.getTriggerId())) {
             LOG.debug("Savepoint not in progress");
             return Optional.empty();
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -47,6 +47,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -101,7 +102,7 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
     }
 
     private boolean observeClusterInfo(FlinkDeployment flinkApp, Configuration configuration) {
-        if (flinkApp.getStatus().getClusterInfo() != null) {
+        if (!flinkApp.getStatus().getClusterInfo().isEmpty()) {
             return true;
         }
         try {
@@ -126,7 +127,7 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
             return;
         }
 
-        flinkApp.getStatus().setClusterInfo(null);
+        flinkApp.getStatus().setClusterInfo(new HashMap<>());
 
         logger.info(
                 "Observing JobManager deployment. Previous status: {}", previousJmStatus.name());

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobHelper.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobHelper.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkSessionJobSpec;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 
 import org.slf4j.Logger;
 
@@ -42,7 +43,7 @@ public class SessionJobHelper {
     }
 
     public boolean savepointInProgress() {
-        return sessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId() != null;
+        return SavepointUtils.savepointInProgress(sessionJob.getStatus().getJobStatus());
     }
 
     public boolean shouldTriggerSavepoint() {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -23,13 +23,15 @@ import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.time.Duration;
 
 /** Savepoint utilities. */
 public class SavepointUtils {
 
     public static boolean savepointInProgress(JobStatus jobStatus) {
-        return jobStatus.getSavepointInfo().getTriggerId() != null;
+        return StringUtils.isNotEmpty(jobStatus.getSavepointInfo().getTriggerId());
     }
 
     public static boolean shouldTriggerSavepoint(JobSpec jobSpec, FlinkDeploymentStatus status) {


### PR DESCRIPTION
Seems like there is a problem with the fabric8 patch logic and it doesn't allow us to set status fields to "null" and thus remove them.

This meant that savepoint trigger information would not be cleared correctly.

I will still investigate to see if there is a potential simpler workaround. 
The problem seems to be caused by 
https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/Serialization.java#L53
https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/utils/serialization/UnmatchedFieldTypeModule.java