### PR TITLE
[FLINK-28592] Custom resource counter metrics improvements

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_metric_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_metric_configuration.html
@@ -45,6 +45,12 @@
             <td>In addition to the system level histograms, enable per namespace tracking of state and transition times.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.resource.metrics.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Enables metrics for FlinkDeployment and FlinkSessionJob custom resources.</td>
+        </tr>
+        <tr>
             <td><h5>metrics.scope.k8soperator.resource</h5></td>
             <td style="word-wrap: break-word;">"&lt;host&gt;.k8soperator.&lt;namespace&gt;.&lt;name&gt;.resource.&lt;resourcens&gt;.&lt;resourcename&gt;"</td>
             <td>String</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -25,8 +25,6 @@ import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentController;
 import org.apache.flink.kubernetes.operator.controller.FlinkSessionJobController;
-import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
-import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.listener.FlinkResourceListener;
 import org.apache.flink.kubernetes.operator.listener.ListenerUtils;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
@@ -120,9 +118,9 @@ public class FlinkOperator {
 
     @VisibleForTesting
     void registerDeploymentController() {
-        var statusRecorder =
-                StatusRecorder.<FlinkDeploymentStatus>create(
-                        client, new MetricManager<>(metricGroup, configManager), listeners);
+        var metricManager =
+                MetricManager.createFlinkDeploymentMetricManager(configManager, metricGroup);
+        var statusRecorder = StatusRecorder.create(client, metricManager, listeners);
         var eventRecorder = EventRecorder.create(client, listeners);
         var reconcilerFactory =
                 new ReconcilerFactory(
@@ -145,9 +143,9 @@ public class FlinkOperator {
     @VisibleForTesting
     void registerSessionJobController() {
         var eventRecorder = EventRecorder.create(client, listeners);
-        var statusRecorder =
-                StatusRecorder.<FlinkSessionJobStatus>create(
-                        client, new MetricManager<>(metricGroup, configManager), listeners);
+        var metricManager =
+                MetricManager.createFlinkSessionJobMetricManager(configManager, metricGroup);
+        var statusRecorder = StatusRecorder.create(client, metricManager, listeners);
         var reconciler =
                 new SessionJobReconciler(
                         client, flinkServiceFactory, configManager, eventRecorder, statusRecorder);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -64,7 +64,7 @@ public class FlinkDeploymentController
     private final Set<FlinkResourceValidator> validators;
     private final ReconcilerFactory reconcilerFactory;
     private final ObserverFactory observerFactory;
-    private final StatusRecorder<FlinkDeploymentStatus> statusRecorder;
+    private final StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder;
     private final EventRecorder eventRecorder;
 
     public FlinkDeploymentController(
@@ -72,7 +72,7 @@ public class FlinkDeploymentController
             Set<FlinkResourceValidator> validators,
             ReconcilerFactory reconcilerFactory,
             ObserverFactory observerFactory,
-            StatusRecorder<FlinkDeploymentStatus> statusRecorder,
+            StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder,
             EventRecorder eventRecorder) {
         this.configManager = configManager;
         this.validators = validators;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -60,14 +60,14 @@ public class FlinkSessionJobController
     private final Set<FlinkResourceValidator> validators;
     private final Reconciler<FlinkSessionJob> reconciler;
     private final Observer<FlinkSessionJob> observer;
-    private final StatusRecorder<FlinkSessionJobStatus> statusRecorder;
+    private final StatusRecorder<FlinkSessionJob, FlinkSessionJobStatus> statusRecorder;
 
     public FlinkSessionJobController(
             FlinkConfigManager configManager,
             Set<FlinkResourceValidator> validators,
             Reconciler<FlinkSessionJob> reconciler,
             Observer<FlinkSessionJob> observer,
-            StatusRecorder<FlinkSessionJobStatus> statusRecorder) {
+            StatusRecorder<FlinkSessionJob, FlinkSessionJobStatus> statusRecorder) {
         this.configManager = configManager;
         this.validators = validators;
         this.reconciler = reconciler;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/CustomResourceMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/CustomResourceMetrics.java
@@ -20,7 +20,7 @@ package org.apache.flink.kubernetes.operator.metrics;
 import io.fabric8.kubernetes.client.CustomResource;
 
 /** Custom resource metric type. */
-public interface CustomResourceMetrics<CR extends CustomResource> {
+public interface CustomResourceMetrics<CR extends CustomResource<?, ?>> {
     void onUpdate(CR customResource);
 
     void onRemove(CR customResource);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
@@ -43,6 +43,13 @@ public class KubernetesOperatorMetricOptions {
                     .withDescription(
                             "Enable KubernetesClient metrics for measuring the HTTP traffic to the Kubernetes API Server.");
 
+    public static final ConfigOption<Boolean> OPERATOR_RESOURCE_METRICS_ENABLED =
+            ConfigOptions.key("kubernetes.operator.resource.metrics.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Enables metrics for FlinkDeployment and FlinkSessionJob custom resources.");
+
     public static final ConfigOption<Boolean> OPERATOR_LIFECYCLE_METRICS_ENABLED =
             ConfigOptions.key("kubernetes.operator.resource.lifecycle.metrics.enabled")
                     .booleanType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -42,19 +42,20 @@ import java.util.Iterator;
 import java.util.List;
 
 /** An observer of savepoint progress. */
-public class SavepointObserver<STATUS extends CommonStatus<?>> {
+public class SavepointObserver<
+        CR extends AbstractFlinkResource<?, STATUS>, STATUS extends CommonStatus<?>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(SavepointObserver.class);
 
     private final FlinkService flinkService;
     private final FlinkConfigManager configManager;
-    private final StatusRecorder<STATUS> statusRecorder;
+    private final StatusRecorder<CR, STATUS> statusRecorder;
     private final EventRecorder eventRecorder;
 
     public SavepointObserver(
             FlinkService flinkService,
             FlinkConfigManager configManager,
-            StatusRecorder<STATUS> statusRecorder,
+            StatusRecorder<CR, STATUS> statusRecorder,
             EventRecorder eventRecorder) {
         this.flinkService = flinkService;
         this.configManager = configManager;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
@@ -38,13 +38,13 @@ import java.util.Optional;
 /** The observer of {@link org.apache.flink.kubernetes.operator.config.Mode#APPLICATION} cluster. */
 public class ApplicationObserver extends AbstractDeploymentObserver {
 
-    private final SavepointObserver<FlinkDeploymentStatus> savepointObserver;
+    private final SavepointObserver<FlinkDeployment, FlinkDeploymentStatus> savepointObserver;
     private final JobStatusObserver<ApplicationObserverContext> jobStatusObserver;
 
     public ApplicationObserver(
             FlinkService flinkService,
             FlinkConfigManager configManager,
-            StatusRecorder<FlinkDeploymentStatus> statusRecorder,
+            StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder,
             EventRecorder eventRecorder) {
         super(flinkService, configManager, eventRecorder);
         this.savepointObserver =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ObserverFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ObserverFactory.java
@@ -36,7 +36,7 @@ public class ObserverFactory {
 
     private final FlinkServiceFactory flinkServiceFactory;
     private final FlinkConfigManager configManager;
-    private final StatusRecorder<FlinkDeploymentStatus> statusRecorder;
+    private final StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder;
     private final EventRecorder eventRecorder;
     private final Map<Tuple2<Mode, KubernetesDeploymentMode>, Observer<FlinkDeployment>>
             observerMap;
@@ -44,7 +44,7 @@ public class ObserverFactory {
     public ObserverFactory(
             FlinkServiceFactory flinkServiceFactory,
             FlinkConfigManager configManager,
-            StatusRecorder<FlinkDeploymentStatus> statusRecorder,
+            StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder,
             EventRecorder eventRecorder) {
         this.flinkServiceFactory = flinkServiceFactory;
         this.configManager = configManager;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
@@ -56,12 +56,12 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
     private final FlinkServiceFactory flinkServiceFactory;
     private final FlinkConfigManager configManager;
     private final EventRecorder eventRecorder;
-    private final StatusRecorder<FlinkSessionJobStatus> statusRecorder;
+    private final StatusRecorder<FlinkSessionJob, FlinkSessionJobStatus> statusRecorder;
 
     public SessionJobObserver(
             FlinkServiceFactory flinkServiceFactory,
             FlinkConfigManager configManager,
-            StatusRecorder<FlinkSessionJobStatus> statusRecorder,
+            StatusRecorder<FlinkSessionJob, FlinkSessionJobStatus> statusRecorder,
             EventRecorder eventRecorder) {
         this.flinkServiceFactory = flinkServiceFactory;
         this.configManager = configManager;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -399,7 +399,7 @@ public class ReconciliationUtils {
                     R resource,
                     Optional<RetryInfo> retryInfo,
                     Exception e,
-                    StatusRecorder<STATUS> statusRecorder) {
+                    StatusRecorder<R, STATUS> statusRecorder) {
 
         retryInfo.ifPresent(
                 r -> {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -63,7 +63,7 @@ public abstract class AbstractFlinkResourceReconciler<
 
     protected final FlinkConfigManager configManager;
     protected final EventRecorder eventRecorder;
-    protected final StatusRecorder<STATUS> statusRecorder;
+    protected final StatusRecorder<CR, STATUS> statusRecorder;
     protected final KubernetesClient kubernetesClient;
 
     public static final String MSG_SUSPENDED = "Suspending existing deployment.";
@@ -75,7 +75,7 @@ public abstract class AbstractFlinkResourceReconciler<
             KubernetesClient kubernetesClient,
             FlinkConfigManager configManager,
             EventRecorder eventRecorder,
-            StatusRecorder<STATUS> statusRecorder) {
+            StatusRecorder<CR, STATUS> statusRecorder) {
         this.kubernetesClient = kubernetesClient;
         this.configManager = configManager;
         this.eventRecorder = eventRecorder;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -55,7 +55,7 @@ public abstract class AbstractJobReconciler<
             KubernetesClient kubernetesClient,
             FlinkConfigManager configManager,
             EventRecorder eventRecorder,
-            StatusRecorder<STATUS> statusRecorder) {
+            StatusRecorder<CR, STATUS> statusRecorder) {
         super(kubernetesClient, configManager, eventRecorder, statusRecorder);
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -60,7 +60,7 @@ public class ApplicationReconciler
             FlinkService flinkService,
             FlinkConfigManager configManager,
             EventRecorder eventRecorder,
-            StatusRecorder<FlinkDeploymentStatus> statusRecorder) {
+            StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder) {
         super(kubernetesClient, configManager, eventRecorder, statusRecorder);
         this.flinkService = flinkService;
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
@@ -40,7 +40,7 @@ public class ReconcilerFactory {
     private final FlinkServiceFactory flinkServiceFactory;
     private final FlinkConfigManager configManager;
     private final EventRecorder eventRecorder;
-    private final StatusRecorder<FlinkDeploymentStatus> deploymentStatusRecorder;
+    private final StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> deploymentStatusRecorder;
     private final Map<Tuple2<Mode, KubernetesDeploymentMode>, Reconciler<FlinkDeployment>>
             reconcilerMap;
 
@@ -49,7 +49,7 @@ public class ReconcilerFactory {
             FlinkServiceFactory flinkServiceFactory,
             FlinkConfigManager configManager,
             EventRecorder eventRecorder,
-            StatusRecorder<FlinkDeploymentStatus> deploymentStatusRecorder) {
+            StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> deploymentStatusRecorder) {
         this.kubernetesClient = kubernetesClient;
         this.flinkServiceFactory = flinkServiceFactory;
         this.configManager = configManager;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -60,7 +60,7 @@ public class SessionReconciler
             FlinkService flinkService,
             FlinkConfigManager configManager,
             EventRecorder eventRecorder,
-            StatusRecorder<FlinkDeploymentStatus> statusRecorder) {
+            StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder) {
         super(kubernetesClient, configManager, eventRecorder, statusRecorder);
         this.flinkService = flinkService;
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -53,7 +53,7 @@ public class SessionJobReconciler
             FlinkServiceFactory flinkServiceFactory,
             FlinkConfigManager configManager,
             EventRecorder eventRecorder,
-            StatusRecorder<FlinkSessionJobStatus> statusRecorder) {
+            StatusRecorder<FlinkSessionJob, FlinkSessionJobStatus> statusRecorder) {
         super(kubernetesClient, configManager, eventRecorder, statusRecorder);
         this.flinkServiceFactory = flinkServiceFactory;
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
@@ -18,22 +18,24 @@
 
 package org.apache.flink.kubernetes.operator;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.status.CommonStatus;
+import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /** Testing statusRecorder. */
-public class TestingStatusRecorder<STATUS extends CommonStatus<?>> extends StatusRecorder<STATUS> {
+public class TestingStatusRecorder<
+                CR extends AbstractFlinkResource<?, STATUS>, STATUS extends CommonStatus<?>>
+        extends StatusRecorder<CR, STATUS> {
 
     public TestingStatusRecorder() {
-        super(null, TestUtils.createTestMetricManager(new Configuration()), (r, s) -> {});
+        super(null, new MetricManager<>(), (r, s) -> {});
     }
 
     @Override
-    public <T extends AbstractFlinkResource<?, STATUS>> void patchAndCacheStatus(T resource) {
+    public void patchAndCacheStatus(CR resource) {
         statusCache.put(
                 getKey(resource),
                 objectMapper.convertValue(resource.getStatus(), ObjectNode.class));

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -17,13 +17,13 @@
 
 package org.apache.flink.kubernetes.operator.controller;
 
-import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.TestingFlinkServiceFactory;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.observer.deployment.ObserverFactory;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.deployment.ReconcilerFactory;
@@ -73,10 +73,7 @@ public class TestingFlinkDeploymentController
 
         eventRecorder = new EventRecorder(kubernetesClient, eventCollector);
         statusRecorder =
-                new StatusRecorder<>(
-                        kubernetesClient,
-                        TestUtils.createTestMetricManager(configManager.getDefaultConfig()),
-                        statusUpdateCounter);
+                new StatusRecorder<>(kubernetesClient, new MetricManager<>(), statusUpdateCounter);
         flinkDeploymentController =
                 new FlinkDeploymentController(
                         configManager,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.flink.kubernetes.operator.listener;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
@@ -52,11 +52,8 @@ public class FlinkResourceListenerTest {
         var listener2 = new TestingListener();
         var listeners = List.<FlinkResourceListener>of(listener1, listener2);
 
-        var statusRecorder =
-                StatusRecorder.<FlinkDeploymentStatus>create(
-                        kubernetesClient,
-                        TestUtils.createTestMetricManager(new Configuration()),
-                        listeners);
+        StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder =
+                StatusRecorder.create(kubernetesClient, new MetricManager<>(), listeners);
         var eventRecorder = EventRecorder.create(kubernetesClient, listeners);
 
         var deployment = TestUtils.buildApplicationCluster();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/TestingMetricListener.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/TestingMetricListener.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.metrics;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/** Utility class for metrics testing. */
+public class TestingMetricListener {
+
+    public static final String DELIMITER = ".";
+    private final KubernetesOperatorMetricGroup metricGroup;
+    private final Map<String, Metric> metrics = new HashMap();
+    private static final String NAMESPACE = "test-op-ns";
+    private static final String NAME = "test-op-name";
+    private static final String HOST = "test-op-host";
+    private Configuration configuration;
+
+    public TestingMetricListener(Configuration configuration) {
+        TestingMetricRegistry registry =
+                TestingMetricRegistry.builder()
+                        .setDelimiter(DELIMITER.charAt(0))
+                        .setRegisterConsumer(
+                                (metric, name, group) -> {
+                                    this.metrics.put(group.getMetricIdentifier(name), metric);
+                                })
+                        .build();
+        this.metricGroup =
+                KubernetesOperatorMetricGroup.create(
+                        registry, configuration, NAMESPACE, NAME, HOST);
+        this.configuration = configuration;
+    }
+
+    public KubernetesOperatorMetricGroup getMetricGroup() {
+        return this.metricGroup;
+    }
+
+    public Optional<Counter> getCounter(String identifier) {
+        return this.getMetric(identifier);
+    }
+
+    public Optional<Histogram> getHistogram(String identifier) {
+        return this.getMetric(identifier);
+    }
+
+    public Optional<Meter> getMeter(String identifier) {
+        return this.getMetric(identifier);
+    }
+
+    public <T> Optional<Gauge<T>> getGauge(String identifier) {
+        return Optional.ofNullable((Gauge<T>) this.metrics.get(identifier));
+    }
+
+    private <T extends Metric> Optional<T> getMetric(String identifier) {
+        return Optional.ofNullable((T) this.metrics.get(identifier));
+    }
+
+    public String getMetricId(String... identifiers) {
+        return metricGroup.getMetricIdentifier(String.join(DELIMITER, identifiers));
+    }
+
+    public String getNamespaceMetricId(String resourceNs, String... identifiers) {
+        return metricGroup
+                .createResourceNamespaceGroup(configuration, resourceNs)
+                .getMetricIdentifier(String.join(DELIMITER, identifiers));
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.TestingFlinkServiceFactory;
 import org.apache.flink.kubernetes.operator.TestingStatusRecorder;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
@@ -59,7 +60,7 @@ public class SessionJobObserverTest {
     public void before() {
         kubernetesClient.resource(TestUtils.buildSessionJob()).createOrReplace();
         var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
-        var statusRecorder = new TestingStatusRecorder<FlinkSessionJobStatus>();
+        var statusRecorder = new TestingStatusRecorder<FlinkSessionJob, FlinkSessionJobStatus>();
         flinkService = new TestingFlinkService();
         FlinkServiceFactory flinkServiceFactory = new TestingFlinkServiceFactory(flinkService);
         observer =

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -77,7 +77,7 @@ public class ApplicationReconcilerTest {
     public void before() {
         kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
         var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
-        var statusRecoder = new TestingStatusRecorder<FlinkDeploymentStatus>();
+        var statusRecoder = new TestingStatusRecorder<FlinkDeployment, FlinkDeploymentStatus>();
         reconciler =
                 new ApplicationReconciler(
                         kubernetesClient,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
@@ -67,7 +67,7 @@ public class SessionJobReconcilerTest {
     private TestingFlinkService flinkService = new TestingFlinkService();
     private EventRecorder eventRecorder;
     private SessionJobReconciler reconciler;
-    private StatusRecorder<FlinkSessionJobStatus> statusRecoder;
+    private StatusRecorder<FlinkSessionJob, FlinkSessionJobStatus> statusRecoder;
 
     @BeforeEach
     public void before() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
@@ -17,10 +17,11 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
+import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -39,10 +40,8 @@ public class StatusRecorderTest {
     @Test
     public void testPatchOnlyWhenChanged() throws InterruptedException {
         var helper =
-                new StatusRecorder<FlinkDeploymentStatus>(
-                        kubernetesClient,
-                        TestUtils.createTestMetricManager(new Configuration()),
-                        (e, s) -> {});
+                new StatusRecorder<FlinkDeployment, FlinkDeploymentStatus>(
+                        kubernetesClient, new MetricManager<>(), (e, s) -> {});
         var deployment = TestUtils.buildApplicationCluster();
         kubernetesClient.resource(deployment).createOrReplace();
         var lastRequest = mockServer.getLastRequest();


### PR DESCRIPTION
## What is the purpose of the change
- add option to turn on/off the base custom resource metrics
- some additional refactor around the `MetricManager`
## Brief change log
- added `kubernetes.operator.resource.metrics.enabled` to turn on/off all CR related metrics
- added `TestingMetricListener` utility class
- refactored the `MetricManager` to use registered `CustomResourceMetrics` interfaces
- fixed generic types on `StatusRecorder`

## Verifying this change
- covered by improved `FlinkDeploymentMetricsTest`, `FlinkSessionJobMetricsTest`
## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation
docs added for `kubernetes.operator.resource.metrics.enabled`
