### PR TITLE
[FLINK-28385] Change the validator to return an error if the Jar URI is an empty string

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -178,7 +178,7 @@ public class DefaultValidator implements FlinkResourceValidator {
             return Optional.empty();
         }
 
-        if (job.getJarURI() == null) {
+        if (StringUtils.isNullOrWhitespaceOnly(job.getJarURI())) {
             return Optional.of("Jar URI must be defined");
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -76,6 +76,9 @@ public class DefaultValidatorTest {
 
         // Test job validation
         testError(dep -> dep.getSpec().getJob().setJarURI(null), "Jar URI must be defined");
+        testError(dep -> dep.getSpec().getJob().setJarURI(""), "Jar URI must be defined");
+        testError(dep -> dep.getSpec().getJob().setJarURI("  "), "Jar URI must be defined");
+
         testError(
                 dep -> dep.getSpec().getJob().setState(JobState.SUSPENDED),
                 "Job must start in running state");


### PR DESCRIPTION
This error may happen if I use Golang to submit the job with some bugs.
