### PR TITLE
[FLINK-28331] Persist status after every observe loop

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -117,6 +117,7 @@ public class FlinkDeploymentController
                         previousDeployment,
                         false);
             }
+            statusRecorder.patchAndCacheStatus(flinkApp);
             reconcilerFactory.getOrCreate(flinkApp).reconcile(flinkApp, context);
         } catch (DeploymentFailedException dfe) {
             handleDeploymentFailed(flinkApp, dfe);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -96,6 +96,7 @@ public class FlinkSessionJobController
         }
 
         try {
+            statusRecorder.patchAndCacheStatus(flinkSessionJob);
             reconciler.reconcile(flinkSessionJob, context);
         } catch (Exception e) {
             throw new ReconciliationException(e);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -434,10 +434,8 @@ public class TestUtils {
     public static FlinkDeploymentController createTestController(
             FlinkConfigManager configManager,
             KubernetesClient kubernetesClient,
-            TestingFlinkService flinkService) {
-
-        var statusRecorder =
-                new StatusRecorder<FlinkDeploymentStatus>(kubernetesClient, (r, s) -> {});
+            TestingFlinkService flinkService,
+            StatusRecorder statusRecorder) {
         var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
         return new FlinkDeploymentController(
                 configManager,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -60,7 +61,11 @@ public class DeploymentRecoveryTest {
         flinkService = new TestingFlinkService(kubernetesClient);
         context = flinkService.getContext();
         testController =
-                TestUtils.createTestController(configManager, kubernetesClient, flinkService);
+                TestUtils.createTestController(
+                        configManager,
+                        kubernetesClient,
+                        flinkService,
+                        new StatusRecorder<>(kubernetesClient, (a, c) -> {}));
         kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatu
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -70,7 +71,8 @@ public class RollbackTest {
                 TestUtils.createTestController(
                         new FlinkConfigManager(new Configuration()),
                         kubernetesClient,
-                        flinkService);
+                        flinkService,
+                        new StatusRecorder<>(kubernetesClient, (a, c) -> {}));
         kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
     }
 


### PR DESCRIPTION
- Moving the status patching from the SavepointObserver to the main reconcile() loop
- Added extra status assertions to verifyBasicReconcileLoop to better reflect the complete lifecycle