### PR TITLE
[FLINK-27257] Flink kubernetes operator triggers savepoint failed because of not all tasks running

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -69,7 +69,8 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
                         .map(Savepoint::getLocation)
                         .orElse(null);
 
-        observeTriggeredSavepointProgress(savepointInfo, jobId, deployedConfig)
+        observeTriggeredSavepointProgress(
+                        savepointInfo, jobId, jobStatus.getState(), deployedConfig)
                 .ifPresent(
                         err ->
                                 EventUtils.createOrUpdateEvent(
@@ -108,11 +109,15 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
      *
      * @param currentSavepointInfo the current savepoint info.
      * @param jobID the jobID of the observed job.
+     * @param jobStatus the status of the observed job.
      * @param deployedConfig Deployed job config.
      * @return The observed error, if no error observed, {@code Optional.empty()} will be returned.
      */
     private Optional<String> observeTriggeredSavepointProgress(
-            SavepointInfo currentSavepointInfo, String jobID, Configuration deployedConfig) {
+            SavepointInfo currentSavepointInfo,
+            String jobID,
+            String jobStatus,
+            Configuration deployedConfig) {
         if (StringUtils.isEmpty(currentSavepointInfo.getTriggerId())) {
             LOG.debug("Savepoint not in progress");
             return Optional.empty();
@@ -120,7 +125,7 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
         LOG.info("Observing savepoint status.");
         SavepointFetchResult savepointFetchResult =
                 flinkService.fetchSavepointInfo(
-                        currentSavepointInfo.getTriggerId(), jobID, deployedConfig);
+                        currentSavepointInfo.getTriggerId(), jobID, jobStatus, deployedConfig);
 
         if (savepointFetchResult.isPending()) {
             if (SavepointUtils.gracePeriodEnded(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -308,7 +308,7 @@ public class TestingFlinkService extends FlinkService {
 
     @Override
     public SavepointFetchResult fetchSavepointInfo(
-            String triggerId, String jobId, Configuration conf) {
+            String triggerId, String jobId, String jobStatus, Configuration conf) {
 
         if (savepointFetchResult == null) {
             savepointFetchResult = SavepointFetchResult.pending();


### PR DESCRIPTION
At present Flink kubernetes operator triggers savepoint failed because of not all tasks running. If the exception is that not all required tasks are currently running, then continue fetch savepoint until it is successfully triggered.

**The brief change log**
- `fetchSavepointInfo` adds the check whether the job status is RUNNING and the exception is that not all required tasks are currently running and continue to fetch savepoint for this situation.