### PR TITLE
[FLINK-28534] Spec change event is triggered twice per upgrade

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -134,12 +134,14 @@ public abstract class AbstractFlinkResourceReconciler<
                 return;
             }
             LOG.info(MSG_SPEC_CHANGED);
-            eventRecorder.triggerEvent(
-                    cr,
-                    EventRecorder.Type.Normal,
-                    EventRecorder.Reason.SpecChanged,
-                    EventRecorder.Component.JobManagerDeployment,
-                    MSG_SPEC_CHANGED);
+            if (reconciliationStatus.getState() != ReconciliationState.UPGRADING) {
+                eventRecorder.triggerEvent(
+                        cr,
+                        EventRecorder.Type.Normal,
+                        EventRecorder.Reason.SpecChanged,
+                        EventRecorder.Component.JobManagerDeployment,
+                        MSG_SPEC_CHANGED);
+            }
             reconcileSpecChange(cr, observeConfig, deployConfig);
         } else if (shouldRollBack(cr, observeConfig)) {
             // Rollbacks are executed in two steps, we initiate it first then return


### PR DESCRIPTION
## What is the purpose of the change
Fix sending unnecessary spec change events during upgrades

## Brief change log
Fixed sending unnecessary spec change events during upgrades

## Verifying this change
Modified existing tests to verify the events triggered during upgrades

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (yes)

## Documentation
  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
