### PR TITLE
[FLINK-28008] Can not get secondary resource from context after operator restart

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -57,7 +57,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.Executors;
 
 /** Main Class for Flink native k8s operator. */
@@ -151,16 +150,8 @@ public class FlinkOperator {
     }
 
     private void overrideControllerConfigs(ControllerConfigurationOverrider<?> overrider) {
-        // TODO: https://github.com/java-operator-sdk/java-operator-sdk/issues/1259
-        String[] watchedNamespaces =
-                configManager
-                        .getOperatorConfiguration()
-                        .getWatchedNamespaces()
-                        .toArray(String[]::new);
-        String fakeNs = UUID.randomUUID().toString();
-        overrider.settingNamespace(fakeNs);
-        overrider.addingNamespaces(watchedNamespaces);
-        overrider.removingNamespaces(fakeNs);
+        overrider.settingNamespaces(
+                configManager.getOperatorConfiguration().getWatchedNamespaces());
         overrider.withRetry(
                 GenericRetry.fromConfiguration(
                         configManager.getOperatorConfiguration().getRetryConfiguration()));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -122,9 +122,10 @@ public class FlinkConfigManager {
                 && this.defaultConfig.toMap().equals(newConf.toMap())) {
             LOG.info("Default configuration did not change, nothing to do...");
             return;
+        } else {
+            LOG.info("Setting default configuration to {}", newConf);
         }
 
-        LOG.info("Updating default configuration to {}", newConf);
         var oldNs =
                 Optional.ofNullable(this.operatorConfiguration)
                         .map(FlinkOperatorConfiguration::getWatchedNamespaces)

--- a/flink-kubernetes-operator/src/main/resources/log4j2.properties
+++ b/flink-kubernetes-operator/src/main/resources/log4j2.properties
@@ -24,3 +24,6 @@ appender.console.name = ConsoleAppender
 appender.console.type = CONSOLE
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %style{%d}{yellow} %style{%-30c{1.}}{cyan} %highlight{[%-5level] [%X{resource.namespace}.%X{resource.name}] %msg%n%throwable}
+
+logger.conf.name = org.apache.flink.configuration.GlobalConfiguration
+logger.conf.level = WARN

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ under the License.
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
         <git-commit-id-maven-plugin.version>5.0.0</git-commit-id-maven-plugin.version>
 
-        <operator.sdk.version>3.0.2</operator.sdk.version>
+        <operator.sdk.version>3.0.3</operator.sdk.version>
         <operator.sdk.admission-controller.version>0.2.0</operator.sdk.admission-controller.version>
 
         <fabric8.version>5.12.2</fabric8.version>


### PR DESCRIPTION
- bumping JOSDK version v3.0.2 -> v3.0.3
- add primaryToSecondary mapper for session jobs
- removing the workaround for setting namespaces (not needed anymore from JOSDK v3.0.3+)
- Changing config dumps into a one-liner