### PR TITLE
[FLINK-28297][FLINK-27914]  Improve operator metric groups + Add JOSDK metric integration

### DIFF
--- a/docs/content/docs/operations/configuration.md
+++ b/docs/content/docs/operations/configuration.md
@@ -52,7 +52,7 @@ To learn more about metrics and logging configuration please refer to the dedica
 
 ## Dynamic Operator Configuration
 
-The Kubernetes operator supports dynamic config changes through the operator ConfigMaps. Dynamic operator configuration is enabled by default, and can be disabled by setting `kubernetes.operator.dynamic.config.enabled`  to false. Time interval for checking dynamic config changes is specified by `kubernetes.operator.dynamic.config.check.interval` of which default value is 5 minutes. 
+The Kubernetes operator supports dynamic config changes through the operator ConfigMaps. Dynamic operator configuration is enabled by default, and can be disabled by setting `kubernetes.operator.dynamic.config.enabled`  to false. Time interval for checking dynamic config changes is specified by `kubernetes.operator.dynamic.config.check.interval` of which default value is 5 minutes.
 
 Verify whether dynamic operator configuration updates is enabled via the `deploy/flink-kubernetes-operator` log has:
 
@@ -70,14 +70,26 @@ Verify whether the config value of `kubernetes.operator.reconcile.interval` is u
 
 ## Operator Configuration Reference
 
-{{< generated/kubernetes_operator_config_configuration >}}
+### System Configuration
 
-## Job Specific Configuration Reference
+General operator system configuration. Cannot be overridden on a per-resource basis.
 
-Job specific configuration can be configured under `spec.flinkConfiguration` and it will override flink configurations defined in `flink-conf.yaml`.
+{{< generated/system_section >}}
 
-- For application clusters, `spec.flinkConfiguration` will be located in `FlinkDeployment` CustomResource.
-- For session clusters, configuring `spec.flinkConfiguration` in parent `FlinkDeployment` will be applied to all session jobs within the session cluster.
-  - You can configure some additional job specific supplemental configuration through `spec.flinkConfiguration` in `FlinkSessionJob` CustomResource. 
-  Those session job level configurations will override the parent session cluster's Flink configuration. Please note only the following configurations are considered to be valid configurations.
-    - `kubernetes.operator.user.artifacts.http.header`
+### Resource/User Configuration
+
+These options can be configured on both an operator and a per-resource level. When set under `spec.flinkConfiguration` for the Flink resources it will override the default value provided in the operator default configuration (`flink-conf.yaml`).
+
+{{< generated/dynamic_section >}}
+
+### System Metrics Configuration
+
+Operator system metrics configuration. Cannot be overridden on a per-resource basis.
+
+{{< generated/kubernetes_operator_metric_configuration >}}
+
+### Advanced System Configuration
+
+Advanced operator system configuration. Cannot be overridden on a per-resource basis.
+
+{{< generated/system_advanced_section >}}

