### PR TITLE
[FLINK-28438] Clear the previous error if session job is running or finished

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -157,7 +157,9 @@ public abstract class JobStatusObserver<CTX> {
             AbstractFlinkResource<?, ?> resource,
             JobStatusMessage clusterJobStatus,
             Configuration deployedConfig) {
-        if (clusterJobStatus.getJobState() == org.apache.flink.api.common.JobStatus.FAILED) {
+        var jobState = clusterJobStatus.getJobState();
+
+        if (jobState == org.apache.flink.api.common.JobStatus.FAILED) {
             try {
                 var result =
                         flinkService.requestJobResult(deployedConfig, clusterJobStatus.getJobId());
@@ -181,6 +183,8 @@ public abstract class JobStatusObserver<CTX> {
             } catch (Exception e) {
                 LOG.warn("Failed to request the job result", e);
             }
+        } else if (jobState == org.apache.flink.api.common.JobStatus.FINISHED || jobState == org.apache.flink.api.common.JobStatus.RUNNING) {
+            resource.getStatus().setError("");
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -183,7 +183,8 @@ public abstract class JobStatusObserver<CTX> {
             } catch (Exception e) {
                 LOG.warn("Failed to request the job result", e);
             }
-        } else if (jobState == org.apache.flink.api.common.JobStatus.FINISHED || jobState == org.apache.flink.api.common.JobStatus.RUNNING) {
+        } else if (jobState == org.apache.flink.api.common.JobStatus.FINISHED
+                || jobState == org.apache.flink.api.common.JobStatus.RUNNING) {
             resource.getStatus().setError("");
         }
     }


### PR DESCRIPTION
Once an error occurs, the error filed will contain the message even if the job is running successfully at the end.
We should clear the error message when the session job is running or finished.