### PR TITLE
[FLINK-27747] Use tar instead of helm package when creating source release

### DIFF
--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -102,8 +102,7 @@ cd ${CLONE_DIR}
 perl -pi -e "s#^  repository: .*#  repository: ghcr.io/apache/flink-kubernetes-operator#" flink-kubernetes-operator-${RELEASE_VERSION}/helm/flink-kubernetes-operator/values.yaml
 perl -pi -e "s#^  tag: .*#  tag: \"${commit_hash}\"#" flink-kubernetes-operator-${RELEASE_VERSION}/helm/flink-kubernetes-operator/values.yaml
 
-helm package --app-version ${RELEASE_VERSION} --version ${RELEASE_VERSION} --destination ${RELEASE_DIR} flink-kubernetes-operator-${RELEASE_VERSION}/helm/flink-kubernetes-operator
-mv ${RELEASE_DIR}/flink-kubernetes-operator-${RELEASE_VERSION}.tgz ${RELEASE_DIR}/flink-kubernetes-operator-${RELEASE_VERSION}-helm.tgz
+tar czf ${RELEASE_DIR}/flink-kubernetes-operator-${RELEASE_VERSION}-helm.tgz -C flink-kubernetes-operator-${RELEASE_VERSION}/helm flink-kubernetes-operator
 
 helm repo index ${RELEASE_DIR}
 attach_header ${RELEASE_DIR}/index.yaml $apache_header


### PR DESCRIPTION
`helm package` command will remove the apache license header in the `Chart.yaml`. Given that we already update the version in `update_branch_version`, it is unnecessary to specify the `--app-version` and `--version` again.

So we could simply use `tar` to prepare the helm package.