### PR TITLE
[FLINK-27685] Scale subresource prototype

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -149,6 +149,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
 | resource | org.apache.flink.kubernetes.operator.crd.spec.Resource | Resource specification for the TaskManager pods. |
+| replicas | java.lang.Integer | Number of TaskManager replicas. If defined, takes precedence over parallelism |
 | podTemplate | io.fabric8.kubernetes.api.model.Pod | TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. |
 
 ### UpgradeMode
@@ -188,6 +189,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | clusterInfo | java.util.Map<java.lang.String,java.lang.String> | Config information from running clusters. |
 | jobManagerDeploymentStatus | org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus | Last observed status of the JobManager deployment. |
 | reconciliationStatus | org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentReconciliationStatus | Status of the last reconcile operation. |
+| taskManager | org.apache.flink.kubernetes.operator.crd.status.TaskManagerInfo | Information about the TaskManagers for the scale subresource. |
 
 ### FlinkSessionJobReconciliationStatus
 **Class**: org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobReconciliationStatus
@@ -287,3 +289,13 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | PERIODIC | Savepoint periodically triggered by the operator. |
 | UPGRADE | Savepoint triggered during stateful upgrade. |
 | UNKNOWN | Savepoint trigger mechanism unknown, such as savepoint retrieved directly from Flink job. |
+
+### TaskManagerInfo
+**Class**: org.apache.flink.kubernetes.operator.crd.status.TaskManagerInfo
+
+**Description**: Last observed status of the Flink job within an application deployment.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| labelSelector | java.lang.String | TaskManager label selector. |
+| replicas | int | Number of TaskManager replicas if defined in the spec. |

--- a/examples/hpa/basic-hpa.yaml
+++ b/examples/hpa/basic-hpa.yaml
@@ -1,0 +1,37 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: basic-hpa
+  namespace: default
+spec:
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageValue: 10Mi
+  scaleTargetRef:
+    apiVersion: flink.apache.org/v1beta1
+    kind: FlinkDeployment
+    name: basic

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkDeploymentStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/FlinkDeploymentStatus.java
@@ -50,4 +50,7 @@ public class FlinkDeploymentStatus extends CommonStatus<FlinkDeploymentSpec> {
     /** Status of the last reconcile operation. */
     private FlinkDeploymentReconciliationStatus reconciliationStatus =
             new FlinkDeploymentReconciliationStatus();
+
+    /** Information about the TaskManagers for the scale subresource. */
+    private TaskManagerInfo taskManager;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/TaskManagerInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/TaskManagerInfo.java
@@ -15,28 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.flink.kubernetes.operator.crd.spec;
+package org.apache.flink.kubernetes.operator.crd.status;
 
 import org.apache.flink.annotation.Experimental;
 
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.model.annotation.SpecReplicas;
+import io.fabric8.kubernetes.model.annotation.LabelSelector;
+import io.fabric8.kubernetes.model.annotation.StatusReplicas;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-/** TaskManager spec. */
+/** Last observed status of the Flink job within an application deployment. */
 @Experimental
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class TaskManagerSpec {
-    /** Resource specification for the TaskManager pods. */
-    private Resource resource;
+@Builder(toBuilder = true)
+public class TaskManagerInfo {
+    /** TaskManager label selector. */
+    @LabelSelector private String labelSelector;
 
-    /** Number of TaskManager replicas. If defined, takes precedence over parallelism */
-    @SpecReplicas private Integer replicas;
-
-    /** TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. */
-    private Pod podTemplate;
+    /** Number of TaskManager replicas if defined in the spec. */
+    @StatusReplicas private int replicas = 0;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractDeploymentReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractDeploymentReconciler.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.reconciler.deployment;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
@@ -71,14 +72,15 @@ public abstract class AbstractDeploymentReconciler implements Reconciler<FlinkDe
         return false;
     }
 
-    protected boolean newSpecIsAlreadyDeployed(FlinkDeployment flinkApp) {
+    protected boolean newSpecIsAlreadyDeployed(FlinkDeployment flinkApp, Configuration deployConf) {
         FlinkDeploymentSpec deployedSpec = ReconciliationUtils.getDeployedSpec(flinkApp);
         if (flinkApp.getSpec().equals(deployedSpec)) {
             LOG.info(
                     "The new spec matches the currently deployed last stable spec. No upgrade needed.");
             ReconciliationUtils.updateForSpecReconciliationSuccess(
                     flinkApp,
-                    deployedSpec.getJob() != null ? deployedSpec.getJob().getState() : null);
+                    deployedSpec.getJob() != null ? deployedSpec.getJob().getState() : null,
+                    deployConf);
             return true;
         }
         return false;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -89,7 +89,8 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
                     false);
             IngressUtils.updateIngressRules(
                     deployMeta, currentDeploySpec, deployConfig, kubernetesClient);
-            ReconciliationUtils.updateForSpecReconciliationSuccess(flinkApp, JobState.RUNNING);
+            ReconciliationUtils.updateForSpecReconciliationSuccess(
+                    flinkApp, JobState.RUNNING, deployConfig);
             return;
         }
 
@@ -103,7 +104,7 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
         Configuration observeConfig = configManager.getObserveConfig(flinkApp);
         boolean specChanged = !currentDeploySpec.equals(lastReconciledSpec);
         if (specChanged) {
-            if (newSpecIsAlreadyDeployed(flinkApp)) {
+            if (newSpecIsAlreadyDeployed(flinkApp, deployConfig)) {
                 return;
             }
             LOG.debug("Detected spec change, starting upgrade process.");
@@ -134,7 +135,8 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
                         lastReconciledSpec.getJob().getUpgradeMode() == UpgradeMode.LAST_STATE);
                 stateAfterReconcile = JobState.RUNNING;
             }
-            ReconciliationUtils.updateForSpecReconciliationSuccess(flinkApp, stateAfterReconcile);
+            ReconciliationUtils.updateForSpecReconciliationSuccess(
+                    flinkApp, stateAfterReconcile, deployConfig);
             IngressUtils.updateIngressRules(
                     deployMeta, currentDeploySpec, deployConfig, kubernetesClient);
         } else if (ReconciliationUtils.shouldRollBack(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconciler.java
@@ -92,7 +92,7 @@ public class FlinkSessionJobReconciler implements Reconciler<FlinkSessionJob> {
                                     flinkSessionJob.getSpec().getJob().getInitialSavepointPath())
                             .orElse(null));
             ReconciliationUtils.updateForSpecReconciliationSuccess(
-                    flinkSessionJob, JobState.RUNNING);
+                    flinkSessionJob, JobState.RUNNING, sessionJobConfig);
             return;
         }
 
