### PR TITLE
[FLINK-27804] Do not observe cluster/job mid upgrade

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -79,7 +79,8 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
 
         // Nothing has been launched so skip observing
         if (lastReconciledSpec == null
-                || reconciliationStatus.getState() == ReconciliationState.ROLLING_BACK) {
+                || reconciliationStatus.getState() == ReconciliationState.ROLLING_BACK
+                || reconciliationStatus.getState() == ReconciliationState.UPGRADING) {
             return;
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -35,7 +35,6 @@ import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
-import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
@@ -128,7 +127,7 @@ public class TestingFlinkService extends FlinkService {
             validateHaMetadataExists(conf);
         }
         if (deployFailure) {
-            throw new DeploymentFailedException("Deployment failure", "test");
+            throw new Exception("Deployment failure");
         }
         if (!jobs.isEmpty()) {
             throw new Exception("Cannot submit 2 application clusters at the same time");

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -327,10 +327,6 @@ public class FlinkDeploymentControllerTest {
                         .getSavepointHistory()
                         .size());
 
-        flinkService.setDeployFailure(true);
-        assertNotEquals(0, testController.reconcile(appCluster, context).getScheduleDelay().get());
-
-        flinkService.setDeployFailure(false);
         testController.reconcile(appCluster, context);
         jobs = flinkService.listJobs();
         assertEquals(1, jobs.size());


### PR DESCRIPTION
UPGRADING state means we have either deleted the deployment for last-state upgrades or observed the result of the cancel with savepoint operation.

No need to further observe anything