### PR TITLE
[FLINK-28207] Improve webhook helm configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install cert-manager
         run: |
           kubectl get pods -A
-          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
           kubectl -n cert-manager wait --all=true --for=condition=Available --timeout=300s deploy
       - name: Build image
         run: |
@@ -136,7 +136,7 @@ jobs:
       - name: Install cert-manager
         run: |
           kubectl get pods -A
-          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
           kubectl -n cert-manager wait --all=true --for=condition=Available --timeout=300s deploy
       - name: Build image
         run: |

--- a/docs/content/docs/operations/helm.md
+++ b/docs/content/docs/operations/helm.md
@@ -67,6 +67,7 @@ The configurable parameters of the Helm chart and which default values as detail
 | rbac.nodesRule.create | Whether to add RBAC rule to list nodes which is needed for rest-service exposed as NodePort type. | false |
 | operatorPod.annotations | Custom annotations to be added to the operator pod (but not the deployment). | |
 | operatorPod.labels | Custom labels to be added to the operator pod (but not the deployment). | |
+| operatorPod.env | Custom env to be added to the operator pod. | |
 | operatorServiceAccount.create | Whether to enable operator service account to create for flink-kubernetes-operator. | true |
 | operatorServiceAccount.annotations | The annotations of operator service account. | |
 | operatorServiceAccount.name | The name of operator service account. | flink-operator |
@@ -80,15 +81,16 @@ The configurable parameters of the Helm chart and which default values as detail
 | podSecurityContext | Defines privilege and access control settings for a pod or container for pod security context.  | runAsUser: 9999<br/>runAsGroup: 9999 |
 | operatorSecurityContext | Defines privilege and access control settings for a pod or container for operator security context.  | |
 | webhookSecurityContext | Defines privilege and access control settings for a pod or container for webhook security context. | |
-| webhook.create | Whether to enable webhook validator to create for flink-kubernetes-operator.                        | true |
-| webhook.mutator.create | Whether to enable webhook mutator to create for flink-kubernetes-operator. | true |
+| webhook.create | Whether to enable validating and mutating webhooks for flink-kubernetes-operator.                        | true |
+| webhook.mutator.create | Enable or disable mutating webhook, overrides `webhook.create` | |
+| webhook.validator.create | Enable or disable validating webhook, overrides `webhook.create` | |
 | webhook.keystore | The ConfigMap of webhook key store. | useDefaultPassword: true |
 | defaultConfiguration.create | Whether to enable default configuration to create for flink-kubernetes-operator. | true |
 | defaultConfiguration.append | Whether to append configuration files with configs.  | true |
 | defaultConfiguration.flink-conf.yaml | The default configuration of flink-conf.yaml. | kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory<br/>kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE<br/>kubernetes.operator.reconcile.interval: 15 s<br/>kubernetes.operator.observer.progress-check.interval: 5 s |
 | defaultConfiguration.log4j-operator.properties | The default configuration of log4j-operator.properties. | |
 | defaultConfiguration.log4j-console.properties | The default configuration of log4j-console.properties. | |
-| defaultConfiguration.metrics.port | The metrics port on the container for default configuration. | |
+| metrics.port | The metrics port on the container for default configuration. | |
 | imagePullSecrets | The image pull secrets of flink-kubernetes-operator. | |
 | nameOverride | Overrides the name with the specified name. | |
 | fullnameOverride | Overrides the fullname with the specified full name. | |
