### PR TITLE
[hotfix] Clean up javadoc errors & build javadoc as part of the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Build with Maven
         run: |
-          set -o pipefail; mvn clean install -Pgenerate-docs | tee ./mvn.log; set +o pipefail
+          set -o pipefail; mvn clean install javadoc:javadoc -Pgenerate-docs | tee ./mvn.log; set +o pipefail
           if [[ $(cat ./mvn.log | grep -E -v 'flink-runtime-.*.jar, flink-kubernetes-operator-.*.jar define 2 overlapping classes' | grep -c "overlapping classes" -) -gt 0 ]];then
             echo "Found overlapping classes, please fix"
             exit 1
@@ -153,7 +153,7 @@ jobs:
           sed -i "s/flinkVersion: .*/flinkVersion: ${{ matrix.version }}/" e2e-tests/data/*.yaml
           git diff HEAD
           echo "Running e2e-tests/$test"
-          bash e2e-tests/${{ matrix.test }} || exit 1          
+          bash e2e-tests/${{ matrix.test }} || exit 1
           git reset --hard
       - name: Stop the operator
         run: |

--- a/flink-kubernetes-docs/src/main/java/org/apache/flink/kubernetes/operator/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-kubernetes-docs/src/main/java/org/apache/flink/kubernetes/operator/docs/configuration/ConfigOptionsDocGenerator.java
@@ -100,8 +100,9 @@ public class ConfigOptionsDocGenerator {
      * are annotated with {@link Documentation.Section}.
      *
      * @param args [0] output directory for the generated files [1] project root directory
+     * @throws Exception Error during doc generation.
      */
