### PR TITLE
[FLINK-26179] Support for periodic savepoints

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -260,6 +260,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | timeStamp | long | Millisecond timestamp at the start of the savepoint operation. |
 | location | java.lang.String | External pointer of the savepoint can be used to recover jobs. |
+| triggerType | org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType | Savepoint trigger mechanism. |
 
 ### SavepointInfo
 **Class**: org.apache.flink.kubernetes.operator.crd.status.SavepointInfo
@@ -270,5 +271,19 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | lastSavepoint | org.apache.flink.kubernetes.operator.crd.status.Savepoint | Last completed savepoint by the operator. |
 | triggerId | java.lang.String | Trigger id of a pending savepoint operation. |
-| triggerTimestamp | java.lang.Long | Trigger timestamp of a pending savepoint operation. |
+| triggerTimestamp | long | Trigger timestamp of a pending savepoint operation. |
+| triggerType | org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType | Savepoint trigger mechanism. |
 | savepointHistory | java.util.List<org.apache.flink.kubernetes.operator.crd.status.Savepoint> | List of recent savepoints. |
+| lastPeriodicSavepointTimestamp | long | Trigger timestamp of last periodic savepoint operation. |
+
+### SavepointTriggerType
+**Class**: org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType
+
+**Description**: Savepoint trigger mechanism.
+
+| Value | Docs |
+| ----- | ---- |
+| MANUAL | Savepoint manually triggered by changing the savepointTriggerNonce. |
+| PERIODIC | Savepoint periodically triggered by the operator. |
+| UPGRADE | Savepoint triggered during stateful upgrade. |
+| UNKNOWN | Savepoint trigger mechanism unknown, such as savepoint retrieved directly from Flink job. |

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -75,6 +75,12 @@
             <td>The interval before a savepoint trigger attempt is marked as unsuccessful.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.periodic.savepoint.interval</h5></td>
+            <td style="word-wrap: break-word;">0 ms</td>
+            <td>Duration</td>
+            <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.reconciler.flink.cancel.job.timeout</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -163,4 +163,12 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Custom HTTP header for HttpArtifactFetcher. The header will be applied when getting the session job artifacts. "
                                     + "Expected format: headerKey1:headerValue1,headerKey2:headerValue2.");
