### PR TITLE
[hotfix] Make image tag in helm chart values as an explicit string

### DIFF
--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -100,7 +100,7 @@ cd ${CLONE_DIR}
 
 # TODO: We might want to be more specific here later on what to replace
 perl -pi -e "s#^  repository: .*#  repository: ghcr.io/apache/flink-kubernetes-operator#" flink-kubernetes-operator-${RELEASE_VERSION}/helm/flink-kubernetes-operator/values.yaml
-perl -pi -e "s#^  tag: .*#  tag: ${commit_hash}#" flink-kubernetes-operator-${RELEASE_VERSION}/helm/flink-kubernetes-operator/values.yaml
+perl -pi -e "s#^  tag: .*#  tag: \"${commit_hash}\"#" flink-kubernetes-operator-${RELEASE_VERSION}/helm/flink-kubernetes-operator/values.yaml
 
 helm package --app-version ${RELEASE_VERSION} --version ${RELEASE_VERSION} --destination ${RELEASE_DIR} flink-kubernetes-operator-${RELEASE_VERSION}/helm/flink-kubernetes-operator
 mv ${RELEASE_DIR}/flink-kubernetes-operator-${RELEASE_VERSION}.tgz ${RELEASE_DIR}/flink-kubernetes-operator-${RELEASE_VERSION}-helm.tgz


### PR DESCRIPTION
I find a strange invalid image event when preparing the 1.0.0 release candidate after `helm install`.

```
Events:
  Type     Reason         Age               From               Message
  ----     ------         ----              ----               -------
  Normal   Scheduled      11s               default-scheduler  Successfully assigned default/flink-kubernetes-operator-7b95cdb948-54kj8 to minikube
  Warning  InspectFailed  8s (x3 over 10s)  kubelet            Failed to apply default image tag "ghcr.io/apache/flink-kubernetes-operator:2.417603e+06": couldn't parse image reference "ghcr.io/apache/flink-kubernetes-operator:2.417603e+06": invalid reference format
  Warning  Failed         8s (x3 over 10s)  kubelet            Error: InvalidImageName
  Warning  InspectFailed  8s (x3 over 10s)  kubelet            Failed to apply default image tag "ghcr.io/apache/flink-kubernetes-operator:2.417603e+06": couldn't parse image reference "ghcr.io/apache/flink-kubernetes-operator:2.417603e+06": invalid reference format
  Warning  Failed         8s (x3 over 10s)  kubelet            Error: InvalidImageName
```

After more debugging, I find the root cause is we do not add the double quotation marks for image tag in helm chart values. This will cause the above issue when the short commit id is numerical. e.g. 2417603
```
image:
  repository: ghcr.io/apache/flink-kubernetes-operator
  pullPolicy: IfNotPresent
  tag: 2417603
```