### PR TITLE
[FLINK-28166] Configurable Automatic Retries on Error

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -48,7 +48,7 @@
             <td><h5>kubernetes.operator.dynamic.namespaces.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Enables dynamic change of watched/monitored namespaces. Defaults to false</td>
+            <td>Enables dynamic change of watched/monitored namespaces.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.upgrade.ignore-pending-savepoint</h5></td>
@@ -111,6 +111,24 @@
             <td>The interval for the controller to reschedule the reconcile process.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.retry.initial.interval</h5></td>
+            <td style="word-wrap: break-word;">5 s</td>
+            <td>Duration</td>
+            <td>Initial interval of automatic reconcile retries on recoverable errors.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.retry.interval.multiplier</h5></td>
+            <td style="word-wrap: break-word;">2.0</td>
+            <td>Double</td>
+            <td>Interval multiplier of automatic reconcile retries on recoverable errors.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.retry.max.attempts</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>Max attempts of automatic reconcile retries on recoverable errors.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.age</h5></td>
             <td style="word-wrap: break-word;">86400000 ms</td>
             <td>Duration</td>
@@ -156,7 +174,7 @@
             <td><h5>kubernetes.operator.watched.namespaces</h5></td>
             <td style="word-wrap: break-word;">"JOSDK_ALL_NAMESPACES"</td>
             <td>String</td>
-            <td>Comma separated list of namespaces the operator monitors for custom resources. Defaults to JOSDK_ALL_NAMESPACES</td>
+            <td>Comma separated list of namespaces the operator monitors for custom resources.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -48,6 +48,7 @@ import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.RegisteredController;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceOverrider;
 import io.javaoperatorsdk.operator.api.config.ControllerConfigurationOverrider;
