### PR TITLE
[FLINK-28450][ci] Validate Helm Chart linting during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
             echo "Please generate the java doc via 'mvn clean install -DskipTests -Pgenerate-docs' again"
             exit 1
           fi
+      - name: Validate helm chart linting
+        run: |
+          helm lint helm/flink-kubernetes-operator
       - name: Start minikube
         run: |
           source e2e-tests/utils.sh

--- a/helm/flink-kubernetes-operator/Chart.yaml
+++ b/helm/flink-kubernetes-operator/Chart.yaml
@@ -23,3 +23,4 @@ description: A Helm chart for the Apache Flink Kubernetes Operator
 type: application
 version: 1.1-SNAPSHOT
 appVersion: 1.1-SNAPSHOT
+icon: https://flink.apache.org/img/logo/png/50/color_50.png


### PR DESCRIPTION
Adds helm chart linting to ci and fixes a warning in the chart.

Please observe this run I triggered on my own fork to simulate an intentional failure:
https://github.com/mbalassi/flink-kubernetes-operator/runs/7236387391?check_suite_focus=true