### PR TITLE
[FLINK-28845] Do not ignore initialSavepointPath if first deploy fails completely

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
@@ -21,10 +21,10 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.spec.AbstractFlinkSpec;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationMetadata;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -68,12 +68,12 @@ public abstract class ReconciliationStatus<SPEC extends AbstractFlinkSpec> {
     }
 
     @JsonIgnore
-    public Tuple2<SPEC, ObjectNode> deserializeLastReconciledSpecWithMeta() {
+    public Tuple2<SPEC, ReconciliationMetadata> deserializeLastReconciledSpecWithMeta() {
         return ReconciliationUtils.deserializeSpecWithMeta(lastReconciledSpec, getSpecClass());
     }
 
     @JsonIgnore
-    public Tuple2<SPEC, ObjectNode> deserializeLastStableSpecWithMeta() {
+    public Tuple2<SPEC, ReconciliationMetadata> deserializeLastStableSpecWithMeta() {
         return ReconciliationUtils.deserializeSpecWithMeta(lastStableSpec, getSpecClass());
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
@@ -116,6 +116,7 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
         if (reconciliationStatus.getState() == ReconciliationState.UPGRADING) {
             checkIfAlreadyUpgraded(flinkSessionJob, deployedConfig, flinkService);
             if (reconciliationStatus.getState() == ReconciliationState.UPGRADING) {
+                ReconciliationUtils.clearLastReconciledSpecIfFirstDeploy(flinkSessionJob);
                 return;
             }
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationMetadata.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationMetadata.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler;
+
+import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Extra metadata to be attached to the reconciled spec. */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ReconciliationMetadata {
+
+    private String apiVersion;
+
+    private ObjectMeta metadata;
+
+    private boolean firstDeployment;
+
+    public static ReconciliationMetadata from(AbstractFlinkResource<?, ?> resource) {
+        ObjectMeta metadata = new ObjectMeta();
+        metadata.setGeneration(resource.getMetadata().getGeneration());
+
+        var firstDeploy = resource.getStatus().getReconciliationStatus().isFirstDeployment();
+
+        return new ReconciliationMetadata(resource.getApiVersion(), metadata, firstDeploy);
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -268,8 +268,9 @@ public class ReconciliationUtils {
      * @return Tuple2 of spec and meta.
      * @param <T> Spec type.
      */
-    public static <T extends AbstractFlinkSpec> Tuple2<T, ObjectNode> deserializeSpecWithMeta(
-            @Nullable String specWithMetaString, Class<T> specClass) {
+    public static <T extends AbstractFlinkSpec>
+            Tuple2<T, ReconciliationMetadata> deserializeSpecWithMeta(
+                    @Nullable String specWithMetaString, Class<T> specClass) {
         if (specWithMetaString == null) {
             return null;
         }
@@ -284,7 +285,8 @@ public class ReconciliationUtils {
                 return Tuple2.of(objectMapper.treeToValue(wrapper, specClass), null);
             } else {
                 return Tuple2.of(
-                        objectMapper.treeToValue(wrapper.get("spec"), specClass), internalMeta);
+                        objectMapper.treeToValue(wrapper.get("spec"), specClass),
+                        objectMapper.convertValue(internalMeta, ReconciliationMetadata.class));
             }
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Could not deserialize spec, this indicates a bug...", e);
@@ -300,33 +302,25 @@ public class ReconciliationUtils {
      */
     public static String writeSpecWithMeta(
             AbstractFlinkSpec spec, AbstractFlinkResource<?, ?> relatedResource) {
-
-        ObjectNode internalMeta = objectMapper.createObjectNode();
-
-        internalMeta.put("apiVersion", relatedResource.getApiVersion());
-        ObjectNode metadata = internalMeta.putObject("metadata");
-        metadata.put("generation", relatedResource.getMetadata().getGeneration());
-
-        if (relatedResource.getStatus().getReconciliationStatus().isFirstDeployment()) {
-            metadata.put("firstDeployment", true);
-        }
-
-        return writeSpecWithMeta(spec, internalMeta);
+        return writeSpecWithMeta(spec, ReconciliationMetadata.from(relatedResource));
     }
 
     /**
      * Serializes the spec and custom meta information into a JSON string.
      *
      * @param spec Flink resource spec.
-     * @param meta Custom meta object.
+     * @param metadata Reconciliation meta object.
      * @return Serialized json.
      */
-    public static String writeSpecWithMeta(AbstractFlinkSpec spec, ObjectNode meta) {
+    public static String writeSpecWithMeta(
+            AbstractFlinkSpec spec, ReconciliationMetadata metadata) {
 
         ObjectNode wrapper = objectMapper.createObjectNode();
 
         wrapper.set("spec", objectMapper.valueToTree(Preconditions.checkNotNull(spec)));
-        wrapper.set(INTERNAL_METADATA_JSON_KEY, meta);
+        wrapper.set(
+                INTERNAL_METADATA_JSON_KEY,
+                objectMapper.valueToTree(Preconditions.checkNotNull(metadata)));
 
         try {
             return objectMapper.writeValueAsString(wrapper);
@@ -438,7 +432,7 @@ public class ReconciliationUtils {
             return -1L;
         }
 
-        return lastSpecWithMeta.f1.get("metadata").get("generation").asLong(-1L);
+        return lastSpecWithMeta.f1.getMetadata().getGeneration();
     }
 
     /**
@@ -455,8 +449,7 @@ public class ReconciliationUtils {
             return;
         }
 
-        var firstDeploymentNode = lastSpecWithMeta.f1.get("metadata").get("firstDeployment");
-        if (firstDeploymentNode != null && firstDeploymentNode.asBoolean(false)) {
+        if (lastSpecWithMeta.f1.isFirstDeployment()) {
             reconStatus.setLastReconciledSpec(null);
         }
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -70,6 +70,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /** {@link FlinkDeploymentController} tests. */
@@ -945,5 +946,20 @@ public class FlinkDeploymentControllerTest {
             }
         }
         return args.stream();
+    }
+
+    @Test
+    public void testInitialSavepointOnError() throws Exception {
+        FlinkDeployment flinkDeployment = TestUtils.buildApplicationCluster();
+        flinkDeployment.getSpec().getJob().setInitialSavepointPath("msp");
+        flinkService.setDeployFailure(true);
+        try {
+            testController.reconcile(flinkDeployment, context);
+            fail();
+        } catch (Exception expected) {
+        }
+        flinkService.setDeployFailure(false);
+        testController.reconcile(flinkDeployment, context);
+        assertEquals("msp", flinkService.listJobs().get(0).f0);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -492,4 +492,19 @@ public class ApplicationObserverTest {
         assertEquals(JobState.RUNNING, specWithMeta.f0.getJob().getState());
         assertEquals(5, specWithMeta.f0.getJob().getParallelism());
     }
+
+    @Test
+    public void validateLastReconciledClearedOnInitialFailure() {
+        FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        deployment.getMetadata().setGeneration(123L);
+
+        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(
+                deployment,
+                new FlinkConfigManager(new Configuration())
+                        .getDeployConfig(deployment.getMetadata(), deployment.getSpec()));
+
+        assertFalse(deployment.getStatus().getReconciliationStatus().isFirstDeployment());
+        observer.observe(deployment, TestUtils.createEmptyContext());
+        assertTrue(deployment.getStatus().getReconciliationStatus().isFirstDeployment());
+    }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -488,7 +488,7 @@ public class ApplicationObserverTest {
                 status.getJobManagerDeploymentStatus());
 
         var specWithMeta = status.getReconciliationStatus().deserializeLastReconciledSpecWithMeta();
-        assertEquals(321L, specWithMeta.f1.get("metadata").get("generation").asLong());
+        assertEquals(321L, specWithMeta.f1.getMetadata().getGeneration());
         assertEquals(JobState.RUNNING, specWithMeta.f0.getJob().getState());
         assertEquals(5, specWithMeta.f0.getJob().getParallelism());
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -149,7 +149,7 @@ public class SessionObserverTest {
                 status.getJobManagerDeploymentStatus());
 
         var specWithMeta = status.getReconciliationStatus().deserializeLastReconciledSpecWithMeta();
-        assertEquals(321L, specWithMeta.f1.get("metadata").get("generation").asLong());
+        assertEquals(321L, specWithMeta.f1.getMetadata().getGeneration());
         assertEquals("1", specWithMeta.f0.getFlinkConfiguration().get("k"));
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.sessionjob.SessionJobReconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkServiceFactory;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
@@ -45,6 +46,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for {@link SessionJobObserver}. */
 @EnableKubernetesMockClient(crud = true)
@@ -340,5 +344,17 @@ public class SessionJobObserverTest {
                         RuntimeException.class, () -> observer.observe(sessionJob, readyContext));
         Assertions.assertTrue(
                 exception.getMessage().contains("doesn't match upgrade target generation"));
+    }
+
+    @Test
+    public void validateLastReconciledClearedOnInitialFailure() {
+        var sessionJob = TestUtils.buildSessionJob();
+        sessionJob.getMetadata().setGeneration(123L);
+
+        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(sessionJob, new Configuration());
+
+        assertFalse(sessionJob.getStatus().getReconciliationStatus().isFirstDeployment());
+        observer.observe(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        assertTrue(sessionJob.getStatus().getReconciliationStatus().isFirstDeployment());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix a bug that would cause the `initialSavepointPath` to be ignored if first deploy attempt fails completely.

## Brief change log

  - *Intorduce metadata flag in lastReconciledSpec for first deployments*
  - *If first deployment fails, completely clear lastReconciledSpec so we once again trigger the first deploy logic instead of upgrade*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added new testcase to FlinkDeploymentControllerTest to verify full flow*
  - *Extended deployment/session job observer tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
