### PR TITLE
[FLINK-27665] Optimize event triggering on DeploymentFailedExceptions

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
@@ -17,78 +17,34 @@
 
 package org.apache.flink.kubernetes.operator.exception;
 
-import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
-
 import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
-import io.fabric8.kubernetes.api.model.Event;
-import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
-
-import java.time.Instant;
 
 /** Exception to signal terminal deployment failure. */
 public class DeploymentFailedException extends RuntimeException {
-    public static final String COMPONENT_JOBMANAGER = "JobManagerDeployment";
+
     public static final String REASON_CRASH_LOOP_BACKOFF = "CrashLoopBackOff";
 
     private static final long serialVersionUID = -1070179896083579221L;
 
-    public final String component;
-    public final String type;
-    public final String reason;
-    public final String lastTransitionTime;
-    public final String lastUpdateTime;
+    private final String reason;
 
-    public DeploymentFailedException(String component, DeploymentCondition deployCondition) {
+    public DeploymentFailedException(DeploymentCondition deployCondition) {
         super(deployCondition.getMessage());
-        this.component = component;
-        this.type = deployCondition.getType();
         this.reason = deployCondition.getReason();
-        this.lastTransitionTime = deployCondition.getLastTransitionTime();
-        this.lastUpdateTime = deployCondition.getLastUpdateTime();
     }
 
-    public DeploymentFailedException(
-            String component, String type, ContainerStateWaiting stateWaiting) {
+    public DeploymentFailedException(ContainerStateWaiting stateWaiting) {
         super(stateWaiting.getMessage());
-        this.component = component;
-        this.type = type;
         this.reason = stateWaiting.getReason();
-        this.lastTransitionTime = null;
-        this.lastUpdateTime = null;
     }
 
-    public DeploymentFailedException(String message, String component, String type, String reason) {
+    public DeploymentFailedException(String message, String reason) {
         super(message);
-        this.component = component;
-        this.type = type;
         this.reason = reason;
-        this.lastTransitionTime = Instant.now().toString();
-        this.lastUpdateTime = lastTransitionTime;
     }
 
-    public static Event asEvent(DeploymentFailedException dfe, FlinkDeployment flinkApp) {
-        EventBuilder evtb =
-                new EventBuilder()
-                        .withApiVersion("v1")
-                        .withNewInvolvedObject()
-                        .withKind(flinkApp.getKind())
-                        .withName(flinkApp.getMetadata().getName())
-                        .withNamespace(flinkApp.getMetadata().getNamespace())
-                        .withUid(flinkApp.getMetadata().getUid())
-                        .endInvolvedObject()
-                        .withType(dfe.type)
-                        .withReason(dfe.reason)
-                        .withFirstTimestamp(dfe.lastTransitionTime)
-                        .withLastTimestamp(dfe.lastUpdateTime)
-                        .withMessage(dfe.getMessage())
-                        .withNewMetadata()
-                        .withGenerateName(flinkApp.getMetadata().getName())
-                        .withNamespace(flinkApp.getMetadata().getNamespace())
-                        .endMetadata()
-                        .withNewSource()
-                        .withComponent(dfe.component)
-                        .endSource();
-        return evtb.build();
+    public String getReason() {
+        return reason;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -232,8 +232,6 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
                     "JobManager deployment is missing and HA data is not available to make stateful upgrades. "
                             + "It is possible that the job has finished or terminally failed, or the configmaps have been deleted. "
                             + "Manual restore required.",
-                    DeploymentFailedException.COMPONENT_JOBMANAGER,
-                    "Error",
                     "UpgradeFailed");
         } else {
             LOG.debug(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -175,8 +175,6 @@ public class FlinkService {
                     "HA metadata not available to restore from last state. "
                             + "It is possible that the job has finished or terminally failed, or the configmaps have been deleted. "
                             + "Manual restore required.",
-                    DeploymentFailedException.COMPONENT_JOBMANAGER,
-                    "Error",
                     "RestoreFailed");
         }
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -38,7 +38,8 @@ public class EventUtils {
 
     /** The component of events. */
     public enum Component {
-        Operator
+        Operator,
+        JobManagerDeployment
     }
 
     public static String generateEventName(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -116,7 +116,7 @@ public class TestingFlinkService extends FlinkService {
     public void submitApplicationCluster(
             JobSpec jobSpec, Configuration conf, boolean requireHaMetadata) throws Exception {
         if (deployFailure) {
-            throw new DeploymentFailedException("Deployment failure", "test", "test", "test");
+            throw new DeploymentFailedException("Deployment failure", "test");
         }
         if (!jobs.isEmpty()) {
             throw new Exception("Cannot submit 2 application clusters at the same time");


### PR DESCRIPTION
- Separated the event related logic from the DeploymentFailedExceptions
- Introduced a new component type for JobManagerDeployment, reporting DeploymentFailedExceptions
- Reduced the event types to Warning and Normal only see [API docs](https://github.com/kubernetes/api/blob/master/events/v1/types.go#L84)