-    public static void main(String[] args) throws IOException, ClassNotFoundException {
+    public static void main(String[] args) throws Exception {
         String outputDirectory = args[0];
         String rootDir = args[1];
         LOG.info(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/artifact/ArtifactFetcher.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/artifact/ArtifactFetcher.java
@@ -31,7 +31,7 @@ public interface ArtifactFetcher {
      * @param flinkConfiguration Flink configuration.
      * @param targetDir The target dir to put the artifact.
      * @return The path of the fetched artifact.
-     * @throws Exception
+     * @throws Exception Error during fetching the artifact.
      */
     File fetch(String uri, Configuration flinkConfiguration, File targetDir) throws Exception;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkVersion.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/FlinkVersion.java
@@ -37,14 +37,24 @@ public enum FlinkVersion {
         return this.ordinal() > otherVersion.ordinal();
     }
 
-    /** Returns all versions within the defined range, inclusive both start and end. */
+    /**
+     * Returns all versions within the defined range, inclusive both start and end.
+     *
+     * @param start Starting version.
+     * @param end Last version.
+     * @return Versions within the range.
+     */
     public static Set<FlinkVersion> rangeOf(FlinkVersion start, FlinkVersion end) {
         return Stream.of(FlinkVersion.values())
                 .filter(v -> v.ordinal() >= start.ordinal() && v.ordinal() <= end.ordinal())
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
-    /** Returns the current version. */
+    /**
+     * Returns the current version.
+     *
+     * @return The current version.
+     */
     public static FlinkVersion current() {
         return values()[values().length - 1];
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/CommonStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/CommonStatus.java
@@ -39,6 +39,10 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
     /** Error information about the FlinkDeployment/FlinkSessionJob. */
     private String error = "";
 
-    /** Status of the last reconcile operation. */
+    /**
+     * Current reconciliation status of this resource.
+     *
+     * @return Current {@link ReconciliationStatus}.
+     */
     public abstract ReconciliationStatus<SPEC> getReconciliationStatus();
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointInfo.java
@@ -67,7 +67,7 @@ public class SavepointInfo {
      * Update last savepoint info and add the savepoint to the history if it isn't already the most
      * recent savepoint.
      *
-     * @param savepoint
+     * @param savepoint Savepoint to be added.
      */
     public void updateLastSavepoint(Savepoint savepoint) {
         if (lastSavepoint == null || !lastSavepoint.getLocation().equals(savepoint.getLocation())) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -51,6 +51,7 @@ public abstract class JobStatusObserver<CTX> {
      *
      * @param resource The custom resource to be observed.
      * @param deployedConfig Deployed job config.
+     * @param ctx Observe context.
      * @return If job found return true, otherwise return false.
      */
     public boolean observe(
@@ -93,7 +94,11 @@ public abstract class JobStatusObserver<CTX> {
         }
     }
 
-    /** Callback when list jobs timeout. */
+    /**
+     * Callback when list jobs timeout.
+     *
+     * @param ctx Observe context.
+     */
     protected abstract void onTimeout(CTX ctx);
 
     /**

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/Reconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/Reconciler.java
@@ -33,6 +33,7 @@ public interface Reconciler<CR> {
      *
      * @param cr the custom resource that has been created or updated
      * @param context the context with which the operation is executed
+     * @throws Exception Error during reconciliation.
      */
     void reconcile(CR cr, Context context) throws Exception;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -72,6 +72,7 @@ public class ReconciliationUtils {
      *
      * @param target Target Flink resource.
      * @param conf Deployment configuration.
+     * @param <SPEC> Spec type.
      */
     public static <SPEC extends AbstractFlinkSpec> void updateStatusForDeployedSpec(
             AbstractFlinkResource<SPEC, ?> target, Configuration conf) {
@@ -88,6 +89,7 @@ public class ReconciliationUtils {
      *
      * @param target Target Flink resource.
      * @param conf Deployment configuration.
+     * @param <SPEC> Spec type.
      */
     public static <SPEC extends AbstractFlinkSpec> void updateStatusBeforeDeploymentAttempt(
             AbstractFlinkResource<SPEC, ?> target, Configuration conf) {
@@ -265,6 +267,7 @@ public class ReconciliationUtils {
      * @param specWithMetaString JSON string.
      * @param specClass Spec class for deserialization.
      * @return Tuple2 of spec and meta.
+     * @param <T> Spec type.
      */
     public static <T extends AbstractFlinkSpec> Tuple2<T, ObjectNode> deserializeSpecWithMeta(
             @Nullable String specWithMetaString, Class<T> specClass) {
@@ -351,6 +354,7 @@ public class ReconciliationUtils {
      *
      * @param deployment The current deployment to be reconciled
      * @param validationError Validation error encountered for the current spec
+     * @param <SPEC> Spec type.
      * @return True if the spec was reset and reconciliation can continue. False if nothing to
      *     reconcile.
      */
@@ -388,6 +392,8 @@ public class ReconciliationUtils {
      * @param e Exception that caused the retry
      * @param metricManager Metric manager to be updated
      * @param statusRecorder statusRecorder object for patching status
+     * @param <STATUS> Status type.
+     * @param <R> Resource type.
      * @return This always returns Empty optional currently, due to the status update logic
      */
     public static <STATUS extends CommonStatus<?>, R extends AbstractFlinkResource<?, STATUS>>
@@ -470,10 +476,11 @@ public class ReconciliationUtils {
 
     /**
      * Updates status in cases where a previously successful deployment wasn't recorded for any
-     * reason. We simply change the job status from SUSPENDED -> RUNNING and ReconciliationState to
+     * reason. We simply change the job status from SUSPENDED to RUNNING and ReconciliationState to
      * DEPLOYED while keeping the metadata.
      *
      * @param resource Flink resource to be updated.
+     * @param <SPEC> Spec type.
      */
     public static <SPEC extends AbstractFlinkSpec> void updateStatusForAlreadyUpgraded(
             AbstractFlinkResource<SPEC, ?> resource) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -196,7 +196,7 @@ public abstract class AbstractFlinkResourceReconciler<
      * @param cr Related Flink resource.
      * @param observeConfig Observe configuration.
      * @param deployConfig Deployment configuration.
-     * @throws Exception
+     * @throws Exception Error during spec upgrade.
      */
     protected abstract void reconcileSpecChange(
             CR cr, Configuration observeConfig, Configuration deployConfig) throws Exception;
@@ -207,7 +207,7 @@ public abstract class AbstractFlinkResourceReconciler<
      * @param cr Related Flink resource.
      * @param ctx Reconciliation context.
      * @param observeConfig Observe configuration.
-     * @throws Exception
+     * @throws Exception Error during rollback.
      */
     protected abstract void rollback(CR cr, Context ctx, Configuration observeConfig)
             throws Exception;
@@ -219,7 +219,7 @@ public abstract class AbstractFlinkResourceReconciler<
      * @param cr Related Flink resource.
      * @param observeConfig Observe configuration.
      * @return True if any further reconciliation action was taken.
-     * @throws Exception
+     * @throws Exception Error during reconciliation.
      */
     protected abstract boolean reconcileOtherChanges(CR cr, Configuration observeConfig)
             throws Exception;
@@ -238,7 +238,7 @@ public abstract class AbstractFlinkResourceReconciler<
      * @param deployConfig Flink conf for the deployment.
      * @param savepoint Optional savepoint path for applications and session jobs.
      * @param requireHaMetadata Flag used by application deployments to validate HA metadata
-     * @throws Exception
+     * @throws Exception Error during deployment.
      */
     protected abstract void deploy(
             CR relatedResource,
@@ -286,7 +286,7 @@ public abstract class AbstractFlinkResourceReconciler<
      *
      * @param reconciliationStatus ReconciliationStatus of the resource.
      * @param configuration Flink cluster configuration.
-     * @return
+     * @return True if the resource should be rolled back.
      */
     private boolean shouldRollBack(
             ReconciliationStatus<SPEC> reconciliationStatus, Configuration configuration) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -216,9 +216,9 @@ public abstract class AbstractJobReconciler<
      * Cancel the job for the given resource using the specified upgrade mode.
      *
      * @param resource Related Flink resource.
-     * @param upgradeMode
+     * @param upgradeMode Upgrade mode used during cancel.
      * @param observeConfig Observe configuration.
-     * @throws Exception
+     * @throws Exception Error during cancellation.
      */
     protected abstract void cancelJob(
             CR resource, UpgradeMode upgradeMode, Configuration observeConfig) throws Exception;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ConfigOptionUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ConfigOptionUtils.java
@@ -34,6 +34,7 @@ public class ConfigOptionUtils {
      * @param config The effective config
      * @param configOption The config option.
      * @param configThreshold The config threshold.
+     * @param <T> Type of the config value.
      * @return The value of {@link ConfigOption} with threshold.
      */
     public static <T extends Comparable<T>> T getValueWithThreshold(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -151,7 +151,14 @@ public class FlinkUtils {
         status.getJobStatus().setState(JobStatus.FINISHED.name());
     }
 
-    /** Wait until the FLink cluster has completely shut down. */
+    /**
+     * Wait until the FLink cluster has completely shut down.
+     *
+     * @param kubernetesClient Kubernetes client.
+     * @param namespace Resource namespace.
+     * @param clusterId Flink clusterId.
+     * @param shutdownTimeout Max time allowed for shutdown.
+     */
     public static void waitForClusterShutdown(
             KubernetesClient kubernetesClient,
             String namespace,
@@ -200,7 +207,13 @@ public class FlinkUtils {
         LOG.info("Cluster shutdown completed.");
     }
 
-    /** Wait until the FLink cluster has completely shut down. */
+    /**
+     * Wait until the FLink cluster has completely shut down.
+     *
+     * @param kubernetesClient Kubernetes client.
+     * @param conf Flink configuration.
+     * @param shutdownTimeout Max time allowed for shutdown.
+     */
     public static void waitForClusterShutdown(
             KubernetesClient kubernetesClient, Configuration conf, long shutdownTimeout) {
         FlinkUtils.waitForClusterShutdown(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -51,6 +51,7 @@ public class SavepointUtils {
      * @param resource Resource that should be savepointed
      * @param conf Observe config of the resource
      * @return True if a savepoint was triggered
+     * @throws Exception Error during savepoint triggering.
      */
     public static boolean triggerSavepointIfNeeded(
             FlinkService flinkService, AbstractFlinkResource<?, ?> resource, Configuration conf)

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
@@ -66,6 +66,7 @@ public class StatusRecorder<STATUS extends CommonStatus<?>> {
      * operator behavior.
      *
      * @param resource Resource for which status update should be performed
+     * @param <T> Resource type.
      */
     @SneakyThrows
     public <T extends AbstractFlinkResource<?, STATUS>> void patchAndCacheStatus(T resource) {
@@ -121,6 +122,7 @@ public class StatusRecorder<STATUS extends CommonStatus<?>> {
      * reconciles a resource for the first time after a restart.
      *
      * @param resource Resource for which the status should be updated from the cache
+     * @param <T> Custom resource type.
      */
     public <T extends CustomResource<?, STATUS>> void updateStatusFromCache(T resource) {
         var key = getKey(resource);
@@ -136,7 +138,12 @@ public class StatusRecorder<STATUS extends CommonStatus<?>> {
         }
     }
 
-    /** Remove cached status for Flink resource. */
+    /**
+     * Remove cached status for Flink resource.
+     *
+     * @param resource Flink resource.
+     * @param <T> Resource type.
+     */
     public <T extends CustomResource<?, STATUS>> void removeCachedStatus(T resource) {
         statusCache.remove(getKey(resource));
     }

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/DefaultRequestMutator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/DefaultRequestMutator.java
@@ -40,7 +40,7 @@ import java.util.Base64;
  * io.javaoperatorsdk.admissioncontroller.mutation.DefaultRequestMutator} with a modified path diff
  * util to serialize out include non-null.
  *
- * @param <T>
+ * @param <T> Resource type.
  */
 public class DefaultRequestMutator<T extends KubernetesResource> implements RequestHandler {
     private static final ObjectMapper mapper =


### PR DESCRIPTION
 - Fix all javadoc errors and warnings
 - Add `javadoc:javadoc` to CI build to ensure that we don't merge javadoc errors.