### PR TITLE
[FLINK-27912] Improve operator config names

### DIFF
--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -201,7 +201,7 @@ It is therefore very likely that savepoints live beyond the max age configuratio
 ## Recovery of missing job deployments
 
 When Kubernetes HA is enabled, the operator can recover the Flink cluster deployments in cases when it was accidentally deleted
-by the user or some external process. Deployment recovery can be turned off in the configuration by setting `kubernetes.operator.reconciler.jm-deployment-recovery.enabled` to `false`, however it is recommended to keep this setting on the default `true` value.
+by the user or some external process. Deployment recovery can be turned off in the configuration by setting `kubernetes.operator.jm-deployment-recovery.enabled` to `false`, however it is recommended to keep this setting on the default `true` value.
 
 This is not something that would usually happen during normal operation and can also indicate a deeper problem, 
 therefore an Error event is also triggered by the system when it detects a missing deployment.

--- a/docs/content/docs/operations/configuration.md
+++ b/docs/content/docs/operations/configuration.md
@@ -44,7 +44,7 @@ defaultConfiguration:
     kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory
     kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE
 
-    kubernetes.operator.reconciler.reschedule.interval: 15 s
+    kubernetes.operator.reconcile.interval: 15 s
     kubernetes.operator.observer.progress-check.interval: 5 s
 ```
 
@@ -60,12 +60,12 @@ Verify whether dynamic operator configuration updates is enabled via the `deploy
 2022-05-28 13:08:29,222 o.a.f.k.o.c.FlinkConfigManager [INFO ] Enabled dynamic config updates, checking config changes every PT5M
 ```
 
-To change config values dynamically the ConfigMap can be directly edited via `kubectl patch` or `kubectl edit` command. For example to change the reschedule interval you can override `kubernetes.operator.reconciler.reschedule.interval`.
+To change config values dynamically the ConfigMap can be directly edited via `kubectl patch` or `kubectl edit` command. For example to change the reschedule interval you can override `kubernetes.operator.reconcile.interval`.
 
-Verify whether the config value of `kubernetes.operator.reconciler.reschedule.interval` is updated to 30 seconds via the `deploy/flink-kubernetes-operator` log has:
+Verify whether the config value of `kubernetes.operator.reconcile.interval` is updated to 30 seconds via the `deploy/flink-kubernetes-operator` log has:
 
 ```text
