### PR TITLE
[FLINK-27257] Retry failed savepoints within grace period

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -69,12 +69,6 @@
             <td>Final delay before deployment is marked ready after port becomes accessible.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.observer.savepoint.trigger.grace-period</h5></td>
-            <td style="word-wrap: break-word;">10 s</td>
-            <td>Duration</td>
-            <td>The interval before a savepoint trigger attempt is marked as unsuccessful.</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.periodic.savepoint.interval</h5></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>
@@ -121,6 +115,12 @@
             <td style="word-wrap: break-word;">10</td>
             <td>Integer</td>
             <td>Maximum number of savepoint history entries to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.savepoint.trigger.grace-period</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>The interval before a savepoint trigger attempt is marked as unsuccessful.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.user.artifacts.base.dir</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -34,7 +34,6 @@ public class FlinkOperatorConfiguration {
     int reconcilerMaxParallelism;
     Duration progressCheckInterval;
     Duration restApiReadyDelay;
-    Duration savepointTriggerGracePeriod;
     Duration flinkClientTimeout;
     String flinkServiceHostOverride;
     Set<String> watchedNamespaces;
@@ -61,11 +60,6 @@ public class FlinkOperatorConfiguration {
         Duration progressCheckInterval =
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions.OPERATOR_OBSERVER_PROGRESS_CHECK_INTERVAL);
-
-        Duration savepointTriggerGracePeriod =
-                operatorConfig.get(
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_OBSERVER_SAVEPOINT_TRIGGER_GRACE_PERIOD);
 
         Duration flinkClientTimeout =
                 operatorConfig.get(
@@ -103,7 +97,6 @@ public class FlinkOperatorConfiguration {
                 reconcilerMaxParallelism,
                 progressCheckInterval,
                 restApiReadyDelay,
-                savepointTriggerGracePeriod,
                 flinkClientTimeout,
                 flinkServiceHostOverride,
                 watchedNamespaces,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -57,7 +57,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "The interval for observing status for in-progress operations such as deployment and savepoints.");
 
-    public static final ConfigOption<Duration> OPERATOR_OBSERVER_SAVEPOINT_TRIGGER_GRACE_PERIOD =
+    public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_TRIGGER_GRACE_PERIOD =
             ConfigOptions.key("kubernetes.operator.savepoint.trigger.grace-period")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(1))

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -58,9 +58,11 @@ public class KubernetesOperatorConfigOptions {
                             "The interval for observing status for in-progress operations such as deployment and savepoints.");
 
     public static final ConfigOption<Duration> OPERATOR_OBSERVER_SAVEPOINT_TRIGGER_GRACE_PERIOD =
-            ConfigOptions.key("kubernetes.operator.observer.savepoint.trigger.grace-period")
+            ConfigOptions.key("kubernetes.operator.savepoint.trigger.grace-period")
                     .durationType()
-                    .defaultValue(Duration.ofSeconds(10))
+                    .defaultValue(Duration.ofMinutes(1))
+                    .withDeprecatedKeys(
+                            "kubernetes.operator.observer.savepoint.trigger.grace-period")
                     .withDescription(
                             "The interval before a savepoint trigger attempt is marked as unsuccessful.");
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -19,7 +19,6 @@ package org.apache.flink.kubernetes.operator.observer;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
@@ -27,12 +26,12 @@ import org.apache.flink.kubernetes.operator.crd.status.CommonStatus;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusHelper;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +60,7 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
 
     public void observeSavepointStatus(
             AbstractFlinkResource<?, STATUS> resource, Configuration deployedConfig) {
+
         var jobStatus = resource.getStatus().getJobStatus();
         var savepointInfo = jobStatus.getSavepointInfo();
         var jobId = jobStatus.getJobId();
@@ -69,96 +69,78 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
                         .map(Savepoint::getLocation)
                         .orElse(null);
 
-        observeTriggeredSavepointProgress(savepointInfo, jobId, deployedConfig)
-                .ifPresent(
-                        err ->
-                                EventUtils.createOrUpdateEvent(
-                                        flinkService.getKubernetesClient(),
-                                        resource,
-                                        EventUtils.Type.Warning,
-                                        "SavepointError",
-                                        SavepointUtils.createSavepointError(
-                                                savepointInfo,
-                                                resource.getSpec()
-                                                        .getJob()
-                                                        .getSavepointTriggerNonce()),
-                                        EventUtils.Component.Operator));
+        // If any manual or periodic savepoint is in progress, observe it
+        if (SavepointUtils.savepointInProgress(jobStatus)) {
+            observeTriggeredSavepoint(resource, jobId, deployedConfig);
+        }
 
-        // We only need to observe latest checkpoint/savepoint for terminal jobs
-        if (JobStatus.valueOf(jobStatus.getState()).isGloballyTerminalState()) {
+        // If job is in globally terminal state, observe last savepoint
+        if (ReconciliationUtils.isJobInTerminalState(resource.getStatus())) {
             observeLatestSavepoint(savepointInfo, jobId, deployedConfig);
         }
 
-        var currentLastSpPath =
-                Optional.ofNullable(savepointInfo.getLastSavepoint())
-                        .map(Savepoint::getLocation)
-                        .orElse(null);
-
-        // If the last savepoint information changes we need to patch the status
-        // to avoid losing this in case of an operator failure after the cluster was shut down
-        if (currentLastSpPath != null && !currentLastSpPath.equals(previousLastSpPath)) {
-            LOG.info(
-                    "Updating resource status after observing new last savepoint {}",
-                    currentLastSpPath);
-            statusHelper.patchAndCacheStatus(resource);
-        }
+        patchStatusOnSavepointChange(resource, savepointInfo, previousLastSpPath);
     }
 
     /**
      * Observe the savepoint result based on the current savepoint info.
      *
-     * @param currentSavepointInfo the current savepoint info.
+     * @param resource the resource being observed
      * @param jobID the jobID of the observed job.
      * @param deployedConfig Deployed job config.
      * @return The observed error, if no error observed, {@code Optional.empty()} will be returned.
      */
-    private Optional<String> observeTriggeredSavepointProgress(
-            SavepointInfo currentSavepointInfo, String jobID, Configuration deployedConfig) {
-        if (StringUtils.isEmpty(currentSavepointInfo.getTriggerId())) {
-            LOG.debug("Savepoint not in progress");
-            return Optional.empty();
-        }
+    private void observeTriggeredSavepoint(
+            AbstractFlinkResource<?, ?> resource, String jobID, Configuration deployedConfig) {
+
+        var savepointInfo = resource.getStatus().getJobStatus().getSavepointInfo();
+
         LOG.info("Observing savepoint status.");
-        SavepointFetchResult savepointFetchResult =
+        var savepointFetchResult =
                 flinkService.fetchSavepointInfo(
-                        currentSavepointInfo.getTriggerId(), jobID, deployedConfig);
+                        savepointInfo.getTriggerId(), jobID, deployedConfig);
 
         if (savepointFetchResult.isPending()) {
-            if (SavepointUtils.gracePeriodEnded(
-                    configManager.getOperatorConfiguration(), currentSavepointInfo)) {
-                String errorMsg =
-                        "Savepoint operation timed out after "
-                                + configManager
-                                        .getOperatorConfiguration()
-                                        .getSavepointTriggerGracePeriod();
-                currentSavepointInfo.resetTrigger();
-                LOG.error(errorMsg);
-                return Optional.of(errorMsg);
-            } else {
-                LOG.info("Savepoint operation not finished yet, waiting within grace period...");
-                return Optional.empty();
-            }
+            LOG.info("Savepoint operation not finished yet...");
+            return;
         }
 
         if (savepointFetchResult.getError() != null) {
-            currentSavepointInfo.resetTrigger();
-            return Optional.of(savepointFetchResult.getError());
+            var err = savepointFetchResult.getError();
+            if (SavepointUtils.gracePeriodEnded(deployedConfig, savepointInfo)) {
+                LOG.error(
+                        "Savepoint attempt failed after grace period. Won't be retried again: "
+                                + err);
+                ReconciliationUtils.updateLastReconciledSavepointTrigger(savepointInfo, resource);
+                EventUtils.createOrUpdateEvent(
+                        flinkService.getKubernetesClient(),
+                        resource,
+                        EventUtils.Type.Warning,
+                        "SavepointError",
+                        SavepointUtils.createSavepointError(
+                                savepointInfo,
+                                resource.getSpec().getJob().getSavepointTriggerNonce()),
+                        EventUtils.Component.Operator);
+            } else {
+                LOG.warn("Savepoint failed within grace period, retrying: " + err);
+            }
+            savepointInfo.resetTrigger();
+            return;
         }
 
-        LOG.info("Savepoint status updated with latest completed savepoint info");
         var savepoint =
                 new Savepoint(
-                        currentSavepointInfo.getTriggerTimestamp(),
+                        savepointInfo.getTriggerTimestamp(),
                         savepointFetchResult.getLocation(),
-                        currentSavepointInfo.getTriggerType());
-        currentSavepointInfo.updateLastSavepoint(savepoint);
+                        savepointInfo.getTriggerType());
 
-        updateSavepointHistory(currentSavepointInfo, savepoint, deployedConfig);
-        return Optional.empty();
+        ReconciliationUtils.updateLastReconciledSavepointTrigger(savepointInfo, resource);
+        savepointInfo.updateLastSavepoint(savepoint);
+        cleanupSavepointHistory(savepointInfo, savepoint, deployedConfig);
     }
 
     @VisibleForTesting
-    void updateSavepointHistory(
+    void cleanupSavepointHistory(
             SavepointInfo currentSavepointInfo,
             Savepoint newSavepoint,
             Configuration deployedConfig) {
@@ -202,6 +184,29 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
         } catch (Exception e) {
             LOG.error("Could not observe latest savepoint information.", e);
             throw new ReconciliationException(e);
+        }
+    }
+
+    /**
+     * Patch the Kubernetes Flink resource status if we observed a new last savepoint. This is
+     * crucial to not lose this information once the reconciler shuts down the cluster.
+     */
+    private void patchStatusOnSavepointChange(
+            AbstractFlinkResource<?, STATUS> resource,
+            SavepointInfo savepointInfo,
+            String previousLastSpPath) {
+        var currentLastSpPath =
+                Optional.ofNullable(savepointInfo.getLastSavepoint())
+                        .map(Savepoint::getLocation)
+                        .orElse(null);
+
+        // If the last savepoint information changes we need to patch the status
+        // to avoid losing this in case of an operator failure after the cluster was shut down
+        if (currentLastSpPath != null && !currentLastSpPath.equals(previousLastSpPath)) {
+            LOG.info(
+                    "Updating resource status after observing new last savepoint {}",
+                    currentLastSpPath);
+            statusHelper.patchAndCacheStatus(resource);
         }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -33,6 +33,8 @@ import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
@@ -95,8 +97,14 @@ public class ReconciliationUtils {
         }
     }
 
-    public static <SPEC extends AbstractFlinkSpec> void updateSavepointReconciliationSuccess(
-            AbstractFlinkResource<SPEC, ?> target) {
+    public static <SPEC extends AbstractFlinkSpec> void updateLastReconciledSavepointTrigger(
+            SavepointInfo savepointInfo, AbstractFlinkResource<SPEC, ?> target) {
+
+        // We only need to update for MANUAL triggers
+        if (savepointInfo.getTriggerType() != SavepointTriggerType.MANUAL) {
+            return;
+        }
+
         var commonStatus = target.getStatus();
         var spec = target.getSpec();
         ReconciliationStatus<SPEC> reconciliationStatus = commonStatus.getReconciliationStatus();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -97,7 +97,7 @@ public class ReconciliationUtils {
         }
     }
 
-    public static <SPEC extends AbstractFlinkSpec> void updateLastReconciledSavepointTrigger(
+    public static <SPEC extends AbstractFlinkSpec> void updateLastReconciledSavepointTriggerNonce(
             SavepointInfo savepointInfo, AbstractFlinkResource<SPEC, ?> target) {
 
         // We only need to update for MANUAL triggers
@@ -107,9 +107,8 @@ public class ReconciliationUtils {
 
         var commonStatus = target.getStatus();
         var spec = target.getSpec();
-        ReconciliationStatus<SPEC> reconciliationStatus = commonStatus.getReconciliationStatus();
-        commonStatus.setError(null);
-        SPEC lastReconciledSpec = reconciliationStatus.deserializeLastReconciledSpec();
+        var reconciliationStatus = commonStatus.getReconciliationStatus();
+        var lastReconciledSpec = reconciliationStatus.deserializeLastReconciledSpec();
         lastReconciledSpec
                 .getJob()
                 .setSavepointTriggerNonce(spec.getJob().getSavepointTriggerNonce());

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -19,7 +19,6 @@ package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
@@ -70,9 +69,6 @@ public class SavepointUtils {
                 resource.getStatus().getJobStatus().getSavepointInfo(),
                 conf);
 
-        if (triggerType == SavepointTriggerType.MANUAL) {
-            ReconciliationUtils.updateSavepointReconciliationSuccess(resource);
-        }
         return true;
     }
 
@@ -135,10 +131,14 @@ public class SavepointUtils {
         return Optional.empty();
     }
 
-    public static boolean gracePeriodEnded(
-            FlinkOperatorConfiguration configuration, SavepointInfo savepointInfo) {
-        var elapsed = System.currentTimeMillis() - savepointInfo.getTriggerTimestamp();
-        return elapsed > configuration.getSavepointTriggerGracePeriod().toMillis();
+    public static boolean gracePeriodEnded(Configuration conf, SavepointInfo savepointInfo) {
+        Duration gracePeriod =
+                conf.get(
+                        KubernetesOperatorConfigOptions
+                                .OPERATOR_OBSERVER_SAVEPOINT_TRIGGER_GRACE_PERIOD);
+        var endOfGracePeriod =
+                Instant.ofEpochMilli(savepointInfo.getTriggerTimestamp()).plus(gracePeriod);
+        return endOfGracePeriod.isBefore(Instant.now());
     }
 
     public static void resetTriggerIfJobNotRunning(
@@ -148,6 +148,7 @@ public class SavepointUtils {
         if (!ReconciliationUtils.isJobRunning(status)
                 && SavepointUtils.savepointInProgress(jobStatus)) {
             var savepointInfo = jobStatus.getSavepointInfo();
+            ReconciliationUtils.updateLastReconciledSavepointTrigger(savepointInfo, resource);
             savepointInfo.resetTrigger();
             LOG.error("Job is not running, cancelling savepoint operation");
             EventUtils.createOrUpdateEvent(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -133,9 +133,7 @@ public class SavepointUtils {
 
     public static boolean gracePeriodEnded(Configuration conf, SavepointInfo savepointInfo) {
         Duration gracePeriod =
-                conf.get(
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_OBSERVER_SAVEPOINT_TRIGGER_GRACE_PERIOD);
+                conf.get(KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_TRIGGER_GRACE_PERIOD);
         var endOfGracePeriod =
                 Instant.ofEpochMilli(savepointInfo.getTriggerTimestamp()).plus(gracePeriod);
         return endOfGracePeriod.isBefore(Instant.now());
@@ -148,7 +146,7 @@ public class SavepointUtils {
         if (!ReconciliationUtils.isJobRunning(status)
                 && SavepointUtils.savepointInProgress(jobStatus)) {
             var savepointInfo = jobStatus.getSavepointInfo();
-            ReconciliationUtils.updateLastReconciledSavepointTrigger(savepointInfo, resource);
+            ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(savepointInfo, resource);
             savepointInfo.resetTrigger();
             LOG.error("Job is not running, cancelling savepoint operation");
             EventUtils.createOrUpdateEvent(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
@@ -53,7 +53,7 @@ public class SavepointObserverTest {
 
         Savepoint sp = new Savepoint(1, "sp1", SavepointTriggerType.MANUAL);
         spInfo.updateLastSavepoint(sp);
-        observer.updateSavepointHistory(spInfo, sp, configManager.getDefaultConfig());
+        observer.cleanupSavepointHistory(spInfo, sp, configManager.getDefaultConfig());
 
         Assertions.assertNotNull(spInfo.getSavepointHistory());
         Assertions.assertIterableEquals(
@@ -73,7 +73,7 @@ public class SavepointObserverTest {
 
         Savepoint sp1 = new Savepoint(1, "sp1", SavepointTriggerType.MANUAL);
         spInfo.updateLastSavepoint(sp1);
-        observer.updateSavepointHistory(spInfo, sp1, conf);
+        observer.cleanupSavepointHistory(spInfo, sp1, conf);
         Assertions.assertIterableEquals(
                 Collections.singletonList(sp1), spInfo.getSavepointHistory());
         Assertions.assertIterableEquals(
@@ -81,7 +81,7 @@ public class SavepointObserverTest {
 
         Savepoint sp2 = new Savepoint(2, "sp2", SavepointTriggerType.MANUAL);
         spInfo.updateLastSavepoint(sp2);
-        observer.updateSavepointHistory(spInfo, sp2, conf);
+        observer.cleanupSavepointHistory(spInfo, sp2, conf);
         Assertions.assertIterableEquals(
                 Collections.singletonList(sp2), spInfo.getSavepointHistory());
         Assertions.assertIterableEquals(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -256,7 +256,7 @@ public class ApplicationReconcilerTest {
                 spDeployment.getStatus().getJobStatus().getSavepointInfo().getTriggerType());
 
         spDeployment.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
-        ReconciliationUtils.updateLastReconciledSavepointTrigger(
+        ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(
                 spDeployment.getStatus().getJobStatus().getSavepointInfo(), spDeployment);
 
         // don't trigger when nonce is the same
@@ -264,7 +264,7 @@ public class ApplicationReconcilerTest {
         assertFalse(SavepointUtils.savepointInProgress(spDeployment.getStatus().getJobStatus()));
 
         spDeployment.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
-        ReconciliationUtils.updateLastReconciledSavepointTrigger(
+        ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(
                 spDeployment.getStatus().getJobStatus().getSavepointInfo(), spDeployment);
 
         // trigger when new nonce is defined
@@ -291,7 +291,7 @@ public class ApplicationReconcilerTest {
                 spDeployment.getStatus().getJobStatus().getSavepointInfo().getTriggerType());
 
         spDeployment.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
-        ReconciliationUtils.updateLastReconciledSavepointTrigger(
+        ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(
                 spDeployment.getStatus().getJobStatus().getSavepointInfo(), spDeployment);
 
         // don't trigger nonce is cleared

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/FlinkSessionJobReconcilerTest.java
@@ -323,7 +323,7 @@ public class FlinkSessionJobReconcilerTest {
                         .getParallelism());
 
         sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
-        ReconciliationUtils.updateLastReconciledSavepointTrigger(
+        ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(
                 sp1SessionJob.getStatus().getJobStatus().getSavepointInfo(), sp1SessionJob);
 
         // running -> suspended
@@ -347,7 +347,7 @@ public class FlinkSessionJobReconcilerTest {
                 flinkService.listSessionJobs());
 
         sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
-        ReconciliationUtils.updateLastReconciledSavepointTrigger(
+        ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(
                 sp1SessionJob.getStatus().getJobStatus().getSavepointInfo(), sp1SessionJob);
 
         // trigger when new nonce is defined
@@ -358,7 +358,7 @@ public class FlinkSessionJobReconcilerTest {
                 sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().getTriggerId());
 
         sp1SessionJob.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
-        ReconciliationUtils.updateLastReconciledSavepointTrigger(
+        ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(
                 sp1SessionJob.getStatus().getJobStatus().getSavepointInfo(), sp1SessionJob);
 
         // don't trigger when nonce is cleared


### PR DESCRIPTION
This PR changes the savepoint triggering / observe flow by only updating the lastReconciledSpec.savepointTriggerNonce after the manual savepoint was successfully completed.

This change allows the reconciler to seamlessly retry the savepoints within the grace period without adding new complicated retry logic.

Other changes:

 - Rename the grace period config to kubernetes.operator.savepoint.trigger.grace-period to more closely reflect the functionality and make it per-job configurable
 - Some other related cleanups and minor refactorings in the SavepointObserver