### PR TITLE
[FLINK-28025] Document the change of serviceAccount in upgrading doc of k8s opeator

### DIFF
--- a/docs/content/docs/operations/upgrade.md
+++ b/docs/content/docs/operations/upgrade.md
@@ -138,3 +138,9 @@ The following steps demonstrate the CRD upgrade process from `v1alpha1` to `v1be
     Starting job 00000000000000000000000000000000 from savepoint /flink-data/savepoints/savepoint-000000-2f40a9c8e4b9/_metadat
     ```
 
+### Changes of default values of FlinkDeployment
+There are some changes or improvement of default values in the fields of the FlinkDeployment in `v1beta1`:
+1. Default value of `crd.spec.Resource#cpu` is `1.0`.
+2. Default value of `crd.spec.JobManagerSpec#replicas` is `1`.
+3. No default value of `crd.spec.FlinkDeploymentSpec#serviceAccount` and users must specify its value explicitly. 
+


### PR DESCRIPTION
1. Add document of #204 in the `Operator Upgrade Process` to emphasize the change of default values when upgrading from 0.1.0 to 1.0.0