### PR TITLE
[FLINK-28356] Move operator metric recording logic into statusrecorder

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -112,7 +112,9 @@ public class FlinkOperator {
     }
 
     private void registerDeploymentController() {
-        var statusRecorder = StatusRecorder.<FlinkDeploymentStatus>create(client, listeners);
+        var statusRecorder =
+                StatusRecorder.<FlinkDeploymentStatus>create(
+                        client, new MetricManager<>(metricGroup), listeners);
         var eventRecorder = EventRecorder.create(client, listeners);
         var reconcilerFactory =
                 new ReconcilerFactory(
@@ -126,7 +128,6 @@ public class FlinkOperator {
                         validators,
                         reconcilerFactory,
                         observerFactory,
-                        new MetricManager<>(metricGroup),
                         statusRecorder,
                         eventRecorder);
         registeredControllers.add(operator.register(controller, this::overrideControllerConfigs));
@@ -134,7 +135,9 @@ public class FlinkOperator {
 
     private void registerSessionJobController() {
         var eventRecorder = EventRecorder.create(client, listeners);
-        var statusRecorder = StatusRecorder.<FlinkSessionJobStatus>create(client, listeners);
+        var statusRecorder =
+                StatusRecorder.<FlinkSessionJobStatus>create(
+                        client, new MetricManager<>(metricGroup), listeners);
         var reconciler =
                 new SessionJobReconciler(
                         client, flinkService, configManager, eventRecorder, statusRecorder);
@@ -142,13 +145,7 @@ public class FlinkOperator {
                 new SessionJobObserver(flinkService, configManager, statusRecorder, eventRecorder);
         var controller =
                 new FlinkSessionJobController(
-                        configManager,
-                        validators,
-                        reconciler,
-                        observer,
-                        new MetricManager<>(metricGroup),
-                        statusRecorder);
-
+                        configManager, validators, reconciler, observer, statusRecorder);
         registeredControllers.add(operator.register(controller, this::overrideControllerConfigs));
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/MetricManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/MetricManager.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /** Metric manager for Operator managed custom resources. */
 public class MetricManager<CR extends CustomResource<?, ?>> {
-    private static final String NS_SCOPE_KEY = "resourcens";
+    public static final String NS_SCOPE_KEY = "resourcens";
     private final MetricGroup metricGroup;
     private final Map<String, CustomResourceMetrics> metrics = new ConcurrentHashMap<>();
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -32,7 +32,6 @@ import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.crd.status.TaskManagerInfo;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
-import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.util.Preconditions;
@@ -390,7 +389,6 @@ public class ReconciliationUtils {
      * @param resource Flink Resource to be updated
      * @param retryInfo Current RetryInformation
      * @param e Exception that caused the retry
-     * @param metricManager Metric manager to be updated
      * @param statusRecorder statusRecorder object for patching status
      * @param <STATUS> Status type.
      * @param <R> Resource type.
@@ -401,7 +399,6 @@ public class ReconciliationUtils {
                     R resource,
                     Optional<RetryInfo> retryInfo,
                     Exception e,
-                    MetricManager<R> metricManager,
                     StatusRecorder<STATUS> statusRecorder) {
 
         retryInfo.ifPresent(
@@ -416,7 +413,6 @@ public class ReconciliationUtils {
         ReconciliationUtils.updateForReconciliationError(
                 resource,
                 (e instanceof ReconciliationException) ? e.getCause().toString() : e.toString());
-        metricManager.onUpdate(resource);
         statusRecorder.patchAndCacheStatus(resource);
 
         // Status was updated already, no need to return anything

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
@@ -20,7 +20,9 @@ package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.status.CommonStatus;
+import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
+import org.apache.flink.metrics.testutils.MetricListener;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -28,7 +30,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class TestingStatusRecorder<STATUS extends CommonStatus<?>> extends StatusRecorder<STATUS> {
 
     public TestingStatusRecorder() {
-        super(null, (r, s) -> {});
+        super(null, new MetricManager<>(new MetricListener().getMetricGroup()), (r, s) -> {});
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -64,8 +64,11 @@ public class TestingFlinkDeploymentController
             KubernetesClient kubernetesClient,
             TestingFlinkService flinkService) {
         eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
-        statusRecorder = new StatusRecorder<>(kubernetesClient, statusUpdateCounter);
-
+        statusRecorder =
+                new StatusRecorder<>(
+                        kubernetesClient,
+                        new MetricManager<>(new MetricListener().getMetricGroup()),
+                        statusUpdateCounter);
         flinkDeploymentController =
                 new FlinkDeploymentController(
                         configManager,
@@ -78,7 +81,6 @@ public class TestingFlinkDeploymentController
                                 statusRecorder),
                         new ObserverFactory(
                                 flinkService, configManager, statusRecorder, eventRecorder),
-                        new MetricManager<>(new MetricListener().getMetricGroup()),
                         statusRecorder,
                         eventRecorder);
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
@@ -21,8 +21,10 @@ import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
+import org.apache.flink.metrics.testutils.MetricListener;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -52,7 +54,10 @@ public class FlinkResourceListenerTest {
         var listeners = List.<FlinkResourceListener>of(listener1, listener2);
 
         var statusRecorder =
-                StatusRecorder.<FlinkDeploymentStatus>create(kubernetesClient, listeners);
+                StatusRecorder.<FlinkDeploymentStatus>create(
+                        kubernetesClient,
+                        new MetricManager<>(new MetricListener().getMetricGroup()),
+                        listeners);
         var eventRecorder = EventRecorder.create(kubernetesClient, listeners);
 
         var deployment = TestUtils.buildApplicationCluster();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.TestingStatusRecorder;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
@@ -38,7 +39,6 @@ import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
-import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.highavailability.JobResultStoreOptions;
 
@@ -76,8 +76,7 @@ public class ApplicationReconcilerTest {
     public void before() {
         kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
         var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
-        var statusRecoder =
-                new StatusRecorder<FlinkDeploymentStatus>(kubernetesClient, (r, e) -> {});
+        var statusRecoder = new TestingStatusRecorder<FlinkDeploymentStatus>();
         reconciler =
                 new ApplicationReconciler(
                         kubernetesClient,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -20,10 +20,10 @@ package org.apache.flink.kubernetes.operator.reconciler.deployment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.TestingStatusRecorder;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -63,7 +63,7 @@ public class SessionReconcilerTest {
                         flinkService,
                         configManager,
                         eventRecorder,
-                        new StatusRecorder<>(kubernetesClient, (r, e) -> {}));
+                        new TestingStatusRecorder<>());
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
         kubernetesClient.resource(deployment).createOrReplace();
         reconciler.reconcile(deployment, context);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.TestingStatusRecorder;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
@@ -84,7 +85,7 @@ public class SessionJobReconcilerTest {
                 new SessionJobReconciler(
                         null, flinkService, configManager, eventRecorder, statusRecoder);
         kubernetesClient.resource(TestUtils.buildSessionJob()).createOrReplace();
-        statusRecoder = new StatusRecorder<FlinkSessionJobStatus>(kubernetesClient, (r, e) -> {});
+        statusRecoder = new TestingStatusRecorder<>();
         reconciler =
                 new SessionJobReconciler(
                         null, flinkService, configManager, eventRecorder, statusRecoder);


### PR DESCRIPTION
Moved the `MetricManager` into` StatusRecorder`. All (status related) metrics are maintained now via the StatusRecorder.