### PR TITLE
[FLINK-28869] Emit a warning event for ClusterDeploymentException

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -116,6 +116,12 @@ public class FlinkDeploymentController
         } catch (DeploymentFailedException dfe) {
             handleDeploymentFailed(flinkApp, dfe);
         } catch (Exception e) {
+            eventRecorder.triggerEvent(
+                    flinkApp,
+                    EventRecorder.Type.Warning,
+                    "ClusterDeploymentException",
+                    e.getMessage(),
+                    EventRecorder.Component.JobManagerDeployment);
             throw new ReconciliationException(e);
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -42,7 +42,7 @@ import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -891,7 +891,7 @@ public class FlinkDeploymentControllerTest {
     }
 
     @Test
-    public void testNonDeploymentFailedException() throws Exception {
+    public void testEventOfNonDeploymentFailedException() throws Exception {
         assertTrue(testController.events().isEmpty());
         var flinkDeployment = TestUtils.buildApplicationCluster();
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Emit warning events for ClusterDeploymentException

## Brief change log

- Trigger a K8s warning event when ClusterDeploymentException occurs.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change added tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (yes / no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
