### PR TITLE
[FLINK-28517] Bump Flink version to 1.15.1

### DIFF
--- a/docs/content/docs/custom-resource/overview.md
+++ b/docs/content/docs/custom-resource/overview.md
@@ -161,7 +161,7 @@ metadata:
 spec:
   deploymentName: basic-session-cluster
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.0/flink-examples-streaming_2.12-1.15.0-TopSpeedWindowing.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.1/flink-examples-streaming_2.12-1.15.1-TopSpeedWindowing.jar
     parallelism: 4
     upgradeMode: stateless
 ```

--- a/examples/basic-session-job.yaml
+++ b/examples/basic-session-job.yaml
@@ -40,7 +40,7 @@ metadata:
 spec:
   deploymentName: basic-session-cluster
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.0/flink-examples-streaming_2.12-1.15.0-TopSpeedWindowing.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.1/flink-examples-streaming_2.12-1.15.1-TopSpeedWindowing.jar
     parallelism: 4
     upgradeMode: stateless
 
@@ -52,7 +52,7 @@ metadata:
 spec:
   deploymentName: basic-session-cluster
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.0/flink-examples-streaming_2.12-1.15.0.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.1/flink-examples-streaming_2.12-1.15.1.jar
     parallelism: 2
     upgradeMode: stateless
     entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample

--- a/examples/flink-sql-runner-example/Dockerfile
+++ b/examples/flink-sql-runner-example/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-FROM flink:1.15.0
+FROM flink:1.15.1
 
 RUN mkdir /opt/flink/usrlib
 ADD target/flink-sql-runner-example-*.jar /opt/flink/usrlib/sql-runner.jar

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
@@ -50,7 +50,7 @@ public class FlinkOperatorITCase {
     private static final String TEST_NAMESPACE = "flink-operator-test";
     private static final String SERVICE_ACCOUNT = "flink-operator";
     private static final String CLUSTER_ROLE_BINDING = "flink-operator-cluster-role-binding";
-    private static final String FLINK_VERSION = "1.15.0";
+    private static final String FLINK_VERSION = "1.15.1";
     private static final String IMAGE = String.format("flink:%s", FLINK_VERSION);
     private static final Logger LOG = LoggerFactory.getLogger(FlinkOperatorITCase.class);
     private KubernetesClient client;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/FlinkServiceTest.java
@@ -292,15 +292,11 @@ public class FlinkServiceTest {
                 "{\"refresh-interval\":3000,\"timezone-name\":\"Coordinated Universal Time\",\"timezone-offset\":0,\"flink-version\":\"1.13.6\",\"flink-revision\":\"b2ca390 @ 2022-02-03T14:54:22+01:00\",\"features\":{\"web-submit\":false}}";
         String flink14Response =
                 "{\"refresh-interval\":3000,\"timezone-name\":\"Coordinated Universal Time\",\"timezone-offset\":0,\"flink-version\":\"1.14.4\",\"flink-revision\":\"895c609 @ 2022-02-25T11:57:14+01:00\",\"features\":{\"web-submit\":false,\"web-cancel\":false}}";
-        String flink15Response =
-                "{\"refresh-interval\":3000,\"timezone-name\":\"Coordinated Universal Time\",\"timezone-offset\":0,\"flink-version\":\"1.15.0\",\"flink-revision\":\"3a4c113 @ 2022-04-20T19:50:32+02:00\",\"features\":{\"web-submit\":false,\"web-cancel\":false}}";
 
         var dashboardConfiguration =
                 objectMapper.readValue(flink13Response, CustomDashboardConfiguration.class);
         dashboardConfiguration =
                 objectMapper.readValue(flink14Response, CustomDashboardConfiguration.class);
-        dashboardConfiguration =
-                objectMapper.readValue(flink15Response, CustomDashboardConfiguration.class);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,7 @@ under the License.
         <fabric8.version>5.12.2</fabric8.version>
         <lombok.version>1.18.22</lombok.version>
 
-        <flink.version>1.15.0</flink.version>
-        <flink.shaded.version>15.0</flink.shaded.version>
+        <flink.version>1.15.1</flink.version>
 
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.1</log4j.version>


### PR DESCRIPTION
## What is the purpose of the change
Bump Flink version to 1.15.1

## Brief change log
- Changed the Flink version from 1.15.0 to 1.15.1 in relevant project files
- Removed redundant `<flink.shaded.version>15.0</flink.shaded.version>` from main `pom.xml` file

## Verifying this change
```
eval $(minikube docker-env)
DOCKER_BUILDKIT=1 docker build . -t flink-kubernetes-operator
helm install flink-kubernetes-operator helm/flink-kubernetes-operator
k create -f examples/basic.yaml
```

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
