### PR TITLE
[FLINK-28637] Set explicit version for okhttp to fix vulnerability (release-1.1)

### DIFF
--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -143,6 +143,29 @@ under the License.
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- okhttp -->
+        <!--
+            Regarding the okhttp explicit version
+            see https://github.com/fabric8io/kubernetes-client/issues/4290
+            and https://issues.apache.org/jira/browse/FLINK-28637
+            -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${okhttp.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-kubernetes-webhook/pom.xml
+++ b/flink-kubernetes-webhook/pom.xml
@@ -73,6 +73,29 @@ under the License.
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- okhttp -->
+        <!--
+            Regarding the okhttp explicit version
+            see https://github.com/fabric8io/kubernetes-client/issues/4290
+            and https://issues.apache.org/jira/browse/FLINK-28637
+            -->
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${okhttp.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,8 @@ under the License.
 
         <spotless.version>2.4.2</spotless.version>
         <it.skip>true</it.skip>
+
+        <okhttp.version>4.10.0</okhttp.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## What is the purpose of the change

Setting explicit version for okhttp until we can upgrade to new version of JSODK with the fix.

## Brief change log

  - Setting explicit version for okhttp to 4.10.0 to fix PRISMA-2022-0239