### PR TITLE
[FLINK-28350] Always use savepoint when switching between Flink versions

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
@@ -94,10 +94,7 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
 
     @Override
     public void observe(FlinkSessionJob flinkSessionJob, Context context) {
-        var lastReconciledSpec =
-                flinkSessionJob.getStatus().getReconciliationStatus().getLastReconciledSpec();
-
-        if (lastReconciledSpec == null) {
+        if (flinkSessionJob.getStatus().getReconciliationStatus().isFirstDeployment()) {
             return;
         }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -91,7 +91,9 @@ public class ApplicationReconciler
                                 .OPERATOR_JOB_UPGRADE_LAST_STATE_FALLBACK_ENABLED)
                 && FlinkUtils.isKubernetesHAActivated(deployConfig)
                 && FlinkUtils.isKubernetesHAActivated(observeConfig)
-                && flinkService.isHaMetadataAvailable(deployConfig)) {
+                && flinkService.isHaMetadataAvailable(deployConfig)
+                && !flinkVersionChanged(
+                        ReconciliationUtils.getDeployedSpec(deployment), deployment.getSpec())) {
             LOG.info(
                     "Job is not running but HA metadata is available for last state restore, ready for upgrade");
             return Optional.of(UpgradeMode.LAST_STATE);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -287,11 +287,7 @@ public class DefaultValidator implements FlinkResourceValidator {
             FlinkDeployment deployment, Map<String, String> effectiveConfig) {
         FlinkDeploymentSpec newSpec = deployment.getSpec();
 
-        if (deployment.getStatus() == null
-                || deployment.getStatus().getReconciliationStatus() == null
-                || deployment.getStatus().getReconciliationStatus().getLastReconciledSpec()
-                        == null) {
-            // New deployment
+        if (deployment.getStatus().getReconciliationStatus().isFirstDeployment()) {
             if (newSpec.getJob() != null && !newSpec.getJob().getState().equals(JobState.RUNNING)) {
                 return Optional.of("Job must start in running state");
             }


### PR DESCRIPTION
As HA metadata is not always compatible (for example Flink 1.14 <-> 1.15) we should always take a savepoint between version upgrades and not allow rollbacks.