### PR TITLE
[FLINK-26891] Record important deployment events

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -30,7 +30,6 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.deployment.ReconcilerFactory;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.EventSourceUtils;
-import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
 
@@ -139,10 +138,10 @@ public class FlinkDeploymentController
         ReconciliationUtils.updateForReconciliationError(flinkApp, dfe.getMessage());
         eventRecorder.triggerEvent(
                 flinkApp,
-                EventUtils.Type.Warning,
+                EventRecorder.Type.Warning,
                 dfe.getReason(),
                 dfe.getMessage(),
-                EventUtils.Component.JobManagerDeployment);
+                EventRecorder.Component.JobManagerDeployment);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -23,7 +23,6 @@ import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
 import org.slf4j.Logger;
@@ -142,10 +141,10 @@ public abstract class JobStatusObserver<CTX> {
             setErrorIfPresent(resource, clusterJobStatus, deployedConfig);
             eventRecorder.triggerEvent(
                     resource,
-                    EventUtils.Type.Normal,
-                    "Status Changed",
-                    message,
-                    EventUtils.Component.Job);
+                    EventRecorder.Type.Normal,
+                    EventRecorder.Reason.StatusChanged,
+                    EventRecorder.Component.Job,
+                    message);
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -31,7 +31,6 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.ConfigOptionUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
@@ -120,12 +119,12 @@ public class SavepointObserver<STATUS extends CommonStatus<?>> {
                         savepointInfo, resource);
                 eventRecorder.triggerEvent(
                         resource,
-                        EventUtils.Type.Warning,
-                        "SavepointError",
+                        EventRecorder.Type.Warning,
+                        EventRecorder.Reason.SavepointError,
+                        EventRecorder.Component.Operator,
                         SavepointUtils.createSavepointError(
                                 savepointInfo,
-                                resource.getSpec().getJob().getSavepointTriggerNonce()),
-                        EventUtils.Component.Operator);
+                                resource.getSpec().getJob().getSavepointTriggerNonce()));
             } else {
                 LOG.warn("Savepoint failed within grace period, retrying: " + err);
             }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -33,7 +33,6 @@ import org.apache.flink.kubernetes.operator.observer.Observer;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 
