### PR TITLE
[FLINK-27913] Remove savepointHistoryMaxCount and savepointHistoryMaxAge from FlinkOperatorConfiguration

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -105,6 +105,18 @@
             <td>The interval for the controller to reschedule the reconcile process.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.savepoint.history.age.threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Age threshold for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.savepoint.history.count.threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>Number threshold of savepoint history entries to retain.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.age</h5></td>
             <td style="word-wrap: break-word;">86400000 ms</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -105,28 +105,28 @@
             <td>The interval for the controller to reschedule the reconcile process.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.savepoint.history.age.threshold</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Duration</td>
-            <td>Age threshold for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.savepoint.history.count.threshold</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>Number threshold of savepoint history entries to retain.</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.age</h5></td>
             <td style="word-wrap: break-word;">86400000 ms</td>
             <td>Duration</td>
             <td>Maximum age for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.savepoint.history.max.age.threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Maximum age threshold for savepoint history entries to retain.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.count</h5></td>
             <td style="word-wrap: break-word;">10</td>
             <td>Integer</td>
             <td>Maximum number of savepoint history entries to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.savepoint.history.max.count.threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>Maximum number threshold of savepoint history entries to retain.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.trigger.grace-period</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -40,7 +40,8 @@ public class FlinkOperatorConfiguration {
     Duration flinkCancelJobTimeout;
     Duration flinkShutdownClusterTimeout;
     String artifactsBaseDir;
-    Configuration operatorConfig;
+    Integer savepointHistoryCountThreshold;
+    Duration savepointHistoryAgeThreshold;
 
     public static FlinkOperatorConfiguration fromConfiguration(
             Configuration operatorConfig, Set<String> watchedNamespaces) {
@@ -78,6 +79,15 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions.OPERATOR_USER_ARTIFACTS_BASE_DIR);
 
+        Integer savepointHistoryCountThreshold =
+                operatorConfig.get(
+                        KubernetesOperatorConfigOptions
+                                .OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT_THRESHOLD);
+        Duration savepointHistoryAgeThreshold =
+                operatorConfig.get(
+                        KubernetesOperatorConfigOptions
+                                .OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD);
+
         String flinkServiceHostOverride = null;
         if (EnvUtils.get("KUBERNETES_SERVICE_HOST") == null) {
             // not running in k8s, simplify local development
@@ -95,6 +105,7 @@ public class FlinkOperatorConfiguration {
                 flinkCancelJobTimeout,
                 flinkShutdownClusterTimeout,
                 artifactsBaseDir,
-                operatorConfig);
+                savepointHistoryCountThreshold,
+                savepointHistoryAgeThreshold);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -40,8 +40,8 @@ public class FlinkOperatorConfiguration {
     Duration flinkCancelJobTimeout;
     Duration flinkShutdownClusterTimeout;
     String artifactsBaseDir;
-    int savepointHistoryMaxCount;
-    Duration savepointHistoryMaxAge;
+    Integer savepointHistoryCountThreshold;
+    Duration savepointHistoryAgeThreshold;
 
     public static FlinkOperatorConfiguration fromConfiguration(
             Configuration operatorConfig, Set<String> watchedNamespaces) {
@@ -79,12 +79,12 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions.OPERATOR_USER_ARTIFACTS_BASE_DIR);
 
-        int savepointHistoryMaxCount =
+        Integer savepointHistoryCountThreshold =
                 operatorConfig.get(
-                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT);
-        Duration savepointHistoryMaxAge =
+                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_COUNT_THRESHOLD);
+        Duration savepointHistoryAgeThreshold =
                 operatorConfig.get(
-                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE);
+                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_AGE_THRESHOLD);
 
         String flinkServiceHostOverride = null;
         if (EnvUtils.get("KUBERNETES_SERVICE_HOST") == null) {
@@ -103,7 +103,7 @@ public class FlinkOperatorConfiguration {
                 flinkCancelJobTimeout,
                 flinkShutdownClusterTimeout,
                 artifactsBaseDir,
-                savepointHistoryMaxCount,
-                savepointHistoryMaxAge);
+                savepointHistoryCountThreshold,
+                savepointHistoryAgeThreshold);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -40,8 +40,7 @@ public class FlinkOperatorConfiguration {
     Duration flinkCancelJobTimeout;
     Duration flinkShutdownClusterTimeout;
     String artifactsBaseDir;
-    Integer savepointHistoryCountThreshold;
-    Duration savepointHistoryAgeThreshold;
+    Configuration operatorConfig;
 
     public static FlinkOperatorConfiguration fromConfiguration(
             Configuration operatorConfig, Set<String> watchedNamespaces) {
@@ -79,13 +78,6 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions.OPERATOR_USER_ARTIFACTS_BASE_DIR);
 
-        Integer savepointHistoryCountThreshold =
-                operatorConfig.get(
-                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_COUNT_THRESHOLD);
-        Duration savepointHistoryAgeThreshold =
-                operatorConfig.get(
-                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_AGE_THRESHOLD);
-
         String flinkServiceHostOverride = null;
         if (EnvUtils.get("KUBERNETES_SERVICE_HOST") == null) {
             // not running in k8s, simplify local development
@@ -103,7 +95,6 @@ public class FlinkOperatorConfiguration {
                 flinkCancelJobTimeout,
                 flinkShutdownClusterTimeout,
                 artifactsBaseDir,
-                savepointHistoryCountThreshold,
-                savepointHistoryAgeThreshold);
+                operatorConfig);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -145,24 +145,18 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Whether to enable recovery of missing/deleted jobmanager deployments.");
 
-    public static final ConfigOption<Integer> OPERATOR_SAVEPOINT_HISTORY_COUNT_THRESHOLD =
-            ConfigOptions.key("kubernetes.operator.savepoint.history.count.threshold")
-                    .intType()
-                    .noDefaultValue()
-                    .withDescription("Number threshold of savepoint history entries to retain.");
-
     public static final ConfigOption<Integer> OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT =
             ConfigOptions.key("kubernetes.operator.savepoint.history.max.count")
                     .intType()
                     .defaultValue(10)
                     .withDescription("Maximum number of savepoint history entries to retain.");
 
-    public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_AGE_THRESHOLD =
-            ConfigOptions.key("kubernetes.operator.savepoint.history.age.threshold")
-                    .durationType()
+    public static final ConfigOption<Integer> OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT_THRESHOLD =
+            ConfigOptions.key(OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT.key() + ".threshold")
+                    .intType()
                     .noDefaultValue()
                     .withDescription(
-                            "Age threshold for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.");
+                            "Maximum number threshold of savepoint history entries to retain.");
 
     public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_MAX_AGE =
             ConfigOptions.key("kubernetes.operator.savepoint.history.max.age")
