### PR TITLE
[FLINK-28478] Always complete in-progress update

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -268,6 +268,10 @@ public abstract class AbstractFlinkResourceReconciler<
      * @return True if desired spec was already deployed.
      */
     private boolean checkNewSpecAlreadyDeployed(CR resource, Configuration deployConf) {
+        if (resource.getStatus().getReconciliationStatus().getState()
+                == ReconciliationState.UPGRADING) {
+            return false;
+        }
         AbstractFlinkSpec deployedSpec = ReconciliationUtils.getDeployedSpec(resource);
         if (resource.getSpec().equals(deployedSpec)) {
             LOG.info(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -144,6 +144,10 @@ public class TestingFlinkService extends FlinkService {
         sessions.clear();
     }
 
+    public Set<String> getSessions() {
+        return sessions;
+    }
+
     @Override
     public void submitApplicationCluster(
             JobSpec jobSpec, Configuration conf, boolean requireHaMetadata) throws Exception {
@@ -186,7 +190,10 @@ public class TestingFlinkService extends FlinkService {
     }
 
     @Override
-    public void submitSessionCluster(Configuration conf) {
+    public void submitSessionCluster(Configuration conf) throws Exception {
+        if (deployFailure) {
+            throw new Exception("Deployment failure");
+        }
         sessions.add(conf.get(KubernetesConfigOptions.CLUSTER_ID));
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Fix bug where session upgrade would not be completed if an exception was thrown directly before submission.

## Brief change log

Fix invalid logic in AbstractFlinkResourceReconciler#checkNewSpecAlreadyDeployed to always return false in UPGRADING state.

## Verifying this change

Added new cases to SessionReconcilerTest to cover this failure scenrio

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (yes)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable