### PR TITLE
[FLINK-28187] Handle SessionJob errors on observe

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
@@ -33,7 +33,6 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.sessionjob.SessionJobReconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.runtime.client.JobStatusMessage;
@@ -179,23 +178,13 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
                         .setState(org.apache.flink.api.common.JobStatus.RECONCILING.name());
                 flinkSessionJob.getStatus().getJobStatus().setJobId(matchedJobID.toHexString());
             } else {
-                LOG.warn(
-                        "Running job {}'s generation {} doesn't match upgrade target generation {}.",
-                        matchedJobID.toHexString(),
-                        deployedGeneration,
-                        upgradeTargetGeneration);
-                if (!matchedJobID.toHexString().equals(oldJobID)) {
-                    var msg =
-                            String.format(
-                                    "The founded Job: %s neither match the old JobID: %s nor the new "
-                                            + "generated JobID: %s. This indicates it's an orphaned job.",
-                                    matchedJobID,
-                                    oldJobID,
-                                    FlinkUtils.generateSessionJobFixedJobID(
-                                            uid, upgradeTargetGeneration));
-                    LOG.error(msg);
-                    throw new RuntimeException(msg);
-                }
+                var msg =
+                        String.format(
+                                "Running job %s's generation %s doesn't match upgrade target generation %s.",
+                                matchedJobID.toHexString(),
+                                deployedGeneration,
+                                upgradeTargetGeneration);
+                throw new RuntimeException(msg);
             }
         }
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
@@ -17,15 +17,19 @@
 
 package org.apache.flink.kubernetes.operator.observer.sessionjob;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
+import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
 import org.apache.flink.kubernetes.operator.observer.Observer;
 import org.apache.flink.kubernetes.operator.observer.SavepointObserver;
 import org.apache.flink.kubernetes.operator.observer.context.VoidObserverContext;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.sessionjob.SessionJobReconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
@@ -38,6 +42,8 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -50,6 +56,7 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
     private final EventRecorder eventRecorder;
     private final SavepointObserver<FlinkSessionJobStatus> savepointObserver;
     private final JobStatusObserver<VoidObserverContext> jobStatusObserver;
+    private final FlinkService flinkService;
 
     public SessionJobObserver(
             FlinkService flinkService,
@@ -58,8 +65,9 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
             EventRecorder eventRecorder) {
         this.configManager = configManager;
         this.eventRecorder = eventRecorder;
+        this.flinkService = flinkService;
         this.savepointObserver =
-                new SavepointObserver(flinkService, configManager, statusRecorder, eventRecorder);
+                new SavepointObserver<>(flinkService, configManager, statusRecorder, eventRecorder);
         this.jobStatusObserver =
                 new JobStatusObserver<>(flinkService, eventRecorder) {
                     @Override
@@ -106,6 +114,14 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
 
         var deployedConfig =
                 configManager.getSessionJobConfig(flinkDepOpt.get(), flinkSessionJob.getSpec());
+        var reconciliationStatus = flinkSessionJob.getStatus().getReconciliationStatus();
+        if (reconciliationStatus.getState() == ReconciliationState.UPGRADING) {
+            checkIfAlreadyUpgraded(flinkSessionJob, deployedConfig);
+            if (reconciliationStatus.getState() == ReconciliationState.UPGRADING) {
+                return;
+            }
+        }
+
         var jobFound =
                 jobStatusObserver.observe(
                         flinkSessionJob, deployedConfig, VoidObserverContext.INSTANCE);
@@ -114,5 +130,63 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
             savepointObserver.observeSavepointStatus(flinkSessionJob, deployedConfig);
         }
         SavepointUtils.resetTriggerIfJobNotRunning(flinkSessionJob, eventRecorder);
+    }
+
+    private void checkIfAlreadyUpgraded(
+            FlinkSessionJob flinkSessionJob, Configuration deployedConfig) {
+        var uid = flinkSessionJob.getMetadata().getUid();
+        Collection<JobStatusMessage> jobStatusMessages;
+        try {
+            jobStatusMessages = flinkService.listJobs(deployedConfig);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to list jobs", e);
+        }
+        var matchedJobs = new ArrayList<JobID>();
+        for (JobStatusMessage jobStatusMessage : jobStatusMessages) {
+            var jobId = jobStatusMessage.getJobId();
+            if (jobId.getLowerPart() == uid.hashCode()
+                    && !jobStatusMessage.getJobState().isGloballyTerminalState()) {
+                matchedJobs.add(jobId);
+            }
+        }
+
+        if (matchedJobs.isEmpty()) {
+            return;
+        } else if (matchedJobs.size() > 1) {
+            // this indicates a bug, which means we have more than one running job for a single
+            // SessionJob CR.
+            throw new RuntimeException(
+                    String.format(
+                            "Unexpected case: %d job found for the resource with uid: %s",
+                            matchedJobs.size(), flinkSessionJob.getMetadata().getUid()));
+        } else {
+            var matchedJobID = matchedJobs.get(0);
+            Long upgradeTargetGeneration =
+                    ReconciliationUtils.getUpgradeTargetGeneration(flinkSessionJob);
+            long deployedGeneration = matchedJobID.getUpperPart();
+
+            if (upgradeTargetGeneration == deployedGeneration) {
+                var oldJobID = flinkSessionJob.getStatus().getJobStatus().getJobId();
+                LOG.info(
+                        "Pending upgrade is already deployed, updating status. Old jobID:{}, new jobID:{}",
+                        oldJobID,
+                        matchedJobID.toHexString());
+                ReconciliationUtils.updateStatusForAlreadyUpgraded(flinkSessionJob);
+                flinkSessionJob
+                        .getStatus()
+                        .getJobStatus()
+                        .setState(org.apache.flink.api.common.JobStatus.RECONCILING.name());
+                flinkSessionJob
+                        .getStatus()
+                        .getJobStatus()
+                        .setJobId(matchedJobs.get(0).toHexString());
+            } else {
+                LOG.warn(
+                        "Running job {}'s generation {} doesn't match upgrade target generation {}.",
+                        matchedJobID.toHexString(),
+                        deployedGeneration,
+                        upgradeTargetGeneration);
+            }
+        }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -115,6 +115,7 @@ public abstract class AbstractFlinkResourceReconciler<
                     deployConfig,
                     Optional.ofNullable(spec.getJob()).map(JobSpec::getInitialSavepointPath),
                     false);
