### PR TITLE
[FLINK-27961] Include the resource uid when generate the event name

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -46,7 +46,12 @@ public class EventUtils {
             HasMetadata target, Type type, String reason, String message, Component component) {
         return component
                 + "."
-                + ((reason + message + type + target.getKind() + target.getMetadata().getName())
+                + ((reason
+                                        + message
+                                        + type
+                                        + target.getKind()
+                                        + target.getMetadata().getName()
+                                        + target.getMetadata().getUid())
                                 .hashCode()
                         & 0x7FFFFFFF);
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
@@ -81,4 +81,28 @@ public class EventUtilsTest {
 
         Assertions.assertEquals(2, event.getCount());
     }
+
+    @Test
+    public void testSameResourceNameWithDifferentUidNotShareEvents() {
+        var flinkApp = TestUtils.buildApplicationCluster();
+        flinkApp.getMetadata().setUid("uid1");
+        var reason = "Cleanup";
+        var message = "message";
+        var name1 =
+                EventUtils.generateEventName(
+                        flinkApp,
+                        EventUtils.Type.Warning,
+                        reason,
+                        message,
+                        EventUtils.Component.Operator);
+        flinkApp.getMetadata().setUid("uid2");
+        var name2 =
+                EventUtils.generateEventName(
+                        flinkApp,
+                        EventUtils.Type.Warning,
+                        reason,
+                        message,
+                        EventUtils.Component.Operator);
+        Assertions.assertNotEquals(name1, name2);
+    }
 }


### PR DESCRIPTION
Currently the event name do not include the uid of the target resource. If a resource is recreated, it will be associated with the former object's events. It's not expected and will be confusing with the empty events when describe the resource.