### PR TITLE
[FLINK-27686] Only patch status on change

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusHelper.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusHelper.java
@@ -19,9 +19,9 @@
 package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.kubernetes.operator.crd.status.CommonStatus;
-import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusHelper;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.fabric8.kubernetes.client.CustomResource;
 
 /** Testing StatusHelper. */
@@ -33,6 +33,8 @@ public class TestingStatusHelper<STATUS extends CommonStatus<?>> extends StatusH
 
     @Override
     public <T extends CustomResource<?, STATUS>> void patchAndCacheStatus(T resource) {
-        statusCache.put(getKey(resource), ReconciliationUtils.clone(resource.getStatus()));
+        statusCache.put(
+                getKey(resource),
+                objectMapper.convertValue(resource.getStatus(), ObjectNode.class));
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusHelperTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusHelperTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test for {@link StatusHelper}. */
+@EnableKubernetesMockClient(crud = true)
+public class StatusHelperTest {
+
+    private KubernetesClient kubernetesClient;
+    private KubernetesMockServer mockServer;
+
+    @Test
+    public void testPatchOnlyWhenChanged() throws InterruptedException {
+        var helper = new StatusHelper<FlinkDeploymentStatus>(kubernetesClient);
+        var deployment = TestUtils.buildApplicationCluster();
+        kubernetesClient.resource(deployment).createOrReplace();
+        var lastRequest = mockServer.getLastRequest();
+
+        helper.patchAndCacheStatus(deployment);
+        assertTrue(mockServer.getLastRequest() != lastRequest);
+        lastRequest = mockServer.getLastRequest();
+        deployment.getStatus().getReconciliationStatus().setState(ReconciliationState.UPGRADING);
+        helper.patchAndCacheStatus(deployment);
+
+        // We intentionally compare references
+        assertTrue(mockServer.getLastRequest() != lastRequest);
+        lastRequest = mockServer.getLastRequest();
+
+        // No update
+        helper.patchAndCacheStatus(deployment);
+        assertTrue(mockServer.getLastRequest() == lastRequest);
+    }
+}


### PR DESCRIPTION
Check whether status changed before applying patch to reduce load on the kubernetes API.