@@ -170,6 +164,13 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(Duration.ofHours(24))
                     .withDescription(
                             "Maximum age for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.");
+
+    public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD =
+            ConfigOptions.key(OPERATOR_SAVEPOINT_HISTORY_MAX_AGE.key() + ".threshold")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Maximum age threshold for savepoint history entries to retain.");
 
     public static final ConfigOption<Map<String, String>> JAR_ARTIFACT_HTTP_HEADER =
             ConfigOptions.key("kubernetes.operator.user.artifacts.http.header")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -145,11 +145,24 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Whether to enable recovery of missing/deleted jobmanager deployments.");
 
+    public static final ConfigOption<Integer> OPERATOR_SAVEPOINT_HISTORY_COUNT_THRESHOLD =
+            ConfigOptions.key("kubernetes.operator.savepoint.history.count.threshold")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription("Number threshold of savepoint history entries to retain.");
+
     public static final ConfigOption<Integer> OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT =
             ConfigOptions.key("kubernetes.operator.savepoint.history.max.count")
                     .intType()
                     .defaultValue(10)
                     .withDescription("Maximum number of savepoint history entries to retain.");
+
+    public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_AGE_THRESHOLD =
+            ConfigOptions.key("kubernetes.operator.savepoint.history.age.threshold")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Age threshold for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.");
 
     public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_MAX_AGE =
             ConfigOptions.key("kubernetes.operator.savepoint.history.max.age")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -150,14 +150,13 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
 
         // maintain history
         List<Savepoint> savepointHistory = currentSavepointInfo.getSavepointHistory();
-        Configuration operatorConfig = configManager.getOperatorConfiguration().getOperatorConfig();
         int maxCount =
                 ConfigOptionUtils.getValueWithThreshold(
-                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT,
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT_THRESHOLD,
                         deployedConfig,
-                        operatorConfig);
+                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT,
+                        configManager
+                                .getOperatorConfiguration()
+                                .getSavepointHistoryCountThreshold());
         while (savepointHistory.size() > maxCount) {
             // remove oldest entries
             disposeSavepointQuietly(savepointHistory.remove(0), deployedConfig);
@@ -165,11 +164,9 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
 
         Duration maxAge =
                 ConfigOptionUtils.getValueWithThreshold(
-                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
                         deployedConfig,
-                        operatorConfig);
+                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                        configManager.getOperatorConfiguration().getSavepointHistoryAgeThreshold());
         long maxTms = System.currentTimeMillis() - maxAge.toMillis();
         Iterator<Savepoint> it = savepointHistory.iterator();
         while (it.hasNext()) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ConfigOptionUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ConfigOptionUtils.java
