### PR TITLE
[tooling] Use 7 letter hash in release scripts

### DIFF
--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -91,7 +91,7 @@ rsync -a \
 
 apache_header=${CLONE_DIR}/flink-kubernetes-operator-${RELEASE_VERSION}/tools/releasing/apache_header.yaml
 # Package helm chart
-commit_hash=$(git log -1 --pretty=format:%h)
+commit_hash=$(git log -1 --pretty=format:%h --abbrev=7)
 
 # Attach apache header to generated crd
 cd flink-kubernetes-operator-${RELEASE_VERSION}/helm/flink-kubernetes-operator/crds


### PR DESCRIPTION
Newer git clients seem to return 8 letter hashes sometimes by default. This fix ensures that our release scripts always uses only the first 7 letters.