### PR TITLE
[hotfix] Remove incorrect savepoint path check

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -287,14 +287,6 @@ public class DefaultValidator implements FlinkResourceValidator {
         JobSpec oldJob = oldSpec.getJob();
         JobSpec newJob = newSpec.getJob();
         if (oldJob != null && newJob != null) {
-            if (oldJob.getState() == JobState.SUSPENDED
-                    && newJob.getState() == JobState.RUNNING
-                    && newJob.getUpgradeMode() == UpgradeMode.SAVEPOINT
-                    && (deployment.getStatus().getJobStatus().getSavepointInfo().getLastSavepoint()
-                            == null)) {
-                return Optional.of("Cannot perform savepoint restore without a valid savepoint");
-            }
-
             if (StringUtils.isNullOrWhitespaceOnly(
                             effectiveConfig.get(CheckpointingOptions.SAVEPOINT_DIRECTORY.key()))
                     && deployment.getStatus().getJobManagerDeploymentStatus()
@@ -396,19 +388,6 @@ public class DefaultValidator implements FlinkResourceValidator {
             }
 
             return Optional.empty();
-        }
-
-        FlinkSessionJobSpec oldSpec =
-                sessionJob.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
-
-        JobSpec oldJob = oldSpec.getJob();
-        JobSpec newJob = newSpec.getJob();
-        if (oldJob.getState() == JobState.SUSPENDED
-                && newJob.getState() == JobState.RUNNING
-                && newJob.getUpgradeMode() == UpgradeMode.SAVEPOINT
-                && (sessionJob.getStatus().getJobStatus().getSavepointInfo().getLastSavepoint()
-                        == null)) {
-            return Optional.of("Cannot perform savepoint restore without a valid savepoint");
         }
 
         return Optional.empty();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -248,28 +248,6 @@ public class DefaultValidatorTest {
                     dep.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
                 });
 
-        testError(
-                dep -> {
-                    dep.setStatus(new FlinkDeploymentStatus());
-                    dep.getStatus().setJobStatus(new JobStatus());
-
-                    dep.getStatus()
-                            .setReconciliationStatus(new FlinkDeploymentReconciliationStatus());
-                    FlinkDeploymentSpec spec = ReconciliationUtils.clone(dep.getSpec());
-                    spec.getJob().setState(JobState.SUSPENDED);
-                    dep.getStatus()
-                            .getReconciliationStatus()
-                            .serializeAndSetLastReconciledSpec(spec);
-
-                    dep.getSpec()
-                            .getFlinkConfiguration()
-                            .put(
-                                    CheckpointingOptions.SAVEPOINT_DIRECTORY.key(),
-                                    "file:///flink-data/savepoints");
-                    dep.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
-                },
-                "Cannot perform savepoint restore without a valid savepoint");
-
         // Test cluster type validation
         testError(
                 dep -> {


### PR DESCRIPTION
The validation for valid lastSavepoint path is obsolete and can actually cause issues when trying to resume a job after a last-state suspend operation.

With the current logic upgradeMode mostly affects how the job is suspended and not how they are restored, as the way the job was suspended directly affects what state is available for restore.

The only exception is stateless restore which directly forces empty state, otherwise the job will always use the last state available (in other words, last-state restore is implicit)