@@ -127,7 +127,7 @@ public class FlinkSessionJobReconciler implements Reconciler<FlinkSessionJob> {
                 stateAfterReconcile = JobState.RUNNING;
             }
             ReconciliationUtils.updateForSpecReconciliationSuccess(
-                    flinkSessionJob, stateAfterReconcile);
+                    flinkSessionJob, stateAfterReconcile, sessionJobConfig);
         } else {
             if (!SavepointUtils.triggerSavepointIfNeeded(
                     flinkService, flinkSessionJob, sessionJobConfig)) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -19,7 +19,9 @@ package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
@@ -277,5 +279,11 @@ public class FlinkUtils {
 
     public static boolean clusterShutdownDisabled(FlinkDeploymentSpec spec) {
         return spec.getFlinkVersion().isNewerVersionThan(FlinkVersion.v1_14);
+    }
+
+    public static int getNumTaskManagers(Configuration conf) {
+        int parallelism = conf.get(CoreOptions.DEFAULT_PARALLELISM);
+        int taskSlots = conf.get(TaskManagerOptions.NUM_TASK_SLOTS);
+        return (parallelism + taskSlots - 1) / taskSlots;
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -167,7 +167,7 @@ public class TestUtils {
                 .flinkVersion(version)
                 .flinkConfiguration(conf)
                 .jobManager(new JobManagerSpec(new Resource(1.0, "2048m"), 1, null))
-                .taskManager(new TaskManagerSpec(new Resource(1.0, "2048m"), null))
+                .taskManager(new TaskManagerSpec(new Resource(1.0, "2048m"), null, null))
                 .build();
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -102,7 +102,8 @@ public class FlinkConfigManagerTest {
         deployment.getSpec().setLogConfiguration(Map.of(Constants.CONFIG_FILE_LOG4J_NAME, "test"));
         deployment.getSpec().setPodTemplate(new Pod());
 
-        ReconciliationUtils.updateForSpecReconciliationSuccess(deployment, JobState.RUNNING);
+        ReconciliationUtils.updateForSpecReconciliationSuccess(
+                deployment, JobState.RUNNING, config);
         Configuration deployConfig = configManager.getObserveConfig(deployment);
         assertFalse(
                 deployConfig.contains(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
+import org.apache.flink.kubernetes.operator.crd.status.TaskManagerInfo;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
@@ -287,6 +288,10 @@ public class FlinkDeploymentControllerTest {
         List<Tuple2<String, JobStatusMessage>> jobs = flinkService.listJobs();
         assertEquals(1, jobs.size());
         assertEquals("s0", jobs.get(0).f0);
+        assertEquals(
+                new TaskManagerInfo(
+                        "component=taskmanager,app=" + appCluster.getMetadata().getName(), 1),
+                appCluster.getStatus().getTaskManager());
 
         List<Tuple2<String, JobStatusMessage>> previousJobs = new ArrayList<>(jobs);
         appCluster.getSpec().getJob().setInitialSavepointPath("s1");
@@ -322,6 +327,7 @@ public class FlinkDeploymentControllerTest {
                         .getSavepointInfo()
                         .getSavepointHistory()
                         .size());
+        assertEquals(new TaskManagerInfo("", 0), appCluster.getStatus().getTaskManager());
 
         testController.reconcile(appCluster, context);
         jobs = flinkService.listJobs();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
@@ -93,7 +93,8 @@ public class FlinkServiceTest {
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         JobStatus jobStatus = deployment.getStatus().getJobStatus();
         jobStatus.setJobId(jobID.toHexString());
-        ReconciliationUtils.updateForSpecReconciliationSuccess(deployment, JobState.RUNNING);
+        ReconciliationUtils.updateForSpecReconciliationSuccess(
+                deployment, JobState.RUNNING, new Configuration());
 
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
         deployment.getStatus().getJobStatus().setState("RUNNING");
@@ -130,7 +131,8 @@ public class FlinkServiceTest {
         JobStatus jobStatus = deployment.getStatus().getJobStatus();
         jobStatus.setJobId(jobID.toHexString());
         jobStatus.setState(org.apache.flink.api.common.JobStatus.RUNNING.name());
-        ReconciliationUtils.updateForSpecReconciliationSuccess(deployment, JobState.RUNNING);
+        ReconciliationUtils.updateForSpecReconciliationSuccess(
+                deployment, JobState.RUNNING, new Configuration());
 
         flinkService.cancelJob(deployment, UpgradeMode.SAVEPOINT);
         assertTrue(stopWithSavepointFuture.isDone());
@@ -143,7 +145,8 @@ public class FlinkServiceTest {
     @Test
     public void testCancelJobWithLastStateUpgradeMode() throws Exception {
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
-        ReconciliationUtils.updateForSpecReconciliationSuccess(deployment, JobState.RUNNING);
+        ReconciliationUtils.updateForSpecReconciliationSuccess(
+                deployment, JobState.RUNNING, new Configuration());
         final TestingClusterClient<String> testingClusterClient =
                 new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
         final FlinkService flinkService = createFlinkService(testingClusterClient);
@@ -198,7 +201,8 @@ public class FlinkServiceTest {
 
         final JobID jobID = JobID.generate();
         final FlinkDeployment flinkDeployment = TestUtils.buildApplicationCluster();
-        ReconciliationUtils.updateForSpecReconciliationSuccess(flinkDeployment, JobState.RUNNING);
+        ReconciliationUtils.updateForSpecReconciliationSuccess(
+                flinkDeployment, JobState.RUNNING, new Configuration());
         JobStatus jobStatus = new JobStatus();
         jobStatus.setJobId(jobID.toString());
         flinkDeployment.getStatus().setJobStatus(jobStatus);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
@@ -19,6 +19,9 @@
 package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
@@ -104,6 +107,22 @@ public class FlinkUtilsTest {
         assertNull(kubernetesClient.configMaps().withName(name).get().getData());
         FlinkUtils.deleteJobGraphInKubernetesHA(
                 clusterId, kubernetesClient.getNamespace(), kubernetesClient);
+    }
+
+    @Test
+    public void testComputeNumTms() {
+        Configuration conf = new Configuration();
+        conf.set(CoreOptions.DEFAULT_PARALLELISM, 2);
+        conf.set(TaskManagerOptions.NUM_TASK_SLOTS, 1);
+
+        assertEquals(2, FlinkUtils.getNumTaskManagers(conf));
+
+        conf.set(TaskManagerOptions.NUM_TASK_SLOTS, 3);
+        assertEquals(1, FlinkUtils.getNumTaskManagers(conf));
+
+        conf.set(CoreOptions.DEFAULT_PARALLELISM, 7);
+        conf.set(TaskManagerOptions.NUM_TASK_SLOTS, 2);
+        assertEquals(4, FlinkUtils.getNumTaskManagers(conf));
     }
 
     private void createHAConfigMapWithData(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -54,7 +54,8 @@ public class ReconciliationUtilsTest {
         current.getStatus()
                 .getReconciliationStatus()
                 .serializeAndSetLastReconciledSpec(ReconciliationUtils.clone(current.getSpec()));
-        ReconciliationUtils.updateForSpecReconciliationSuccess(current, JobState.SUSPENDED);
+        ReconciliationUtils.updateForSpecReconciliationSuccess(
+                current, JobState.SUSPENDED, new Configuration());
 
         UpdateControl<FlinkDeployment> updateControl =
                 ReconciliationUtils.toUpdateControl(operatorConfiguration, current, previous, true);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.IngressSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
+import org.apache.flink.kubernetes.operator.crd.spec.TaskManagerSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentReconciliationStatus;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
@@ -76,9 +77,21 @@ public class DefaultValidatorTest {
         testError(
                 dep -> dep.getSpec().getJob().setParallelism(0),
                 "Job parallelism must be larger than 0");
+
         testError(
-                dep -> dep.getSpec().getJob().setParallelism(-1),
-                "Job parallelism must be larger than 0");
+                dep -> {
+                    var tmSpec = new TaskManagerSpec();
+                    tmSpec.setReplicas(0);
+                    dep.getSpec().setTaskManager(tmSpec);
+                },
+                "TaskManager replicas must be larger than 0");
+
+        testSuccess(
+                dep -> {
+                    dep.getSpec().getTaskManager().setReplicas(1);
+                    dep.getSpec().getJob().setParallelism(0);
+                });
+
         testError(
                 dep -> {
                     dep.getSpec().setFlinkConfiguration(new HashMap<>());

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -6048,6 +6048,8 @@ spec:
                       memory:
                         type: string
                     type: object
+                  replicas:
+                    type: integer
                   podTemplate:
                     properties:
                       apiVersion:
@@ -9112,6 +9114,13 @@ spec:
                     - ROLLED_BACK
                     type: string
                 type: object
+              taskManager:
+                properties:
+                  labelSelector:
+                    type: string
+                  replicas:
+                    type: integer
+                type: object
               jobStatus:
                 properties:
                   jobName:
@@ -9178,4 +9187,8 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.taskManager.labelSelector
+        specReplicasPath: .spec.taskManager.replicas
+        statusReplicasPath: .status.taskManager.replicas
       status: {}


### PR DESCRIPTION
This is a proof of concept of introducing Kubernetes scaling capabilities and support for using the Horizontal Pod Autoscaler for application deployments.

**Background:** 
https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource
https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/

**Scaling for Flink applications:**
Our initial idea was to use the parallelism as the scaling unit/parameter. This is however not a really good match for the Kubernetes scaling behaviour, where you have a concept of replicas and watch pods/containers to decide whether to scale up or down. By using parallelism you will end up with confusing terminology and half used task managers (where not all the slots are taken)

We decided it might be better to use the number of taskmanager pods as the replica count for scaling purposes as it more closely matches what is actually happening under the hood

**In this PR:**
We introduce `taskManager.replicas` in the spec, which is by default `null`. When defined it takes precedence over the job parallelism setting and the parallelism is computed using `replicas * numTaskSlots`.

We also expose the taskmanager replicas together with the pod label selector in the status (this is necessary for the scale subresource). 

After setting the correct annotations the generate subresource looks like this:

```
subresources:
      scale:
        labelSelectorPath: .status.taskManager.labelSelector
        specReplicasPath: .spec.taskManager.replicas
        statusReplicasPath: .status.taskManager.replicas
```

With this we can now crate a job and hpa:
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/5880972/169222154-eac7c296-1b05-4a59-b897-36688d080fe8.png">

The HorizontalPodAutoscaler policy will continuously monitor the TM pods and scale the number up/down.

 