@@ -97,14 +99,14 @@ The configurable parameters of the Helm chart and which default values as detail
 
 For more information check the [Helm documentation](https://helm.sh/docs/helm/helm_install/).
 
-## Validating webhook
+## Operator webhooks
 
-In order to use the webhook for FlinkDeployment validation, you must install the cert-manager on the Kubernetes cluster:
+In order to use the webhooks in the operator, you must install the cert-manager on the Kubernetes cluster:
 ```
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
 ```
 
-The webhook can be disabled during helm install by passing the `--set webhook.create=false` parameter or editing the `values.yaml` directly.
+The webhooks can be disabled during helm install by passing the `--set webhook.create=false` parameter or editing the `values.yaml` directly.
 
 ## Watching only specific namespaces
 
@@ -120,7 +122,7 @@ As a result, for users who run the flink kubernetes operator with older k8s vers
 kubectl label namespace <target namespace name> kubernetes.io/metadata.name=<target namespace name>
 ```
 
-Besides, users can define their own namespaceSelector to filter the requests due to customized requirements. 
+Besides, users can define their own namespaceSelector to filter the requests due to customized requirements.
 
 For example, if users label their namespace with key-value pair {customized_namespace_key: &lt;target namespace name&gt; }
 the corresponding namespaceSelector that only accepts requests from this namespace could be:

--- a/docs/content/docs/try-flink-kubernetes-operator/quick-start.md
+++ b/docs/content/docs/try-flink-kubernetes-operator/quick-start.md
@@ -66,7 +66,7 @@ We also recommend [k9s](https://k9scli.io/) as GUI for kubernetes, but it is opt
 
 Install the certificate manager on your Kubernetes cluster to enable adding the webhook component (only needed once per Kubernetes cluster):
 ```bash
-kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.yaml
+kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
 ```
 
 {{< hint info >}}

--- a/helm/flink-kubernetes-operator/templates/_helpers.tpl
+++ b/helm/flink-kubernetes-operator/templates/_helpers.tpl
@@ -88,3 +88,43 @@ Create the name of the job service account to use
 {{- default "default" .Values.jobServiceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "validating-webhook-enabled" -}}
+{{- if hasKey .Values.webhook "validator" }}
+{{- if .Values.webhook.validator.create }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- else }}
+{{- if or (.Values.webhook.create) }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "mutating-webhook-enabled" -}}
+{{- if hasKey .Values.webhook "mutator" }}
+{{- if .Values.webhook.mutator.create }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- else }}
+{{- if or (.Values.webhook.create) }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "webhook-enabled" -}}
+{{- if or (eq (include "validating-webhook-enabled" .) "true") (eq (include "mutating-webhook-enabled" .) "true") }}
+{{- printf "true" }}
+{{- else }}
+{{- printf "false" }}
+{{- end }}
+{{- end }}

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -90,7 +90,7 @@ spec:
             {{- if .Values.operatorVolumeMounts.create }}
                 {{- toYaml .Values.operatorVolumeMounts.data | nindent 12 }}
             {{- end }}
-        {{- if .Values.webhook.create }}
+        {{- if eq (include "webhook-enabled" .) "true" }}
         - name: flink-webhook
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -146,7 +146,7 @@ spec:
         {{- if .Values.operatorVolumes.create }}
               {{- toYaml .Values.operatorVolumes.data | nindent 8 }}
         {{- end }}
-        {{- if .Values.webhook.create }}
+        {{- if eq (include "webhook-enabled" .) "true" }}
         - name: keystore
           secret:
             secretName: webhook-server-cert

--- a/helm/flink-kubernetes-operator/templates/webhook.yaml
+++ b/helm/flink-kubernetes-operator/templates/webhook.yaml
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 ---
-{{- if or .Values.webhook.create .Values.webhook.mutator.create }}
+{{- if eq (include "webhook-enabled" .) "true" }}
 ---
 apiVersion: v1
 kind: Service
@@ -76,7 +76,7 @@ metadata:
 spec:
   selfSigned: {}
 {{- end }}
-{{- if .Values.webhook.create }}
+{{- if eq (include "validating-webhook-enabled" .) "true" }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -112,7 +112,7 @@ webhooks:
         values: [{{- range .Values.watchNamespaces }}{{ . | quote }},{{- end}}]
   {{- end }}
 {{- end }}
-{{ if .Values.webhook.mutator.create }}
+{{- if eq (include "mutating-webhook-enabled" .) "true" }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -83,8 +83,10 @@ webhookSecurityContext: {}
 
 webhook:
   create: true
-  mutator:
-    create: true
+  # validator:
+  #   create: true
+  # mutator:
+  #   create: true
   keystore:
     useDefaultPassword: true
   # passwordSecretRef:


### PR DESCRIPTION
## What is the purpose of the change

Improve and clarify webhook configuraiton in helm chart.

## Brief change log

  - webhook.create provides the default enable/disable flag for both mutating and validating webhook
  - webhook.mutator/validator.create can optionally override this setting
  - Upgrade cert-manager 1.8.0 -> 1.8.2

## Verifying this change

Manually tested on minikube

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
