### PR TITLE
[FLINK-28233] Clear error status correctly for stable deployments

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/CommonStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/CommonStatus.java
@@ -37,7 +37,7 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
     private JobStatus jobStatus = new JobStatus();
 
     /** Error information about the FlinkDeployment/FlinkSessionJob. */
-    private String error;
+    private String error = "";
 
     /** Status of the last reconcile operation. */
     public abstract ReconciliationStatus<SPEC> getReconciliationStatus();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -224,7 +224,7 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
         if (status.getJobManagerDeploymentStatus() != JobManagerDeploymentStatus.ERROR
                 && !JobStatus.FAILED.name().equals(dep.getStatus().getJobStatus().getState())
                 && reconciliationStatus.isLastReconciledSpecStable()) {
-            status.setError(null);
+            status.setError("");
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -76,7 +76,7 @@ public class ReconciliationUtils {
         var spec = target.getSpec();
 
         ReconciliationStatus<SPEC> reconciliationStatus = status.getReconciliationStatus();
-        status.setError(null);
+        status.setError("");
 
         // For application deployments we update the taskmanager info
         if (target instanceof FlinkDeployment && spec.getJob() != null) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractDeploymentReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractDeploymentReconciler.java
@@ -32,6 +32,7 @@ import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +67,7 @@ public abstract class AbstractDeploymentReconciler implements Reconciler<FlinkDe
         ReconciliationStatus<?> reconciliationStatus = status.getReconciliationStatus();
         if (reconciliationStatus.getState() != ReconciliationState.ROLLING_BACK) {
             LOG.warn("Preparing to roll back to last stable spec.");
-            if (status.getError() == null) {
+            if (StringUtils.isEmpty(status.getError())) {
                 status.setError(
                         "Deployment is not ready within the configured timeout, rolling back.");
             }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -106,7 +106,7 @@ public class FlinkDeploymentControllerTest {
         // Validate reconciliation status
         ReconciliationStatus<FlinkDeploymentSpec> reconciliationStatus =
                 appCluster.getStatus().getReconciliationStatus();
-        assertNull(appCluster.getStatus().getError());
+        assertEquals("", appCluster.getStatus().getError());
         assertEquals(appCluster.getSpec(), reconciliationStatus.deserializeLastReconciledSpec());
         assertNull(appCluster.getStatus().getReconciliationStatus().getLastStableSpec());
 
@@ -679,7 +679,7 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 JobManagerDeploymentStatus.READY,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
-        assertNull(appCluster.getStatus().getError());
+        assertEquals("", appCluster.getStatus().getError());
 
         assertEquals(
                 appCluster.getStatus().getReconciliationStatus().getLastReconciledSpec(),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -315,7 +315,7 @@ public class RollbackTest {
         assertEquals(
                 ReconciliationState.DEPLOYED,
                 deployment.getStatus().getReconciliationStatus().getState());
-        assertNull(deployment.getStatus().getError());
+        assertEquals("", deployment.getStatus().getError());
 
         deployment.getSpec().setRestartNonce(456L);
         triggerRollback.run();
@@ -347,7 +347,7 @@ public class RollbackTest {
             assertEquals(
                     ReconciliationState.DEPLOYED,
                     deployment.getStatus().getReconciliationStatus().getState());
-            assertNull(deployment.getStatus().getError());
+            assertEquals("", deployment.getStatus().getError());
 
             deployment.getSpec().getJob().setState(JobState.RUNNING);
             testController.reconcile(deployment, context);
@@ -360,7 +360,7 @@ public class RollbackTest {
             assertEquals(
                     ReconciliationState.DEPLOYED,
                     deployment.getStatus().getReconciliationStatus().getState());
-            assertNull(deployment.getStatus().getError());
+            assertEquals("", deployment.getStatus().getError());
 
             // Verify suspending a rolled back job
             triggerRollback.run();
@@ -378,7 +378,7 @@ public class RollbackTest {
             assertEquals(
                     ReconciliationState.DEPLOYED,
                     deployment.getStatus().getReconciliationStatus().getState());
-            assertNull(deployment.getStatus().getError());
+            assertEquals("", deployment.getStatus().getError());
         }
     }
 }


### PR DESCRIPTION
We used to try clearing errors out by setting this `null` but due to how Status patching works, this basically means no update was made.

This commit fixes this by setting to empty string instead.