### PR TITLE
[FLINK-28480] Forward timeControllerExecution time as histogram for JOSDK Metrics interface

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetricsTest.java
@@ -19,11 +19,14 @@ package org.apache.flink.kubernetes.operator.metrics;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
 
+import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceAction;
@@ -35,15 +38,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** {@link OperatorJosdkMetrics} tests. */
 public class OperatorJosdkMetricsTest {
 
     private final ResourceID resourceId = new ResourceID("testns", "testname");
+    private final String controllerName = "testController";
     private final String resourcePrefix =
             "testhost.k8soperator.flink-operator-test.testopname.resource.testname.testns.JOSDK.";
     private final String systemPrefix =
             "testhost.k8soperator.flink-operator-test.testopname.system.";
+    private final String executionPrefix = systemPrefix + "JOSDK." + controllerName + ".";
 
     private Map<String, Metric> metrics = new HashMap<>();
     private OperatorJosdkMetrics operatorMetrics;
@@ -62,6 +69,85 @@ public class OperatorJosdkMetricsTest {
                 new OperatorJosdkMetrics(
                         TestUtils.createTestMetricGroup(registry, new Configuration()),
                         new Configuration());
+    }
+
+    @Test
+    public void testTimeControllerExecution() throws Exception {
+        Metrics.ControllerExecution<Object> successExecution =
+                new Metrics.ControllerExecution<>() {
+                    @Override
+                    public String name() {
+                        return "reconcile";
+                    }
+
+                    @Override
+                    public String controllerName() {
+                        return controllerName;
+                    }
+
+                    @Override
+                    public String successTypeName(Object o) {
+                        return "resource";
+                    }
+
+                    @Override
+                    public Object execute() throws Exception {
+                        return null;
+                    }
+                };
+        operatorMetrics.timeControllerExecution(successExecution);
+        assertEquals(1, metrics.size());
+        assertEquals(1, getHistogram("reconcile", "resource").getCount());
+        assertTrue(getHistogram("reconcile", "resource").getStatistics().getMin() > 0);
+        operatorMetrics.timeControllerExecution(successExecution);
+        operatorMetrics.timeControllerExecution(successExecution);
+        assertEquals(1, metrics.size());
+        assertEquals(3, getHistogram("reconcile", "resource").getCount());
+        assertTrue(getHistogram("reconcile", "resource").getStatistics().getMin() > 0);
+
+        Metrics.ControllerExecution<Object> failureExecution =
+                new Metrics.ControllerExecution<>() {
+                    @Override
+                    public String name() {
+                        return "cleanup";
+                    }
+
+                    @Override
+                    public String controllerName() {
+                        return controllerName;
+                    }
+
+                    @Override
+                    public String successTypeName(Object o) {
+                        return null;
+                    }
+
+                    @Override
+                    public Object execute() throws Exception {
+                        throw new ReconciliationException(new RuntimeException());
+                    }
+                };
+        try {
+            operatorMetrics.timeControllerExecution(failureExecution);
+            fail();
+        } catch (Exception e) {
+            assertEquals(2, metrics.size());
+            assertEquals(1, getHistogram("cleanup", "failed").getCount());
+            assertTrue(getHistogram("cleanup", "failed").getStatistics().getMin() > 0);
+        }
+        try {
+            operatorMetrics.timeControllerExecution(failureExecution);
+            fail();
+        } catch (Exception ignored) {
+        }
+        try {
+            operatorMetrics.timeControllerExecution(failureExecution);
+            fail();
+        } catch (Exception e) {
+            assertEquals(2, metrics.size());
+            assertEquals(3, getHistogram("cleanup", "failed").getCount());
+            assertTrue(getHistogram("cleanup", "failed").getStatistics().getMin() > 0);
+        }
     }
 
     @Test
@@ -111,6 +197,10 @@ public class OperatorJosdkMetricsTest {
         operatorMetrics.monitorSizeOf(Map.of("a", "b", "c", "d"), "mymap");
         assertEquals(8, metrics.size());
         assertEquals(2, ((Gauge<Integer>) metrics.get(systemPrefix + "mymap.size")).getValue());
+    }
+
+    private Histogram getHistogram(String... names) {
+        return ((Histogram) metrics.get(executionPrefix + String.join(".", names) + ".Nanos"));
     }
 
     private long getCount(String name) {


### PR DESCRIPTION
## What is the purpose of the change

Currently the JOSDK metrics forwarder logic doesn't implement the `timeControllerExecution` function.  We should implement it with the following logic.

1. Measure execution time for successful failed executions
2. Based on the name of the ControllerExectution (reconcile/cleanup) and controller name, track the following histogram metrics metrics

`JOSDK.{ControllerExecution.controllerName}.{ControllerExecution.name}.{ControllerExecution.successTypeName}/failed`

## Brief change log

  - Introduces the `Histogram` metric in the `timeControllerExecution` with the metric name format `JOSDK.{ControllerExecution.controllerName}.{ControllerExecution.name}.{ControllerExecution.successTypeName}/failed`.

## Verifying this change

  - *`OperatorJosdkMetricsTest` adds the `testTimeControllerExecution` to verify whether the `Histogram` metric is correct.*
  - The `Histogram` metric in the `timeControllerExecution` is as follows:
  
```
-- Histograms -----------------------------------------------------------------
flink-kubernetes-operator-7679966cd6-d4p2g.k8soperator.default.flink-kubernetes-operator.system.JOSDK.flinkdeploymentcontroller.reconcile.resource.Nanos: count=6, min=6517100, max=1198002100, mean=3.375813833333334E8, stddev=4.5900281423332655E8, p50=1.997605E8, p75=6.04624825E8, p95=1.1980021E9, p98=1.1980021E9, p99=1.1980021E9, p999=1.1980021E9
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / **no**)
  - Core observer or reconciler logic that is regularly executed: (yes / **no**)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)