### PR TITLE
[FLINK-27728] Adding os update to debian image

### DIFF
--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: all
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ RUN chown -R flink:flink $FLINK_HOME && \
     chown flink:flink /docker-entrypoint.sh
 
 # Updating Debian
-RUN apt-get update
+RUN apt-get update && apt-get install -y apt-transport-https
 RUN apt-get upgrade -y
 
 USER flink

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,9 @@ RUN chown -R flink:flink $FLINK_HOME && \
     chown flink:flink $FLINK_KUBERNETES_SHADED_JAR && \
     chown flink:flink /docker-entrypoint.sh
 
+RUN apt-get update
+RUN apt-get upgrade -y
+
 USER flink
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN chown -R flink:flink $FLINK_HOME && \
     chown flink:flink $FLINK_KUBERNETES_SHADED_JAR && \
     chown flink:flink /docker-entrypoint.sh
 
+# Updating Debian
 RUN apt-get update
 RUN apt-get upgrade -y
 


### PR DESCRIPTION
Signed-off-by: James Busche <jbusche@us.ibm.com>

When the flink-kubernetes-operator is build with the:
```
RUN apt-get update
RUN apt-get upgrade -y
```
Then  four current vulnerabilities will be solved.  This will likely help solve many future upcoming OS vulnerabilities as they become known and solved in the near future. 