-2022-05-28 13:08:30,115 o.a.f.k.o.c.FlinkConfigManager [INFO ] Updating default configuration to {kubernetes.operator.reconciler.reschedule.interval=PT30S}
+2022-05-28 13:08:30,115 o.a.f.k.o.c.FlinkConfigManager [INFO ] Updating default configuration to {kubernetes.operator.reconcile.interval=PT30S}
 ```
 
 ## Operator Configuration Reference

--- a/docs/content/docs/operations/helm.md
+++ b/docs/content/docs/operations/helm.md
@@ -82,7 +82,7 @@ The configurable parameters of the Helm chart and which default values as detail
 | webhook.keystore | The ConfigMap of webhook key store. | useDefaultPassword: true |
 | defaultConfiguration.create | Whether to enable default configuration to create for flink-kubernetes-operator. | true |
 | defaultConfiguration.append | Whether to append configuration files with configs.  | true |
-| defaultConfiguration.flink-conf.yaml | The default configuration of flink-conf.yaml. | kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory<br/>kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE<br/>kubernetes.operator.reconciler.reschedule.interval: 15 s<br/>kubernetes.operator.observer.progress-check.interval: 5 s |
+| defaultConfiguration.flink-conf.yaml | The default configuration of flink-conf.yaml. | kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory<br/>kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE<br/>kubernetes.operator.reconcile.interval: 15 s<br/>kubernetes.operator.observer.progress-check.interval: 5 s |
 | defaultConfiguration.log4j-operator.properties | The default configuration of log4j-operator.properties. | |
 | defaultConfiguration.log4j-console.properties | The default configuration of log4j-console.properties. | |
 | defaultConfiguration.metrics.port | The metrics port on the container for default configuration. | |

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -51,16 +51,28 @@
             <td>Enables dynamic change of watched/monitored namespaces. Defaults to false</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.flink.client.cancel.timeout</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>The timeout for the reconciler to wait for flink to cancel job.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.flink.client.timeout</h5></td>
+            <td style="word-wrap: break-word;">10 s</td>
+            <td>Duration</td>
+            <td>The timeout for the observer to wait the flink rest client to return.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.jm-deployment-recovery.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable recovery of missing/deleted jobmanager deployments.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.upgrade.ignore-pending-savepoint</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Whether to ignore pending savepoint during job upgrade.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.observer.flink.client.timeout</h5></td>
-            <td style="word-wrap: break-word;">10 s</td>
-            <td>Duration</td>
-            <td>The timeout for the observer to wait the flink rest client to return.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.observer.progress-check.interval</h5></td>
@@ -81,34 +93,22 @@
             <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.reconciler.flink.cancel.job.timeout</h5></td>
+            <td><h5>kubernetes.operator.reconcile.interval</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
-            <td>The timeout for the reconciler to wait for flink to cancel job.</td>
+            <td>The interval for the controller to reschedule the reconcile process.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.reconciler.flink.cluster.shutdown.timeout</h5></td>
-            <td style="word-wrap: break-word;">1 min</td>
-            <td>Duration</td>
-            <td>The timeout for the reconciler to wait for flink to shutdown cluster.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.reconciler.jm-deployment-recovery.enabled</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Whether to enable recovery of missing/deleted jobmanager deployments.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.reconciler.max.parallelism</h5></td>
+            <td><h5>kubernetes.operator.reconcile.parallelism</h5></td>
             <td style="word-wrap: break-word;">5</td>
             <td>Integer</td>
             <td>The maximum number of threads running the reconciliation loop. Use -1 for infinite.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.reconciler.reschedule.interval</h5></td>
+            <td><h5>kubernetes.operator.resource.cleanup.timeout</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
-            <td>The interval for the controller to reschedule the reconcile process.</td>
+            <td>The timeout for the resource clean up to wait for flink to shutdown cluster.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.age</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -50,12 +50,11 @@ public class FlinkOperatorConfiguration {
 
     public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
         Duration reconcileInterval =
-                operatorConfig.get(
-                        KubernetesOperatorConfigOptions.OPERATOR_RECONCILER_RESCHEDULE_INTERVAL);
+                operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL);
 
         int reconcilerMaxParallelism =
                 operatorConfig.getInteger(
-                        KubernetesOperatorConfigOptions.OPERATOR_RECONCILER_MAX_PARALLELISM);
+                        KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_PARALLELISM);
 
         Duration restApiReadyDelay =
                 operatorConfig.get(
@@ -66,18 +65,15 @@ public class FlinkOperatorConfiguration {
                         KubernetesOperatorConfigOptions.OPERATOR_OBSERVER_PROGRESS_CHECK_INTERVAL);
 
         Duration flinkClientTimeout =
-                operatorConfig.get(
-                        KubernetesOperatorConfigOptions.OPERATOR_OBSERVER_FLINK_CLIENT_TIMEOUT);
+                operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_FLINK_CLIENT_TIMEOUT);
 
         Duration flinkCancelJobTimeout =
                 operatorConfig.get(
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_RECONCILER_FLINK_CANCEL_JOB_TIMEOUT);
+                        KubernetesOperatorConfigOptions.OPERATOR_FLINK_CLIENT_CANCEL_TIMEOUT);
 
         Duration flinkShutdownClusterTimeout =
                 operatorConfig.get(
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_RECONCILER_FLINK_CLUSTER_SHUTDOWN_TIMEOUT);
+                        KubernetesOperatorConfigOptions.OPERATOR_RESOURCE_CLEANUP_TIMEOUT);
 
         String artifactsBaseDir =
                 operatorConfig.get(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -30,10 +30,11 @@ import java.util.Map;
 /** This class holds configuration constants used by flink operator. */
 public class KubernetesOperatorConfigOptions {
 
-    public static final ConfigOption<Duration> OPERATOR_RECONCILER_RESCHEDULE_INTERVAL =
-            ConfigOptions.key("kubernetes.operator.reconciler.reschedule.interval")
+    public static final ConfigOption<Duration> OPERATOR_RECONCILE_INTERVAL =
+            ConfigOptions.key("kubernetes.operator.reconcile.interval")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(60))
+                    .withDeprecatedKeys("kubernetes.operator.reconciler.reschedule.interval")
                     .withDescription(
                             "The interval for the controller to reschedule the reconcile process.");
 
@@ -44,10 +45,11 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Final delay before deployment is marked ready after port becomes accessible.");
 
-    public static final ConfigOption<Integer> OPERATOR_RECONCILER_MAX_PARALLELISM =
-            ConfigOptions.key("kubernetes.operator.reconciler.max.parallelism")
+    public static final ConfigOption<Integer> OPERATOR_RECONCILE_PARALLELISM =
+            ConfigOptions.key("kubernetes.operator.reconcile.parallelism")
                     .intType()
                     .defaultValue(ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER)
+                    .withDeprecatedKeys("kubernetes.operator.reconciler.max.parallelism")
                     .withDescription(
                             "The maximum number of threads running the reconciliation loop. Use -1 for infinite.");
 
@@ -67,26 +69,30 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "The interval before a savepoint trigger attempt is marked as unsuccessful.");
 
-    public static final ConfigOption<Duration> OPERATOR_OBSERVER_FLINK_CLIENT_TIMEOUT =
-            ConfigOptions.key("kubernetes.operator.observer.flink.client.timeout")
+    public static final ConfigOption<Duration> OPERATOR_FLINK_CLIENT_TIMEOUT =
+            ConfigOptions.key("kubernetes.operator.flink.client.timeout")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(10))
+                    .withDeprecatedKeys("kubernetes.operator.observer.flink.client.timeout")
                     .withDescription(
                             "The timeout for the observer to wait the flink rest client to return.");
 
-    public static final ConfigOption<Duration> OPERATOR_RECONCILER_FLINK_CANCEL_JOB_TIMEOUT =
-            ConfigOptions.key("kubernetes.operator.reconciler.flink.cancel.job.timeout")
+    public static final ConfigOption<Duration> OPERATOR_FLINK_CLIENT_CANCEL_TIMEOUT =
+            ConfigOptions.key("kubernetes.operator.flink.client.cancel.timeout")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(1))
+                    .withDeprecatedKeys("kubernetes.operator.reconciler.flink.cancel.job.timeout")
                     .withDescription(
                             "The timeout for the reconciler to wait for flink to cancel job.");
 
-    public static final ConfigOption<Duration> OPERATOR_RECONCILER_FLINK_CLUSTER_SHUTDOWN_TIMEOUT =
-            ConfigOptions.key("kubernetes.operator.reconciler.flink.cluster.shutdown.timeout")
+    public static final ConfigOption<Duration> OPERATOR_RESOURCE_CLEANUP_TIMEOUT =
+            ConfigOptions.key("kubernetes.operator.resource.cleanup.timeout")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(60))
+                    .withDeprecatedKeys(
+                            "kubernetes.operator.reconciler.flink.cluster.shutdown.timeout")
                     .withDescription(
-                            "The timeout for the reconciler to wait for flink to shutdown cluster.");
+                            "The timeout for the resource clean up to wait for flink to shutdown cluster.");
 
     public static final ConfigOption<Boolean> DEPLOYMENT_ROLLBACK_ENABLED =
             ConfigOptions.key("kubernetes.operator.deployment.rollback.enabled")
@@ -139,10 +145,12 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(1000)
                     .withDescription("Max config cache size.");
 
-    public static final ConfigOption<Boolean> OPERATOR_RECOVER_JM_DEPLOYMENT_ENABLED =
-            ConfigOptions.key("kubernetes.operator.reconciler.jm-deployment-recovery.enabled")
+    public static final ConfigOption<Boolean> OPERATOR_JM_DEPLOYMENT_RECOVERY_ENABLED =
+            ConfigOptions.key("kubernetes.operator.jm-deployment-recovery.enabled")
                     .booleanType()
                     .defaultValue(true)
+                    .withDeprecatedKeys(
+                            "kubernetes.operator.reconciler.jm-deployment-recovery.enabled")
                     .withDescription(
                             "Whether to enable recovery of missing/deleted jobmanager deployments.");
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -309,7 +309,7 @@ public class ReconciliationUtils {
 
         if (!ReconciliationUtils.jmMissingForRunningDeployment(deployment)
                 || !conf.get(
-                        KubernetesOperatorConfigOptions.OPERATOR_RECOVER_JM_DEPLOYMENT_ENABLED)) {
+                        KubernetesOperatorConfigOptions.OPERATOR_JM_DEPLOYMENT_RECOVERY_ENABLED)) {
             return false;
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
@@ -53,8 +53,7 @@ public class FlinkOperatorTest {
         parallelism.ifPresent(
                 p ->
                         operatorConfig.setInteger(
-                                KubernetesOperatorConfigOptions.OPERATOR_RECONCILER_MAX_PARALLELISM,
-                                p));
+                                KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_PARALLELISM, p));
         new FlinkOperator(operatorConfig);
         return ConfigurationServiceProvider.instance().getExecutorService();
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -98,12 +98,10 @@ public class FlinkConfigManagerTest {
         assertFalse(
                 configManager
                         .getDefaultConfig()
-                        .contains(
-                                KubernetesOperatorConfigOptions
-                                        .OPERATOR_RECONCILER_RESCHEDULE_INTERVAL));
+                        .contains(KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL));
 
         config.set(
-                KubernetesOperatorConfigOptions.OPERATOR_RECONCILER_RESCHEDULE_INTERVAL,
+                KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL,
                 Duration.ofSeconds(15));
 
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
@@ -114,8 +112,7 @@ public class FlinkConfigManagerTest {
                 deployment, JobState.RUNNING, config);
         Configuration deployConfig = configManager.getObserveConfig(deployment);
         assertFalse(
-                deployConfig.contains(
-                        KubernetesOperatorConfigOptions.OPERATOR_RECONCILER_RESCHEDULE_INTERVAL));
+                deployConfig.contains(KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL));
         assertTrue(new File(deployConfig.get(DeploymentOptionsInternal.CONF_DIR)).exists());
         assertTrue(
                 new File(deployConfig.get(KubernetesConfigOptions.KUBERNETES_POD_TEMPLATE))
@@ -157,9 +154,7 @@ public class FlinkConfigManagerTest {
                 Duration.ofSeconds(15),
                 configManager
                         .getDefaultConfig()
-                        .get(
-                                KubernetesOperatorConfigOptions
-                                        .OPERATOR_RECONCILER_RESCHEDULE_INTERVAL));
+                        .get(KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL));
         assertEquals(
                 Duration.ofSeconds(15),
                 configManager.getOperatorConfiguration().getReconcileInterval());
@@ -168,8 +163,6 @@ public class FlinkConfigManagerTest {
                 Duration.ofSeconds(15),
                 configManager
                         .getObserveConfig(deployment)
-                        .get(
-                                KubernetesOperatorConfigOptions
-                                        .OPERATOR_RECONCILER_RESCHEDULE_INTERVAL));
+                        .get(KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL));
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -420,12 +420,12 @@ public class DefaultValidatorTest {
                             .setFlinkConfiguration(
                                     Map.of(
                                             KubernetesOperatorConfigOptions
-                                                    .OPERATOR_RECONCILER_RESCHEDULE_INTERVAL
+                                                    .OPERATOR_RECONCILE_INTERVAL
                                                     .key(),
                                             "60"));
                 },
                 flinkDeployment -> {},
-                "Invalid session job flinkConfiguration key: kubernetes.operator.reconciler.reschedule.interval."
+                "Invalid session job flinkConfiguration key: kubernetes.operator.reconcile.interval."
                         + " Allowed keys are [kubernetes.operator.user.artifacts.http.header]");
     }
 

--- a/helm/flink-kubernetes-operator/conf/flink-conf.yaml
+++ b/helm/flink-kubernetes-operator/conf/flink-conf.yaml
@@ -27,14 +27,14 @@ taskmanager.memory.process.size: 1728m
 parallelism.default: 2
 
 # Flink operator related configs
-# kubernetes.operator.reconciler.reschedule.interval: 60 s
-# kubernetes.operator.reconciler.max.parallelism: 5
-# kubernetes.operator.reconciler.flink.cancel.job.timeout: 1 min
-# kubernetes.operator.reconciler.flink.cluster.shutdown.timeout: 60 s
+# kubernetes.operator.reconcile.interval: 60 s
+# kubernetes.operator.reconcile.parallelism: 5
+# kubernetes.operator.flink.client.cancel.timeout: 1 min
+# kubernetes.operator.resource.cleanup.timeout: 60 s
 # kubernetes.operator.observer.rest-ready.delay: 10 s
 # kubernetes.operator.observer.progress-check.interval: 10 s
 # kubernetes.operator.observer.savepoint.trigger.grace-period: 10 s
-# kubernetes.operator.observer.flink.client.timeout: 10 s
+# kubernetes.operator.flink.client.timeout: 10 s
 # kubernetes.operator.deployment.rollback.enabled: false
 # kubernetes.operator.deployment.readiness.timeout: 1min
 # kubernetes.operator.user.artifacts.base.dir: /opt/flink/artifacts

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -89,7 +89,7 @@ defaultConfiguration:
     kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory
     kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE
 
-    kubernetes.operator.reconciler.reschedule.interval: 15 s
+    kubernetes.operator.reconcile.interval: 15 s
     kubernetes.operator.observer.progress-check.interval: 5 s
   log4j-operator.properties: |+
     # Flink Operator Logging Overrides


### PR DESCRIPTION
[FLINK-27912] Improve operator config names



From | To
-- | --
kubernetes.operator.reconciler.flink.cancel.job.timeout | kubernetes.operator.flink.client.cancel.timeout
kubernetes.operator.reconciler.flink.cluster.shutdown.timeout | kubernetes.operator.resource.cleanup.timeout
kubernetes.operator.observer.flink.client.timeout | kubernetes.operator.flink.client.timeout
kubernetes.operator.reconciler.jm-deployment-recovery.enabled | kubernetes.operator.jm-deployment-recovery.enabled
kubernetes.operator.reconciler.reschedule.interval | kubernetes.operator.reconcile.interval
kubernetes.operator.reconciler.max.parallelism | kubernetes.operator.reconcile.parallelism

- change helm default flinkconfig values
- html doc for **kubernetes_operator_config_configuration.html**
- Replaced related fields in the document
- Replaced relevant fields in unit tests

@gyfora PLAT