### PR TITLE
[FLINK-27497] Track terminal job states in the observer

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/context/VoidObserverContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/context/VoidObserverContext.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.observer.context;
 
-/** A empty observer context. */
+/** An empty observer context. */
 public class VoidObserverContext {
     public static final VoidObserverContext INSTANCE = new VoidObserverContext();
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -217,6 +217,7 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
         FlinkDeploymentStatus status = dep.getStatus();
         ReconciliationStatus reconciliationStatus = status.getReconciliationStatus();
         if (status.getJobManagerDeploymentStatus() != JobManagerDeploymentStatus.ERROR
+                && !JobStatus.FAILED.name().equals(dep.getStatus().getJobStatus().getState())
                 && reconciliationStatus.isLastReconciledSpecStable()) {
             status.setError(null);
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -53,6 +53,7 @@ import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneClientHAServices;
 import org.apache.flink.runtime.jobgraph.RestoreMode;
+import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.rest.FileUpload;
 import org.apache.flink.runtime.rest.RestClient;
 import org.apache.flink.runtime.rest.handler.async.AsynchronousOperationResult;
@@ -331,6 +332,19 @@ public class FlinkService {
         try (ClusterClient<String> clusterClient = getClusterClient(conf)) {
             return clusterClient
                     .listJobs()
+                    .get(
+                            configManager
+                                    .getOperatorConfiguration()
+                                    .getFlinkClientTimeout()
+                                    .getSeconds(),
+                            TimeUnit.SECONDS);
+        }
+    }
+
+    public JobResult requestJobResult(Configuration conf, JobID jobID) throws Exception {
+        try (ClusterClient<String> clusterClient = getClusterClient(conf)) {
+            return clusterClient
+                    .requestJobResult(jobID)
                     .get(
                             configManager
                                     .getOperatorConfiguration()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -39,7 +39,8 @@ public class EventUtils {
     /** The component of events. */
     public enum Component {
         Operator,
-        JobManagerDeployment
+        JobManagerDeployment,
+        Job
     }
 
     public static String generateEventName(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingClusterClient.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingClusterClient.java
@@ -71,6 +71,11 @@ public class TestingClusterClient<T> extends RestClusterClient<T> {
                 throw new UnsupportedOperationException();
             };
 
+    private Function<JobID, CompletableFuture<JobResult>> requestResultFunction =
+            jobID ->
+                    CompletableFuture.completedFuture(
+                            new JobResult.Builder().jobId(jobID).netRuntime(1).build());
+
     private final Configuration configuration;
     private final T clusterId;
 
@@ -107,6 +112,11 @@ public class TestingClusterClient<T> extends RestClusterClient<T> {
     public void setListJobsFunction(
             Supplier<CompletableFuture<Collection<JobStatusMessage>>> listJobsFunction) {
         this.listJobsFunction = listJobsFunction;
+    }
+
+    public void setRequestResultFunction(
+            Function<JobID, CompletableFuture<JobResult>> requestResultFunction) {
+        this.requestResultFunction = requestResultFunction;
     }
 
     @Override
@@ -151,7 +161,7 @@ public class TestingClusterClient<T> extends RestClusterClient<T> {
 
     @Override
     public CompletableFuture<JobResult> requestJobResult(@Nonnull JobID jobId) {
-        throw new UnsupportedOperationException();
+        return requestResultFunction.apply(jobId);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -57,7 +57,7 @@ public class DeploymentRecoveryTest {
 
     @BeforeEach
     public void setup() {
-        flinkService = new TestingFlinkService();
+        flinkService = new TestingFlinkService(kubernetesClient);
         context = flinkService.getContext();
         testController =
                 TestUtils.createTestController(configManager, kubernetesClient, flinkService);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -78,7 +78,7 @@ public class FlinkDeploymentControllerTest {
 
     @BeforeEach
     public void setup() {
-        flinkService = new TestingFlinkService();
+        flinkService = new TestingFlinkService(kubernetesClient);
         context = flinkService.getContext();
         testController =
                 TestUtils.createTestController(configManager, kubernetesClient, flinkService);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -64,7 +64,7 @@ public class RollbackTest {
 
     @BeforeEach
     public void setup() {
-        flinkService = new TestingFlinkService();
+        flinkService = new TestingFlinkService(kubernetesClient);
         context = flinkService.getContext();
         testController =
                 TestUtils.createTestController(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -45,7 +45,7 @@ public class SessionJobObserverTest {
     @Test
     public void testBasicObserve() throws Exception {
         final var sessionJob = TestUtils.buildSessionJob();
-        final var flinkService = new TestingFlinkService();
+        final var flinkService = new TestingFlinkService(kubernetesClient);
         final var reconciler = new FlinkSessionJobReconciler(null, flinkService, configManager);
         final var observer =
                 new SessionJobObserver(flinkService, configManager, new TestingStatusHelper<>());
@@ -106,7 +106,7 @@ public class SessionJobObserverTest {
     @Test
     public void testObserveWithEffectiveConfig() throws Exception {
         final var sessionJob = TestUtils.buildSessionJob();
-        final var flinkService = new TestingFlinkService();
+        final var flinkService = new TestingFlinkService(kubernetesClient);
         final var reconciler = new FlinkSessionJobReconciler(null, flinkService, configManager);
         final var observer =
                 new SessionJobObserver(flinkService, configManager, new TestingStatusHelper<>());


### PR DESCRIPTION
This PR improve the logic in `JobStatusObserver`
- generate an event after each job state changed. 
- fetch the JobResult for `FAILED` job and forward the error to the CR status
