### PR TITLE
chore: move up imagePullSecrets field in the Helm values

### DIFF
--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -27,6 +27,8 @@ image:
   pullPolicy: IfNotPresent
   tag: latest
 
+imagePullSecrets: []
+
 rbac:
   create: true
 
@@ -108,7 +110,6 @@ defaultConfiguration:
 metrics:
   port:
 
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
When I added the`imagePullSecrets`, I found it now worked as expected.
The reason is that there exists an `imagePullSecrets` field at the bottom of the file that is not easy to notice.