+
+    public static final ConfigOption<Duration> PERIODIC_SAVEPOINT_INTERVAL =
+            ConfigOptions.key("kubernetes.operator.periodic.savepoint.interval")
+                    .durationType()
+                    .defaultValue(Duration.ZERO)
+                    .withDescription(
+                            "Interval at which periodic savepoints will be triggered. "
+                                    + "The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/Savepoint.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/Savepoint.java
@@ -35,7 +35,10 @@ public class Savepoint {
     /** External pointer of the savepoint can be used to recover jobs. */
     private String location;
 
-    public static Savepoint of(String location) {
-        return new Savepoint(System.currentTimeMillis(), location);
+    /** Savepoint trigger mechanism. */
+    private SavepointTriggerType triggerType = SavepointTriggerType.UNKNOWN;
+
+    public static Savepoint of(String location, SavepointTriggerType type) {
+        return new Savepoint(System.currentTimeMillis(), location, type);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointTriggerType.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointTriggerType.java
@@ -15,26 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.flink.kubernetes.operator.observer;
+package org.apache.flink.kubernetes.operator.crd.status;
 
-import lombok.Value;
-
-/** Result of a fetch savepoint operation. */
-@Value
-public class SavepointFetchResult {
-    String location;
-    boolean pending;
-    String error;
-
-    public static SavepointFetchResult error(String error) {
-        return new SavepointFetchResult(null, false, error);
-    }
-
-    public static SavepointFetchResult pending() {
-        return new SavepointFetchResult(null, true, null);
-    }
-
-    public static SavepointFetchResult completed(String location) {
-        return new SavepointFetchResult(location, false, null);
-    }
+/** Savepoint trigger mechanism. */
+public enum SavepointTriggerType {
+    /** Savepoint manually triggered by changing the savepointTriggerNonce. */
+    MANUAL,
+    /** Savepoint periodically triggered by the operator. */
+    PERIODIC,
+    /** Savepoint triggered during stateful upgrade. */
+    UPGRADE,
+    /** Savepoint trigger mechanism unknown, such as savepoint retrieved directly from Flink job. */
+    UNKNOWN
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -55,10 +55,10 @@ public abstract class JobStatusObserver<CTX> {
             clusterJobStatuses = new ArrayList<>(flinkService.listJobs(deployedConfig));
         } catch (Exception e) {
             LOG.error("Exception while listing jobs", e);
+            ifRunningMoveToReconciling(jobStatus, previousJobStatus);
             if (e instanceof TimeoutException) {
                 onTimeout(ctx);
             }
-            ifRunningMoveToReconciling(jobStatus, previousJobStatus);
             return false;
         }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
@@ -28,6 +28,7 @@ import org.apache.flink.kubernetes.operator.observer.SavepointObserver;
 import org.apache.flink.kubernetes.operator.observer.context.VoidObserverContext;
 import org.apache.flink.kubernetes.operator.reconciler.sessionjob.SessionJobHelper;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusHelper;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.util.Preconditions;
@@ -44,6 +45,7 @@ import java.util.stream.Collectors;
 public class SessionJobObserver implements Observer<FlinkSessionJob> {
 
     private static final Logger LOG = LoggerFactory.getLogger(SessionJobObserver.class);
+    private final FlinkService flinkService;
     private final FlinkConfigManager configManager;
     private final SavepointObserver savepointObserver;
     private final JobStatusObserver<VoidObserverContext> jobStatusObserver;
@@ -52,6 +54,7 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
             FlinkService flinkService,
             FlinkConfigManager configManager,
             StatusHelper<FlinkSessionJobStatus> statusHelper) {
+        this.flinkService = flinkService;
         this.configManager = configManager;
         this.savepointObserver = new SavepointObserver(flinkService, configManager, statusHelper);
         this.jobStatusObserver =
@@ -118,5 +121,7 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
         if (jobFound) {
             savepointObserver.observeSavepointStatus(flinkSessionJob, deployedConfig);
         }
+        SavepointUtils.resetTriggerIfJobNotRunning(
+                flinkService.getKubernetesClient(), flinkSessionJob);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -286,17 +286,15 @@ public class ReconciliationUtils {
                         == JobManagerDeploymentStatus.MISSING);
     }
 
-    public static boolean isJobInTerminalState(FlinkDeploymentStatus status) {
+    public static boolean isJobInTerminalState(CommonStatus<?> status) {
         var jobState = status.getJobStatus().getState();
         return org.apache.flink.api.common.JobStatus.valueOf(jobState).isGloballyTerminalState();
     }
 
-    public static boolean isJobRunning(FlinkDeploymentStatus status) {
-        JobManagerDeploymentStatus deploymentStatus = status.getJobManagerDeploymentStatus();
-        return deploymentStatus == JobManagerDeploymentStatus.READY
-                && org.apache.flink.api.common.JobStatus.RUNNING
-                        .name()
-                        .equals(status.getJobStatus().getState());
+    public static boolean isJobRunning(CommonStatus<?> status) {
+        return org.apache.flink.api.common.JobStatus.RUNNING
+                .name()
+                .equals(status.getJobStatus().getState());
     }
 
     /**

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -197,6 +197,12 @@ public class DefaultValidator implements FlinkResourceValidator {
                         String.format(
                                 "Savepoint could not be manually triggered for the running job while config key[%s] is not set",
                                 CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
+            } else if (configuration.contains(
+                    KubernetesOperatorConfigOptions.PERIODIC_SAVEPOINT_INTERVAL)) {
+                return Optional.of(
+                        String.format(
+                                "Periodic savepoints cannot be enabled when config key[%s] is not set",
+                                CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
             }
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -70,6 +70,7 @@ import org.junit.jupiter.api.Assertions;
 
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -102,6 +103,7 @@ public class TestUtils {
                 new ObjectMetaBuilder()
                         .withName(TEST_DEPLOYMENT_NAME)
                         .withNamespace(TEST_NAMESPACE)
+                        .withCreationTimestamp(Instant.now().toString())
                         .build());
         deployment.setSpec(getTestFlinkDeploymentSpec(version));
         return deployment;
@@ -132,6 +134,7 @@ public class TestUtils {
                 new ObjectMetaBuilder()
                         .withName(TEST_SESSION_JOB_NAME)
                         .withNamespace(TEST_NAMESPACE)
+                        .withCreationTimestamp(Instant.now().toString())
                         .build());
         sessionJob.setSpec(
                 FlinkSessionJobSpec.builder()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -214,7 +215,8 @@ public class RollbackTest {
                     dep.getStatus()
                             .getJobStatus()
                             .getSavepointInfo()
-                            .updateLastSavepoint(Savepoint.of("test"));
+                            .updateLastSavepoint(
+                                    Savepoint.of("test", SavepointTriggerType.UPGRADE));
                     testController.reconcile(dep, context);
                 },
                 () -> {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
@@ -18,18 +18,25 @@
 package org.apache.flink.kubernetes.operator.observer;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.TestingStatusHelper;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
+import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for {@link SavepointObserver}. */
 public class SavepointObserverTest {
@@ -44,7 +51,8 @@ public class SavepointObserverTest {
         SavepointInfo spInfo = new SavepointInfo();
         Assertions.assertTrue(spInfo.getSavepointHistory().isEmpty());
 
-        Savepoint sp = new Savepoint(1, "sp1");
+        Savepoint sp = new Savepoint(1, "sp1", SavepointTriggerType.MANUAL);
+        spInfo.updateLastSavepoint(sp);
         observer.updateSavepointHistory(spInfo, sp, configManager.getDefaultConfig());
 
         Assertions.assertNotNull(spInfo.getSavepointHistory());
@@ -63,18 +71,54 @@ public class SavepointObserverTest {
                 new SavepointObserver(flinkService, configManager, new TestingStatusHelper<>());
         SavepointInfo spInfo = new SavepointInfo();
 
-        Savepoint sp1 = new Savepoint(1, "sp1");
+        Savepoint sp1 = new Savepoint(1, "sp1", SavepointTriggerType.MANUAL);
+        spInfo.updateLastSavepoint(sp1);
         observer.updateSavepointHistory(spInfo, sp1, conf);
         Assertions.assertIterableEquals(
                 Collections.singletonList(sp1), spInfo.getSavepointHistory());
         Assertions.assertIterableEquals(
                 Collections.emptyList(), flinkService.getDisposedSavepoints());
 
-        Savepoint sp2 = new Savepoint(2, "sp2");
+        Savepoint sp2 = new Savepoint(2, "sp2", SavepointTriggerType.MANUAL);
+        spInfo.updateLastSavepoint(sp2);
         observer.updateSavepointHistory(spInfo, sp2, conf);
         Assertions.assertIterableEquals(
                 Collections.singletonList(sp2), spInfo.getSavepointHistory());
         Assertions.assertIterableEquals(
                 Collections.singletonList(sp1.getLocation()), flinkService.getDisposedSavepoints());
+    }
+
+    @Test
+    public void testPeriodicSavepoint() throws Exception {
+        var conf = new Configuration();
+        var deployment = TestUtils.buildApplicationCluster();
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec());
+
+        var jobStatus = deployment.getStatus().getJobStatus();
+        jobStatus.setState("RUNNING");
+
+        var savepointInfo = jobStatus.getSavepointInfo();
+        var observer =
+                new SavepointObserver(flinkService, configManager, new TestingStatusHelper<>());
+        flinkService.triggerSavepoint(null, SavepointTriggerType.PERIODIC, savepointInfo, conf);
+
+        var triggerTs = savepointInfo.getTriggerTimestamp();
+        assertEquals(0L, savepointInfo.getLastPeriodicSavepointTimestamp());
+        assertEquals(SavepointTriggerType.PERIODIC, savepointInfo.getTriggerType());
+        assertTrue(SavepointUtils.savepointInProgress(jobStatus));
+        assertTrue(triggerTs > 0);
+
+        // Pending
+        observer.observeSavepointStatus(deployment, conf);
+        // Completed
+        observer.observeSavepointStatus(deployment, conf);
+        assertEquals(triggerTs, savepointInfo.getLastPeriodicSavepointTimestamp());
+        assertFalse(SavepointUtils.savepointInProgress(jobStatus));
+        assertEquals(savepointInfo.getLastSavepoint(), savepointInfo.getSavepointHistory().get(0));
+        assertEquals(
+                SavepointTriggerType.PERIODIC, savepointInfo.getLastSavepoint().getTriggerType());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.TestingStatusHelper;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.reconciler.sessionjob.FlinkSessionJobReconciler;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 
@@ -152,20 +153,22 @@ public class SessionJobObserverTest {
         Assertions.assertFalse(
                 SavepointUtils.savepointInProgress(sessionJob.getStatus().getJobStatus()));
 
-        flinkService.triggerSavepoint(jobID, savepointInfo, new Configuration());
+        flinkService.triggerSavepoint(
+                jobID, SavepointTriggerType.MANUAL, savepointInfo, new Configuration());
         Assertions.assertTrue(
                 SavepointUtils.savepointInProgress(sessionJob.getStatus().getJobStatus()));
         Assertions.assertEquals("trigger_0", savepointInfo.getTriggerId());
-        observer.observe(sessionJob, readyContext); // pending
-        observer.observe(sessionJob, readyContext); // error
 
-        flinkService.triggerSavepoint(jobID, savepointInfo, new Configuration());
+        flinkService.triggerSavepoint(
+                jobID, SavepointTriggerType.MANUAL, savepointInfo, new Configuration());
         Assertions.assertTrue(
                 SavepointUtils.savepointInProgress(sessionJob.getStatus().getJobStatus()));
         Assertions.assertEquals("trigger_1", savepointInfo.getTriggerId());
-        flinkService.triggerSavepoint(jobID, savepointInfo, new Configuration());
+        flinkService.triggerSavepoint(
+                jobID, SavepointTriggerType.MANUAL, savepointInfo, new Configuration());
         Assertions.assertTrue(
                 SavepointUtils.savepointInProgress(sessionJob.getStatus().getJobStatus()));
+        observer.observe(sessionJob, readyContext); // pending
         observer.observe(sessionJob, readyContext); // success
         Assertions.assertEquals("savepoint_0", savepointInfo.getLastSavepoint().getLocation());
         Assertions.assertFalse(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 
@@ -194,6 +195,14 @@ public class FlinkSessionJobReconcilerTest {
                         .getSavepointInfo()
                         .getSavepointHistory()
                         .size());
+        assertEquals(
+                SavepointTriggerType.UPGRADE,
+                statefulSessionJob
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .getLastSavepoint()
+                        .getTriggerType());
 
         // upgraded
         reconciler.reconcile(statefulSessionJob, readyContext);
@@ -299,6 +308,9 @@ public class FlinkSessionJobReconcilerTest {
         assertEquals(
                 "trigger_0",
                 sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
+        assertEquals(
+                SavepointTriggerType.MANUAL,
+                sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerType());
 
         // parallelism not changed
         assertEquals(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -203,6 +204,7 @@ public class FlinkServiceTest {
         flinkDeployment.getStatus().setJobStatus(jobStatus);
         flinkService.triggerSavepoint(
                 flinkDeployment.getStatus().getJobStatus().getJobId(),
+                SavepointTriggerType.MANUAL,
                 flinkDeployment.getStatus().getJobStatus().getSavepointInfo(),
                 configuration);
         assertTrue(triggerSavepointFuture.isDone());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SavepointUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SavepointUtilsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
+import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for {@link SavepointUtils}. */
+public class SavepointUtilsTest {
+
+    private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
+
+    @Test
+    public void testTriggering() {
+        FlinkDeployment deployment = TestUtils.buildApplicationCluster(FlinkVersion.v1_15);
+        deployment
+                .getMetadata()
+                .setCreationTimestamp(Instant.now().minus(Duration.ofMinutes(15)).toString());
+
+        deployment.getStatus().getJobStatus().setState(JobStatus.RUNNING.name());
+        deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec());
+
+        assertEquals(
+                Optional.empty(),
+                SavepointUtils.shouldTriggerSavepoint(
+                        deployment, configManager.getObserveConfig(deployment)));
+
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(KubernetesOperatorConfigOptions.PERIODIC_SAVEPOINT_INTERVAL.key(), "10m");
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec());
+
+        assertEquals(
+                Optional.of(SavepointTriggerType.PERIODIC),
+                SavepointUtils.shouldTriggerSavepoint(
+                        deployment, configManager.getObserveConfig(deployment)));
+        deployment.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
+
+        deployment.getSpec().getJob().setSavepointTriggerNonce(123L);
+        assertEquals(
+                Optional.of(SavepointTriggerType.MANUAL),
+                SavepointUtils.shouldTriggerSavepoint(
+                        deployment, configManager.getObserveConfig(deployment)));
+    }
+}

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9132,11 +9132,25 @@ spec:
                             type: integer
                           location:
                             type: string
+                          triggerType:
+                            enum:
+                            - MANUAL
+                            - PERIODIC
+                            - UPGRADE
+                            - UNKNOWN
+                            type: string
                         type: object
                       triggerId:
                         type: string
                       triggerTimestamp:
                         type: integer
+                      triggerType:
+                        enum:
+                        - MANUAL
+                        - PERIODIC
+                        - UPGRADE
+                        - UNKNOWN
+                        type: string
                       savepointHistory:
                         items:
                           properties:
@@ -9144,8 +9158,17 @@ spec:
                               type: integer
                             location:
                               type: string
+                            triggerType:
+                              enum:
+                              - MANUAL
+                              - PERIODIC
+                              - UPGRADE
+                              - UNKNOWN
+                              type: string
                           type: object
                         type: array
+                      lastPeriodicSavepointTimestamp:
+                        type: integer
                     type: object
                 type: object
               error:

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -96,11 +96,25 @@ spec:
                             type: integer
                           location:
                             type: string
+                          triggerType:
+                            enum:
+                            - MANUAL
+                            - PERIODIC
+                            - UPGRADE
+                            - UNKNOWN
+                            type: string
                         type: object
                       triggerId:
                         type: string
                       triggerTimestamp:
                         type: integer
+                      triggerType:
+                        enum:
+                        - MANUAL
+                        - PERIODIC
+                        - UPGRADE
+                        - UNKNOWN
+                        type: string
                       savepointHistory:
                         items:
                           properties:
@@ -108,8 +122,17 @@ spec:
                               type: integer
                             location:
                               type: string
+                            triggerType:
+                              enum:
+                              - MANUAL
+                              - PERIODIC
+                              - UPGRADE
+                              - UNKNOWN
+                              type: string
                           type: object
                         type: array
+                      lastPeriodicSavepointTimestamp:
+                        type: integer
                     type: object
                 type: object
               error:


### PR DESCRIPTION
This PR contains a few key improvements for savepoint triggering / management:

 1. Unify and simplify savepoint triggering between application and session jobs
 2. Simplify savepoint info update logic
 3. Add trigger type information to savepoints (we can also add new features to the cleanup logic based on this as a next step)
 4. Introduce periodic savepoint triggering
 5. Improve test coverage