@@ -247,10 +246,10 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
         ReconciliationUtils.updateForReconciliationError(deployment, err);
         eventRecorder.triggerEvent(
                 deployment,
-                EventUtils.Type.Warning,
-                "Missing",
-                err,
-                EventUtils.Component.JobManagerDeployment);
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.Missing,
+                EventRecorder.Component.JobManagerDeployment,
+                err);
     }
 
     /**

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -33,7 +33,6 @@ import org.apache.flink.kubernetes.operator.reconciler.Reconciler;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -70,10 +69,6 @@ public abstract class AbstractFlinkResourceReconciler<
     public static final String MSG_SPEC_CHANGED = "Detected spec change, starting reconciliation.";
     public static final String MSG_ROLLBACK = "Rolling back failed deployment.";
     public static final String MSG_SUBMIT = "Starting deployment";
-    public static final String REASON_SUSPENDED = "Suspended";
-    public static final String REASON_SPEC_CHANGED = "Spec Changed";
-    public static final String REASON_ROLLBACK = "Rollback";
-    public static final String REASON_SUBMIT = "Submit";
 
     public AbstractFlinkResourceReconciler(
             KubernetesClient kubernetesClient,
@@ -131,10 +126,10 @@ public abstract class AbstractFlinkResourceReconciler<
             LOG.info(MSG_SPEC_CHANGED);
             eventRecorder.triggerEvent(
                     cr,
-                    EventUtils.Type.Normal,
-                    REASON_SPEC_CHANGED,
-                    MSG_SPEC_CHANGED,
-                    EventUtils.Component.JobManagerDeployment);
+                    EventRecorder.Type.Normal,
+                    EventRecorder.Reason.SpecChanged,
+                    EventRecorder.Component.JobManagerDeployment,
+                    MSG_SPEC_CHANGED);
             reconcileSpecChange(cr, observeConfig, deployConfig);
         } else if (shouldRollBack(reconciliationStatus, observeConfig)) {
             // Rollbacks are executed in two steps, we initiate it first then return
@@ -144,10 +139,10 @@ public abstract class AbstractFlinkResourceReconciler<
             LOG.warn(MSG_ROLLBACK);
             eventRecorder.triggerEvent(
                     cr,
-                    EventUtils.Type.Normal,
-                    REASON_ROLLBACK,
-                    MSG_ROLLBACK,
-                    EventUtils.Component.JobManagerDeployment);
+                    EventRecorder.Type.Normal,
+                    EventRecorder.Reason.Rollback,
+                    EventRecorder.Component.JobManagerDeployment,
+                    MSG_ROLLBACK);
             rollback(cr, ctx, observeConfig);
         } else if (!reconcileOtherChanges(cr, observeConfig)) {
             LOG.info("Resource fully reconciled, nothing to do...");

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -30,7 +30,6 @@ import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -100,10 +99,10 @@ public abstract class AbstractJobReconciler<
             }
             eventRecorder.triggerEvent(
                     resource,
-                    EventUtils.Type.Normal,
-                    REASON_SUSPENDED,
-                    MSG_SUSPENDED,
-                    EventUtils.Component.JobManagerDeployment);
+                    EventRecorder.Type.Normal,
+                    EventRecorder.Reason.Suspended,
+                    EventRecorder.Component.JobManagerDeployment,
+                    MSG_SUSPENDED);
             // We must record the upgrade mode used to the status later
             currentDeploySpec.getJob().setUpgradeMode(availableUpgradeMode.get());
             cancelJob(resource, availableUpgradeMode.get(), observeConfig);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -30,7 +30,6 @@ import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
 import org.apache.flink.runtime.highavailability.JobResultStoreOptions;
@@ -141,10 +140,10 @@ public class ApplicationReconciler
         }
         eventRecorder.triggerEvent(
                 relatedResource,
-                EventUtils.Type.Normal,
-                REASON_SUBMIT,
-                MSG_SUBMIT,
-                EventUtils.Component.JobManagerDeployment);
+                EventRecorder.Type.Normal,
+                EventRecorder.Reason.Submit,
+                EventRecorder.Component.JobManagerDeployment,
+                MSG_SUBMIT);
         flinkService.submitApplicationCluster(spec.getJob(), deployConfig, requireHaMetadata);
         status.getJobStatus().setState(org.apache.flink.api.common.JobStatus.RECONCILING.name());
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -103,7 +103,7 @@ public class SessionReconciler
                         .getFlinkShutdownClusterTimeout()
                         .toSeconds());
         deploy(
-                deployment.getMetadata(),
+                deployment,
                 deploySpec,
                 deployment.getStatus(),
                 effectiveConfig,
@@ -113,7 +113,7 @@ public class SessionReconciler
 
     @Override
     protected void deploy(
-            ObjectMeta meta,
+            FlinkDeployment cr,
             FlinkDeploymentSpec spec,
             FlinkDeploymentStatus status,
             Configuration deployConfig,
@@ -122,7 +122,7 @@ public class SessionReconciler
             throws Exception {
         flinkService.submitSessionCluster(deployConfig);
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
-        IngressUtils.updateIngressRules(meta, spec, deployConfig, kubernetesClient);
+        IngressUtils.updateIngressRules(cr.getMetadata(), spec, deployConfig, kubernetesClient);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -29,7 +29,6 @@ import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
 
@@ -166,10 +165,10 @@ public class SessionReconciler
                                     .collect(Collectors.toList()));
             if (eventRecorder.triggerEvent(
                     deployment,
-                    EventUtils.Type.Warning,
-                    "Cleanup",
-                    error,
-                    EventUtils.Component.Operator)) {
+                    EventRecorder.Type.Warning,
+                    EventRecorder.Reason.Cleanup,
+                    EventRecorder.Component.Operator,
+                    error)) {
                 LOG.warn(error);
             }
             return DeleteControl.noFinalizerRemoval()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -79,7 +79,7 @@ public class SessionJobReconciler
 
     @Override
     protected void deploy(
-            ObjectMeta meta,
+            FlinkSessionJob cr,
             FlinkSessionJobSpec sessionJobSpec,
             FlinkSessionJobStatus status,
             Configuration deployConfig,
@@ -88,7 +88,7 @@ public class SessionJobReconciler
             throws Exception {
         var jobID =
                 flinkService.submitJobToSessionCluster(
-                        meta, sessionJobSpec, deployConfig, savepoint.orElse(null));
+                        cr.getMetadata(), sessionJobSpec, deployConfig, savepoint.orElse(null));
         status.setJobStatus(
                 new JobStatus()
                         .toBuilder()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -46,10 +46,19 @@ public class EventRecorder {
 
     public boolean triggerEvent(
             AbstractFlinkResource<?, ?> resource,
-            EventUtils.Type type,
+            Type type,
+            Reason reason,
+            Component component,
+            String message) {
+        return triggerEvent(resource, type, reason.toString(), message, component);
+    }
+
+    public boolean triggerEvent(
+            AbstractFlinkResource<?, ?> resource,
+            Type type,
             String reason,
             String message,
-            EventUtils.Component component) {
+            Component component) {
         return EventUtils.createOrUpdateEvent(
                 client,
                 resource,
@@ -93,5 +102,30 @@ public class EventRecorder {
                                     }
                                 });
         return new EventRecorder(client, biConsumer);
+    }
+
+    /** The type of the events. */
+    public enum Type {
+        Normal,
+        Warning
+    }
+
+    /** The component of events. */
+    public enum Component {
+        Operator,
+        JobManagerDeployment,
+        Job
+    }
+
+    /** The reason codes of events. */
+    public enum Reason {
+        Suspended,
+        SpecChanged,
+        Rollback,
+        Submit,
+        StatusChanged,
+        SavepointError,
+        Cleanup,
+        Missing
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -32,21 +32,12 @@ import java.util.function.Consumer;
  */
 public class EventUtils {
 
-    /** The type of the events. */
-    public enum Type {
-        Normal,
-        Warning
-    }
-
-    /** The component of events. */
-    public enum Component {
-        Operator,
-        JobManagerDeployment,
-        Job
-    }
-
     public static String generateEventName(
-            HasMetadata target, Type type, String reason, String message, Component component) {
+            HasMetadata target,
+            EventRecorder.Type type,
+            String reason,
+            String message,
+            EventRecorder.Component component) {
         return component
                 + "."
                 + ((reason
@@ -62,10 +53,10 @@ public class EventUtils {
     public static boolean createOrUpdateEvent(
             KubernetesClient client,
             HasMetadata target,
-            Type type,
+            EventRecorder.Type type,
             String reason,
             String message,
-            Component component,
+            EventRecorder.Component component,
             Consumer<Event> eventListener) {
         var eventName = generateEventName(target, type, reason, message, component);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -150,11 +150,11 @@ public class SavepointUtils {
             LOG.error("Job is not running, cancelling savepoint operation");
             eventRecorder.triggerEvent(
                     resource,
-                    EventUtils.Type.Warning,
-                    "SavepointError",
+                    EventRecorder.Type.Warning,
+                    EventRecorder.Reason.SavepointError,
+                    EventRecorder.Component.Operator,
                     createSavepointError(
-                            savepointInfo, resource.getSpec().getJob().getSavepointTriggerNonce()),
-                    EventUtils.Component.Operator);
+                            savepointInfo, resource.getSpec().getJob().getSavepointTriggerNonce()));
         }
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -94,17 +93,17 @@ public class FlinkResourceListenerTest {
 
         eventRecorder.triggerEvent(
                 deployment,
-                EventUtils.Type.Warning,
-                "SavepointError",
-                "err",
-                EventUtils.Component.Operator);
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.SavepointError,
+                EventRecorder.Component.Operator,
+                "err");
         assertEquals(1, listener1.events.size());
         eventRecorder.triggerEvent(
                 deployment,
-                EventUtils.Type.Warning,
-                "SavepointError",
-                "err",
-                EventUtils.Component.Operator);
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.SavepointError,
+                EventRecorder.Component.Operator,
+                "err");
         assertEquals(2, listener1.events.size());
 
         for (int i = 0; i < listener1.events.size(); i++) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -492,14 +492,14 @@ public class ApplicationReconcilerTest {
 
         status.getJobStatus().setState(org.apache.flink.api.common.JobStatus.FINISHED.name());
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
-        reconciler.deploy(deployMeta, spec, status, deployConfig, Optional.empty(), false);
+        reconciler.deploy(flinkApp, spec, status, deployConfig, Optional.empty(), false);
 
         String path1 = deployConfig.get(JobResultStoreOptions.STORAGE_PATH);
         Assertions.assertTrue(path1.startsWith(haStoragePath));
 
         status.getJobStatus().setState(org.apache.flink.api.common.JobStatus.FINISHED.name());
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
-        reconciler.deploy(deployMeta, spec, status, deployConfig, Optional.empty(), false);
+        reconciler.deploy(flinkApp, spec, status, deployConfig, Optional.empty(), false);
         String path2 = deployConfig.get(JobResultStoreOptions.STORAGE_PATH);
         Assertions.assertTrue(path2.startsWith(haStoragePath));
         assertNotEquals(path1, path2);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
@@ -32,7 +32,6 @@ import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
@@ -67,10 +66,10 @@ public class SessionJobReconcilerTest {
                     @Override
                     public boolean triggerEvent(
                             AbstractFlinkResource<?, ?> resource,
-                            EventUtils.Type type,
+                            Type type,
                             String reason,
                             String message,
-                            EventUtils.Component component) {
+                            Component component) {
                         return false;
                     }
                 };

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
@@ -40,18 +40,18 @@ public class EventUtilsTest {
         var eventName =
                 EventUtils.generateEventName(
                         flinkApp,
-                        EventUtils.Type.Warning,
+                        EventRecorder.Type.Warning,
                         reason,
                         message,
-                        EventUtils.Component.Operator);
+                        EventRecorder.Component.Operator);
         Assertions.assertTrue(
                 EventUtils.createOrUpdateEvent(
                         kubernetesClient,
                         flinkApp,
-                        EventUtils.Type.Warning,
+                        EventRecorder.Type.Warning,
                         reason,
                         message,
-                        EventUtils.Component.Operator,
+                        EventRecorder.Component.Operator,
                         e -> {}));
         var event =
                 kubernetesClient
@@ -68,10 +68,10 @@ public class EventUtilsTest {
                 EventUtils.createOrUpdateEvent(
                         kubernetesClient,
                         flinkApp,
-                        EventUtils.Type.Warning,
+                        EventRecorder.Type.Warning,
                         reason,
                         message,
-                        EventUtils.Component.Operator,
+                        EventRecorder.Component.Operator,
                         e -> {}));
         event =
                 kubernetesClient
@@ -93,18 +93,18 @@ public class EventUtilsTest {
         var name1 =
                 EventUtils.generateEventName(
                         flinkApp,
-                        EventUtils.Type.Warning,
+                        EventRecorder.Type.Warning,
                         reason,
                         message,
-                        EventUtils.Component.Operator);
+                        EventRecorder.Component.Operator);
         flinkApp.getMetadata().setUid("uid2");
         var name2 =
                 EventUtils.generateEventName(
                         flinkApp,
-                        EventUtils.Type.Warning,
+                        EventRecorder.Type.Warning,
                         reason,
                         message,
-                        EventUtils.Component.Operator);
+                        EventRecorder.Component.Operator);
         Assertions.assertNotEquals(name1, name2);
     }
 }


### PR DESCRIPTION
Record events that may be of interest to users when looking at the deployment with describe. Generally, these will be conversions of existing log messages. I added couple examples for illustration, will add more like submit or trigger/complete savepoint if there is agreement on the approach.

<img width="814" alt="image" src="https://user-images.githubusercontent.com/263695/176065958-21adefae-2242-43fe-8b50-003258dfda65.png">

