### PR TITLE
[FLINK-28087]Add validation for the meta.name of FlinkDeployment CR.

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -109,7 +109,7 @@ public class DefaultValidator implements FlinkResourceValidator {
         if (!matcher.matches()) {
             return Optional.of(
                     String.format(
-                            "The FlinkDeployment meta.name: %s is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'), and the length must be no more than 45 characters.",
+                            "The FlinkDeployment name: %s is invalid, must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123'), and the length must be no more than 45 characters.",
                             name));
         }
         return Optional.empty();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -54,7 +54,7 @@ import java.util.regex.Pattern;
 /** Default validator implementation for {@link FlinkDeployment}. */
 public class DefaultValidator implements FlinkResourceValidator {
     private static final Pattern DEPLOYMENT_NAME_PATTERN =
-            Pattern.compile("[a-z]([-a-z\\d]*[a-z\\d])?");
+            Pattern.compile("[a-z]([-a-z\\d]{0,43}[a-z\\d])?");
     private static final String[] FORBIDDEN_CONF_KEYS =
             new String[] {
                 KubernetesConfigOptions.NAMESPACE.key(), KubernetesConfigOptions.CLUSTER_ID.key()
@@ -109,7 +109,7 @@ public class DefaultValidator implements FlinkResourceValidator {
         if (!matcher.matches()) {
             return Optional.of(
                     String.format(
-                            "The FlinkDeployment meta.name: %s is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'",
+                            "The FlinkDeployment meta.name: %s is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'), and the length must be no more than 45 characters.",
                             name));
         }
         return Optional.empty();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -105,16 +105,12 @@ public class DefaultValidator implements FlinkResourceValidator {
     }
 
     private Optional<String> validateDeploymentName(String name) {
-        if (name == null) {
-            return Optional.of("FlinkDeployment name must be define.");
-        } else {
-            Matcher matcher = DEPLOYMENT_NAME_PATTERN.matcher(name);
-            if (!matcher.matches()) {
-                return Optional.of(
-                        String.format(
-                                "The FlinkDeployment meta.name: %s is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'",
-                                name));
-            }
+        Matcher matcher = DEPLOYMENT_NAME_PATTERN.matcher(name);
+        if (!matcher.matches()) {
+            return Optional.of(
+                    String.format(
+                            "The FlinkDeployment meta.name: %s is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'",
+                            name));
         }
         return Optional.empty();
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -72,7 +72,7 @@ public class DefaultValidatorTest {
         testSuccess(dep -> dep.getMetadata().setName("session-cluster"));
         testError(
                 dep -> dep.getMetadata().setName("session-cluster-1.13"),
-                "The FlinkDeployment meta.name: session-cluster-1.13 is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'");
+                "The FlinkDeployment meta.name: session-cluster-1.13 is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'), and the length must be no more than 45 characters.");
 
         // Test job validation
         testError(dep -> dep.getSpec().getJob().setJarURI(null), "Jar URI must be defined");

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -68,6 +68,13 @@ public class DefaultValidatorTest {
     public void testValidationWithoutDefaultConfig() {
         testSuccess(dep -> {});
 
+        // Test meta.name
+        testSuccess(dep -> dep.getMetadata().setName("session-cluster"));
+        testError(dep -> dep.getMetadata().setName(null), "FlinkDeployment name must be define.");
+        testError(
+                dep -> dep.getMetadata().setName("session-cluster-1.13"),
+                "The FlinkDeployment meta.name: session-cluster-1.13 is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'");
+
         // Test job validation
         testError(dep -> dep.getSpec().getJob().setJarURI(null), "Jar URI must be defined");
         testError(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -72,7 +72,7 @@ public class DefaultValidatorTest {
         testSuccess(dep -> dep.getMetadata().setName("session-cluster"));
         testError(
                 dep -> dep.getMetadata().setName("session-cluster-1.13"),
-                "The FlinkDeployment meta.name: session-cluster-1.13 is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'), and the length must be no more than 45 characters.");
+                "The FlinkDeployment name: session-cluster-1.13 is invalid, must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123'), and the length must be no more than 45 characters.");
 
         // Test job validation
         testError(dep -> dep.getSpec().getJob().setJarURI(null), "Jar URI must be defined");

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -70,10 +70,9 @@ public class DefaultValidatorTest {
 
         // Test meta.name
         testSuccess(dep -> dep.getMetadata().setName("session-cluster"));
-        testError(dep -> dep.getMetadata().setName(null), "FlinkDeployment name must be define.");
         testError(
                 dep -> dep.getMetadata().setName("session-cluster-1.13"),
-                "The FlinkDeployment meta.name: session-cluster-1.13 is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'");
+                "The FlinkDeployment meta.name: session-cluster-1.13 is a invalid value, and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'");
 
         // Test job validation
         testError(dep -> dep.getSpec().getJob().setJarURI(null), "Jar URI must be defined");

--- a/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
+++ b/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
@@ -37,6 +37,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.DefaultHttpRes
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import io.fabric8.kubernetes.api.model.GroupVersionKind;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
 import org.junit.jupiter.api.Assertions;
@@ -99,6 +100,9 @@ public class AdmissionHandlerTest {
     public void testHandleValidateRequestWithAdmissionReview() throws IOException {
         final EmbeddedChannel embeddedChannel = new EmbeddedChannel(admissionHandler);
         final FlinkDeployment flinkDeployment = new FlinkDeployment();
+        ObjectMeta objectMeta = new ObjectMeta();
+        objectMeta.setName("basic-session-cluster");
+        flinkDeployment.setMetadata(objectMeta);
         flinkDeployment.setSpec(new FlinkDeploymentSpec());
         final AdmissionRequest admissionRequest = new AdmissionRequest();
         admissionRequest.setOperation(CREATE.name());


### PR DESCRIPTION
The meta.name of FlinkDeployment CR must be match the regex:
` '[a-z]([-a-z0-9]*[a-z0-9])?'`

By RRC-1035, a DNS-1035 label must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?').

The rest service name of Flink Cluster uses the meta.name of FlinkDeployment CR, So the value of meta.name must follow the convention of DNS-1035 label.

To avoid operator repeatedly creating and destroying flink clusters due to invalid service name, So I suggest add validation for the meta.name of FlinkDeployment CR.