### PR TITLE
[hotfix] Clean up warnings and unnecessary code in tests

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
@@ -87,15 +87,14 @@ public class FlinkOperatorITCase {
 
         await().atMost(1, MINUTES)
                 .untilAsserted(
-                        () -> {
-                            assertThat(
-                                    client.apps()
-                                            .deployments()
-                                            .inNamespace(TEST_NAMESPACE)
-                                            .withName(flinkDeployment.getMetadata().getName())
-                                            .isReady(),
-                                    is(true));
-                        });
+                        () ->
+                                assertThat(
+                                        client.apps()
+                                                .deployments()
+                                                .inNamespace(TEST_NAMESPACE)
+                                                .withName(flinkDeployment.getMetadata().getName())
+                                                .isReady(),
+                                        is(true)));
     }
 
     private static FlinkDeployment buildSessionCluster() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingClusterClient.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingClusterClient.java
@@ -76,12 +76,10 @@ public class TestingClusterClient<T> extends RestClusterClient<T> {
                     CompletableFuture.completedFuture(
                             new JobResult.Builder().jobId(jobID).netRuntime(1).build());
 
-    private final Configuration configuration;
     private final T clusterId;
 
     public TestingClusterClient(Configuration configuration, T clusterId) throws Exception {
         super(configuration, clusterId, (c, e) -> new StandaloneClientHAServices("localhost"));
-        this.configuration = configuration;
         this.clusterId = clusterId;
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkServiceFactory.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkServiceFactory.java
@@ -22,16 +22,9 @@ import org.apache.flink.kubernetes.operator.crd.spec.KubernetesDeploymentMode;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.service.FlinkServiceFactory;
 
-import java.lang.module.Configuration;
-
 /** Flink service factory mock for tests. */
 public class TestingFlinkServiceFactory extends FlinkServiceFactory {
     private final FlinkService flinkService;
-
-    public TestingFlinkServiceFactory() {
-        super(null, null);
-        flinkService = new TestingFlinkService();
-    }
 
     public TestingFlinkServiceFactory(FlinkService flinkService) {
         super(null, null);
@@ -43,10 +36,6 @@ public class TestingFlinkServiceFactory extends FlinkServiceFactory {
     }
 
     public FlinkService getOrCreate(FlinkDeployment deployment) {
-        return flinkService;
-    }
-
-    public FlinkService getOrCreate(Configuration configuration) {
         return flinkService;
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -57,7 +57,6 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -82,8 +81,7 @@ public class FlinkConfigBuilderTest {
         final Container container0 = new Container();
         container0.setName("container0");
         final Pod pod0 =
-                TestUtils.getTestPod(
-                        "pod0 hostname", "pod0 api version", Arrays.asList(container0));
+                TestUtils.getTestPod("pod0 hostname", "pod0 api version", List.of(container0));
 
         flinkDeployment.getSpec().setPodTemplate(pod0);
         flinkDeployment.getSpec().setIngress(IngressSpec.builder().template("test.com").build());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
-import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.utils.Constants;
@@ -65,8 +64,7 @@ public class FlinkConfigManagerTest {
                                                 .key(),
                                         "false")));
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
-        ReconciliationStatus reconciliationStatus =
-                deployment.getStatus().getReconciliationStatus();
+        var reconciliationStatus = deployment.getStatus().getReconciliationStatus();
 
         deployment.getSpec().getFlinkConfiguration().put(testConf.key(), "reconciled");
         reconciliationStatus.serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -50,7 +50,7 @@ public class DeploymentRecoveryTest {
     private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
 
     private TestingFlinkService flinkService;
-    private Context context;
+    private Context<FlinkDeployment> context;
     private TestingFlinkDeploymentController testController;
 
     private KubernetesClient kubernetesClient;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -79,7 +79,7 @@ public class FlinkDeploymentControllerTest {
     private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
 
     private TestingFlinkService flinkService;
-    private Context context;
+    private Context<FlinkDeployment> context;
     private TestingFlinkDeploymentController testController;
 
     private KubernetesMockServer mockServer;
@@ -100,7 +100,7 @@ public class FlinkDeploymentControllerTest {
 
         UpdateControl<FlinkDeployment> updateControl;
 
-        FlinkDeployment appCluster = TestUtils.buildApplicationCluster(FlinkVersion.v1_16);
+        FlinkDeployment appCluster = TestUtils.buildApplicationCluster(flinkVersion);
         assertEquals(
                 JobManagerDeploymentStatus.MISSING,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
@@ -217,12 +217,13 @@ public class FlinkDeploymentControllerTest {
         var submittedEventValidatingResponseProvider =
                 new TestUtils.ValidatingResponseProvider<>(
                         new EventBuilder().withNewMetadata().endMetadata().build(),
-                        r -> {
-                            assertTrue(
-                                    r.getBody()
-                                            .readUtf8()
-                                            .contains(AbstractFlinkResourceReconciler.MSG_SUBMIT));
-                        });
+                        r ->
+                                assertTrue(
+                                        r.getBody()
+                                                .readUtf8()
+                                                .contains(
+                                                        AbstractFlinkResourceReconciler
+                                                                .MSG_SUBMIT)));
         mockServer
                 .expect()
                 .post()
@@ -233,9 +234,11 @@ public class FlinkDeploymentControllerTest {
         var validatingResponseProvider =
                 new TestUtils.ValidatingResponseProvider<>(
                         new EventBuilder().withNewMetadata().endMetadata().build(),
-                        r -> {
-                            assertTrue(r.getBody().readUtf8().contains(TestUtils.DEPLOYMENT_ERROR));
-                        });
+                        r ->
+                                assertTrue(
+                                        r.getBody()
+                                                .readUtf8()
+                                                .contains(TestUtils.DEPLOYMENT_ERROR)));
         mockServer
                 .expect()
                 .post()
@@ -288,12 +291,13 @@ public class FlinkDeploymentControllerTest {
         var submittedEventValidatingResponseProvider =
                 new TestUtils.ValidatingResponseProvider<>(
                         new EventBuilder().withNewMetadata().endMetadata().build(),
-                        r -> {
-                            assertTrue(
-                                    r.getBody()
-                                            .readUtf8()
-                                            .contains(AbstractFlinkResourceReconciler.MSG_SUBMIT));
-                        });
+                        r ->
+                                assertTrue(
+                                        r.getBody()
+                                                .readUtf8()
+                                                .contains(
+                                                        AbstractFlinkResourceReconciler
+                                                                .MSG_SUBMIT)));
         mockServer
                 .expect()
                 .post()
@@ -516,7 +520,7 @@ public class FlinkDeploymentControllerTest {
         testController.reconcile(appCluster, context);
         jobs = flinkService.listJobs();
         assertEquals(1, jobs.size());
-        assertEquals(null, jobs.get(0).f0);
+        assertNull(jobs.get(0).f0);
 
         testController.reconcile(appCluster, context);
         testController.reconcile(appCluster, context);
@@ -549,7 +553,7 @@ public class FlinkDeploymentControllerTest {
                 EventRecorder.Reason.valueOf(testController.events().poll().getReason()));
         jobs = flinkService.listJobs();
         assertEquals(1, jobs.size());
-        assertEquals(null, jobs.get(0).f0);
+        assertNull(jobs.get(0).f0);
 
         // Inject validation error in the middle of the upgrade
         appCluster.getSpec().setRestartNonce(123L);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class RollbackTest {
 
     private TestingFlinkService flinkService;
-    private Context context;
+    private Context<FlinkDeployment> context;
 
     private TestingFlinkDeploymentController testController;
 
@@ -193,7 +193,7 @@ public class RollbackTest {
     @ParameterizedTest
     @EnumSource(FlinkVersion.class)
     public void testRollbackStateless(FlinkVersion flinkVersion) throws Exception {
-        var dep = TestUtils.buildApplicationCluster();
+        var dep = TestUtils.buildApplicationCluster(flinkVersion);
         dep.getSpec().getJob().setUpgradeMode(UpgradeMode.STATELESS);
 
         testRollback(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -63,7 +63,7 @@ public class TestingFlinkDeploymentController
     private EventCollector eventCollector = new EventCollector();
 
     private EventRecorder eventRecorder;
-    private StatusRecorder statusRecorder;
+    private StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder;
 
     public TestingFlinkDeploymentController(
             FlinkConfigManager configManager,
@@ -137,16 +137,14 @@ public class TestingFlinkDeploymentController
     }
 
     private static class StatusUpdateCounter
-            implements BiConsumer<
-                    AbstractFlinkResource<?, FlinkDeploymentStatus>, FlinkDeploymentStatus> {
+            implements BiConsumer<FlinkDeployment, FlinkDeploymentStatus> {
 
         private FlinkDeployment currentResource;
         private int counter;
 
         @Override
         public void accept(
-                AbstractFlinkResource<?, FlinkDeploymentStatus>
-                        flinkDeploymentStatusAbstractFlinkResource,
+                FlinkDeployment flinkDeploymentStatusAbstractFlinkResource,
                 FlinkDeploymentStatus flinkDeploymentStatus) {
             currentResource.setStatus(flinkDeploymentStatusAbstractFlinkResource.getStatus());
             counter++;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricGroupTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricGroupTest.java
@@ -26,8 +26,8 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricOptions.SCOPE_NAMING_KUBERNETES_OPERATOR;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** @link KubernetesOperatorMetricGroup tests. */
 public class KubernetesOperatorMetricGroupTest {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetricsTest.java
@@ -62,9 +62,8 @@ public class OperatorJosdkMetricsTest {
                 TestingMetricRegistry.builder()
                         .setDelimiter(".".charAt(0))
                         .setRegisterConsumer(
-                                (metric, name, group) -> {
-                                    metrics.put(group.getMetricIdentifier(name), metric);
-                                })
+                                (metric, name, group) ->
+                                        metrics.put(group.getMetricIdentifier(name), metric))
                         .build();
         operatorMetrics =
                 new OperatorJosdkMetrics(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
@@ -23,6 +23,8 @@ import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.TestingStatusRecorder;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
@@ -49,14 +51,13 @@ public class SavepointObserverTest {
     private KubernetesClient kubernetesClient;
     private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
     private final TestingFlinkService flinkService = new TestingFlinkService();
-    private SavepointObserver observer;
-    private final EventRecorder eventRecorder = new EventRecorder(null, (r, e) -> {});
+    private SavepointObserver<FlinkDeployment, FlinkDeploymentStatus> observer;
 
     @BeforeEach
     public void before() {
         var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
         observer =
-                new SavepointObserver(
+                new SavepointObserver<>(
                         flinkService, configManager, new TestingStatusRecorder<>(), eventRecorder);
     }
 
@@ -132,7 +133,7 @@ public class SavepointObserverTest {
     }
 
     @Test
-    public void testPeriodicSavepoint() throws Exception {
+    public void testPeriodicSavepoint() {
         var conf = new Configuration();
         var deployment = TestUtils.buildApplicationCluster();
         deployment

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -49,8 +49,8 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -59,7 +59,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnableKubernetesMockClient(crud = true)
 public class ApplicationObserverTest {
     private KubernetesClient kubernetesClient;
-    private final Context readyContext = TestUtils.createContextWithReadyJobManagerDeployment();
+    private final Context<FlinkDeployment> readyContext =
+            TestUtils.createContextWithReadyJobManagerDeployment();
     private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
     private final TestingFlinkService flinkService = new TestingFlinkService();
     private ApplicationObserver observer;
@@ -432,10 +433,10 @@ public class ApplicationObserverTest {
         Exception exception =
                 assertThrows(
                         DeploymentFailedException.class,
-                        () -> {
-                            observer.observe(
-                                    deployment, TestUtils.createContextWithInProgressDeployment());
-                        });
+                        () ->
+                                observer.observe(
+                                        deployment,
+                                        TestUtils.createContextWithInProgressDeployment()));
         assertEquals(podFailedMessage, exception.getMessage());
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -39,7 +39,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 /** {@link SessionObserver} unit tests. */
 public class SessionObserverTest {
-    private final Context readyContext = TestUtils.createContextWithReadyJobManagerDeployment();
+    private final Context<FlinkDeployment> readyContext =
+            TestUtils.createContextWithReadyJobManagerDeployment();
     private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
     private final TestingFlinkService flinkService = new TestingFlinkService();
     private SessionObserver observer;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -214,10 +214,7 @@ public class SessionJobObserverTest {
                 });
         // submit job
         Assertions.assertThrows(
-                RuntimeException.class,
-                () -> {
-                    reconciler.reconcile(sessionJob, readyContext);
-                });
+                RuntimeException.class, () -> reconciler.reconcile(sessionJob, readyContext));
         Assertions.assertNotNull(sessionJob.getStatus().getReconciliationStatus());
         Assertions.assertEquals(
                 ReconciliationState.UPGRADING,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.utils.StandaloneKubernetesUtils;
-import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -35,10 +34,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** @link StandaloneFlinkService unit tests */
 @EnableKubernetesMockClient(crud = true)
@@ -57,10 +54,6 @@ public class StandaloneFlinkServiceTest {
         kubernetesClient = mockServer.createClient().inAnyNamespace();
         flinkStandaloneService =
                 new StandaloneFlinkService(kubernetesClient, new FlinkConfigManager(configuration));
-
-        ExecutorService executorService =
-                Executors.newFixedThreadPool(
-                        1, new ExecutorThreadFactory("flink-kubeclient-io-for-standalone-service"));
     }
 
     @Test
@@ -102,12 +95,11 @@ public class StandaloneFlinkServiceTest {
 
     private Configuration buildConfig(FlinkDeployment flinkDeployment, Configuration configuration)
             throws Exception {
-        return configuration =
-                FlinkConfigBuilder.buildFrom(
-                        flinkDeployment.getMetadata().getNamespace(),
-                        flinkDeployment.getMetadata().getName(),
-                        flinkDeployment.getSpec(),
-                        configuration);
+        return FlinkConfigBuilder.buildFrom(
+                flinkDeployment.getMetadata().getNamespace(),
+                flinkDeployment.getMetadata().getName(),
+                flinkDeployment.getSpec(),
+                configuration);
     }
 
     private void createDeployments() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
@@ -36,8 +36,8 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,20 +53,17 @@ public class FlinkUtilsTest {
     KubernetesMockServer mockServer;
 
     @Test
-    public void testMergePods() throws Exception {
-
+    public void testMergePods() {
         Container container1 = new Container();
         container1.setName("container1");
         Container container2 = new Container();
         container2.setName("container2");
 
-        Pod pod1 =
-                TestUtils.getTestPod(
-                        "pod1 hostname", "pod1 api version", Arrays.asList(container2));
+        Pod pod1 = TestUtils.getTestPod("pod1 hostname", "pod1 api version", List.of(container2));
 
         Pod pod2 =
                 TestUtils.getTestPod(
-                        "pod2 hostname", "pod2 api version", Arrays.asList(container1, container2));
+                        "pod2 hostname", "pod2 api version", List.of(container1, container2));
 
         Pod mergedPod = FlinkUtils.mergePodTemplates(pod1, pod2);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtilsTest.java
@@ -36,7 +36,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Test class for {@link ValidatorUtils}. */
 public class ValidatorUtilsTest {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -158,15 +158,14 @@ public class DefaultValidatorTest {
                         CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
 
         testError(
-                dep -> {
-                    dep.getSpec()
-                            .setFlinkConfiguration(
-                                    Map.of(
-                                            KubernetesOperatorConfigOptions
-                                                    .PERIODIC_SAVEPOINT_INTERVAL
-                                                    .key(),
-                                            "1m"));
-                },
+                dep ->
+                        dep.getSpec()
+                                .setFlinkConfiguration(
+                                        Map.of(
+                                                KubernetesOperatorConfigOptions
+                                                        .PERIODIC_SAVEPOINT_INTERVAL
+                                                        .key(),
+                                                "1m")),
                 String.format(
                         "Periodic savepoints cannot be enabled when config key[%s] is not set",
                         CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
@@ -466,36 +465,33 @@ public class DefaultValidatorTest {
                 "The LAST_STATE upgrade mode is not supported in session job now.");
 
         testSessionJobValidateWithModifier(
-                sessionJob -> {
-                    sessionJob.getSpec().getJob().setState(JobState.SUSPENDED);
-                },
+                sessionJob -> sessionJob.getSpec().getJob().setState(JobState.SUSPENDED),
                 flinkDeployment -> {},
                 "Job must start in running state");
 
         testSessionJobValidateWithModifier(
-                sessionJob -> {
-                    sessionJob
-                            .getSpec()
-                            .setFlinkConfiguration(
-                                    Map.of(
-                                            KubernetesOperatorConfigOptions.JAR_ARTIFACT_HTTP_HEADER
-                                                    .key(),
-                                            "headerKey1:headerValue1,headerKey2:headerValue2"));
-                },
+                sessionJob ->
+                        sessionJob
+                                .getSpec()
+                                .setFlinkConfiguration(
+                                        Map.of(
+                                                KubernetesOperatorConfigOptions
+                                                        .JAR_ARTIFACT_HTTP_HEADER
+                                                        .key(),
+                                                "headerKey1:headerValue1,headerKey2:headerValue2")),
                 flinkDeployment -> {},
                 null);
 
         testSessionJobValidateWithModifier(
-                sessionJob -> {
-                    sessionJob
-                            .getSpec()
-                            .setFlinkConfiguration(
-                                    Map.of(
-                                            KubernetesOperatorConfigOptions
-                                                    .OPERATOR_RECONCILE_INTERVAL
-                                                    .key(),
-                                            "60"));
-                },
+                sessionJob ->
+                        sessionJob
+                                .getSpec()
+                                .setFlinkConfiguration(
+                                        Map.of(
+                                                KubernetesOperatorConfigOptions
+                                                        .OPERATOR_RECONCILE_INTERVAL
+                                                        .key(),
+                                                "60")),
                 flinkDeployment -> {},
                 "Invalid session job flinkConfiguration key: kubernetes.operator.reconcile.interval."
                         + " Allowed keys are [kubernetes.operator.user.artifacts.http.header]");


### PR DESCRIPTION
## What is the purpose of the change

Clean up warnings and some unnecessary, duplicated in the operator tests. 

 - Fix missing generic parameters
 - Remove unused methods/params
 - Code style cleanup
 - Remove some code duplications
 - Replace deprecated junit.assert use

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
