### PR TITLE
[FLINK-27688] Add pluggable FlinkResourceListener interface

### DIFF
--- a/docs/content/docs/operations/listeners.md
+++ b/docs/content/docs/operations/listeners.md
@@ -1,0 +1,41 @@
+---
+title: "Custom Listeners"
+weight: 5
+type: docs
+aliases:
+- /operations/listeners.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Custom Flink Resource Listeners
+
+The Flink Kubernetes Operator allows users to listen to events and status updates triggered for the Flink Resources managed by the operator.
+This feature enables tighter integration with the user's own data platform.
+
+By implementing the `FlinkResourceListener` interface users can listen to both events and status updates per resource type (`FlinkDeployment` / `FlinkSessionJob`). These methods will be called after the respective events have been triggered by the system.
+Using the context provided on each listener method users can also get access to the related Flink resource and the `KubernetesClient` itself in order to trigger any further events etc on demand.
+
+Similar to [custom validator implementations]({{< ref "docs/operations/validator" >}}) resource listeners are loaded via the Flink [Plugins](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/plugins) mechanism.
+
+In order to enable your custom `FlinkResourceListener` you need to:
+
+ 1. Implement the interface
+ 2. Add your listener class to `org.apache.flink.kubernetes.operator.listener.FlinkResourceListener` in `META-INF/services`
+ 3. Package your JAR and add it to the plugins directory of your operator image (`/opt/flink/plugins`)

--- a/docs/content/docs/operations/validator.md
+++ b/docs/content/docs/operations/validator.md
@@ -1,5 +1,5 @@
 ---
-title: "Validator"
+title: "Custom Resource Validators"
 weight: 5
 type: docs
 aliases:
@@ -26,21 +26,21 @@ under the License.
 
 # Custom `FlinkResourceValidator` implementation
 
-`FlinkResourceValidator`, an interface for validating the resources of `FlinkDeployment` and `FlinkSessionJob`,  is a pluggable component based on the [Plugins](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/plugins) mechanism. During development, we can customize the implementation of `FlinkResourceValidator` and make sure to retain the service definition in `META-INF/services`. 
+`FlinkResourceValidator`, an interface for validating the resources of `FlinkDeployment` and `FlinkSessionJob`,  is a pluggable component based on the [Plugins](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/plugins) mechanism. During development, we can customize the implementation of `FlinkResourceValidator` and make sure to retain the service definition in `META-INF/services`.
 The following steps demonstrate how to develop and use a custom validator.
 
 1. Implement `FlinkResourceValidator` interface:
     ```java
     package org.apache.flink.kubernetes.operator.validation;
-   
+
     import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
     import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
-   
+
     import java.util.Optional;
-   
+
     /** Custom validator implementation of {@link FlinkResourceValidator}. */
     public class CustomValidator implements FlinkResourceValidator {
-   
+
         @Override
         public Optional<String> validateDeployment(FlinkDeployment deployment) {
             if (deployment.getSpec().getFlinkVersion() == null) {
@@ -48,7 +48,7 @@ The following steps demonstrate how to develop and use a custom validator.
             }
             return Optional.empty();
         }
-   
+
         @Override
         public Optional<String> validateSessionJob(
                  FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
@@ -67,7 +67,7 @@ The following steps demonstrate how to develop and use a custom validator.
 
 3. Use the Maven tool to package the project and generate the custom validator JAR.
 
-4. Create Dockerfile to build a custom image from the `apache/flink-kubernetes-operator` official image and copy the generated JAR to custom validator plugin directory. 
+4. Create Dockerfile to build a custom image from the `apache/flink-kubernetes-operator` official image and copy the generated JAR to custom validator plugin directory.
     `/opt/flink/plugins` is the value of `FLINK_PLUGINS_DIR` environment variable in the flink-kubernetes-operator helm chart. The structure of custom validator directory under `/opt/flink/plugins` is as follows:
     ```text
     /opt/flink/plugins
@@ -75,7 +75,7 @@ The following steps demonstrate how to develop and use a custom validator.
         │   ├── custom-validator.jar
         └── ...
     ```
-    
+
     With the custom validator directory location, the Dockerfile is defined as follows:
     ```shell script
     FROM apache/flink-kubernetes-operator

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -277,16 +277,16 @@ under the License.
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>create-test-validator-jar</id>
+                        <id>create-test-plugin-jar</id>
                         <phase>process-test-classes</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>
                         <configuration>