@@ -31,24 +31,18 @@ public class ConfigOptionUtils {
     /**
      * Gets the value of {@link ConfigOption} with threshold.
      *
+     * @param config The effective config
      * @param configOption The config option.
-     * @param thresholdOption The threshold option.
-     * @param effectiveConfig The effective config.
-     * @param operatorConfig The operator config.
+     * @param configThreshold The config threshold.
      * @return The value of {@link ConfigOption} with threshold.
      */
     public static <T extends Comparable<T>> T getValueWithThreshold(
-            ConfigOption<T> configOption,
-            ConfigOption<T> thresholdOption,
-            Configuration effectiveConfig,
-            Configuration operatorConfig) {
-        T configValue = effectiveConfig.get(configOption);
-        T configThreshold = operatorConfig.get(thresholdOption);
+            Configuration config, ConfigOption<T> configOption, T configThreshold) {
+        T configValue = config.get(configOption);
         if (configThreshold != null && configValue.compareTo(configThreshold) > 0) {
             LOG.warn(
-                    "Uses the config threshold [{}] of '{}' instead of the config value [{}] of '{}'.",
+                    "Uses the config threshold [{}] instead of the config value [{}] of '{}'.",
                     configThreshold,
-                    thresholdOption.key(),
                     configValue,
                     configOption.key());
             return configThreshold;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ConfigOptionUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ConfigOptionUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** {@link ConfigOption} utilities. */
+public class ConfigOptionUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigOptionUtils.class);
+
+    /**
+     * Gets the value of {@link ConfigOption} with threshold.
+     *
+     * @param configOption The config option.
+     * @param thresholdOption The threshold option.
+     * @param effectiveConfig The effective config.
+     * @param operatorConfig The operator config.
+     * @return The value of {@link ConfigOption} with threshold.
+     */
+    public static <T extends Comparable<T>> T getValueWithThreshold(
+            ConfigOption<T> configOption,
+            ConfigOption<T> thresholdOption,
+            Configuration effectiveConfig,
+            Configuration operatorConfig) {
+        T configValue = effectiveConfig.get(configOption);
+        T configThreshold = operatorConfig.get(thresholdOption);
+        if (configThreshold != null && configValue.compareTo(configThreshold) > 0) {
+            LOG.warn(
+                    "Uses the config threshold [{}] of '{}' instead of the config value [{}] of '{}'.",
+                    configThreshold,
+                    thresholdOption.key(),
+                    configValue,
+                    configOption.key());
+            return configThreshold;
+        }
+        return configValue;
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
@@ -95,7 +95,7 @@ public class SavepointObserverTest {
                 KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
                 Duration.ofMillis(System.currentTimeMillis() * 2));
         conf.set(
-                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_AGE_THRESHOLD,
+                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
                 Duration.ofMillis(5));
         configManager.updateDefaultConfig(conf);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ConfigOptionUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ConfigOptionUtilsTest.java
@@ -36,28 +36,18 @@ public class ConfigOptionUtilsTest {
         config.set(
                 KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
                 Duration.ofMillis(5));
-        config.set(
-                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
-                Duration.ofMillis(10));
         assertEquals(
                 ConfigOptionUtils.getValueWithThreshold(
-                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
                         config,
-                        config),
+                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                        Duration.ofMillis(10)),
                 Duration.ofMillis(5));
 
-        config.set(
-                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
-                Duration.ofMillis(4));
         assertEquals(
                 ConfigOptionUtils.getValueWithThreshold(
-                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
                         config,
-                        config),
+                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                        Duration.ofMillis(4)),
                 Duration.ofMillis(4));
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ConfigOptionUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ConfigOptionUtilsTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test class for {@link ConfigOptionUtils}. */
+public class ConfigOptionUtilsTest {
+
+    @Test
+    public void testValueWithThreshold() {
+        Configuration config = new Configuration();
+        config.set(
+                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                Duration.ofMillis(5));
+        config.set(
+                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
+                Duration.ofMillis(10));
+        assertEquals(
+                ConfigOptionUtils.getValueWithThreshold(
+                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                        KubernetesOperatorConfigOptions
+                                .OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
+                        config,
+                        config),
+                Duration.ofMillis(5));
+
+        config.set(
+                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
+                Duration.ofMillis(4));
+        assertEquals(
+                ConfigOptionUtils.getValueWithThreshold(
+                        KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                        KubernetesOperatorConfigOptions
+                                .OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
+                        config,
+                        config),
+                Duration.ofMillis(4));
+    }
+}


### PR DESCRIPTION
Currently `savepointHistoryMaxCount` and `savepointHistoryMaxAge` is part of the `FlinkOperatorConfiguration` class which means that users cannot override this from their user deployment. `savepointHistoryMaxCount` and `savepointHistoryMaxAge` should be removed and get directly from the effective config. A max allowed value for these configurations that is configured on the FlinkOperatorConfiguration level so that users cannot infinitely grow the status size and cause problems for the k8s api should be introduced.