### PR TITLE
[FLINK-28625] Guard against changing target session deployment for sessionjob

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -89,11 +89,7 @@ public class DefaultValidator implements FlinkResourceValidator {
                         deployment.getMetadata().getName(),
                         deployment.getMetadata().getNamespace()),
                 validateLogConfig(spec.getLogConfiguration()),
-                validateJobSpec(
-                        spec.getJob(),
-                        spec.getTaskManager(),
-                        effectiveConfig,
-                        KubernetesDeploymentMode.getDeploymentMode(deployment)),
+                validateJobSpec(spec.getJob(), spec.getTaskManager(), effectiveConfig),
                 validateJmSpec(spec.getJobManager(), effectiveConfig),
                 validateTmSpec(spec.getTaskManager()),
                 validateSpecChange(deployment, effectiveConfig),
@@ -178,10 +174,7 @@ public class DefaultValidator implements FlinkResourceValidator {
     }
 
     private Optional<String> validateJobSpec(
-            JobSpec job,
-            @Nullable TaskManagerSpec tm,
-            Map<String, String> confMap,
-            KubernetesDeploymentMode mode) {
+            JobSpec job, @Nullable TaskManagerSpec tm, Map<String, String> confMap) {
         if (job == null) {
             return Optional.empty();
         }
@@ -384,11 +377,7 @@ public class DefaultValidator implements FlinkResourceValidator {
         return firstPresent(
                 validateNotApplicationCluster(sessionCluster),
                 validateSessionClusterId(sessionJob, sessionCluster),
-                validateJobSpec(
-                        sessionJob.getSpec().getJob(),
-                        null,
-                        effectiveConfig,
-                        KubernetesDeploymentMode.getDeploymentMode(sessionCluster)));
+                validateJobSpec(sessionJob.getSpec().getJob(), null, effectiveConfig));
     }
 
     private Optional<String> validateJobNotEmpty(FlinkSessionJob sessionJob) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -361,6 +361,7 @@ public class DefaultValidator implements FlinkResourceValidator {
 
     private Optional<String> validateSessionJobOnly(FlinkSessionJob sessionJob) {
         return firstPresent(
+                validateDeploymentName(sessionJob.getSpec().getDeploymentName()),
                 validateJobNotEmpty(sessionJob),
                 validateNotLastStateUpgradeMode(sessionJob),
                 validateSpecChange(sessionJob),
@@ -419,16 +420,24 @@ public class DefaultValidator implements FlinkResourceValidator {
     private Optional<String> validateSpecChange(FlinkSessionJob sessionJob) {
         FlinkSessionJobSpec newSpec = sessionJob.getSpec();
 
-        if (sessionJob.getStatus() == null
-                || sessionJob.getStatus().getReconciliationStatus() == null
-                || sessionJob.getStatus().getReconciliationStatus().getLastReconciledSpec()
-                        == null) {
+        if (sessionJob.getStatus().getReconciliationStatus().getLastReconciledSpec() == null) {
             // New job
             if (newSpec.getJob() != null && !newSpec.getJob().getState().equals(JobState.RUNNING)) {
                 return Optional.of("Job must start in running state");
             }
 
             return Optional.empty();
+        } else {
+            var lastReconciledSpec =
+                    sessionJob
+                            .getStatus()
+                            .getReconciliationStatus()
+                            .deserializeLastReconciledSpec();
+            if (!lastReconciledSpec
+                    .getDeploymentName()
+                    .equals(sessionJob.getSpec().getDeploymentName())) {
+                return Optional.of("The deploymentName can't be changed");
+            }
         }
 
         return Optional.empty();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -499,6 +499,17 @@ public class DefaultValidatorTest {
                 flinkDeployment -> {},
                 "Invalid session job flinkConfiguration key: kubernetes.operator.reconcile.interval."
                         + " Allowed keys are [kubernetes.operator.user.artifacts.http.header]");
+
+        testSessionJobValidateWithModifier(
+                sessionJob -> {
+                    sessionJob
+                            .getStatus()
+                            .getReconciliationStatus()
+                            .serializeAndSetLastReconciledSpec(sessionJob.getSpec(), sessionJob);
+                    sessionJob.getSpec().setDeploymentName("new-deployment-name");
+                },
+                flinkDeployment -> {},
+                "The deploymentName can't be changed");
     }
 
     private void testSessionJobValidateWithModifier(


### PR DESCRIPTION
## What is the purpose of the change

This PR is meant to enhance the validation for the session job to guard against changing target session deployment.

## Brief change log

- Add validation for the deployment change.

## Verifying this change

This change added tests and can be verified as follows:

org.apache.flink.kubernetes.operator.validation.DefaultValidatorTest#testSessionJobWithSession

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