+import io.javaoperatorsdk.operator.processing.retry.GenericRetry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -160,6 +161,9 @@ public class FlinkOperator {
         overrider.settingNamespace(fakeNs);
         overrider.addingNamespaces(watchedNamespaces);
         overrider.removingNamespaces(fakeNs);
+        overrider.withRetry(
+                GenericRetry.fromConfiguration(
+                        configManager.getOperatorConfiguration().getRetryConfiguration()));
     }
 
     public void run() {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -194,13 +194,32 @@ public class KubernetesOperatorConfigOptions {
                     .stringType()
                     .defaultValue(Constants.WATCH_ALL_NAMESPACES)
                     .withDescription(
-                            "Comma separated list of namespaces the operator monitors for custom resources. Defaults to "
-                                    + Constants.WATCH_ALL_NAMESPACES);
+                            "Comma separated list of namespaces the operator monitors for custom resources.");
 
     public static final ConfigOption<Boolean> OPERATOR_DYNAMIC_NAMESPACES_ENABLED =
             ConfigOptions.key("kubernetes.operator.dynamic.namespaces.enabled")
                     .booleanType()
                     .defaultValue(false)
+                    .withDescription("Enables dynamic change of watched/monitored namespaces.");
+
+    public static final ConfigOption<Duration> OPERATOR_RETRY_INITIAL_INTERVAL =
+            ConfigOptions.key("kubernetes.operator.retry.initial.interval")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(5))
                     .withDescription(
-                            "Enables dynamic change of watched/monitored namespaces. Defaults to false");
+                            "Initial interval of automatic reconcile retries on recoverable errors.");
+
+    public static final ConfigOption<Double> OPERATOR_RETRY_INTERVAL_MULTIPLIER =
+            ConfigOptions.key("kubernetes.operator.retry.interval.multiplier")
+                    .doubleType()
+                    .defaultValue(2.0)
+                    .withDescription(
+                            "Interval multiplier of automatic reconcile retries on recoverable errors.");
+
+    public static final ConfigOption<Integer> OPERATOR_RETRY_MAX_ATTEMPTS =
+            ConfigOptions.key("kubernetes.operator.retry.max.attempts")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "Max attempts of automatic reconcile retries on recoverable errors.");
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorRetryConfigurationTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorRetryConfigurationTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.config;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+/** {@link FlinkOperatorConfiguration.FlinkOperatorRetryConfiguration} tests. */
+public class FlinkOperatorRetryConfigurationTest {
+
+    @Test
+    public void testRetryConfiguration() {
+
+        // default values
+        FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
+        Assertions.assertEquals(
+                KubernetesOperatorConfigOptions.OPERATOR_RETRY_INITIAL_INTERVAL
+                        .defaultValue()
+                        .toMillis(),
+                configManager
+                        .getOperatorConfiguration()
+                        .getRetryConfiguration()
+                        .getInitialInterval());
+        Assertions.assertEquals(
+                KubernetesOperatorConfigOptions.OPERATOR_RETRY_INTERVAL_MULTIPLIER.defaultValue(),
+                configManager
+                        .getOperatorConfiguration()
+                        .getRetryConfiguration()
+                        .getIntervalMultiplier());
+        Assertions.assertEquals(
+                KubernetesOperatorConfigOptions.OPERATOR_RETRY_MAX_ATTEMPTS.defaultValue(),
+                configManager.getOperatorConfiguration().getRetryConfiguration().getMaxAttempts());
+
+        // overrides
+        var overrides =
+                Configuration.fromMap(
+                        Map.of(
+                                KubernetesOperatorConfigOptions.OPERATOR_RETRY_INITIAL_INTERVAL
+                                        .key(),
+                                "1 s",
+                                KubernetesOperatorConfigOptions.OPERATOR_RETRY_INTERVAL_MULTIPLIER
+                                        .key(),
+                                "2.0",
+                                KubernetesOperatorConfigOptions.OPERATOR_RETRY_MAX_ATTEMPTS.key(),
+                                "3"));
+        configManager.updateDefaultConfig(overrides);
+        Assertions.assertEquals(
+                1000L,
+                configManager
+                        .getOperatorConfiguration()
+                        .getRetryConfiguration()
+                        .getInitialInterval());
+        Assertions.assertEquals(
+                2.0,
+                configManager
+                        .getOperatorConfiguration()
+                        .getRetryConfiguration()
+                        .getIntervalMultiplier());
+        Assertions.assertEquals(
+                3,
+                configManager.getOperatorConfiguration().getRetryConfiguration().getMaxAttempts());
+        Assertions.assertEquals(
+                8000L,
+                configManager.getOperatorConfiguration().getRetryConfiguration().getMaxInterval());
+    }
+}

--- a/helm/flink-kubernetes-operator/conf/flink-conf.yaml
+++ b/helm/flink-kubernetes-operator/conf/flink-conf.yaml
@@ -39,6 +39,11 @@ parallelism.default: 2
 # kubernetes.operator.deployment.readiness.timeout: 1min
 # kubernetes.operator.user.artifacts.base.dir: /opt/flink/artifacts
 # kubernetes.operator.job.upgrade.ignore-pending-savepoint: false
+# kubernetes.operator.watched.namespaces: ns1,ns2
+# kubernetes.operator.dynamic.namespaces.enabled: false
+# kubernetes.operator.retry.initial.interval: 5 s
+# kubernetes.operator.retry.interval.multiplier: 2
+# kubernetes.operator.retry.max.attempts: 10
 
 # kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory
 # kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE


### PR DESCRIPTION
JOSDK defaults to the following retry configuration (exponential backoff)
```
GenericRetry.defaultLimitedExponentialRetry()
    .setInitialInterval(2000)
    .setIntervalMultiplier(1.5D)
    .setMaxAttempts(5);
```
This PR makes it configurable via the following operator config options:
```
kubernetes.operator.retry.initial.interval: 5 s
kubernetes.operator.retry.interval.multiplier: 2
kubernetes.operator.retry.max.attempts: 10
```