### PR TITLE
[FLINK-28496] Label selector setting for operator

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -81,6 +81,12 @@
             <td>Enables last-state fallback for savepoint upgrade mode. When the job is not running thus savepoint cannot be triggered but HA metadata is available for last state restore the operator can initiate the upgrade process when the flag is enabled.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.label.selector</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Label selector of the custom resources to be watched. Please see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for the format supported.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.observer.progress-check.interval</h5></td>
             <td style="word-wrap: break-word;">10 s</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/system_section.html
+++ b/docs/layouts/shortcodes/generated/system_section.html
@@ -27,6 +27,12 @@
             <td>The timeout for the observer to wait the flink rest client to return.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.label.selector</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Label selector of the custom resources to be watched. Please see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for the format supported.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.reconcile.interval</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -53,6 +53,7 @@ public class FlinkOperatorConfiguration {
     Integer savepointHistoryCountThreshold;
     Duration savepointHistoryAgeThreshold;
     RetryConfiguration retryConfiguration;
+    String labelSelector;
 
     public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
         Duration reconcileInterval =
@@ -125,6 +126,9 @@ public class FlinkOperatorConfiguration {
 
         RetryConfiguration retryConfiguration = new FlinkOperatorRetryConfiguration(operatorConfig);
 
+        String labelSelector =
+                operatorConfig.getString(KubernetesOperatorConfigOptions.OPERATOR_LABEL_SELECTOR);
+
         return new FlinkOperatorConfiguration(
                 reconcileInterval,
                 reconcilerMaxParallelism,
@@ -142,7 +146,8 @@ public class FlinkOperatorConfiguration {
                 artifactsBaseDir,
                 savepointHistoryCountThreshold,
                 savepointHistoryAgeThreshold,
-                retryConfiguration);
+                retryConfiguration,
+                labelSelector);
     }
 
     /** Enables configurable retry mechanism for reconciliation errors. */

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -234,6 +234,15 @@ public class KubernetesOperatorConfigOptions {
                             "Comma separated list of namespaces the operator monitors for custom resources.");
 
     @Documentation.Section(SECTION_SYSTEM)
+    public static final ConfigOption<String> OPERATOR_LABEL_SELECTOR =
+            ConfigOptions.key("kubernetes.operator.label.selector")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Label selector of the custom resources to be watched. Please see "
+                                    + "https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for the format supported.");
+
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Boolean> OPERATOR_DYNAMIC_NAMESPACES_ENABLED =
             ConfigOptions.key("kubernetes.operator.dynamic.namespaces.enabled")
                     .booleanType()

--- a/helm/flink-kubernetes-operator/conf/flink-conf.yaml
+++ b/helm/flink-kubernetes-operator/conf/flink-conf.yaml
@@ -40,6 +40,7 @@ parallelism.default: 2
 # kubernetes.operator.user.artifacts.base.dir: /opt/flink/artifacts
 # kubernetes.operator.job.upgrade.ignore-pending-savepoint: false
 # kubernetes.operator.watched.namespaces: ns1,ns2
+# kubernetes.operator.label.selector: flink=enabled
 # kubernetes.operator.dynamic.namespaces.enabled: false
 # kubernetes.operator.retry.initial.interval: 5 s
 # kubernetes.operator.retry.interval.multiplier: 2


### PR DESCRIPTION
## What is the purpose of the change

Adds support for labelselector on Flink custom resources. This enables having multiple operators potentially watch the same namespace for blue/green deployment scenarios. When no selector is set the existing behavior of watching all resources of a namespace is reatined.

## Verifying this change

I have added a test for it verifying that we properly pass the labelselector configuration to JOSDK. Unfortunately the test fails when run together with a specific other test, have to fix this. It might make sense to add an e2e test to cover this too.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (via the configuration description)