--- a/docs/content/docs/operations/metrics-logging.md
+++ b/docs/content/docs/operations/metrics-logging.md
@@ -28,7 +28,6 @@ under the License.
 
 The Flink Kubernetes Operator (Operator) extends the [Flink Metric System](https://nightlies.apache.org/flink/flink-docs-master/docs/ops/metrics/) that allows gathering and exposing metrics to centralized monitoring solutions. 
 
-
 ## Deployment Metrics
 The Operator gathers aggregates metrics about managed resources.
 
@@ -39,7 +38,7 @@ The Operator gathers aggregates metrics about managed resources.
 | Namespace | FlinkSessionJob.Count          | Number of managed FlinkSessionJob instances per namespace                                                                                                   | Gauge |
 
 ## System Metrics
-The Operator gathers metrics about the JVM process and exposes it similarly to core Flink [System metrics](https://nightlies.apache.org/flink/flink-docs-master/docs/ops/metrics/#system-metrics). The list of metrics are not repeated in this document. 
+The Operator gathers metrics about the JVM process and exposes it similarly to core Flink [System metrics](https://nightlies.apache.org/flink/flink-docs-master/docs/ops/metrics/#system-metrics). The list of metrics are not repeated in this document.
 
 ## Metric Reporters
 

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -1,0 +1,72 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>kubernetes.operator.deployment.readiness.timeout</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>The timeout for deployments to become ready/stable before being rolled back if rollback is enabled.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.deployment.rollback.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable rolling back failed deployment upgrades.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.jm-deployment-recovery.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable recovery of missing/deleted jobmanager deployments.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.job.upgrade.ignore-pending-savepoint</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to ignore pending savepoint during job upgrade.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.job.upgrade.last-state-fallback.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Enables last-state fallback for savepoint upgrade mode. When the job is not running thus savepoint cannot be triggered but HA metadata is available for last state restore the operator can initiate the upgrade process when the flag is enabled.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.periodic.savepoint.interval</h5></td>
+            <td style="word-wrap: break-word;">0 ms</td>
+            <td>Duration</td>
+            <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.savepoint.history.max.age</h5></td>
+            <td style="word-wrap: break-word;">86400000 ms</td>
+            <td>Duration</td>
+            <td>Maximum age for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.savepoint.history.max.count</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>Maximum number of savepoint history entries to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.savepoint.trigger.grace-period</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>The interval before a savepoint trigger attempt is marked as unsuccessful.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.user.artifacts.http.header</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Map</td>
+            <td>Custom HTTP header for HttpArtifactFetcher. The header will be applied when getting the session job artifacts. Expected format: headerKey1:headerValue1,headerKey2:headerValue2.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -81,6 +81,12 @@
             <td>Enables last-state fallback for savepoint upgrade mode. When the job is not running thus savepoint cannot be triggered but HA metadata is available for last state restore the operator can initiate the upgrade process when the flag is enabled.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.josdk.metrics.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Enable forwarding of Java Operator SDK metrics to the Flink metric registry.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.observer.progress-check.interval</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -81,12 +81,6 @@
             <td>Enables last-state fallback for savepoint upgrade mode. When the job is not running thus savepoint cannot be triggered but HA metadata is available for last state restore the operator can initiate the upgrade process when the flag is enabled.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.josdk.metrics.enabled</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Enable forwarding of Java Operator SDK metrics to the Flink metric registry.</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.observer.progress-check.interval</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_metric_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_metric_configuration.html
@@ -1,0 +1,36 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>kubernetes.operator.josdk.metrics.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Enable forwarding of Java Operator SDK metrics to the Flink metric registry.</td>
+        </tr>
+        <tr>
+            <td><h5>metrics.scope.k8soperator.resource</h5></td>
+            <td style="word-wrap: break-word;">"&lt;host&gt;.k8soperator.&lt;namespace&gt;.&lt;name&gt;.resource.&lt;resourcens&gt;.&lt;resourcename&gt;"</td>
+            <td>String</td>
+            <td>Defines the scope format string that is applied to all metrics scoped to the kubernetes operator resource.</td>
+        </tr>
+        <tr>
+            <td><h5>metrics.scope.k8soperator.resourcens</h5></td>
+            <td style="word-wrap: break-word;">"&lt;host&gt;.k8soperator.&lt;namespace&gt;.&lt;name&gt;.namespace.&lt;resourcens&gt;"</td>
+            <td>String</td>
+            <td>Defines the scope format string that is applied to all metrics scoped to the kubernetes operator resource namespace.</td>
+        </tr>
+        <tr>
+            <td><h5>metrics.scope.k8soperator.system</h5></td>
+            <td style="word-wrap: break-word;">"&lt;host&gt;.k8soperator.&lt;namespace&gt;.&lt;name&gt;.system"</td>
+            <td>String</td>
+            <td>Defines the scope format string that is applied to all metrics scoped to the kubernetes operator.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/generated/system_advanced_section.html
+++ b/docs/layouts/shortcodes/generated/system_advanced_section.html
@@ -1,0 +1,60 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>kubernetes.operator.config.cache.size</h5></td>
+            <td style="word-wrap: break-word;">1000</td>
+            <td>Integer</td>
+            <td>Max config cache size.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.config.cache.timeout</h5></td>
+            <td style="word-wrap: break-word;">10 min</td>
+            <td>Duration</td>
+            <td>Expiration time for cached configs.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.dynamic.config.check.interval</h5></td>
+            <td style="word-wrap: break-word;">5 min</td>
+            <td>Duration</td>
+            <td>Time interval for checking config changes.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.dynamic.config.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable on-the-fly config changes through the operator configmap.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.observer.progress-check.interval</h5></td>
+            <td style="word-wrap: break-word;">10 s</td>
+            <td>Duration</td>
+            <td>The interval for observing status for in-progress operations such as deployment and savepoints.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.observer.rest-ready.delay</h5></td>
+            <td style="word-wrap: break-word;">10 s</td>
+            <td>Duration</td>
+            <td>Final delay before deployment is marked ready after port becomes accessible.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.savepoint.history.max.age.threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Maximum age threshold for savepoint history entries to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.savepoint.history.max.count.threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>Maximum number threshold of savepoint history entries to retain.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/generated/system_section.html
+++ b/docs/layouts/shortcodes/generated/system_section.html
@@ -1,0 +1,78 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>kubernetes.operator.dynamic.namespaces.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enables dynamic change of watched/monitored namespaces.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.flink.client.cancel.timeout</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>The timeout for the reconciler to wait for flink to cancel job.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.flink.client.timeout</h5></td>
+            <td style="word-wrap: break-word;">10 s</td>
+            <td>Duration</td>
+            <td>The timeout for the observer to wait the flink rest client to return.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.reconcile.interval</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>The interval for the controller to reschedule the reconcile process.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.reconcile.parallelism</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>The maximum number of threads running the reconciliation loop. Use -1 for infinite.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.resource.cleanup.timeout</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>The timeout for the resource clean up to wait for flink to shutdown cluster.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.retry.initial.interval</h5></td>
+            <td style="word-wrap: break-word;">5 s</td>
+            <td>Duration</td>
+            <td>Initial interval of automatic reconcile retries on recoverable errors.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.retry.interval.multiplier</h5></td>
+            <td style="word-wrap: break-word;">2.0</td>
+            <td>Double</td>
+            <td>Interval multiplier of automatic reconcile retries on recoverable errors.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.retry.max.attempts</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>Max attempts of automatic reconcile retries on recoverable errors.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.user.artifacts.base.dir</h5></td>
+            <td style="word-wrap: break-word;">"/opt/flink/artifacts"</td>
+            <td>String</td>
+            <td>The base dir to put the session job artifacts.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.watched.namespaces</h5></td>
+            <td style="word-wrap: break-word;">"JOSDK_ALL_NAMESPACES"</td>
+            <td>String</td>
+            <td>Comma separated list of namespaces the operator monitors for custom resources.</td>
+        </tr>
+    </tbody>
+</table>

--- a/flink-kubernetes-docs/src/main/java/org/apache/flink/kubernetes/operator/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-kubernetes-docs/src/main/java/org/apache/flink/kubernetes/operator/docs/configuration/ConfigOptionsDocGenerator.java
@@ -72,7 +72,9 @@ public class ConfigOptionsDocGenerator {
     static final OptionsClassLocation[] LOCATIONS =
             new OptionsClassLocation[] {
                 new OptionsClassLocation(
-                        "flink-kubernetes-operator", "org.apache.flink.kubernetes.operator.config")
+                        "flink-kubernetes-operator", "org.apache.flink.kubernetes.operator.config"),
+                new OptionsClassLocation(
+                        "flink-kubernetes-operator", "org.apache.flink.kubernetes.operator.metrics")
             };
     static final String DEFAULT_PATH_PREFIX = "src/main/java";
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.kubernetes.operator.listener.FlinkResourceListener;
 import org.apache.flink.kubernetes.operator.listener.ListenerUtils;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
 import org.apache.flink.kubernetes.operator.metrics.MetricManager;
+import org.apache.flink.kubernetes.operator.metrics.OperatorJosdkMetrics;
 import org.apache.flink.kubernetes.operator.metrics.OperatorMetricUtils;
 import org.apache.flink.kubernetes.operator.observer.deployment.ObserverFactory;
 import org.apache.flink.kubernetes.operator.observer.sessionjob.SessionJobObserver;
@@ -79,12 +80,12 @@ public class FlinkOperator {
                 conf != null
                         ? new FlinkConfigManager(conf) // For testing only
                         : new FlinkConfigManager(this::handleNamespaceChanges);
+        this.metricGroup =
+                OperatorMetricUtils.initOperatorMetrics(configManager.getDefaultConfig());
         this.operator = new Operator(client, this::overrideOperatorConfigs);
         this.flinkService = new FlinkService(client, configManager);
         this.validators = ValidatorUtils.discoverValidators(configManager);
         this.listeners = ListenerUtils.discoverListeners(configManager);
-        this.metricGroup =
-                OperatorMetricUtils.initOperatorMetrics(configManager.getDefaultConfig());
         PluginManager pluginManager =
                 PluginUtils.createPluginManagerFromRootFolder(configManager.getDefaultConfig());
         FileSystem.initialize(configManager.getDefaultConfig(), pluginManager);
@@ -108,6 +109,10 @@ public class FlinkOperator {
         } else {
             LOG.info("Configuring operator with {} reconciliation threads.", parallelism);
             overrider.withConcurrentReconciliationThreads(parallelism);
+        }
+        if (configManager.getOperatorConfiguration().getJosdkMetricsEnabled()) {
+            overrider.withMetrics(
+                    new OperatorJosdkMetrics(metricGroup, configManager.getDefaultConfig()));
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -110,7 +110,7 @@ public class FlinkOperator {
             LOG.info("Configuring operator with {} reconciliation threads.", parallelism);
             overrider.withConcurrentReconciliationThreads(parallelism);
         }
-        if (configManager.getOperatorConfiguration().getJosdkMetricsEnabled()) {
+        if (configManager.getOperatorConfiguration().isJosdkMetricsEnabled()) {
             overrider.withMetrics(
                     new OperatorJosdkMetrics(metricGroup, configManager.getDefaultConfig()));
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -131,7 +131,7 @@ public class FlinkConfigManager {
                         .orElse(Set.of());
         this.operatorConfiguration = FlinkOperatorConfiguration.fromConfiguration(newConf);
         var newNs = this.operatorConfiguration.getWatchedNamespaces();
-        if (this.operatorConfiguration.getDynamicNamespacesEnabled() && !oldNs.equals(newNs)) {
+        if (this.operatorConfiguration.isDynamicNamespacesEnabled() && !oldNs.equals(newNs)) {
             this.namespaceListener.accept(operatorConfiguration.getWatchedNamespaces());
         }
         this.defaultConfig = newConf.clone();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -43,6 +43,7 @@ public class FlinkOperatorConfiguration {
     String flinkServiceHostOverride;
     Set<String> watchedNamespaces;
     Boolean dynamicNamespacesEnabled;
+    Boolean josdkMetricsEnabled;
     Duration flinkCancelJobTimeout;
     Duration flinkShutdownClusterTimeout;
     String artifactsBaseDir;
@@ -109,6 +110,9 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions.OPERATOR_DYNAMIC_NAMESPACES_ENABLED);
 
+        boolean josdkMetricsEnabled =
+                operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_JOSDK_METRICS_ENABLED);
+
         RetryConfiguration retryConfiguration = new FlinkOperatorRetryConfiguration(operatorConfig);
 
         return new FlinkOperatorConfiguration(
@@ -120,6 +124,7 @@ public class FlinkOperatorConfiguration {
                 flinkServiceHostOverride,
                 watchedNamespaces,
                 dynamicNamespacesEnabled,
+                josdkMetricsEnabled,
                 flinkCancelJobTimeout,
                 flinkShutdownClusterTimeout,
                 artifactsBaseDir,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -19,6 +19,7 @@
 package org.apache.flink.kubernetes.operator.config;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricOptions;
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 
 import io.javaoperatorsdk.operator.api.config.RetryConfiguration;
@@ -42,8 +43,8 @@ public class FlinkOperatorConfiguration {
     Duration flinkClientTimeout;
     String flinkServiceHostOverride;
     Set<String> watchedNamespaces;
-    Boolean dynamicNamespacesEnabled;
-    Boolean josdkMetricsEnabled;
+    boolean dynamicNamespacesEnabled;
+    boolean josdkMetricsEnabled;
     Duration flinkCancelJobTimeout;
     Duration flinkShutdownClusterTimeout;
     String artifactsBaseDir;
@@ -111,7 +112,7 @@ public class FlinkOperatorConfiguration {
                         KubernetesOperatorConfigOptions.OPERATOR_DYNAMIC_NAMESPACES_ENABLED);
 
         boolean josdkMetricsEnabled =
-                operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_JOSDK_METRICS_ENABLED);
+                operatorConfig.get(KubernetesOperatorMetricOptions.OPERATOR_JOSDK_METRICS_ENABLED);
 
         RetryConfiguration retryConfiguration = new FlinkOperatorRetryConfiguration(operatorConfig);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes.operator.config;
 
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
@@ -30,6 +31,11 @@ import java.util.Map;
 /** This class holds configuration constants used by flink operator. */
 public class KubernetesOperatorConfigOptions {
 
+    public static final String SECTION_SYSTEM = "system";
+    public static final String SECTION_ADVANCED = "system_advanced";
+    public static final String SECTION_DYNAMIC = "dynamic";
+
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Duration> OPERATOR_RECONCILE_INTERVAL =
             ConfigOptions.key("kubernetes.operator.reconcile.interval")
                     .durationType()
@@ -38,6 +44,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "The interval for the controller to reschedule the reconcile process.");
 
+    @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Duration> OPERATOR_OBSERVER_REST_READY_DELAY =
             ConfigOptions.key("kubernetes.operator.observer.rest-ready.delay")
                     .durationType()
@@ -45,6 +52,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Final delay before deployment is marked ready after port becomes accessible.");
 
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Integer> OPERATOR_RECONCILE_PARALLELISM =
             ConfigOptions.key("kubernetes.operator.reconcile.parallelism")
                     .intType()
@@ -53,6 +61,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "The maximum number of threads running the reconciliation loop. Use -1 for infinite.");
 
+    @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Duration> OPERATOR_OBSERVER_PROGRESS_CHECK_INTERVAL =
             ConfigOptions.key("kubernetes.operator.observer.progress-check.interval")
                     .durationType()
@@ -60,6 +69,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "The interval for observing status for in-progress operations such as deployment and savepoints.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_TRIGGER_GRACE_PERIOD =
             ConfigOptions.key("kubernetes.operator.savepoint.trigger.grace-period")
                     .durationType()
@@ -69,6 +79,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "The interval before a savepoint trigger attempt is marked as unsuccessful.");
 
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Duration> OPERATOR_FLINK_CLIENT_TIMEOUT =
             ConfigOptions.key("kubernetes.operator.flink.client.timeout")
                     .durationType()
@@ -77,6 +88,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "The timeout for the observer to wait the flink rest client to return.");
 
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Duration> OPERATOR_FLINK_CLIENT_CANCEL_TIMEOUT =
             ConfigOptions.key("kubernetes.operator.flink.client.cancel.timeout")
                     .durationType()
@@ -85,6 +97,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "The timeout for the reconciler to wait for flink to cancel job.");
 
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Duration> OPERATOR_RESOURCE_CLEANUP_TIMEOUT =
             ConfigOptions.key("kubernetes.operator.resource.cleanup.timeout")
                     .durationType()
@@ -94,12 +107,14 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "The timeout for the resource clean up to wait for flink to shutdown cluster.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> DEPLOYMENT_ROLLBACK_ENABLED =
             ConfigOptions.key("kubernetes.operator.deployment.rollback.enabled")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Whether to enable rolling back failed deployment upgrades.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Duration> DEPLOYMENT_READINESS_TIMEOUT =
             ConfigOptions.key("kubernetes.operator.deployment.readiness.timeout")
                     .durationType()
@@ -108,18 +123,21 @@ public class KubernetesOperatorConfigOptions {
                             "The timeout for deployments to become ready/stable "
                                     + "before being rolled back if rollback is enabled.");
 
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<String> OPERATOR_USER_ARTIFACTS_BASE_DIR =
             ConfigOptions.key("kubernetes.operator.user.artifacts.base.dir")
                     .stringType()
                     .defaultValue("/opt/flink/artifacts")
                     .withDescription("The base dir to put the session job artifacts.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> JOB_UPGRADE_IGNORE_PENDING_SAVEPOINT =
             ConfigOptions.key("kubernetes.operator.job.upgrade.ignore-pending-savepoint")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Whether to ignore pending savepoint during job upgrade.");
 
+    @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Boolean> OPERATOR_DYNAMIC_CONFIG_ENABLED =
             ConfigOptions.key("kubernetes.operator.dynamic.config.enabled")
                     .booleanType()
@@ -127,24 +145,28 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Whether to enable on-the-fly config changes through the operator configmap.");
 
+    @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Duration> OPERATOR_DYNAMIC_CONFIG_CHECK_INTERVAL =
             ConfigOptions.key("kubernetes.operator.dynamic.config.check.interval")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(5))
                     .withDescription("Time interval for checking config changes.");
 
+    @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Duration> OPERATOR_CONFIG_CACHE_TIMEOUT =
             ConfigOptions.key("kubernetes.operator.config.cache.timeout")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(10))
                     .withDescription("Expiration time for cached configs.");
 
+    @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Integer> OPERATOR_CONFIG_CACHE_SIZE =
             ConfigOptions.key("kubernetes.operator.config.cache.size")
                     .intType()
                     .defaultValue(1000)
                     .withDescription("Max config cache size.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> OPERATOR_JM_DEPLOYMENT_RECOVERY_ENABLED =
             ConfigOptions.key("kubernetes.operator.jm-deployment-recovery.enabled")
                     .booleanType()
@@ -154,12 +176,14 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Whether to enable recovery of missing/deleted jobmanager deployments.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Integer> OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT =
             ConfigOptions.key("kubernetes.operator.savepoint.history.max.count")
                     .intType()
                     .defaultValue(10)
                     .withDescription("Maximum number of savepoint history entries to retain.");
 
+    @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Integer> OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT_THRESHOLD =
             ConfigOptions.key(OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT.key() + ".threshold")
                     .intType()
@@ -167,6 +191,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Maximum number threshold of savepoint history entries to retain.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_MAX_AGE =
             ConfigOptions.key("kubernetes.operator.savepoint.history.max.age")
                     .durationType()
@@ -174,6 +199,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Maximum age for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.");
 
+    @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD =
             ConfigOptions.key(OPERATOR_SAVEPOINT_HISTORY_MAX_AGE.key() + ".threshold")
                     .durationType()
@@ -181,6 +207,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Maximum age threshold for savepoint history entries to retain.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Map<String, String>> JAR_ARTIFACT_HTTP_HEADER =
             ConfigOptions.key("kubernetes.operator.user.artifacts.http.header")
                     .mapType()
@@ -189,6 +216,7 @@ public class KubernetesOperatorConfigOptions {
                             "Custom HTTP header for HttpArtifactFetcher. The header will be applied when getting the session job artifacts. "
                                     + "Expected format: headerKey1:headerValue1,headerKey2:headerValue2.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Duration> PERIODIC_SAVEPOINT_INTERVAL =
             ConfigOptions.key("kubernetes.operator.periodic.savepoint.interval")
                     .durationType()
@@ -197,6 +225,7 @@ public class KubernetesOperatorConfigOptions {
                             "Interval at which periodic savepoints will be triggered. "
                                     + "The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop.");
 
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<String> OPERATOR_WATCHED_NAMESPACES =
             ConfigOptions.key("kubernetes.operator.watched.namespaces")
                     .stringType()
@@ -204,19 +233,14 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Comma separated list of namespaces the operator monitors for custom resources.");
 
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Boolean> OPERATOR_DYNAMIC_NAMESPACES_ENABLED =
             ConfigOptions.key("kubernetes.operator.dynamic.namespaces.enabled")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Enables dynamic change of watched/monitored namespaces.");
 
-    public static final ConfigOption<Boolean> OPERATOR_JOSDK_METRICS_ENABLED =
-            ConfigOptions.key("kubernetes.operator.josdk.metrics.enabled")
-                    .booleanType()
-                    .defaultValue(true)
-                    .withDescription(
-                            "Enable forwarding of Java Operator SDK metrics to the Flink metric registry.");
-
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Duration> OPERATOR_RETRY_INITIAL_INTERVAL =
             ConfigOptions.key("kubernetes.operator.retry.initial.interval")
                     .durationType()
@@ -224,6 +248,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Initial interval of automatic reconcile retries on recoverable errors.");
 
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Double> OPERATOR_RETRY_INTERVAL_MULTIPLIER =
             ConfigOptions.key("kubernetes.operator.retry.interval.multiplier")
                     .doubleType()
@@ -231,6 +256,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Interval multiplier of automatic reconcile retries on recoverable errors.");
 
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Integer> OPERATOR_RETRY_MAX_ATTEMPTS =
             ConfigOptions.key("kubernetes.operator.retry.max.attempts")
                     .intType()
@@ -238,6 +264,7 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Max attempts of automatic reconcile retries on recoverable errors.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> OPERATOR_JOB_UPGRADE_LAST_STATE_FALLBACK_ENABLED =
             ConfigOptions.key("kubernetes.operator.job.upgrade.last-state-fallback.enabled")
                     .booleanType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -210,6 +210,13 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(false)
                     .withDescription("Enables dynamic change of watched/monitored namespaces.");
 
+    public static final ConfigOption<Boolean> OPERATOR_JOSDK_METRICS_ENABLED =
+            ConfigOptions.key("kubernetes.operator.josdk.metrics.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Enable forwarding of Java Operator SDK metrics to the Flink metric registry.");
+
     public static final ConfigOption<Duration> OPERATOR_RETRY_INITIAL_INTERVAL =
             ConfigOptions.key("kubernetes.operator.retry.initial.interval")
                     .durationType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricGroup.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricGroup.java
@@ -26,14 +26,12 @@ import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
 import java.util.Map;
 
-/** Flink based operator metric group. */
-public class KubernetesOperatorMetricGroup
-        extends AbstractMetricGroup<KubernetesOperatorMetricGroup> {
+/** Base metric group for Flink Operator System metrics. */
+public class KubernetesOperatorMetricGroup extends AbstractMetricGroup<AbstractMetricGroup<?>> {
 
-    private static final String GROUP_NAME = "k8soperator";
-    private final String namespace;
-    private final String name;
-    private final String hostname;
+    protected final String namespace;
+    protected final String name;
+    protected final String hostname;
 
     private KubernetesOperatorMetricGroup(
             MetricRegistry registry,
@@ -45,6 +43,16 @@ public class KubernetesOperatorMetricGroup
         this.namespace = namespace;
         this.name = name;
         this.hostname = hostname;
+    }
+
+    public KubernetesResourceNamespaceMetricGroup createResourceNamespaceGroup(
+            Configuration config, String resourceNs) {
+        return new KubernetesResourceNamespaceMetricGroup(
+                registry,
+                this,
+                KubernetesResourceNamespaceScopeFormat.fromConfig(config)
+                        .formatScope(namespace, name, hostname, resourceNs),
+                resourceNs);
     }
 
     public static KubernetesOperatorMetricGroup create(
@@ -71,7 +79,7 @@ public class KubernetesOperatorMetricGroup
 
     @Override
     protected final String getGroupName(CharacterFilter filter) {
-        return GROUP_NAME;
+        return "k8soperator";
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
@@ -31,7 +31,7 @@ public class KubernetesOperatorMetricOptions {
 
     public static final ConfigOption<String> SCOPE_NAMING_KUBERNETES_OPERATOR_RESOURCENS =
             ConfigOptions.key("metrics.scope.k8soperator.resourcens")
-                    .defaultValue("<host>.k8soperator.<namespace>.<name>.namespace.<resourcens>.")
+                    .defaultValue("<host>.k8soperator.<namespace>.<name>.namespace.<resourcens>")
                     .withDescription(
                             "Defines the scope format string that is applied to all metrics scoped to the kubernetes operator resource namespace.");
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
@@ -22,6 +22,14 @@ import org.apache.flink.configuration.ConfigOptions;
 
 /** Configuration options for metrics. */
 public class KubernetesOperatorMetricOptions {
+
+    public static final ConfigOption<Boolean> OPERATOR_JOSDK_METRICS_ENABLED =
+            ConfigOptions.key("kubernetes.operator.josdk.metrics.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Enable forwarding of Java Operator SDK metrics to the Flink metric registry.");
+
     public static final ConfigOption<String> SCOPE_NAMING_KUBERNETES_OPERATOR =
             ConfigOptions.key("metrics.scope.k8soperator.system")
                     .defaultValue("<host>.k8soperator.<namespace>.<name>.system")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
@@ -23,8 +23,22 @@ import org.apache.flink.configuration.ConfigOptions;
 /** Configuration options for metrics. */
 public class KubernetesOperatorMetricOptions {
     public static final ConfigOption<String> SCOPE_NAMING_KUBERNETES_OPERATOR =
-            ConfigOptions.key("metrics.scope.k8soperator")
-                    .defaultValue("<host>.k8soperator.<namespace>.<name>")
+            ConfigOptions.key("metrics.scope.k8soperator.system")
+                    .defaultValue("<host>.k8soperator.<namespace>.<name>.system")
+                    .withDeprecatedKeys("metrics.scope.k8soperator")
                     .withDescription(
                             "Defines the scope format string that is applied to all metrics scoped to the kubernetes operator.");
+
+    public static final ConfigOption<String> SCOPE_NAMING_KUBERNETES_OPERATOR_RESOURCENS =
+            ConfigOptions.key("metrics.scope.k8soperator.resourcens")
+                    .defaultValue("<host>.k8soperator.<namespace>.<name>.namespace.<resourcens>.")
+                    .withDescription(
+                            "Defines the scope format string that is applied to all metrics scoped to the kubernetes operator resource namespace.");
+
+    public static final ConfigOption<String> SCOPE_NAMING_KUBERNETES_OPERATOR_RESOURCE =
+            ConfigOptions.key("metrics.scope.k8soperator.resource")
+                    .defaultValue(
+                            "<host>.k8soperator.<namespace>.<name>.resource.<resourcens>.<resourcename>")
+                    .withDescription(
+                            "Defines the scope format string that is applied to all metrics scoped to the kubernetes operator resource.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesResourceMetricGroup.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesResourceMetricGroup.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.metrics;
+
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+
+import java.util.Map;
+
+/** Base metric group for Flink Operator Resource level metrics. */
+public class KubernetesResourceMetricGroup
+        extends AbstractMetricGroup<KubernetesResourceNamespaceMetricGroup> {
+
+    private final String resourceName;
+
+    protected KubernetesResourceMetricGroup(
+            MetricRegistry registry,
+            KubernetesResourceNamespaceMetricGroup parent,
+            String[] scope,
+            String resourceName) {
+        super(registry, scope, parent);
+        this.resourceName = resourceName;
+    }
+
+    @Override
+    protected final void putVariables(Map<String, String> variables) {
+        variables.put(KubernetesResourceScopeFormat.RESOURCE, resourceName);
+    }
+
+    @Override
+    protected final String getGroupName(CharacterFilter filter) {
+        return "resource";
+    }
+
+    @Override
+    protected final QueryScopeInfo createQueryServiceMetricInfo(CharacterFilter filter) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesResourceNamespaceMetricGroup.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesResourceNamespaceMetricGroup.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.metrics;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.groups.AbstractMetricGroup;
+
+import java.util.Map;
+
+/** Base metric group for Flink Operator Resource namespace level metrics. */
+public class KubernetesResourceNamespaceMetricGroup
+        extends AbstractMetricGroup<KubernetesOperatorMetricGroup> {
+
+    private final String resourceNs;
+
+    protected KubernetesResourceNamespaceMetricGroup(
+            MetricRegistry registry,
+            KubernetesOperatorMetricGroup parent,
+            String[] scope,
+            String resourceNs) {
+        super(registry, scope, parent);
+        this.resourceNs = resourceNs;
+    }
+
+    public KubernetesResourceMetricGroup createResourceNamespaceGroup(
+            Configuration config, String resourceName) {
+        return new KubernetesResourceMetricGroup(
+                registry,
+                this,
+                KubernetesResourceScopeFormat.fromConfig(config)
+                        .formatScope(
+                                parent.namespace,
+                                parent.name,
+                                parent.hostname,
+                                resourceNs,
+                                resourceName),
+                resourceName);
+    }
+
+    @Override
+    protected final void putVariables(Map<String, String> variables) {
+        variables.put(KubernetesResourceNamespaceScopeFormat.RESOURCE_NS, resourceNs);
+    }
+
+    @Override
+    protected final String getGroupName(CharacterFilter filter) {
+        return "namespace";
+    }
+
+    @Override
+    protected final QueryScopeInfo createQueryServiceMetricInfo(CharacterFilter filter) {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesResourceNamespaceScopeFormat.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesResourceNamespaceScopeFormat.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.metrics;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+
+import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricOptions.SCOPE_NAMING_KUBERNETES_OPERATOR_RESOURCENS;
+import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorScopeFormat.NAME;
+import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorScopeFormat.NAMESPACE;
+
+/** Format for metrics. * */
+public class KubernetesResourceNamespaceScopeFormat extends ScopeFormat {
+
+    public static final String RESOURCE_NS = asVariable("resourcens");
+
+    public KubernetesResourceNamespaceScopeFormat(String format) {
+        super(format, null, new String[] {NAMESPACE, NAME, SCOPE_HOST, RESOURCE_NS});
+    }
+
+    public String[] formatScope(String namespace, String name, String hostname, String resourceNs) {
+        final String[] template = copyTemplate();
+        final String[] values = {namespace, name, hostname, resourceNs};
+        return bindVariables(template, values);
+    }
+
+    public static KubernetesResourceNamespaceScopeFormat fromConfig(Configuration config) {
+        String format = config.getString(SCOPE_NAMING_KUBERNETES_OPERATOR_RESOURCENS);
+        return new KubernetesResourceNamespaceScopeFormat(format);
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesResourceScopeFormat.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesResourceScopeFormat.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.metrics;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+
+import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricOptions.SCOPE_NAMING_KUBERNETES_OPERATOR_RESOURCE;
+import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorScopeFormat.NAME;
+import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorScopeFormat.NAMESPACE;
+import static org.apache.flink.kubernetes.operator.metrics.KubernetesResourceNamespaceScopeFormat.RESOURCE_NS;
+
+/** Format for metrics. * */
+public class KubernetesResourceScopeFormat extends ScopeFormat {
+
+    public static final String RESOURCE = asVariable("resourcename");
+
+    public KubernetesResourceScopeFormat(String format) {
+        super(format, null, new String[] {NAMESPACE, NAME, SCOPE_HOST, RESOURCE_NS, RESOURCE});
+    }
+
+    public String[] formatScope(
+            String namespace,
+            String name,
+            String hostname,
+            String resourceNs,
+            String resourceName) {
+        final String[] template = copyTemplate();
+        final String[] values = {namespace, name, hostname, resourceNs, resourceName};
+        return bindVariables(template, values);
+    }
+
+    public static KubernetesResourceScopeFormat fromConfig(Configuration config) {
+        String format = config.getString(SCOPE_NAMING_KUBERNETES_OPERATOR_RESOURCE);
+        return new KubernetesResourceScopeFormat(format);
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetrics.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.metrics;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+
+import io.javaoperatorsdk.operator.api.monitoring.Metrics;
+import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
+import io.javaoperatorsdk.operator.processing.event.Event;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEvent;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implementation of {@link Metrics} to monitor and forward JOSDK metrics to {@link MetricRegistry}.
+ */
+public class OperatorJosdkMetrics implements Metrics {
+
+    private static final String OPERATOR_SDK_GROUP = "JOSDK";
+    private static final String RECONCILIATION = "Reconciliation";
+    private static final String RESOURCE = "Resource";
+    private static final String EVENT = "Event";
+
+    private final KubernetesOperatorMetricGroup operatorMetricGroup;
+    private final Configuration conf;
+
+    private final Map<ResourceID, KubernetesResourceNamespaceMetricGroup> resourceNsMetricGroups =
+            new ConcurrentHashMap<>();
+    private final Map<ResourceID, KubernetesResourceMetricGroup> resourceMetricGroups =
+            new ConcurrentHashMap<>();
+
+    private final Map<String, Counter> counters = new ConcurrentHashMap<>();
+
+    public OperatorJosdkMetrics(
+            KubernetesOperatorMetricGroup operatorMetricGroup, Configuration conf) {
+        this.operatorMetricGroup = operatorMetricGroup;
+        this.conf = conf;
+    }
+
+    @Override
+    public void receivedEvent(Event event) {
+        if (event instanceof ResourceEvent) {
+            var action = ((ResourceEvent) event).getAction();
+            counter(
+                            getResourceMg(event.getRelatedCustomResourceID()),
+                            Collections.emptyList(),
+                            RESOURCE,
+                            EVENT)
+                    .inc();
+            counter(
+                            getResourceMg(event.getRelatedCustomResourceID()),
+                            Collections.emptyList(),
+                            RESOURCE,
+                            EVENT,
+                            action.name())
+                    .inc();
+        }
+    }
+
+    @Override
+    public void cleanupDoneFor(ResourceID resourceID) {
+        counter(getResourceMg(resourceID), Collections.emptyList(), RECONCILIATION, "cleanup")
+                .inc();
+    }
+
+    @Override
+    public void reconcileCustomResource(ResourceID resourceID, RetryInfo retryInfoNullable) {
+        counter(getResourceMg(resourceID), Collections.emptyList(), RECONCILIATION).inc();
+
+        if (retryInfoNullable != null) {
+            counter(getResourceMg(resourceID), Collections.emptyList(), RECONCILIATION, "retries")
+                    .inc();
+        }
+    }
+
+    @Override
+    public void finishedReconciliation(ResourceID resourceID) {
+        counter(getResourceMg(resourceID), Collections.emptyList(), RECONCILIATION, "finished")
+                .inc();
+    }
+
+    @Override
+    public void failedReconciliation(ResourceID resourceID, Exception exception) {
+        counter(getResourceMg(resourceID), Collections.emptyList(), RECONCILIATION, "failed").inc();
+    }
+
+    @Override
+    public <T extends Map<?, ?>> T monitorSizeOf(T map, String name) {
+        operatorMetricGroup.addGroup(name).gauge("size", map::size);
+        return map;
+    }
+
+    private Counter counter(
+            MetricGroup parent, List<Tuple2<String, String>> additionalTags, String... names) {
+        MetricGroup group = parent.addGroup(OPERATOR_SDK_GROUP);
+        for (String name : names) {
+            group = group.addGroup(name);
+        }
+        for (Tuple2<String, String> tag : additionalTags) {
+            group = group.addGroup(tag.f0, tag.f1);
+        }
+        var finalGroup = group;
+        return counters.computeIfAbsent(
+                String.join(".", group.getScopeComponents()), s -> finalGroup.counter("Count"));
+    }
+
+    private KubernetesResourceNamespaceMetricGroup getResourceNsMg(ResourceID resourceID) {
+        return resourceNsMetricGroups.computeIfAbsent(
+                resourceID,
+                rid ->
+                        operatorMetricGroup.createResourceNamespaceGroup(
+                                conf, rid.getNamespace().orElse("default")));
+    }
+
+    private KubernetesResourceMetricGroup getResourceMg(ResourceID resourceID) {
+        return resourceMetricGroups.computeIfAbsent(
+                resourceID,
+                rid -> getResourceNsMg(rid).createResourceNamespaceGroup(conf, rid.getName()));
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/OperatorMetricUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/OperatorMetricUtils.java
@@ -43,7 +43,7 @@ public class OperatorMetricUtils {
     private static final String OPERATOR_METRICS_PREFIX = "kubernetes.operator.metrics.";
     private static final String METRICS_PREFIX = "metrics.";
 
-    public static MetricGroup initOperatorMetrics(Configuration defaultConfig) {
+    public static KubernetesOperatorMetricGroup initOperatorMetrics(Configuration defaultConfig) {
         Configuration metricConfig = createMetricConfig(defaultConfig);
         LOG.info("Initializing operator metrics using conf: {}", metricConfig);
         PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(metricConfig);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
@@ -18,11 +18,10 @@
 
 package org.apache.flink.kubernetes.operator;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.status.CommonStatus;
-import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
-import org.apache.flink.metrics.testutils.MetricListener;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -30,7 +29,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class TestingStatusRecorder<STATUS extends CommonStatus<?>> extends StatusRecorder<STATUS> {
 
     public TestingStatusRecorder() {
-        super(null, new MetricManager<>(new MetricListener().getMetricGroup()), (r, s) -> {});
+        super(null, TestUtils.createTestMetricManager(new Configuration()), (r, s) -> {});
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -17,19 +17,18 @@
 
 package org.apache.flink.kubernetes.operator.controller;
 
+import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
-import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.observer.deployment.ObserverFactory;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.deployment.ReconcilerFactory;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
-import org.apache.flink.metrics.testutils.MetricListener;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Cleaner;
@@ -67,7 +66,7 @@ public class TestingFlinkDeploymentController
         statusRecorder =
                 new StatusRecorder<>(
                         kubernetesClient,
-                        new MetricManager<>(new MetricListener().getMetricGroup()),
+                        TestUtils.createTestMetricManager(configManager.getDefaultConfig()),
                         statusUpdateCounter);
         flinkDeploymentController =
                 new FlinkDeploymentController(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
@@ -17,14 +17,13 @@
 
 package org.apache.flink.kubernetes.operator.listener;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
-import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
-import org.apache.flink.metrics.testutils.MetricListener;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -56,7 +55,7 @@ public class FlinkResourceListenerTest {
         var statusRecorder =
                 StatusRecorder.<FlinkDeploymentStatus>create(
                         kubernetesClient,
-                        new MetricManager<>(new MetricListener().getMetricGroup()),
+                        TestUtils.createTestMetricManager(new Configuration()),
                         listeners);
         var eventRecorder = EventRecorder.create(kubernetesClient, listeners);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetricsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.metrics;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
+
+import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceAction;
+import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** {@link OperatorJosdkMetrics} tests. */
+public class OperatorJosdkMetricsTest {
+
+    private final ResourceID resourceId = new ResourceID("testns", "testname");
+    private final String resourcePrefix =
+            "testhost.k8soperator.flink-operator-test.testopname.resource.testname.testns.JOSDK.";
+    private final String systemPrefix =
+            "testhost.k8soperator.flink-operator-test.testopname.system.";
+
+    private Map<String, Metric> metrics = new HashMap<>();
+    private OperatorJosdkMetrics operatorMetrics;
+
+    @BeforeEach
+    public void setup() {
+        TestingMetricRegistry registry =
+                TestingMetricRegistry.builder()
+                        .setDelimiter(".".charAt(0))
+                        .setRegisterConsumer(
+                                (metric, name, group) -> {
+                                    metrics.put(group.getMetricIdentifier(name), metric);
+                                })
+                        .build();
+        operatorMetrics =
+                new OperatorJosdkMetrics(
+                        TestUtils.createTestMetricGroup(registry, new Configuration()),
+                        new Configuration());
+    }
+
+    @Test
+    public void testMetrics() {
+        operatorMetrics.failedReconciliation(resourceId, null);
+        assertEquals(1, metrics.size());
+        assertEquals(1, getCount("Reconciliation.failed"));
+        operatorMetrics.failedReconciliation(resourceId, null);
+        operatorMetrics.failedReconciliation(resourceId, null);
+        assertEquals(1, metrics.size());
+        assertEquals(3, getCount("Reconciliation.failed"));
+
+        operatorMetrics.reconcileCustomResource(resourceId, null);
+        assertEquals(2, metrics.size());
+        assertEquals(1, getCount("Reconciliation"));
+
+        operatorMetrics.reconcileCustomResource(
+                resourceId,
+                new RetryInfo() {
+                    @Override
+                    public int getAttemptCount() {
+                        return 0;
+                    }
+
+                    @Override
+                    public boolean isLastAttempt() {
+                        return false;
+                    }
+                });
+        assertEquals(3, metrics.size());
+        assertEquals(2, getCount("Reconciliation"));
+        assertEquals(1, getCount("Reconciliation.retries"));
+
+        operatorMetrics.receivedEvent(new ResourceEvent(ResourceAction.ADDED, resourceId, null));
+        assertEquals(5, metrics.size());
+        assertEquals(1, getCount("Resource.Event"));
+        assertEquals(1, getCount("Resource.Event.ADDED"));
+
+        operatorMetrics.cleanupDoneFor(resourceId);
+        assertEquals(6, metrics.size());
+        assertEquals(1, getCount("Reconciliation.cleanup"));
+
+        operatorMetrics.finishedReconciliation(resourceId);
+        assertEquals(7, metrics.size());
+        assertEquals(1, getCount("Reconciliation.finished"));
+
+        operatorMetrics.monitorSizeOf(Map.of("a", "b", "c", "d"), "mymap");
+        assertEquals(8, metrics.size());
+        assertEquals(2, ((Gauge<Integer>) metrics.get(systemPrefix + "mymap.size")).getValue());
+    }
+
+    private long getCount(String name) {
+        return ((Counter) metrics.get(resourcePrefix + name + ".Count")).getCount();
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
@@ -17,21 +17,25 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.metrics.MetricManager;
-import org.apache.flink.metrics.testutils.MetricListener;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+
 import static org.apache.flink.kubernetes.operator.metrics.FlinkDeploymentMetrics.METRIC_GROUP_NAME;
-import static org.apache.flink.kubernetes.operator.metrics.MetricManager.NS_SCOPE_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -47,7 +51,7 @@ public class StatusRecorderTest {
         var helper =
                 new StatusRecorder<FlinkDeploymentStatus>(
                         kubernetesClient,
-                        new MetricManager<>(new MetricListener().getMetricGroup()),
+                        TestUtils.createTestMetricManager(new Configuration()),
                         (e, s) -> {});
         var deployment = TestUtils.buildApplicationCluster();
         kubernetesClient.resource(deployment).createOrReplace();
@@ -70,49 +74,64 @@ public class StatusRecorderTest {
 
     @Test
     public void testFlinkDeploymentMetrics() throws InterruptedException {
-        var metricListener = new MetricListener();
+        var metrics = new HashMap<String, Metric>();
+        TestingMetricRegistry registry =
+                TestingMetricRegistry.builder()
+                        .setDelimiter(".".charAt(0))
+                        .setRegisterConsumer(
+                                (metric, name, group) -> {
+                                    metrics.put(group.getMetricIdentifier(name), metric);
+                                })
+                        .build();
+
+        var metricManager =
+                (MetricManager) TestUtils.createTestMetricManager(registry, new Configuration());
         var helper =
                 new StatusRecorder<FlinkDeploymentStatus>(
-                        kubernetesClient,
-                        new MetricManager<>(metricListener.getMetricGroup()),
-                        (e, s) -> {});
+                        kubernetesClient, metricManager, (e, s) -> {});
 
         var deployment = TestUtils.buildApplicationCluster();
         kubernetesClient.resource(deployment).createOrReplace();
 
         helper.updateStatusFromCache(deployment);
-        assertEquals(1, metricListener.getGauge(totalIdentifier(deployment)).get().getValue());
-        assertEquals(1, metricListener.getGauge(perStatusIdentifier(deployment)).get().getValue());
+        assertEquals(1, ((Gauge) metrics.get(totalIdentifier(deployment))).getValue());
+        assertEquals(1, ((Gauge) metrics.get(perStatusIdentifier(deployment))).getValue());
 
         for (JobManagerDeploymentStatus status : JobManagerDeploymentStatus.values()) {
             deployment.getStatus().setJobManagerDeploymentStatus(status);
             helper.patchAndCacheStatus(deployment);
-            assertEquals(1, metricListener.getGauge(totalIdentifier(deployment)).get().getValue());
-            assertEquals(
-                    1, metricListener.getGauge(perStatusIdentifier(deployment)).get().getValue());
+            assertEquals(1, ((Gauge) metrics.get(totalIdentifier(deployment))).getValue());
+            assertEquals(1, ((Gauge) metrics.get(perStatusIdentifier(deployment))).getValue());
         }
 
         helper.removeCachedStatus(deployment);
-        assertEquals(0, metricListener.getGauge(totalIdentifier(deployment)).get().getValue());
+        assertEquals(0, ((Gauge) metrics.get(totalIdentifier(deployment))).getValue());
         for (JobManagerDeploymentStatus status : JobManagerDeploymentStatus.values()) {
-            assertEquals(
-                    0, metricListener.getGauge(perStatusIdentifier(deployment)).get().getValue());
+            assertEquals(0, ((Gauge) metrics.get(perStatusIdentifier(deployment))).getValue());
         }
     }
 
-    private String[] totalIdentifier(FlinkDeployment deployment) {
-        return new String[] {
-            NS_SCOPE_KEY, deployment.getMetadata().getNamespace(), METRIC_GROUP_NAME, "Count"
-        };
+    private String totalIdentifier(FlinkDeployment deployment) {
+        String baseScope = "testhost.k8soperator.flink-operator-test.testopname.";
+        String[] metricScope =
+                new String[] {
+                    "namespace", deployment.getMetadata().getNamespace(), METRIC_GROUP_NAME, "Count"
+                };
+        return baseScope + String.join(".", metricScope);
     }
 
-    private String[] perStatusIdentifier(FlinkDeployment deployment) {
-        return new String[] {
-            NS_SCOPE_KEY,
-            deployment.getMetadata().getNamespace(),
-            METRIC_GROUP_NAME,
-            deployment.getStatus().getJobManagerDeploymentStatus().name(),
-            "Count"
-        };
+    private String perStatusIdentifier(FlinkDeployment deployment) {
+
+        String baseScope = "testhost.k8soperator.flink-operator-test.testopname.";
+        String[] metricScope =
+                new String[] {
+                    "namespace",
+                    deployment.getMetadata().getNamespace(),
+                    METRIC_GROUP_NAME,
+                    deployment.getStatus().getJobManagerDeploymentStatus().name(),
+                    "Count"
+                };
+
+        return baseScope + String.join(".", metricScope);
     }
 }

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
@@ -63,7 +63,7 @@ public class FlinkOperatorWebhook {
         EnvUtils.logEnvironmentInfo(LOG, "Flink Kubernetes Webhook", args);
         var informerManager = new InformerManager(new DefaultKubernetesClient());
         var configManager = new FlinkConfigManager(informerManager::setNamespaces);
-        if (!configManager.getOperatorConfiguration().getDynamicNamespacesEnabled()) {
+        if (!configManager.getOperatorConfiguration().isDynamicNamespacesEnabled()) {
             informerManager.setNamespaces(
                     configManager.getOperatorConfiguration().getWatchedNamespaces());
         }


### PR DESCRIPTION
Clean up and formalize operator metric scopes:
 - `system`: Operator level metrics
 - `namespace`: Resource Namespace level metrics (belonging to one of the watched namespaces)
 - `resource` : Resource level metrics

Before:
```
hostname.k8soperator.default.flink-kubernetes-operator.Status.JVM.Memory.Mapped.MemoryUsed: 0
hostname.k8soperator.default.flink-kubernetes-operator.resourcens.default.FlinkDeployment.DEPLOYING.Count: 0
```

After:
```
hostname.k8soperator.default.flink-kubernetes-operator.system.Status.JVM.Memory.Mapped.MemoryUsed: 0
hostname.k8soperator.default.flink-kubernetes-operator.namespace.default.FlinkDeployment.DEPLOYING.Count: 0
```

One given metric called `Metric` in the 3 scopes:
```
<prefix>.system.Metric
<prefix>.namespace.resourceNs.Metric
<prefix>.resource.resoureNs.resourceName.Metric
```

As an addition based on this work, this PR also includes a minimalistic integration with the JOSDK built in metrics:

sample output
```
hostname.k8soperator.default.flink-kubernetes-operator.resource.default.basic-example.JOSDK.Reconciliation.finished.Count: 4
hostname.k8soperator.default.flink-kubernetes-operator.resource.default.basic-example.JOSDK.Reconciliation.started.Count: 4

hostname.k8soperator.default.flink-kubernetes-operator.resource.default.basic-example.JOSDK.Resource.Event.Count: 5
hostname.k8soperator.default.flink-kubernetes-operator.resource.default.basic-example.JOSDK.Resource.Event.ADDED.Count: 2
hostname.k8soperator.default.flink-kubernetes-operator.resource.default.basic-example.JOSDK.Resource.Event.DELETED.Count: 1
hostname.k8soperator.default.flink-kubernetes-operator.resource.default.basic-example.JOSDK.Resource.Event.UPDATED.Count: 2
```