-                            <finalName>test-validator</finalName>
+                            <finalName>test-plugins</finalName>
                             <attach>false</attach>
                             <descriptors>
-                                <descriptor>src/test/assembly/test-validator-assembly.xml</descriptor>
+                                <descriptor>src/test/assembly/test-plugins-assembly.xml</descriptor>
                             </descriptors>
                         </configuration>
                     </execution>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListener.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListener.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.listener;
+
+import org.apache.flink.core.plugin.Plugin;
+import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.crd.status.CommonStatus;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
+
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+/** Listener interface for Flink resource related events and status changes. */
+public interface FlinkResourceListener extends Plugin {
+
+    void onDeploymentStatusUpdate(StatusUpdateContext<FlinkDeployment, FlinkDeploymentStatus> ctx);
+
+    void onDeploymentEvent(ResourceEventContext<FlinkDeployment> ctx);
+
+    void onSessionJobStatusUpdate(StatusUpdateContext<FlinkSessionJob, FlinkSessionJobStatus> ctx);
+
+    void onSessionJobEvent(ResourceEventContext<FlinkSessionJob> ctx);
+
+    /** Base for Resource Event and StatusUpdate contexts. */
+    interface ResourceContext<R extends AbstractFlinkResource<?, ?>> {
+        R getFlinkResource();
+
+        KubernetesClient getKubernetesClient();
+    }
+
+    /** Context for Resource Event listener methods. */
+    interface ResourceEventContext<R extends AbstractFlinkResource<?, ?>>
+            extends ResourceContext<R> {
+        Event getEvent();
+    }
+
+    /** Context for Status listener methods. */
+    interface StatusUpdateContext<R extends AbstractFlinkResource<?, S>, S extends CommonStatus<?>>
+            extends ResourceContext<R> {
+
+        default S getNewStatus() {
+            return getFlinkResource().getStatus();
+        }
+
+        S getPreviousStatus();
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/ListenerUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/ListenerUtils.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.listener;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.DelegatingConfiguration;
+import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Flink resource listener utilities. */
+public class ListenerUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FlinkUtils.class);
+
+    private static final String PREFIX = "kubernetes.operator.plugins.listeners.";
+    private static final String SUFFIX = ".class";
+    private static final Pattern PTN =
+            Pattern.compile(Pattern.quote(PREFIX) + "([\\S&&[^.]]*)" + Pattern.quote(SUFFIX));
+    private static final List<String> EXTRA_PARENT_FIRST_PATTERNS =
+            List.of("io.fabric8", "com.fasterxml");
+
+    /**
+     * Load {@link FlinkResourceListener} implementations from the plugin directory. Only listeners
+     * that are explicitly named and configured will be enabled.
+     *
+     * <p>Config format: kubernetes.operator.plugins.listeners.test.class: com.myorg.MyListener
+     * kubernetes.operator.plugins.listeners.test.k1: v1
+     *
+     * @param configManager {@link FlinkConfigManager} to access plugin configurations.
+     * @return Enabled listeners.
+     */
+    public static Collection<FlinkResourceListener> discoverListeners(
+            FlinkConfigManager configManager) {
+        var listeners = new ArrayList<FlinkResourceListener>();
+        var conf = getListenerBaseConf(configManager);
+
+        Map<String, Configuration> listenerConfigs = loadListenerConfigs(conf);
+        PluginUtils.createPluginManagerFromRootFolder(conf)
+                .load(FlinkResourceListener.class)
+                .forEachRemaining(
+                        listener -> {
+                            String clazz = listener.getClass().getName();
+                            LOG.info(
+                                    "Discovered resource listener from plugin directory[{}]: {}.",
+                                    System.getenv()
+                                            .getOrDefault(
+                                                    ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+                                                    ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS),
+                                    clazz);
+
+                            if (listenerConfigs.containsKey(clazz)) {
+                                LOG.info("Initializing {}", clazz);
+                                listener.configure(listenerConfigs.get(clazz));
+                                listeners.add(listener);
+                            } else {
+                                LOG.warn("No configuration found for {}", clazz);
+                            }
+                        });
+        return listeners;
+    }
+
+    private static Configuration getListenerBaseConf(FlinkConfigManager configManager) {
+        var conf = new Configuration(configManager.getDefaultConfig());
+        List<String> additionalPatterns =
+                new ArrayList<>(
+                        conf.getOptional(
+                                        CoreOptions
+                                                .PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL)
+                                .orElse(Collections.emptyList()));
+        additionalPatterns.addAll(EXTRA_PARENT_FIRST_PATTERNS);
+        conf.set(
+                CoreOptions.PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
+                additionalPatterns);
+        return conf;
+    }
+
+    @VisibleForTesting
+    protected static Map<String, Configuration> loadListenerConfigs(Configuration configuration) {
+        Map<String, Configuration> listenerConfigs = new HashMap<>();
+        for (var enableListeners : findEnabledListeners(configuration)) {
+            DelegatingConfiguration delegatingConfiguration =
+                    new DelegatingConfiguration(configuration, PREFIX + enableListeners.f0 + '.');
+            listenerConfigs.put(enableListeners.f1, delegatingConfiguration);
+        }
+        return listenerConfigs;
+    }
+
+    private static Set<Tuple2<String, String>> findEnabledListeners(Configuration configuration) {
+        Set<Tuple2<String, String>> result = new HashSet<>();
+        for (String key : configuration.keySet()) {
+            Matcher matcher = PTN.matcher(key);
+            if (matcher.matches()) {
+                result.add(
+                        Tuple2.of(
+                                matcher.group(1),
+                                configuration.get(
+                                        ConfigOptions.key(key).stringType().noDefaultValue())));
+            }
+        }
+        return result;
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -21,6 +21,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
@@ -38,9 +39,11 @@ public abstract class JobStatusObserver<CTX> {
     private static final Logger LOG = LoggerFactory.getLogger(JobStatusObserver.class);
     private static final int MAX_ERROR_STRING_LENGTH = 512;
     private final FlinkService flinkService;
+    private final EventRecorder eventRecorder;
 
-    public JobStatusObserver(FlinkService flinkService) {
+    public JobStatusObserver(FlinkService flinkService, EventRecorder eventRecorder) {
         this.flinkService = flinkService;
+        this.eventRecorder = eventRecorder;
     }
 
     /**
@@ -135,8 +138,7 @@ public abstract class JobStatusObserver<CTX> {
             LOG.info(message);
 
             setErrorIfPresent(resource, clusterJobStatus, deployedConfig);
-            EventUtils.createOrUpdateEvent(
-                    flinkService.getKubernetesClient(),
+            eventRecorder.triggerEvent(
                     resource,
                     EventUtils.Type.Normal,
                     "Status Changed",

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
@@ -27,10 +27,10 @@ import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
 import org.apache.flink.kubernetes.operator.observer.SavepointObserver;
 import org.apache.flink.kubernetes.operator.observer.context.ApplicationObserverContext;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
-import org.apache.flink.kubernetes.operator.utils.StatusHelper;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import java.util.List;
@@ -46,14 +46,15 @@ public class ApplicationObserver extends AbstractDeploymentObserver {
     private final JobStatusObserver<ApplicationObserverContext> jobStatusObserver;
 
     public ApplicationObserver(
-            KubernetesClient kubernetesClient,
             FlinkService flinkService,
             FlinkConfigManager configManager,
-            StatusHelper<FlinkDeploymentStatus> statusHelper) {
-        super(kubernetesClient, flinkService, configManager);
-        this.savepointObserver = new SavepointObserver<>(flinkService, configManager, statusHelper);
+            StatusRecorder<FlinkDeploymentStatus> statusRecorder,
+            EventRecorder eventRecorder) {
+        super(flinkService, configManager, eventRecorder);
+        this.savepointObserver =
+                new SavepointObserver(flinkService, configManager, statusRecorder, eventRecorder);
         this.jobStatusObserver =
-                new JobStatusObserver<>(flinkService) {
+                new JobStatusObserver<>(flinkService, eventRecorder) {
                     @Override
                     public void onTimeout(ApplicationObserverContext ctx) {
                         observeJmDeployment(ctx.flinkApp, ctx.context, ctx.deployedConfig);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
@@ -21,8 +21,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 
 import java.util.concurrent.TimeoutException;
@@ -31,10 +31,10 @@ import java.util.concurrent.TimeoutException;
 public class SessionObserver extends AbstractDeploymentObserver {
 
     public SessionObserver(
-            KubernetesClient kubernetesClient,
             FlinkService flinkService,
-            FlinkConfigManager configManager) {
-        super(kubernetesClient, flinkService, configManager);
+            FlinkConfigManager configManager,
+            EventRecorder eventRecorder) {
+        super(flinkService, configManager, eventRecorder);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -40,7 +40,7 @@ import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
-import org.apache.flink.kubernetes.operator.utils.StatusHelper;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -372,7 +372,7 @@ public class ReconciliationUtils {
      * @param retryInfo Current RetryInformation
      * @param e Exception that caused the retry
      * @param metricManager Metric manager to be updated
-     * @param statusHelper StatusHelper object for patching status
+     * @param statusRecorder statusRecorder object for patching status
      * @return This always returns Empty optional currently, due to the status update logic
      */
     public static <STATUS extends CommonStatus<?>, R extends AbstractFlinkResource<?, STATUS>>
@@ -381,7 +381,7 @@ public class ReconciliationUtils {
                     Optional<RetryInfo> retryInfo,
                     Exception e,
                     MetricManager<R> metricManager,
-                    StatusHelper<STATUS> statusHelper) {
+                    StatusRecorder<STATUS> statusRecorder) {
 
         retryInfo.ifPresent(
                 r -> {
@@ -391,12 +391,12 @@ public class ReconciliationUtils {
                             r.isLastAttempt());
                 });
 
-        statusHelper.updateStatusFromCache(resource);
+        statusRecorder.updateStatusFromCache(resource);
         ReconciliationUtils.updateForReconciliationError(
                 resource,
                 (e instanceof ReconciliationException) ? e.getCause().toString() : e.toString());
         metricManager.onUpdate(resource);
-        statusHelper.patchAndCacheStatus(resource);
+        statusRecorder.patchAndCacheStatus(resource);
 
         // Status was updated already, no need to return anything
         return ErrorStatusUpdateControl.noStatusUpdate();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractDeploymentReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractDeploymentReconciler.java
@@ -27,6 +27,7 @@ import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.reconciler.Reconciler;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -40,16 +41,19 @@ public abstract class AbstractDeploymentReconciler implements Reconciler<FlinkDe
     private static final Logger LOG = LoggerFactory.getLogger(AbstractDeploymentReconciler.class);
 
     protected final FlinkConfigManager configManager;
+    protected final EventRecorder eventRecorder;
     protected final KubernetesClient kubernetesClient;
     protected final FlinkService flinkService;
 
     public AbstractDeploymentReconciler(
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
-            FlinkConfigManager configManager) {
+            FlinkConfigManager configManager,
+            EventRecorder eventRecorder) {
         this.kubernetesClient = kubernetesClient;
         this.flinkService = flinkService;
         this.configManager = configManager;
+        this.eventRecorder = eventRecorder;
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -35,6 +35,7 @@ import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
@@ -62,8 +63,9 @@ public class ApplicationReconciler extends AbstractDeploymentReconciler {
     public ApplicationReconciler(
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
-            FlinkConfigManager configManager) {
-        super(kubernetesClient, flinkService, configManager);
+            FlinkConfigManager configManager,
+            EventRecorder eventRecorder) {
+        super(kubernetesClient, flinkService, configManager, eventRecorder);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.reconciler.Reconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 
@@ -34,15 +35,18 @@ public class ReconcilerFactory {
     private final KubernetesClient kubernetesClient;
     private final FlinkService flinkService;
     private final FlinkConfigManager configManager;
+    private final EventRecorder eventRecorder;
     private final Map<Mode, Reconciler<FlinkDeployment>> reconcilerMap;
 
     public ReconcilerFactory(
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
-            FlinkConfigManager configManager) {
+            FlinkConfigManager configManager,
+            EventRecorder eventRecorder) {
         this.kubernetesClient = kubernetesClient;
         this.flinkService = flinkService;
         this.configManager = configManager;
+        this.eventRecorder = eventRecorder;
         this.reconcilerMap = new ConcurrentHashMap<>();
     }
 
@@ -53,10 +57,10 @@ public class ReconcilerFactory {
                     switch (mode) {
                         case SESSION:
                             return new SessionReconciler(
-                                    kubernetesClient, flinkService, configManager);
+                                    kubernetesClient, flinkService, configManager, eventRecorder);
                         case APPLICATION:
                             return new ApplicationReconciler(
-                                    kubernetesClient, flinkService, configManager);
+                                    kubernetesClient, flinkService, configManager, eventRecorder);
                         default:
                             throw new UnsupportedOperationException(
                                     String.format("Unsupported running mode: %s", mode));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -28,6 +28,7 @@ import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
@@ -52,8 +53,9 @@ public class SessionReconciler extends AbstractDeploymentReconciler {
     public SessionReconciler(
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
-            FlinkConfigManager configManager) {
-        super(kubernetesClient, flinkService, configManager);
+            FlinkConfigManager configManager,
+            EventRecorder eventRecorder) {
+        super(kubernetesClient, flinkService, configManager, eventRecorder);
     }
 
     @Override
@@ -155,8 +157,7 @@ public class SessionReconciler extends AbstractDeploymentReconciler {
                             sessionJobs.stream()
                                     .map(job -> job.getMetadata().getName())
                                     .collect(Collectors.toList()));
-            if (EventUtils.createOrUpdateEvent(
-                    kubernetesClient,
+            if (eventRecorder.triggerEvent(
                     flinkApp,
                     EventUtils.Type.Warning,
                     "Cleanup",

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.listener.FlinkResourceListener;
+
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
+/** Helper class for creating Kubernetes events for Flink resources. */
+public class EventRecorder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EventRecorder.class);
+
+    private final KubernetesClient client;
+    private final BiConsumer<AbstractFlinkResource<?, ?>, Event> eventListener;
+
+    public EventRecorder(
+            KubernetesClient client, BiConsumer<AbstractFlinkResource<?, ?>, Event> eventListener) {
+        this.client = client;
+        this.eventListener = eventListener;
+    }
+
+    public boolean triggerEvent(
+            AbstractFlinkResource<?, ?> resource,
+            EventUtils.Type type,
+            String reason,
+            String message,
+            EventUtils.Component component) {
+        return EventUtils.createOrUpdateEvent(
+                client,
+                resource,
+                type,
+                reason,
+                message,
+                component,
+                e -> eventListener.accept(resource, e));
+    }
+
+    public static EventRecorder create(
+            KubernetesClient client, Collection<FlinkResourceListener> listeners) {
+
+        BiConsumer<AbstractFlinkResource<?, ?>, Event> biConsumer =
+                (resource, event) ->
+                        listeners.forEach(
+                                listener -> {
+                                    var ctx =
+                                            new FlinkResourceListener.ResourceEventContext() {
+                                                @Override
+                                                public Event getEvent() {
+                                                    return event;
+                                                }
+
+                                                @Override
+                                                public AbstractFlinkResource<?, ?>
+                                                        getFlinkResource() {
+                                                    return resource;
+                                                }
+
+                                                @Override
+                                                public KubernetesClient getKubernetesClient() {
+                                                    return client;
+                                                }
+                                            };
+
+                                    if (resource instanceof FlinkDeployment) {
+                                        listener.onDeploymentEvent(ctx);
+                                    } else {
+                                        listener.onSessionJobEvent(ctx);
+                                    }
+                                });
+        return new EventRecorder(client, biConsumer);
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -27,7 +27,6 @@ import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,7 +139,7 @@ public class SavepointUtils {
     }
 
     public static void resetTriggerIfJobNotRunning(
-            KubernetesClient client, AbstractFlinkResource<?, ?> resource) {
+            AbstractFlinkResource<?, ?> resource, EventRecorder eventRecorder) {
         var status = resource.getStatus();
         var jobStatus = status.getJobStatus();
         if (!ReconciliationUtils.isJobRunning(status)
@@ -149,8 +148,7 @@ public class SavepointUtils {
             ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(savepointInfo, resource);
             savepointInfo.resetTrigger();
             LOG.error("Job is not running, cancelling savepoint operation");
-            EventUtils.createOrUpdateEvent(
-                    client,
+            eventRecorder.triggerEvent(
                     resource,
                     EventUtils.Type.Warning,
                     "SavepointError",

--- a/flink-kubernetes-operator/src/test/assembly/test-plugins-assembly.xml
+++ b/flink-kubernetes-operator/src/test/assembly/test-plugins-assembly.xml
@@ -29,6 +29,7 @@ under the License.
             <!-- the service impl -->
             <includes>
                 <include>org/apache/flink/kubernetes/operator/validation/TestValidator.class</include>
+                <include>org/apache/flink/kubernetes/operator/listener/TestingListener.class</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
@@ -18,21 +18,21 @@
 
 package org.apache.flink.kubernetes.operator;
 
+import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.status.CommonStatus;
-import org.apache.flink.kubernetes.operator.utils.StatusHelper;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.fabric8.kubernetes.client.CustomResource;
 
-/** Testing StatusHelper. */
-public class TestingStatusHelper<STATUS extends CommonStatus<?>> extends StatusHelper<STATUS> {
+/** Testing statusRecorder. */
+public class TestingStatusRecorder<STATUS extends CommonStatus<?>> extends StatusRecorder<STATUS> {
 
-    public TestingStatusHelper() {
-        super(null);
+    public TestingStatusRecorder() {
+        super(null, (r, s) -> {});
     }
 
     @Override
-    public <T extends CustomResource<?, STATUS>> void patchAndCacheStatus(T resource) {
+    public <T extends AbstractFlinkResource<?, STATUS>> void patchAndCacheStatus(T resource) {
         statusCache.put(
                 getKey(resource),
                 objectMapper.convertValue(resource.getStatus(), ObjectNode.class));

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.listener;
+
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+import org.apache.flink.kubernetes.operator.utils.EventUtils;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link FlinkResourceListener}. */
+@EnableKubernetesMockClient(crud = true)
+public class FlinkResourceListenerTest {
+
+    private KubernetesClient kubernetesClient;
+
+    @BeforeEach
+    public void before() {
+        kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
+    }
+
+    @Test
+    public void testListeners() {
+        var listener1 = new TestingListener();
+        var listener2 = new TestingListener();
+        var listeners = List.<FlinkResourceListener>of(listener1, listener2);
+
+        var statusRecorder =
+                StatusRecorder.<FlinkDeploymentStatus>create(kubernetesClient, listeners);
+        var eventRecorder = EventRecorder.create(kubernetesClient, listeners);
+
+        var deployment = TestUtils.buildApplicationCluster();
+        statusRecorder.updateStatusFromCache(deployment);
+
+        statusRecorder.patchAndCacheStatus(deployment);
+        assertTrue(listener1.updates.isEmpty());
+        assertTrue(listener2.updates.isEmpty());
+        assertTrue(listener1.events.isEmpty());
+        assertTrue(listener2.events.isEmpty());
+
+        deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.ERROR);
+
+        statusRecorder.patchAndCacheStatus(deployment);
+        assertEquals(1, listener1.updates.size());
+        assertEquals(deployment, listener1.updates.get(0).getFlinkResource());
+
+        assertEquals(1, listener2.updates.size());
+        assertEquals(deployment, listener2.updates.get(0).getFlinkResource());
+
+        deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
+        statusRecorder.patchAndCacheStatus(deployment);
+
+        assertEquals(2, listener1.updates.size());
+        assertEquals(deployment, listener1.updates.get(0).getFlinkResource());
+        assertEquals(2, listener2.updates.size());
+        assertEquals(deployment, listener2.updates.get(0).getFlinkResource());
+
+        var updateContext =
+                (FlinkResourceListener.StatusUpdateContext<FlinkDeployment, FlinkDeploymentStatus>)
+                        listener1.updates.get(1);
+        assertEquals(
+                JobManagerDeploymentStatus.ERROR,
+                updateContext.getPreviousStatus().getJobManagerDeploymentStatus());
+        assertEquals(
+                JobManagerDeploymentStatus.DEPLOYING,
+                updateContext.getNewStatus().getJobManagerDeploymentStatus());
+
+        eventRecorder.triggerEvent(
+                deployment,
+                EventUtils.Type.Warning,
+                "SavepointError",
+                "err",
+                EventUtils.Component.Operator);
+        assertEquals(1, listener1.events.size());
+        eventRecorder.triggerEvent(
+                deployment,
+                EventUtils.Type.Warning,
+                "SavepointError",
+                "err",
+                EventUtils.Component.Operator);
+        assertEquals(2, listener1.events.size());
+
+        for (int i = 0; i < listener1.events.size(); i++) {
+            assertEquals(listener1.events.get(i).getEvent(), listener2.events.get(i).getEvent());
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/ListenerUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/ListenerUtilsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.listener;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test for {@link ListenerUtils}. */
+public class ListenerUtilsTest {
+
+    @TempDir Path temporaryFolder;
+
+    @Test
+    public void testListenerConfiguration() throws IOException {
+        Map<String, String> testConfig = new HashMap<>();
+
+        testConfig.put(
+                "kubernetes.operator.plugins.listeners.test1.class",
+                TestingListener.class.getName());
+        testConfig.put("kubernetes.operator.plugins.listeners.test1.k1", "v1");
+        testConfig.put("kubernetes.operator.plugins.listeners.test1.k2", "v2");
+        testConfig.put("k3", "v3");
+
+        Map<String, String> originalEnv = System.getenv();
+        try {
+            Map<String, String> systemEnv = new HashMap<>(originalEnv);
+            systemEnv.put(
+                    ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+                    TestUtils.getTestPluginsRootDir(temporaryFolder));
+            TestUtils.setEnv(systemEnv);
+            var listeners =
+                    new ArrayList<>(
+                            ListenerUtils.discoverListeners(
+                                    new FlinkConfigManager(Configuration.fromMap(testConfig))));
+            assertEquals(1, listeners.size());
+
+            var testingListener = (TestingListener) listeners.get(0);
+            assertEquals(
+                    Map.of("k1", "v1", "k2", "v2", "class", TestingListener.class.getName()),
+                    testingListener.config.toMap());
+        } finally {
+            TestUtils.setEnv(originalEnv);
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/TestingListener.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/TestingListener.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.listener;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Listener implementation for testing. */
+public class TestingListener implements FlinkResourceListener {
+
+    public List<StatusUpdateContext<?, ?>> updates = new ArrayList<>();
+    public List<ResourceEventContext<?>> events = new ArrayList<>();
+    public Configuration config;
+
+    public void onStatusUpdate(StatusUpdateContext<?, ?> ctx) {
+        updates.add(ctx);
+    }
+
+    public void onEvent(ResourceEventContext<?> ctx) {
+        events.add(ctx);
+    }
+
+    @Override
+    public void onDeploymentStatusUpdate(
+            StatusUpdateContext<FlinkDeployment, FlinkDeploymentStatus> ctx) {
+        onStatusUpdate(ctx);
+    }
+
+    @Override
+    public void onDeploymentEvent(ResourceEventContext<FlinkDeployment> ctx) {
+        onEvent(ctx);
+    }
+
+    @Override
+    public void onSessionJobStatusUpdate(
+            StatusUpdateContext<FlinkSessionJob, FlinkSessionJobStatus> ctx) {
+        onStatusUpdate(ctx);
+    }
+
+    @Override
+    public void onSessionJobEvent(ResourceEventContext<FlinkSessionJob> ctx) {
+        onEvent(ctx);
+    }
+
+    @Override
+    public void configure(Configuration config) {
+        this.config = config;
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,8 @@ public class SessionObserverTest {
     public void observeSessionCluster() {
         TestingFlinkService flinkService = new TestingFlinkService();
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
-        SessionObserver observer = new SessionObserver(null, flinkService, configManager);
+        SessionObserver observer =
+                new SessionObserver(flinkService, configManager, new EventRecorder(null, null));
         deployment
                 .getStatus()
                 .getReconciliationStatus()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SessionReconcilerTest {
 
     private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
+    private final EventRecorder eventRecorder = new EventRecorder(null, (r, e) -> {});
 
     @Test
     public void testStartSession() throws Exception {
@@ -50,7 +52,8 @@ public class SessionReconcilerTest {
                     }
                 };
 
-        SessionReconciler reconciler = new SessionReconciler(null, flinkService, configManager);
+        SessionReconciler reconciler =
+                new SessionReconciler(null, flinkService, configManager, eventRecorder);
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
         reconciler.reconcile(deployment, context);
         assertEquals(1, count.get());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
@@ -51,7 +51,8 @@ public class EventUtilsTest {
                         EventUtils.Type.Warning,
                         reason,
                         message,
-                        EventUtils.Component.Operator));
+                        EventUtils.Component.Operator,
+                        e -> {}));
         var event =
                 kubernetesClient
                         .v1()
@@ -70,7 +71,8 @@ public class EventUtilsTest {
                         EventUtils.Type.Warning,
                         reason,
                         message,
-                        EventUtils.Component.Operator));
+                        EventUtils.Component.Operator,
+                        e -> {}));
         event =
                 kubernetesClient
                         .v1()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
@@ -28,16 +28,16 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Test for {@link StatusHelper}. */
+/** Test for {@link StatusRecorder}. */
 @EnableKubernetesMockClient(crud = true)
-public class StatusHelperTest {
+public class StatusRecorderTest {
 
     private KubernetesClient kubernetesClient;
     private KubernetesMockServer mockServer;
 
     @Test
     public void testPatchOnlyWhenChanged() throws InterruptedException {
-        var helper = new StatusHelper<FlinkDeploymentStatus>(kubernetesClient);
+        var helper = new StatusRecorder<FlinkDeploymentStatus>(kubernetesClient, (e, s) -> {});
         var deployment = TestUtils.buildApplicationCluster();
         kubernetesClient.resource(deployment).createOrReplace();
         var lastRequest = mockServer.getLastRequest();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtilsTest.java
@@ -25,14 +25,11 @@ import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.validation.DefaultValidator;
 import org.apache.flink.kubernetes.operator.validation.TestValidator;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,30 +37,20 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /** Test class for {@link ValidatorUtils}. */
 public class ValidatorUtilsTest {
 
-    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    private static final String VALIDATOR_NAME = "test-validator";
-    private static final String VALIDATOR_JAR = VALIDATOR_NAME + "-test-jar.jar";
+    @TempDir public Path temporaryFolder;
 
     @Test
     public void testDiscoverValidators() throws IOException {
-        File validatorRootFolder = temporaryFolder.newFolder();
-        File testValidatorFolder = new File(validatorRootFolder, VALIDATOR_NAME);
-        assertTrue(testValidatorFolder.mkdirs());
-        File testValidatorJar = new File("target", VALIDATOR_JAR);
-        assertTrue(testValidatorJar.exists());
-        Files.copy(
-                testValidatorJar.toPath(),
-                Paths.get(testValidatorFolder.toString(), VALIDATOR_JAR));
         Map<String, String> originalEnv = System.getenv();
         try {
             Map<String, String> systemEnv = new HashMap<>(originalEnv);
-            systemEnv.put(ConfigConstants.ENV_FLINK_PLUGINS_DIR, validatorRootFolder.getPath());
+            systemEnv.put(
+                    ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+                    TestUtils.getTestPluginsRootDir(temporaryFolder));
             TestUtils.setEnv(systemEnv);
             assertEquals(
                     new HashSet<>(

--- a/flink-kubernetes-operator/src/test/resources/META-INF/services/org.apache.flink.kubernetes.operator.listener.FlinkResourceListener
+++ b/flink-kubernetes-operator/src/test/resources/META-INF/services/org.apache.flink.kubernetes.operator.listener.FlinkResourceListener
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.kubernetes.operator.listener.TestingListener


### PR DESCRIPTION
This PR introduces a new interface called FlinkResourceListener that allows operator users to listen to resource status changes and events triggered by the operator itself.

This provides a key integration point for platforms built on top of the operators. Similar to custom validators or metrics reporters, FlinkResourceListener implementations are also loaded using the built in plugin mechanism.

To listeners are integrated into the StatusHelper and the newly introduced EventHelper objects which will seamlessly forward all updates/events without added complexity.

The PR also improves event triggering and simplifies some test cases that were affected by this change.