### PR TITLE
[FLINK-27889] fix: Catch the error when last reconciled spec is null

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -324,7 +324,12 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
     @Override
     @SneakyThrows
     protected void shutdown(FlinkDeployment flinkApp) {
-        flinkService.cancelJob(flinkApp, UpgradeMode.STATELESS);
+        var status = flinkApp.getStatus();
+        if (status.getReconciliationStatus().getLastReconciledSpec() == null) {
+            flinkService.deleteClusterDeployment(flinkApp.getMetadata(), status, true);
+        } else {
+            flinkService.cancelJob(flinkApp, UpgradeMode.STATELESS);
+        }
     }
 
     private void triggerSavepoint(FlinkDeployment deployment) throws Exception {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -276,6 +276,14 @@ public class FlinkDeploymentControllerTest {
 
     @ParameterizedTest
     @EnumSource(FlinkVersion.class)
+    public void cleanUpDeploymentWithError(FlinkVersion flinkVersion) {
+        FlinkDeployment flinkDeployment = TestUtils.buildApplicationCluster();
+        var deleteControl = testController.cleanup(flinkDeployment, context);
+        assertNotNull(deleteControl);
+    }
+
+    @ParameterizedTest
+    @EnumSource(FlinkVersion.class)
     public void verifyUpgradeFromSavepoint(FlinkVersion flinkVersion) {
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster(flinkVersion);
         appCluster.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);


### PR DESCRIPTION
[[](https://github.com/apache/flink-kubernetes-operator/commit/1f47f33485f0af8d1367b55b98dccbe12db452c2)[FLINK-27889](https://issues.apache.org/jira/browse/FLINK-27889)[] fix: Catch the error when last reconciled spec is null](https://github.com/apache/flink-kubernetes-operator/commit/1f47f33485f0af8d1367b55b98dccbe12db452c2)