### PR TITLE
[FLINK-28472] Add JmDeploymentStatus as a group for JobManagerDeploymentStatuscount metrics

### DIFF
--- a/docs/content/docs/operations/metrics-logging.md
+++ b/docs/content/docs/operations/metrics-logging.md
@@ -31,11 +31,11 @@ The Flink Kubernetes Operator (Operator) extends the [Flink Metric System](https
 ## Deployment Metrics
 The Operator gathers aggregates metrics about managed resources.
 
-| Scope     | Metrics                        | Description                                                                                                                                                 | Type  |
-|-----------|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
-| Namespace | FlinkDeployment.Count          | Number of managed FlinkDeployment instances per namespace                                                                                                   | Gauge |
-| Namespace | FlinkDeployment.<Status>.Count | Number of managed FlinkDeployment resources per <Status> per namespace. <Status> can take values from: READY, DEPLOYED_NOT_READY, DEPLOYING, MISSING, ERROR | Gauge |
-| Namespace | FlinkSessionJob.Count          | Number of managed FlinkSessionJob instances per namespace                                                                                                   | Gauge |
+| Scope     | Metrics                                           | Description                                                                                                                                                 | Type  |
+|-----------|---------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
+| Namespace | FlinkDeployment.Count                             | Number of managed FlinkDeployment instances per namespace                                                                                                   | Gauge |
+| Namespace | FlinkDeployment.JmDeploymentStatus.<Status>.Count | Number of managed FlinkDeployment resources per <Status> per namespace. <Status> can take values from: READY, DEPLOYED_NOT_READY, DEPLOYING, MISSING, ERROR | Gauge |
+| Namespace | FlinkSessionJob.Count                             | Number of managed FlinkSessionJob instances per namespace                                                                                                   | Gauge |
 
 ## System Metrics
 The Operator gathers metrics about the JVM process and exposes it similarly to core Flink [System metrics](https://nightlies.apache.org/flink/flink-docs-master/docs/ops/metrics/#system-metrics). The list of metrics are not repeated in this document.

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetrics.java
@@ -31,20 +31,26 @@ import java.util.concurrent.ConcurrentHashMap;
 public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeployment> {
 
     private final Map<JobManagerDeploymentStatus, Set<String>> statuses = new HashMap<>();
-    public static final String METRIC_GROUP_NAME = "FlinkDeployment";
+    public static final String FLINK_DEPLOYMENT_GROUP_NAME = "FlinkDeployment";
+    public static final String JM_DEPLOYMENT_STATUS_GROUP_NAME = "JmDeploymentStatus";
+    public static final String COUNTER_NAME = "Count";
 
     public FlinkDeploymentMetrics(MetricGroup parentMetricGroup) {
-        MetricGroup flinkDeploymentMetrics = parentMetricGroup.addGroup(METRIC_GROUP_NAME);
+        MetricGroup flinkDeploymentMetrics =
+                parentMetricGroup.addGroup(FLINK_DEPLOYMENT_GROUP_NAME);
         for (JobManagerDeploymentStatus status : JobManagerDeploymentStatus.values()) {
             statuses.put(status, ConcurrentHashMap.newKeySet());
         }
         for (JobManagerDeploymentStatus status : JobManagerDeploymentStatus.values()) {
             statuses.put(status, new HashSet<>());
-            MetricGroup metricGroup = flinkDeploymentMetrics.addGroup(status.toString());
-            metricGroup.gauge("Count", () -> statuses.get(status).size());
+            MetricGroup metricGroup =
+                    flinkDeploymentMetrics
+                            .addGroup(JM_DEPLOYMENT_STATUS_GROUP_NAME)
+                            .addGroup(status.toString());
+            metricGroup.gauge(COUNTER_NAME, () -> statuses.get(status).size());
         }
         flinkDeploymentMetrics.gauge(
-                "Count", () -> statuses.values().stream().mapToInt(Set::size).sum());
+                COUNTER_NAME, () -> statuses.values().stream().mapToInt(Set::size).sum());
     }
 
     public void onUpdate(FlinkDeployment flinkApp) {


### PR DESCRIPTION
## What is the purpose of the change

Add JmDeploymentStatus as a group for JobManagerDeploymentStatuscount metrics.

## Brief change log

Before:
```
localhost.k8soperator.default.flink-kubernetes-operator.namespace.default.FlinkDeployment.READY.Count: 1
```
After:
```
localhost.k8soperator.default.flink-kubernetes-operator.namespace.default.FlinkDeployment.JMDeploymentStatus.READY.Count: 1
```

## Verifying this change
This change is already covered by existing tests, such as:

- `StatusRecorderTest` (removed redundant tests)

- `FlinkDeploymentMetricsTest` (updated existing tests)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no) 
    - Metrics documentation is updated