### PR TITLE
[FLINK-28228] Never skip generations when observing already upgraded deployment

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -115,7 +115,8 @@ public class FlinkOperator {
         var statusRecorder = StatusRecorder.<FlinkDeploymentStatus>create(client, listeners);
         var eventRecorder = EventRecorder.create(client, listeners);
         var reconcilerFactory =
-                new ReconcilerFactory(client, flinkService, configManager, eventRecorder);
+                new ReconcilerFactory(
+                        client, flinkService, configManager, eventRecorder, statusRecorder);
         var observerFactory =
                 new ObserverFactory(flinkService, configManager, statusRecorder, eventRecorder);
 
@@ -133,9 +134,10 @@ public class FlinkOperator {
 
     private void registerSessionJobController() {
         var eventRecorder = EventRecorder.create(client, listeners);
-        var reconciler =
-                new SessionJobReconciler(client, flinkService, configManager, eventRecorder);
         var statusRecorder = StatusRecorder.<FlinkSessionJobStatus>create(client, listeners);
+        var reconciler =
+                new SessionJobReconciler(
+                        client, flinkService, configManager, eventRecorder, statusRecorder);
         var observer =
                 new SessionJobObserver(flinkService, configManager, statusRecorder, eventRecorder);
         var controller =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
@@ -94,4 +94,9 @@ public abstract class ReconciliationStatus<SPEC extends AbstractFlinkSpec> {
         }
         return lastReconciledSpec.equals(lastStableSpec);
     }
+
+    @JsonIgnore
+    public boolean isFirstDeployment() {
+        return lastReconciledSpec == null;
+    }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -263,7 +263,7 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
      */
     private void checkIfAlreadyUpgraded(FlinkDeployment flinkDep, Context context) {
         var status = flinkDep.getStatus();
-        if (status.getReconciliationStatus().getLastReconciledSpec() == null) {
+        if (status.getReconciliationStatus().isFirstDeployment()) {
             return;
         }
         Optional<Deployment> depOpt = context.getSecondaryResource(Deployment.class);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -63,13 +63,33 @@ public class ReconciliationUtils {
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
+    /**
+     * Update status after successful deployment of a new resource spec. Existing reconciliation
+     * errors will be cleared, lastReconciled spec will be updated and for suspended jobs it will
+     * also be marked stable.
+     *
+     * <p>For Application deployments TaskManager info will also be updated.
+     *
+     * @param target Target Flink resource.
+     * @param conf Deployment configuration.
+     */
     public static <SPEC extends AbstractFlinkSpec> void updateStatusForDeployedSpec(
             AbstractFlinkResource<SPEC, ?> target, Configuration conf) {
         var job = target.getSpec().getJob();
         updateStatusForSpecReconciliation(target, job != null ? job.getState() : null, conf, false);
     }
 
-    public static <SPEC extends AbstractFlinkSpec> void updateStatusBeforeSpecUpgrade(
+    /**
+     * Update status before deployment attempt of a new resource spec. Existing reconciliation
+     * errors will be cleared, lastReconciled spec will be updated and reconciliation status marked
+     * UPGRADING.
+     *
+     * <p>For Application deployments TaskManager info will also be updated.
+     *
+     * @param target Target Flink resource.
+     * @param conf Deployment configuration.
+     */
+    public static <SPEC extends AbstractFlinkSpec> void updateStatusBeforeDeploymentAttempt(
             AbstractFlinkResource<SPEC, ?> target, Configuration conf) {
         updateStatusForSpecReconciliation(target, JobState.SUSPENDED, conf, true);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -90,6 +90,7 @@ public abstract class AbstractFlinkResourceReconciler<
         var spec = cr.getSpec();
         var deployConfig = getDeployConfig(cr.getMetadata(), spec, ctx);
         var status = cr.getStatus();
+        var reconciliationStatus = cr.getStatus().getReconciliationStatus();
 
         // If the resource is not ready for reconciliation we simply return
         if (!readyToReconcile(cr, ctx, deployConfig)) {
@@ -97,11 +98,9 @@ public abstract class AbstractFlinkResourceReconciler<
             return;
         }
 
-        var firstDeployment = status.getReconciliationStatus().getLastReconciledSpec() == null;
-
         // If this is the first deployment for the resource we simply submit the job and return.
         // No further logic is required at this point.
-        if (firstDeployment) {
+        if (reconciliationStatus.isFirstDeployment()) {
             LOG.info("Deploying for the first time");
 
             // Before we try to submit the job we record the current spec in the status so we can
@@ -120,7 +119,6 @@ public abstract class AbstractFlinkResourceReconciler<
             return;
         }
 
-        var reconciliationStatus = cr.getStatus().getReconciliationStatus();
         SPEC lastReconciledSpec =
                 cr.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
         SPEC currentDeploySpec = cr.getSpec();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -106,7 +106,7 @@ public abstract class AbstractFlinkResourceReconciler<
 
             // Before we try to submit the job we record the current spec in the status so we can
             // handle subsequent deployment and status update errors
-            ReconciliationUtils.updateStatusBeforeSpecUpgrade(cr, deployConfig);
+            ReconciliationUtils.updateStatusBeforeDeploymentAttempt(cr, deployConfig);
             statusRecorder.patchAndCacheStatus(cr);
 
             deploy(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -31,6 +31,7 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -55,8 +56,9 @@ public abstract class AbstractJobReconciler<
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
             FlinkConfigManager configManager,
-            EventRecorder eventRecorder) {
-        super(kubernetesClient, flinkService, configManager, eventRecorder);
+            EventRecorder eventRecorder,
+            StatusRecorder<STATUS> statusRecorder) {
+        super(kubernetesClient, flinkService, configManager, eventRecorder, statusRecorder);
     }
 
     @Override
@@ -87,7 +89,6 @@ public abstract class AbstractJobReconciler<
 
         JobState currentJobState = lastReconciledSpec.getJob().getState();
         JobState desiredJobState = currentDeploySpec.getJob().getState();
-        JobState newState = currentJobState;
         if (currentJobState == JobState.RUNNING) {
             if (desiredJobState == JobState.RUNNING) {
                 LOG.info("Upgrading/Restarting running job, suspending first...");
@@ -106,9 +107,17 @@ public abstract class AbstractJobReconciler<
             // We must record the upgrade mode used to the status later
             currentDeploySpec.getJob().setUpgradeMode(availableUpgradeMode.get());
             cancelJob(resource, availableUpgradeMode.get(), observeConfig);
-            newState = JobState.SUSPENDED;
+            if (desiredJobState == JobState.RUNNING) {
+                ReconciliationUtils.updateStatusBeforeSpecUpgrade(resource, deployConfig);
+            } else {
+                ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig);
+            }
         }
         if (currentJobState == JobState.SUSPENDED && desiredJobState == JobState.RUNNING) {
+            // We record the target spec into an upgrading state before deploying
+            ReconciliationUtils.updateStatusBeforeSpecUpgrade(resource, deployConfig);
+            statusRecorder.patchAndCacheStatus(resource);
+
             restoreJob(
                     resource,
                     currentDeploySpec,
@@ -116,9 +125,9 @@ public abstract class AbstractJobReconciler<
                     deployConfig,
                     // We decide to enforce HA based on how job was previously suspended
                     lastReconciledSpec.getJob().getUpgradeMode() == UpgradeMode.LAST_STATE);
-            newState = JobState.RUNNING;
+
+            ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig);
         }
-        ReconciliationUtils.updateForSpecReconciliationSuccess(resource, newState, deployConfig);
     }
 
     protected Optional<UpgradeMode> getAvailableUpgradeMode(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -108,14 +108,14 @@ public abstract class AbstractJobReconciler<
             currentDeploySpec.getJob().setUpgradeMode(availableUpgradeMode.get());
             cancelJob(resource, availableUpgradeMode.get(), observeConfig);
             if (desiredJobState == JobState.RUNNING) {
-                ReconciliationUtils.updateStatusBeforeSpecUpgrade(resource, deployConfig);
+                ReconciliationUtils.updateStatusBeforeDeploymentAttempt(resource, deployConfig);
             } else {
                 ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig);
             }
         }
         if (currentJobState == JobState.SUSPENDED && desiredJobState == JobState.RUNNING) {
             // We record the target spec into an upgrading state before deploying
-            ReconciliationUtils.updateStatusBeforeSpecUpgrade(resource, deployConfig);
+            ReconciliationUtils.updateStatusBeforeDeploymentAttempt(resource, deployConfig);
             statusRecorder.patchAndCacheStatus(resource);
 
             restoreJob(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -204,7 +204,7 @@ public class ApplicationReconciler
     @SneakyThrows
     protected DeleteControl cleanupInternal(FlinkDeployment deployment, Context context) {
         var status = deployment.getStatus();
-        if (status.getReconciliationStatus().getLastReconciledSpec() == null) {
+        if (status.getReconciliationStatus().isFirstDeployment()) {
             flinkService.deleteClusterDeployment(deployment.getMetadata(), status, true);
         } else {
             flinkService.cancelJob(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -32,6 +32,7 @@ import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.runtime.highavailability.JobResultStoreOptions;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 
@@ -56,8 +57,9 @@ public class ApplicationReconciler
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
             FlinkConfigManager configManager,
-            EventRecorder eventRecorder) {
-        super(kubernetesClient, flinkService, configManager, eventRecorder);
+            EventRecorder eventRecorder,
+            StatusRecorder<FlinkDeploymentStatus> statusRecorder) {
+        super(kubernetesClient, flinkService, configManager, eventRecorder, statusRecorder);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
@@ -20,9 +20,11 @@ package org.apache.flink.kubernetes.operator.reconciler.deployment;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.reconciler.Reconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 
@@ -36,17 +38,20 @@ public class ReconcilerFactory {
     private final FlinkService flinkService;
     private final FlinkConfigManager configManager;
     private final EventRecorder eventRecorder;
+    private final StatusRecorder<FlinkDeploymentStatus> deploymentStatusRecorder;
     private final Map<Mode, Reconciler<FlinkDeployment>> reconcilerMap;
 
     public ReconcilerFactory(
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
             FlinkConfigManager configManager,
-            EventRecorder eventRecorder) {
+            EventRecorder eventRecorder,
+            StatusRecorder<FlinkDeploymentStatus> deploymentStatusRecorder) {
         this.kubernetesClient = kubernetesClient;
         this.flinkService = flinkService;
         this.configManager = configManager;
         this.eventRecorder = eventRecorder;
+        this.deploymentStatusRecorder = deploymentStatusRecorder;
         this.reconcilerMap = new ConcurrentHashMap<>();
     }
 
@@ -57,10 +62,18 @@ public class ReconcilerFactory {
                     switch (mode) {
                         case SESSION:
                             return new SessionReconciler(
-                                    kubernetesClient, flinkService, configManager, eventRecorder);
+                                    kubernetesClient,
+                                    flinkService,
+                                    configManager,
+                                    eventRecorder,
+                                    deploymentStatusRecorder);
                         case APPLICATION:
                             return new ApplicationReconciler(
-                                    kubernetesClient, flinkService, configManager, eventRecorder);
+                                    kubernetesClient,
+                                    flinkService,
+                                    configManager,
+                                    eventRecorder,
+                                    deploymentStatusRecorder);
                         default:
                             throw new UnsupportedOperationException(
                                     String.format("Unsupported running mode: %s", mode));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -31,6 +31,7 @@ import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -57,8 +58,9 @@ public class SessionReconciler
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
             FlinkConfigManager configManager,
-            EventRecorder eventRecorder) {
-        super(kubernetesClient, flinkService, configManager, eventRecorder);
+            EventRecorder eventRecorder,
+            StatusRecorder<FlinkDeploymentStatus> statusRecorder) {
+        super(kubernetesClient, flinkService, configManager, eventRecorder, statusRecorder);
     }
 
     @Override
@@ -82,16 +84,23 @@ public class SessionReconciler
     protected void reconcileSpecChange(
             FlinkDeployment deployment, Configuration observeConfig, Configuration deployConfig)
             throws Exception {
-        upgradeSessionCluster(deployment, deployment.getSpec(), deployConfig);
-        ReconciliationUtils.updateForSpecReconciliationSuccess(deployment, null, deployConfig);
+        deleteSessionCluster(deployment, observeConfig);
+
+        // We record the target spec into an upgrading state before deploying
+        ReconciliationUtils.updateStatusBeforeSpecUpgrade(deployment, deployConfig);
+        statusRecorder.patchAndCacheStatus(deployment);
+
+        deploy(
+                deployment,
+                deployment.getSpec(),
+                deployment.getStatus(),
+                deployConfig,
+                Optional.empty(),
+                false);
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, deployConfig);
     }
 
-    private void upgradeSessionCluster(
-            FlinkDeployment deployment,
-            FlinkDeploymentSpec deploySpec,
-            Configuration effectiveConfig)
-            throws Exception {
-        LOG.info("Upgrading session cluster");
+    private void deleteSessionCluster(FlinkDeployment deployment, Configuration effectiveConfig) {
         flinkService.deleteClusterDeployment(
                 deployment.getMetadata(), deployment.getStatus(), false);
         FlinkUtils.waitForClusterShutdown(
@@ -101,13 +110,6 @@ public class SessionReconciler
                         .getOperatorConfiguration()
                         .getFlinkShutdownClusterTimeout()
                         .toSeconds());
-        deploy(
-                deployment,
-                deploySpec,
-                deployment.getStatus(),
-                effectiveConfig,
-                Optional.empty(),
-                false);
     }
 
     @Override
@@ -133,7 +135,16 @@ public class SessionReconciler
         FlinkDeploymentSpec rollbackSpec = reconciliationStatus.deserializeLastStableSpec();
         Configuration rollbackConfig =
                 configManager.getDeployConfig(deployment.getMetadata(), rollbackSpec);
-        upgradeSessionCluster(deployment, rollbackSpec, rollbackConfig);
+
+        deleteSessionCluster(deployment, observeConfig);
+        deploy(
+                deployment,
+                rollbackSpec,
+                deployment.getStatus(),
+                rollbackConfig,
+                Optional.empty(),
+                false);
+
         reconciliationStatus.setState(ReconciliationState.ROLLED_BACK);
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -87,7 +87,7 @@ public class SessionReconciler
         deleteSessionCluster(deployment, observeConfig);
 
         // We record the target spec into an upgrading state before deploying
-        ReconciliationUtils.updateStatusBeforeSpecUpgrade(deployment, deployConfig);
+        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(deployment, deployConfig);
         statusRecorder.patchAndCacheStatus(deployment);
 
         deploy(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -29,6 +29,7 @@ import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.reconciler.deployment.AbstractJobReconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -49,8 +50,9 @@ public class SessionJobReconciler
             KubernetesClient kubernetesClient,
             FlinkService flinkService,
             FlinkConfigManager configManager,
-            EventRecorder eventRecorder) {
-        super(kubernetesClient, flinkService, configManager, eventRecorder);
+            EventRecorder eventRecorder,
+            StatusRecorder<FlinkSessionJobStatus> statusRecorder) {
+        super(kubernetesClient, flinkService, configManager, eventRecorder, statusRecorder);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -442,7 +442,12 @@ public class TestUtils {
         return new FlinkDeploymentController(
                 configManager,
                 ValidatorUtils.discoverValidators(configManager),
-                new ReconcilerFactory(kubernetesClient, flinkService, configManager, eventRecorder),
+                new ReconcilerFactory(
+                        kubernetesClient,
+                        flinkService,
+                        configManager,
+                        eventRecorder,
+                        statusRecorder),
                 new ObserverFactory(flinkService, configManager, statusRecorder, eventRecorder),
                 new MetricManager<>(new MetricListener().getMetricGroup()),
                 statusRecorder,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.DeploymentOptionsInternal;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
-import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
@@ -108,8 +107,7 @@ public class FlinkConfigManagerTest {
         deployment.getSpec().setLogConfiguration(Map.of(Constants.CONFIG_FILE_LOG4J_NAME, "test"));
         deployment.getSpec().setPodTemplate(new Pod());
 
-        ReconciliationUtils.updateForSpecReconciliationSuccess(
-                deployment, JobState.RUNNING, config);
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, config);
         Configuration deployConfig = configManager.getObserveConfig(deployment);
         assertFalse(
                 deployConfig.contains(KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL));

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -479,11 +479,8 @@ public class ApplicationObserverTest {
                 JobManagerDeploymentStatus.DEPLOYED_NOT_READY,
                 status.getJobManagerDeploymentStatus());
         assertEquals(
-                JobState.RUNNING,
-                status.getReconciliationStatus()
-                        .deserializeLastReconciledSpec()
-                        .getJob()
-                        .getState());
+                deployment.getSpec(),
+                status.getReconciliationStatus().deserializeLastReconciledSpec());
 
         // Test regular upgrades
         deployment.getSpec().getJob().setParallelism(5);
@@ -509,7 +506,10 @@ public class ApplicationObserverTest {
                 .getMetadata()
                 .getAnnotations()
                 .put(FlinkUtils.CR_GENERATION_LABEL, "321");
+
         deployment.getMetadata().setGeneration(322L);
+        deployment.getSpec().getJob().setParallelism(4);
+
         observer.observe(deployment, context);
 
         assertEquals(ReconciliationState.DEPLOYED, reconStatus.getState());
@@ -543,7 +543,6 @@ public class ApplicationObserverTest {
         assertEquals(ReconciliationState.DEPLOYED, reconStatus.getState());
         specWithMeta = status.getReconciliationStatus().deserializeLastReconciledSpecWithMeta();
         assertEquals(401, specWithMeta.f1.get("metadata").get("generation").asLong());
-        assertEquals(JobState.RUNNING, specWithMeta.f0.getJob().getState());
-        assertEquals(6, specWithMeta.f0.getJob().getParallelism());
+        assertEquals(deployment.getSpec(), specWithMeta.f0);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -458,7 +458,7 @@ public class ApplicationObserverTest {
         // Test regular upgrades
         deployment.getSpec().getJob().setParallelism(5);
         deployment.getMetadata().setGeneration(321L);
-        ReconciliationUtils.updateStatusBeforeSpecUpgrade(
+        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(
                 deployment,
                 new FlinkConfigManager(new Configuration())
                         .getDeployConfig(deployment.getMetadata(), deployment.getSpec()));

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -116,7 +116,7 @@ public class SessionObserverTest {
         // Test regular upgrades
         deployment.getSpec().getFlinkConfiguration().put("k", "1");
         deployment.getMetadata().setGeneration(321L);
-        ReconciliationUtils.updateStatusBeforeSpecUpgrade(
+        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(
                 deployment,
                 new FlinkConfigManager(new Configuration())
                         .getDeployConfig(deployment.getMetadata(), deployment.getSpec()));

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.reconciler.sessionjob.SessionJobReconciler;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
-import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -54,9 +53,7 @@ public class SessionJobObserverTest {
     public void before() {
         kubernetesClient.resource(TestUtils.buildSessionJob()).createOrReplace();
         var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
-        var statusRecoder =
-                new StatusRecorder<FlinkSessionJobStatus>(kubernetesClient, (r, e) -> {});
-        TestingStatusRecorder<FlinkSessionJobStatus> statusRecorder = new TestingStatusRecorder<>();
+        var statusRecorder = new TestingStatusRecorder<FlinkSessionJobStatus>();
         observer =
                 new SessionJobObserver(flinkService, configManager, statusRecorder, eventRecorder);
         reconciler =
@@ -65,7 +62,7 @@ public class SessionJobObserverTest {
                         flinkService,
                         configManager,
                         eventRecorder,
-                        statusRecoder);
+                        statusRecorder);
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.reconciler.sessionjob.SessionJobReconciler;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -51,13 +52,20 @@ public class SessionJobObserverTest {
 
     @BeforeEach
     public void before() {
+        kubernetesClient.resource(TestUtils.buildSessionJob()).createOrReplace();
         var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
+        var statusRecoder =
+                new StatusRecorder<FlinkSessionJobStatus>(kubernetesClient, (r, e) -> {});
         TestingStatusRecorder<FlinkSessionJobStatus> statusRecorder = new TestingStatusRecorder<>();
         observer =
                 new SessionJobObserver(flinkService, configManager, statusRecorder, eventRecorder);
         reconciler =
                 new SessionJobReconciler(
-                        kubernetesClient, flinkService, configManager, eventRecorder);
+                        kubernetesClient,
+                        flinkService,
+                        configManager,
+                        eventRecorder,
+                        statusRecoder);
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.highavailability.JobResultStoreOptions;
 
@@ -73,10 +74,17 @@ public class ApplicationReconcilerTest {
 
     @BeforeEach
     public void before() {
+        kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
         var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
+        var statusRecoder =
+                new StatusRecorder<FlinkDeploymentStatus>(kubernetesClient, (r, e) -> {});
         reconciler =
                 new ApplicationReconciler(
-                        kubernetesClient, flinkService, configManager, eventRecorder);
+                        kubernetesClient,
+                        flinkService,
+                        configManager,
+                        eventRecorder,
+                        statusRecoder);
     }
 
     @ParameterizedTest

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.kubernetes.operator.TestingClusterClient;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
-import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
@@ -94,8 +93,7 @@ public class FlinkServiceTest {
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         JobStatus jobStatus = deployment.getStatus().getJobStatus();
         jobStatus.setJobId(jobID.toHexString());
-        ReconciliationUtils.updateForSpecReconciliationSuccess(
-                deployment, JobState.RUNNING, new Configuration());
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
 
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
         deployment.getStatus().getJobStatus().setState("RUNNING");
@@ -133,8 +131,7 @@ public class FlinkServiceTest {
         JobStatus jobStatus = deployment.getStatus().getJobStatus();
         jobStatus.setJobId(jobID.toHexString());
         jobStatus.setState(org.apache.flink.api.common.JobStatus.RUNNING.name());
-        ReconciliationUtils.updateForSpecReconciliationSuccess(
-                deployment, JobState.RUNNING, new Configuration());
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
 
         flinkService.cancelJob(
                 deployment, UpgradeMode.SAVEPOINT, configManager.getObserveConfig(deployment));
@@ -148,8 +145,7 @@ public class FlinkServiceTest {
     @Test
     public void testCancelJobWithLastStateUpgradeMode() throws Exception {
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
-        ReconciliationUtils.updateForSpecReconciliationSuccess(
-                deployment, JobState.RUNNING, new Configuration());
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
         final TestingClusterClient<String> testingClusterClient =
                 new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
         final FlinkService flinkService = createFlinkService(testingClusterClient);
@@ -205,8 +201,7 @@ public class FlinkServiceTest {
 
         final JobID jobID = JobID.generate();
         final FlinkDeployment flinkDeployment = TestUtils.buildApplicationCluster();
-        ReconciliationUtils.updateForSpecReconciliationSuccess(
-                flinkDeployment, JobState.RUNNING, new Configuration());
+        ReconciliationUtils.updateStatusForDeployedSpec(flinkDeployment, new Configuration());
         JobStatus jobStatus = new JobStatus();
         jobStatus.setJobId(jobID.toString());
         flinkDeployment.getStatus().setJobStatus(jobStatus);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -51,7 +51,7 @@ public class ReconciliationUtilsTest {
         ReconciliationUtils.updateStatusForDeployedSpec(app, new Configuration());
         FlinkDeployment previous = ReconciliationUtils.clone(app);
         FlinkDeployment current = ReconciliationUtils.clone(app);
-        ReconciliationUtils.updateStatusBeforeSpecUpgrade(current, new Configuration());
+        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(current, new Configuration());
 
         UpdateControl<FlinkDeployment> updateControl =
                 ReconciliationUtils.toUpdateControl(operatorConfiguration, current, previous, true);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -48,12 +48,10 @@ public class ReconciliationUtilsTest {
         FlinkDeployment app = TestUtils.buildApplicationCluster();
         app.getSpec().getJob().setState(JobState.RUNNING);
         app.getStatus().getReconciliationStatus().setState(ReconciliationState.DEPLOYED);
-        ReconciliationUtils.updateForSpecReconciliationSuccess(
-                app, JobState.RUNNING, new Configuration());
+        ReconciliationUtils.updateStatusForDeployedSpec(app, new Configuration());
         FlinkDeployment previous = ReconciliationUtils.clone(app);
         FlinkDeployment current = ReconciliationUtils.clone(app);
-        ReconciliationUtils.updateForSpecReconciliationSuccess(
-                current, JobState.SUSPENDED, new Configuration());
+        ReconciliationUtils.updateStatusBeforeSpecUpgrade(current, new Configuration());
 
         UpdateControl<FlinkDeployment> updateControl =
                 ReconciliationUtils.toUpdateControl(operatorConfiguration, current, previous, true);


### PR DESCRIPTION
This PR makes some major improvements to the spec upgrade and initial deployment flow.

Most importantly, everytime before deploying a new spec (initial deployment or during upgrade) we patch the status and record the spec being upgraded to in the `lastReconciledSpec` with `UPGRADING` ReconciliationState.

This allow us to always detect when an UPGRADE was successful even if the subsequent status upgrade failed for any reason.