### PR TITLE
[FLINK-27914] Integrate JOSDK metrics with Flink Metrics reporter

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -75,6 +75,12 @@
             <td>Whether to ignore pending savepoint during job upgrade.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.josdk.metrics.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Enables that Metrics of Java Operator SDK forwards metrics to the Flink metric registries.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.observer.progress-check.interval</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -43,6 +43,7 @@ public class FlinkOperatorConfiguration {
     String flinkServiceHostOverride;
     Set<String> watchedNamespaces;
     Boolean dynamicNamespacesEnabled;
+    Boolean josdkMetricsEnabled;
     Duration flinkCancelJobTimeout;
     Duration flinkShutdownClusterTimeout;
     String artifactsBaseDir;
@@ -109,6 +110,9 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions.OPERATOR_DYNAMIC_NAMESPACES_ENABLED);
 
+        boolean josdkMetricsEnabled =
+                operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_JOSDK_METRICS_ENABLED);
+
         RetryConfiguration retryConfiguration = new FlinkOperatorRetryConfiguration(operatorConfig);
 
         return new FlinkOperatorConfiguration(
@@ -120,6 +124,7 @@ public class FlinkOperatorConfiguration {
                 flinkServiceHostOverride,
                 watchedNamespaces,
                 dynamicNamespacesEnabled,
+                josdkMetricsEnabled,
                 flinkCancelJobTimeout,
                 flinkShutdownClusterTimeout,
                 artifactsBaseDir,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -210,6 +210,13 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(false)
                     .withDescription("Enables dynamic change of watched/monitored namespaces.");
 
+    public static final ConfigOption<Boolean> OPERATOR_JOSDK_METRICS_ENABLED =
+            ConfigOptions.key("kubernetes.operator.josdk.metrics.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Enables that Metrics of Java Operator SDK forwards metrics to the Flink metric registries.");
+
     public static final ConfigOption<Duration> OPERATOR_RETRY_INITIAL_INTERVAL =
             ConfigOptions.key("kubernetes.operator.retry.initial.interval")
                     .durationType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/FlinkOperatorMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/FlinkOperatorMetrics.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.metrics;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+
+import io.javaoperatorsdk.operator.Operator;
+import io.javaoperatorsdk.operator.api.monitoring.Metrics;
+import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
+import io.javaoperatorsdk.operator.processing.event.Event;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implementation of {@link Metrics} to monitor the operations of {@link Operator} and forward
+ * metrics to {@link MetricRegistry}.
+ */
+public class FlinkOperatorMetrics implements Metrics {
+
+    private final MetricGroup metricGroup;
+    private final Map<String, MetricGroup> metricGroups;
+    private final Map<String, Counter> counters;
+
+    private static final String RECONCILIATIONS = "reconciliations.";
+    public static final String COUNT = "count";
+
+    public FlinkOperatorMetrics(MetricGroup metricGroup) {
+        this.metricGroup = metricGroup;
+        this.counters = new ConcurrentHashMap<>();
+        this.metricGroups = new ConcurrentHashMap<>();
+    }
+
+    public <T> T timeControllerExecution(ControllerExecution<T> execution) throws Exception {
+        MetricGroup executionGroup =
+                metricGroup(metricGroup, "controller", execution.controllerName(), "execution");
+        try {
+            T result = execution.execute();
+            counter(executionGroup, execution.name(), "success", execution.successTypeName(result));
+            return result;
+        } catch (Exception e) {
+            counter(executionGroup, execution.name(), "failure", e.getClass().getSimpleName());
+            throw e;
+        }
+    }
+
+    public void receivedEvent(Event event) {
+        incrementCounter(
+                event.getRelatedCustomResourceID(),
+                "events.received",
+                "event",
+                event.getClass().getSimpleName());
+    }
+
+    @Override
+    public void cleanupDoneFor(ResourceID resourceID) {
+        incrementCounter(resourceID, "events.delete");
+    }
+
+    @Override
+    public void reconcileCustomResource(ResourceID resourceID, RetryInfo retryInfoNullable) {
+        Optional<RetryInfo> retryInfo = Optional.ofNullable(retryInfoNullable);
+        incrementCounter(
+                resourceID,
+                RECONCILIATIONS + "started",
+                RECONCILIATIONS + "retries.number",
+                "" + retryInfo.map(RetryInfo::getAttemptCount).orElse(0),
+                RECONCILIATIONS + "retries.last",
+                "" + retryInfo.map(RetryInfo::isLastAttempt).orElse(true));
+    }
+
+    @Override
+    public void finishedReconciliation(ResourceID resourceID) {
+        incrementCounter(resourceID, RECONCILIATIONS + "success");
+    }
+
+    public void failedReconciliation(ResourceID resourceID, Exception exception) {
+        var cause = exception.getCause();
+        if (cause == null) {
+            cause = exception;
+        } else if (cause instanceof RuntimeException) {
+            cause = cause.getCause() != null ? cause.getCause() : cause;
+        }
+        incrementCounter(
+                resourceID,
+                RECONCILIATIONS + "failed",
+                "exception",
+                cause.getClass().getSimpleName());
+    }
+
+    public <T extends Map<?, ?>> T monitorSizeOf(T map, String name) {
+        metricGroup.gauge(name + ".size", map::size);
+        return map;
+    }
+
+    private void incrementCounter(
+            ResourceID resourceID, String counterName, String... additionalTags) {
+        incrementCounter(metricGroup, resourceID, counterName);
+        if (additionalTags != null && additionalTags.length > 0) {
+            counter(metricGroup, String.join(".", additionalTags));
+            incrementCounter(
+                    metricGroup(metricGroup, String.join(".", additionalTags)),
+                    resourceID,
+                    counterName);
+        }
+    }
+
+    private void incrementCounter(
+            MetricGroup metricGroup, ResourceID resourceID, String counterName) {
+        counter(
+                metricGroup,
+                String.join(".", "counter", counterName),
+                String.join(".", "resource", resourceID.getName()),
+                String.join(".", "namespace", resourceID.getNamespace().orElse("")),
+                String.join(
+                        ".",
+                        "scope",
+                        resourceID.getNamespace().isPresent() ? "namespace" : "cluster"));
+    }
+
+    private MetricGroup metricGroup(MetricGroup parentGroup, String... groupNames) {
+        MetricGroup childGroup = parentGroup;
+        for (String groupName : groupNames) {
+            String groupIdentifier = childGroup.getMetricIdentifier(groupName);
+            if (metricGroups.containsKey(groupIdentifier)) {
+                childGroup = metricGroups.get(groupIdentifier);
+            } else {
+                childGroup = childGroup.addGroup(groupName);
+                metricGroups.put(groupIdentifier, childGroup);
+            }
+        }
+        return childGroup;
+    }
+
+    private void counter(MetricGroup parentGroup, String... counterMetrics) {
+        MetricGroup childGroup = parentGroup;
+        for (String counterMetric : counterMetrics) {
+            String metricIdentifier = childGroup.getMetricIdentifier(counterMetric);
+            childGroup = metricGroup(childGroup, counterMetric);
+            MetricGroup counterGroup = childGroup;
+            counters.computeIfAbsent(metricIdentifier, m -> counterGroup.counter(COUNT)).inc();
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/FlinkOperatorMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/FlinkOperatorMetricsTest.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.metrics;
+
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.testutils.MetricListener;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.javaoperatorsdk.operator.api.monitoring.Metrics;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceAction;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.apache.flink.kubernetes.operator.TestUtils.buildApplicationCluster;
+import static org.apache.flink.kubernetes.operator.TestUtils.buildSessionCluster;
+import static org.apache.flink.kubernetes.operator.metrics.FlinkOperatorMetrics.COUNT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/** {@link FlinkOperatorMetrics} tests. */
+public class FlinkOperatorMetricsTest {
+
+    private MetricListener metricListener;
+    private FlinkOperatorMetrics operatorMetrics;
+
+    private static final String COUNTER = String.join(".", "counter", "events.received");
+    private static final String EVENT =
+            String.join(".", "event", ResourceEvent.class.getSimpleName());
+
+    @BeforeEach
+    public void setup() {
+        metricListener = new MetricListener();
+        operatorMetrics = new FlinkOperatorMetrics(metricListener.getMetricGroup());
+    }
+
+    @Test
+    public void testTimeControllerExecution() throws Exception {
+        String execution =
+                String.join(".", "controller", "TestController", "execution", "reconcile");
+        String executionMetric = String.join(".", execution, COUNT);
+        String successMetric = String.join(".", execution, "success", COUNT);
+        String successTypeMetric = String.join(".", execution, "success", "resource", COUNT);
+        String failureMetric = String.join(".", execution, "failure", COUNT);
+        String failureExceptionMetric =
+                String.join(
+                        ".",
+                        execution,
+                        "failure",
+                        ReconciliationException.class.getSimpleName(),
+                        COUNT);
+        assertFalse(counter(executionMetric).isPresent());
+        assertFalse(counter(successMetric).isPresent());
+        assertFalse(counter(successTypeMetric).isPresent());
+        assertFalse(counter(failureMetric).isPresent());
+        assertFalse(counter(failureExceptionMetric).isPresent());
+        FlinkDeployment flinkDeployment = buildApplicationCluster();
+        Metrics.ControllerExecution<FlinkDeployment> successExecution =
+                new Metrics.ControllerExecution<>() {
+
+                    @Override
+                    public String name() {
+                        return "reconcile";
+                    }
+
+                    @Override
+                    public String controllerName() {
+                        return "TestController";
+                    }
+
+                    @Override
+                    public String successTypeName(FlinkDeployment flinkDeployment) {
+                        return "resource";
+                    }
+
+                    @Override
+                    public FlinkDeployment execute() throws Exception {
+                        return flinkDeployment;
+                    }
+                };
+        operatorMetrics.timeControllerExecution(successExecution);
+        assertEquals(1, counter(executionMetric).get().getCount());
+        assertEquals(1, counter(successMetric).get().getCount());
+        assertEquals(1, counter(successTypeMetric).get().getCount());
+        operatorMetrics.timeControllerExecution(successExecution);
+        assertEquals(2, counter(executionMetric).get().getCount());
+        assertEquals(2, counter(successMetric).get().getCount());
+        assertEquals(2, counter(successTypeMetric).get().getCount());
+        try {
+            operatorMetrics.timeControllerExecution(
+                    new Metrics.ControllerExecution<FlinkDeployment>() {
+
+                        @Override
+                        public String name() {
+                            return "reconcile";
+                        }
+
+                        @Override
+                        public String controllerName() {
+                            return "TestController";
+                        }
+
+                        @Override
+                        public String successTypeName(FlinkDeployment flinkDeployment) {
+                            return "resource";
+                        }
+
+                        @Override
+                        public FlinkDeployment execute() throws Exception {
+                            throw new ReconciliationException(new RuntimeException());
+                        }
+                    });
+            fail("Failed to test timeControllerExecution with ReconciliationException.");
+        } catch (Exception exception) {
+            assertTrue(exception instanceof ReconciliationException);
+            assertEquals(3, counter(executionMetric).get().getCount());
+            assertEquals(1, counter(failureMetric).get().getCount());
+            assertEquals(1, counter(failureExceptionMetric).get().getCount());
+        }
+    }
+
+    @Test
+    public void testReceivedEvent() {
+        FlinkDeployment flinkDeployment = buildSessionCluster();
+        String counterMetric = String.join(".", COUNTER, COUNT);
+        String eventMetric = String.join(".", EVENT, COUNT);
+        String eventCounterMetric = String.join(".", EVENT, counterMetric);
+        assertFalse(counter(counterMetric).isPresent());
+        assertFalse(counter(eventMetric).isPresent());
+        assertFalse(counter(eventCounterMetric).isPresent());
+        verifyCounter(flinkDeployment);
+        assertEquals(1, counter(counterMetric).get().getCount());
+        assertEquals(1, counter(eventMetric).get().getCount());
+        assertEquals(1, counter(eventCounterMetric).get().getCount());
+        flinkDeployment = buildApplicationCluster();
+        ObjectMeta metaData = flinkDeployment.getMetadata();
+        metaData.setName("test" + flinkDeployment.getMetadata().getName());
+        metaData.setNamespace("test" + flinkDeployment.getMetadata().getNamespace());
+        verifyCounter(flinkDeployment);
+        assertEquals(2, counter(counterMetric).get().getCount());
+        assertEquals(2, counter(eventMetric).get().getCount());
+        assertEquals(2, counter(eventCounterMetric).get().getCount());
+    }
+
+    private void verifyCounter(FlinkDeployment flinkDeployment) {
+        ResourceID resourceID = ResourceID.fromResource(flinkDeployment);
+        String resource = String.join(".", "resource", resourceID.getName());
+        String namespace = String.join(".", "namespace", resourceID.getNamespace().orElse(""));
+        String scope =
+                String.join(
+                        ".",
+                        "scope",
+                        resourceID.getNamespace().isPresent() ? "namespace" : "cluster");
+        String counterResourceMetric = String.join(".", COUNTER, resource, COUNT);
+        String counterNamespaceMetric = String.join(".", COUNTER, resource, namespace, COUNT);
+        String counterScopeMetric = String.join(".", COUNTER, resource, namespace, scope, COUNT);
+        String eventResourceMetric = String.join(".", EVENT, counterResourceMetric);
+        String eventNamespaceMetric = String.join(".", EVENT, counterNamespaceMetric);
+        String eventScopeMetric = String.join(".", EVENT, counterScopeMetric);
+        assertFalse(counter(counterResourceMetric).isPresent());
+        assertFalse(counter(counterNamespaceMetric).isPresent());
+        assertFalse(counter(counterScopeMetric).isPresent());
+        assertFalse(counter(eventResourceMetric).isPresent());
+        assertFalse(counter(eventNamespaceMetric).isPresent());
+        assertFalse(counter(eventScopeMetric).isPresent());
+        ResourceEvent resourceEvent =
+                new ResourceEvent(ResourceAction.ADDED, resourceID, flinkDeployment);
+        operatorMetrics.receivedEvent(resourceEvent);
+        assertEquals(1, counter(counterResourceMetric).get().getCount());
+        assertEquals(1, counter(counterNamespaceMetric).get().getCount());
+        assertEquals(1, counter(counterScopeMetric).get().getCount());
+        assertEquals(1, counter(eventResourceMetric).get().getCount());
+        assertEquals(1, counter(eventNamespaceMetric).get().getCount());
+        assertEquals(1, counter(eventScopeMetric).get().getCount());
+    }
+
+    private Optional<Counter> counter(String metricName) {
+        return metricListener.getCounter(metricName);
+    }
+}


### PR DESCRIPTION
The Java Operator SDK comes with an internal `Metrics` interface which could be implemented to forward metrics/measurements to the Flink metric registries. 

**The brief change log**
- Introduces `FlinkOperatorMetrics` that is the implementation of `Metrics` to monitor the operations of `Operator` and forward metrics to `MetricRegistry`.