+
             ReconciliationUtils.updateStatusForDeployedSpec(cr, deployConfig);
             return;
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
@@ -31,6 +32,7 @@ import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -314,5 +316,17 @@ public class FlinkUtils {
                                 .orElse(Collections.emptyMap()));
         labels.put(CR_GENERATION_LABEL, generation.toString());
         conf.set(KubernetesConfigOptions.JOB_MANAGER_ANNOTATIONS, labels);
+    }
+
+    /**
+     * The jobID's lower part is the resource uid, the higher part is the resource generation.
+     *
+     * @param meta the meta of the resource.
+     * @return the generated jobID.
+     */
+    public static JobID generateSessionJobFixedJobID(ObjectMeta meta) {
+        return new JobID(
+                Preconditions.checkNotNull(meta.getUid()).hashCode(),
+                Preconditions.checkNotNull(meta.getGeneration()));
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -325,8 +325,18 @@ public class FlinkUtils {
      * @return the generated jobID.
      */
     public static JobID generateSessionJobFixedJobID(ObjectMeta meta) {
+        return generateSessionJobFixedJobID(meta.getUid(), meta.getGeneration());
+    }
+
+    /**
+     * The jobID's lower part is the resource uid, the higher part is the resource generation.
+     *
+     * @param uid the uid of the resource.
+     * @param generation the generation of the resource.
+     * @return the generated jobID.
+     */
+    public static JobID generateSessionJobFixedJobID(String uid, Long generation) {
         return new JobID(
-                Preconditions.checkNotNull(meta.getUid()).hashCode(),
-                Preconditions.checkNotNull(meta.getGeneration()));
+                Preconditions.checkNotNull(uid).hashCode(), Preconditions.checkNotNull(generation));
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -82,6 +82,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -146,6 +147,8 @@ public class TestUtils {
                         .withName(TEST_SESSION_JOB_NAME)
                         .withNamespace(TEST_NAMESPACE)
                         .withCreationTimestamp(Instant.now().toString())
+                        .withUid(UUID.randomUUID().toString())
+                        .withGeneration(1L)
                         .build());
         sessionJob.setSpec(
                 FlinkSessionJobSpec.builder()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -208,12 +208,11 @@ public class SessionJobObserverTest {
                     throw new RuntimeException("Failed after submitted job");
                 });
         // submit job
-        try {
-            reconciler.reconcile(sessionJob, readyContext);
-            Assertions.fail("Expect an exception here");
-        } catch (Exception ignore) {
-
-        }
+        Assertions.assertThrows(
+                RuntimeException.class,
+                () -> {
+                    reconciler.reconcile(sessionJob, readyContext);
+                });
         Assertions.assertNotNull(sessionJob.getStatus().getReconciliationStatus());
         Assertions.assertEquals(
                 ReconciliationState.UPGRADING,
@@ -256,15 +255,14 @@ public class SessionJobObserverTest {
         sessionJob.getMetadata().setGeneration(11L);
 
         // upgrade
-        try {
-            // suspend
-            reconciler.reconcile(sessionJob, readyContext);
-            // upgrade
-            reconciler.reconcile(sessionJob, readyContext);
-            Assertions.fail("Expect an exception here");
-        } catch (Exception ignore) {
-
-        }
+        Assertions.assertThrows(
+                RuntimeException.class,
+                () -> {
+                    // suspend
+                    reconciler.reconcile(sessionJob, readyContext);
+                    // upgrade
+                    reconciler.reconcile(sessionJob, readyContext);
+                });
 
         Assertions.assertEquals(
                 ReconciliationState.UPGRADING,
@@ -307,15 +305,14 @@ public class SessionJobObserverTest {
         sessionJob.getSpec().getJob().setParallelism(10);
         sessionJob.getMetadata().setGeneration(11L);
         // upgrade
-        try {
-            // suspend
-            reconciler.reconcile(sessionJob, readyContext);
-            // upgrade
-            reconciler.reconcile(sessionJob, readyContext);
-            Assertions.fail("Expect an exception here");
-        } catch (Exception ignore) {
-
-        }
+        Assertions.assertThrows(
+                RuntimeException.class,
+                () -> {
+                    // suspend
+                    reconciler.reconcile(sessionJob, readyContext);
+                    // upgrade
+                    reconciler.reconcile(sessionJob, readyContext);
+                });
 
         Assertions.assertEquals(
                 ReconciliationState.UPGRADING,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -339,6 +339,6 @@ public class SessionJobObserverTest {
                 Assertions.assertThrows(
                         RuntimeException.class, () -> observer.observe(sessionJob, readyContext));
         Assertions.assertTrue(
-                exception.getMessage().contains("This indicates it's an orphaned job"));
+                exception.getMessage().contains("doesn't match upgrade target generation"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR is meant to use the same mechanism of the `AbstractDeploymentObserver`. It can recognize the lost job information now, based on the fixed jobId generator. 

## Brief change log

  - Use the `uid.hashcode` + `generation` to make up the `JobID`.
  - Detect the jobs in the session cluster with the same uid prefix and generation. 

## Verifying this change

- new tests to verify the change. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
