### PR TITLE
[FLINK-27820] Handle deployment errors on observe

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -122,7 +122,6 @@ public class FlinkOperator {
         var controller =
                 new FlinkDeploymentController(
                         configManager,
-                        client,
                         validators,
                         reconcilerFactory,
                         observerFactory,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -25,6 +25,7 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 
 import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
 import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
@@ -144,7 +145,9 @@ public class FlinkConfigManager {
     }
 
     public Configuration getDeployConfig(ObjectMeta objectMeta, FlinkDeploymentSpec spec) {
-        return getConfig(objectMeta, spec);
+        var conf = getConfig(objectMeta, spec);
+        FlinkUtils.setGenerationAnnotation(conf, objectMeta.getGeneration());
+        return conf;
     }
 
     public Configuration getObserveConfig(FlinkDeployment deployment) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -18,7 +18,6 @@
 package org.apache.flink.kubernetes.operator.controller;
 
 import org.apache.flink.api.common.JobStatus;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
@@ -53,7 +52,6 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 /** Controller that runs the main reconcile loop for Flink deployments. */
 @ControllerConfiguration()
@@ -73,8 +71,6 @@ public class FlinkDeploymentController
     private final MetricManager<FlinkDeployment> metricManager;
     private final StatusRecorder<FlinkDeploymentStatus> statusRecorder;
     private final EventRecorder eventRecorder;
-    private final ConcurrentHashMap<Tuple2<String, String>, FlinkDeploymentStatus> statusCache =
-            new ConcurrentHashMap<>();
 
     public FlinkDeploymentController(
             FlinkConfigManager configManager,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -34,7 +34,6 @@ import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Cleaner;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
@@ -63,7 +62,6 @@ public class FlinkDeploymentController
     private static final Logger LOG = LoggerFactory.getLogger(FlinkDeploymentController.class);
 
     private final FlinkConfigManager configManager;
-    private final KubernetesClient kubernetesClient;
 
     private final Set<FlinkResourceValidator> validators;
     private final ReconcilerFactory reconcilerFactory;
@@ -74,7 +72,6 @@ public class FlinkDeploymentController
 
     public FlinkDeploymentController(
             FlinkConfigManager configManager,
-            KubernetesClient kubernetesClient,
             Set<FlinkResourceValidator> validators,
             ReconcilerFactory reconcilerFactory,
             ObserverFactory observerFactory,
@@ -82,7 +79,6 @@ public class FlinkDeploymentController
             StatusRecorder<FlinkDeploymentStatus> statusRecorder,
             EventRecorder eventRecorder) {
         this.configManager = configManager;
-        this.kubernetesClient = kubernetesClient;
         this.validators = validators;
         this.reconcilerFactory = reconcilerFactory;
         this.observerFactory = observerFactory;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/FlinkDeployment.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/FlinkDeployment.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.crd;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 
@@ -39,8 +40,9 @@ public class FlinkDeployment
         extends AbstractFlinkResource<FlinkDeploymentSpec, FlinkDeploymentStatus>
         implements Namespaced {
 
+    @VisibleForTesting
     @Override
-    protected FlinkDeploymentStatus initStatus() {
+    public FlinkDeploymentStatus initStatus() {
         return new FlinkDeploymentStatus();
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -280,14 +280,8 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
                                     .map(Long::valueOf)
                                     .orElse(-1L);
 
-                    // For first deployments we get the generation from the metadata directly
-                    // otherwise take it simply from the lastReconciledSpec
                     Long upgradeTargetGeneration =
-                            Optional.ofNullable(
-                                            status.getReconciliationStatus()
-                                                    .deserializeLastReconciledSpecWithMeta())
-                                    .map(t -> t.f1.get("metadata").get("generation").asLong(-1L))
-                                    .orElse(flinkDep.getMetadata().getGeneration());
+                            ReconciliationUtils.getUpgradeTargetGeneration(flinkDep);
 
                     if (deployedGeneration.equals(upgradeTargetGeneration)) {
                         logger.info(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -46,6 +46,8 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -57,6 +59,8 @@ public class FlinkUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlinkUtils.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public static final String CR_GENERATION_LABEL = "flinkdeployment.flink.apache.org/generation";
 
     public static Pod mergePodTemplates(Pod toPod, Pod fromPod) {
         if (fromPod == null) {
@@ -285,5 +289,17 @@ public class FlinkUtils {
         int parallelism = conf.get(CoreOptions.DEFAULT_PARALLELISM);
         int taskSlots = conf.get(TaskManagerOptions.NUM_TASK_SLOTS);
         return (parallelism + taskSlots - 1) / taskSlots;
+    }
+
+    public static void setGenerationAnnotation(Configuration conf, Long generation) {
+        if (generation == null) {
+            return;
+        }
+        var labels =
+                new HashMap<>(
+                        conf.getOptional(KubernetesConfigOptions.JOB_MANAGER_ANNOTATIONS)
+                                .orElse(Collections.emptyMap()));
+        labels.put(CR_GENERATION_LABEL, generation.toString());
+        conf.set(KubernetesConfigOptions.JOB_MANAGER_ANNOTATIONS, labels);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -441,7 +441,6 @@ public class TestUtils {
         var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
         return new FlinkDeploymentController(
                 configManager,
-                kubernetesClient,
                 ValidatorUtils.discoverValidators(configManager),
                 new ReconcilerFactory(kubernetesClient, flinkService, configManager, eventRecorder),
                 new ObserverFactory(flinkService, configManager, statusRecorder, eventRecorder),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -49,6 +49,7 @@ import org.apache.flink.metrics.testutils.MetricListener;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.ContainerStatusBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -68,6 +69,8 @@ import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ManagedDepen
 import okhttp3.Headers;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Assertions;
+
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
@@ -131,6 +134,7 @@ public class TestUtils {
                                 .upgradeMode(UpgradeMode.STATELESS)
                                 .state(JobState.RUNNING)
                                 .build());
+        deployment.setStatus(deployment.initStatus());
         return deployment;
     }
 
@@ -211,35 +215,6 @@ public class TestUtils {
         return new PodListBuilder().withItems(pod).build();
     }
 
-    public static Context createEmptyContext() {
-        return new Context() {
-            @Override
-            public Optional<RetryInfo> getRetryInfo() {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional getSecondaryResource(Class aClass, String s) {
-                return Optional.empty();
-            }
-
-            @Override
-            public Set getSecondaryResources(Class expectedType) {
-                return null;
-            }
-
-            @Override
-            public ControllerConfiguration getControllerConfiguration() {
-                return null;
-            }
-
-            @Override
-            public ManagedDependentResourceContext managedDependentResourceContext() {
-                return null;
-            }
-        };
-    }
-
     public static Deployment createDeployment(boolean ready) {
         DeploymentStatus status = new DeploymentStatus();
         status.setAvailableReplicas(ready ? 1 : 0);
@@ -247,12 +222,13 @@ public class TestUtils {
         DeploymentSpec spec = new DeploymentSpec();
         spec.setReplicas(1);
         Deployment deployment = new Deployment();
+        deployment.setMetadata(new ObjectMeta());
         deployment.setSpec(spec);
         deployment.setStatus(status);
         return deployment;
     }
 
-    public static Context createContextWithReadyJobManagerDeployment() {
+    public static Context createContextWithDeployment(@Nullable Deployment deployment) {
         return new Context() {
             @Override
             public Optional<RetryInfo> getRetryInfo() {
@@ -261,7 +237,7 @@ public class TestUtils {
 
             @Override
             public Optional getSecondaryResource(Class expectedType, String eventSourceName) {
-                return Optional.of(createDeployment(true));
+                return Optional.ofNullable(deployment);
             }
 
             @Override
@@ -281,33 +257,16 @@ public class TestUtils {
         };
     }
 
+    public static Context createEmptyContext() {
+        return createContextWithDeployment(null);
+    }
+
+    public static Context createContextWithReadyJobManagerDeployment() {
+        return createContextWithDeployment(createDeployment(true));
+    }
+
     public static Context createContextWithInProgressDeployment() {
-        return new Context() {
-            @Override
-            public Optional<RetryInfo> getRetryInfo() {
-                return Optional.empty();
-            }
-
-            @Override
-            public Optional getSecondaryResource(Class expectedType, String eventSourceName) {
-                return Optional.of(createDeployment(false));
-            }
-
-            @Override
-            public Set getSecondaryResources(Class expectedType) {
-                return null;
-            }
-
-            @Override
-            public ControllerConfiguration getControllerConfiguration() {
-                return null;
-            }
-
-            @Override
-            public ManagedDependentResourceContext managedDependentResourceContext() {
-                return null;
-            }
-        };
+        return createContextWithDeployment(createDeployment(false));
     }
 
     public static Context createContextWithReadyFlinkDeployment() {
@@ -329,7 +288,7 @@ public class TestUtils {
                 session.getSpec().getFlinkConfiguration().putAll(flinkDepConfig);
                 session.getStatus()
                         .getReconciliationStatus()
-                        .serializeAndSetLastReconciledSpec(session.getSpec());
+                        .serializeAndSetLastReconciledSpec(session.getSpec(), session);
                 return Optional.of(session);
             }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
@@ -138,7 +138,7 @@ public class SavepointObserverTest {
         deployment
                 .getStatus()
                 .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec());
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
 
         var jobStatus = deployment.getStatus().getJobStatus();
         jobStatus.setState("RUNNING");

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -22,7 +22,9 @@ import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -42,10 +44,8 @@ public class SessionObserverTest {
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
         SessionObserver observer =
                 new SessionObserver(flinkService, configManager, new EventRecorder(null, null));
-        deployment
-                .getStatus()
-                .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec());
+        ReconciliationUtils.updateForSpecReconciliationSuccess(
+                deployment, JobState.RUNNING, new Configuration());
 
         observer.observe(deployment, readyContext);
         assertNull(deployment.getStatus().getReconciliationStatus().getLastStableSpec());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -20,10 +20,10 @@ package org.apache.flink.kubernetes.operator.utils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
-import org.apache.flink.kubernetes.operator.crd.CrdConstants;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -46,11 +46,11 @@ public class ReconciliationUtilsTest {
     public void testRescheduleUpgradeImmediately() {
         FlinkDeployment app = TestUtils.buildApplicationCluster();
         app.getSpec().getJob().setState(JobState.RUNNING);
+        app.getStatus().getReconciliationStatus().setState(ReconciliationState.DEPLOYED);
+        ReconciliationUtils.updateForSpecReconciliationSuccess(
+                app, JobState.RUNNING, new Configuration());
         FlinkDeployment previous = ReconciliationUtils.clone(app);
         FlinkDeployment current = ReconciliationUtils.clone(app);
-        current.getStatus()
-                .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(ReconciliationUtils.clone(current.getSpec()));
         ReconciliationUtils.updateForSpecReconciliationSuccess(
                 current, JobState.SUSPENDED, new Configuration());
 
@@ -72,12 +72,17 @@ public class ReconciliationUtilsTest {
     @Test
     public void testSpecSerializationWithVersion() throws JsonProcessingException {
         FlinkDeployment app = TestUtils.buildApplicationCluster();
-        String serialized = ReconciliationUtils.writeSpecWithCurrentVersion(app.getSpec());
+        app.getMetadata().setGeneration(12L);
+        String serialized = ReconciliationUtils.writeSpecWithMeta(app.getSpec(), app);
         ObjectNode node = (ObjectNode) new ObjectMapper().readTree(serialized);
-        assertEquals(CrdConstants.API_VERSION, node.get("apiVersion").asText());
+
+        ObjectNode internalMeta =
+                (ObjectNode) node.get(ReconciliationUtils.INTERNAL_METADATA_JSON_KEY);
+        assertEquals("flink.apache.org/v1beta1", internalMeta.get("apiVersion").asText());
+        assertEquals(12L, internalMeta.get("metadata").get("generation").asLong());
         assertEquals(
                 app.getSpec(),
-                ReconciliationUtils.deserializedSpecWithVersion(
-                        serialized, FlinkDeploymentSpec.class));
+                ReconciliationUtils.deserializeSpecWithMeta(serialized, FlinkDeploymentSpec.class)
+                        .f0);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /** Test for {@link org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils}. */
 public class ReconciliationUtilsTest {
@@ -84,5 +85,17 @@ public class ReconciliationUtilsTest {
                 app.getSpec(),
                 ReconciliationUtils.deserializeSpecWithMeta(serialized, FlinkDeploymentSpec.class)
                         .f0);
+
+        // test backward compatibility
+        String oldSerialized =
+                "{\"job\":{\"jarURI\":\"local:///opt/flink/examples/streaming/StateMachineExample.jar\",\"parallelism\":2,\"entryClass\":null,\"args\":[],\"state\":\"running\",\"savepointTriggerNonce\":null,\"initialSavepointPath\":null,\"upgradeMode\":\"stateless\",\"allowNonRestoredState\":null},\"restartNonce\":null,\"flinkConfiguration\":{\"taskmanager.numberOfTaskSlots\":\"2\"},\"image\":\"flink:1.15\",\"imagePullPolicy\":null,\"serviceAccount\":\"flink\",\"flinkVersion\":\"v1_15\",\"ingress\":null,\"podTemplate\":null,\"jobManager\":{\"resource\":{\"cpu\":1.0,\"memory\":\"2048m\"},\"replicas\":1,\"podTemplate\":null},\"taskManager\":{\"resource\":{\"cpu\":1.0,\"memory\":\"2048m\"},\"podTemplate\":null},\"logConfiguration\":null,\"apiVersion\":\"v1beta1\"}";
+
+        var migrated =
+                ReconciliationUtils.deserializeSpecWithMeta(
+                        oldSerialized, FlinkDeploymentSpec.class);
+        assertEquals(
+                "local:///opt/flink/examples/streaming/StateMachineExample.jar",
+                migrated.f0.getJob().getJarURI());
+        assertNull(migrated.f1);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SavepointUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SavepointUtilsTest.java
@@ -53,7 +53,7 @@ public class SavepointUtilsTest {
         deployment
                 .getStatus()
                 .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec());
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
 
         assertEquals(
                 Optional.empty(),
@@ -67,7 +67,7 @@ public class SavepointUtilsTest {
         deployment
                 .getStatus()
                 .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec());
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
 
         assertEquals(
                 Optional.of(SavepointTriggerType.PERIODIC),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
@@ -45,7 +45,7 @@ public class StatusRecorderTest {
         helper.patchAndCacheStatus(deployment);
         assertTrue(mockServer.getLastRequest() != lastRequest);
         lastRequest = mockServer.getLastRequest();
-        deployment.getStatus().getReconciliationStatus().setState(ReconciliationState.UPGRADING);
+        deployment.getStatus().getReconciliationStatus().setState(ReconciliationState.ROLLING_BACK);
         helper.patchAndCacheStatus(deployment);
 
         // We intentionally compare references

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -257,7 +257,7 @@ public class DefaultValidatorTest {
 
                     dep.getStatus()
                             .getReconciliationStatus()
-                            .serializeAndSetLastReconciledSpec(spec);
+                            .serializeAndSetLastReconciledSpec(spec, dep);
 
                     dep.getSpec()
                             .getFlinkConfiguration()
@@ -278,7 +278,7 @@ public class DefaultValidatorTest {
                     dep.getStatus()
                             .getReconciliationStatus()
                             .serializeAndSetLastReconciledSpec(
-                                    ReconciliationUtils.clone(dep.getSpec()));
+                                    ReconciliationUtils.clone(dep.getSpec()), dep);
                     dep.getSpec().setJob(null);
                 },
                 "Cannot switch from job to session cluster");
@@ -294,7 +294,7 @@ public class DefaultValidatorTest {
                     spec.setJob(null);
                     dep.getStatus()
                             .getReconciliationStatus()
-                            .serializeAndSetLastReconciledSpec(spec);
+                            .serializeAndSetLastReconciledSpec(spec, dep);
                 },
                 "Cannot switch from session to job cluster");
 
@@ -316,7 +316,7 @@ public class DefaultValidatorTest {
 
                     dep.getStatus()
                             .getReconciliationStatus()
-                            .serializeAndSetLastReconciledSpec(spec);
+                            .serializeAndSetLastReconciledSpec(spec, dep);
                     dep.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
                 },
                 String.format(


### PR DESCRIPTION
This change allows the operator to recover from errors during and directly after Flink cluster submissions. One common cause for this would be a temporary unavailability of the kubernetes API which would prevent us from updating the status after deployment.

Before this change this would lead to a fatal error where the operator would try to submit the flink cluster again and again (even though it is already deployed)

To solve this case the following changes were introduced:

- LastReconciledSpec now contains the CR generation for the deployed spec. During upgrades this is recorded during the first SUSPEND step of the upgrade operation
- The CR generation is also added as an annotation to the Flink Cluster Deployment object
- The default ReonciliationStatus for new deployments is now UPGRADING (previously it was DEPLOYED)
- In the observer, if the reconciliation status is UPGRADING (new or upgrading deployments) we check whether the Deployment is there and if so we compare the generation annotation. If it matches to the target generation, we know it was a succesful upgrade so we upgrade the status