### PR TITLE
[FLINK-28846] Trigger event on validation error

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -152,7 +152,12 @@ public class FlinkOperator {
         var observer = new SessionJobObserver(flinkServiceFactory, configManager, eventRecorder);
         var controller =
                 new FlinkSessionJobController(
-                        configManager, validators, reconciler, observer, statusRecorder);
+                        configManager,
+                        validators,
+                        reconciler,
+                        observer,
+                        statusRecorder,
+                        eventRecorder);
         registeredControllers.add(operator.register(controller, this::overrideControllerConfigs));
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -157,6 +157,12 @@ public class FlinkDeploymentController
         for (FlinkResourceValidator validator : validators) {
             Optional<String> validationError = validator.validateDeployment(deployment);
             if (validationError.isPresent()) {
+                eventRecorder.triggerEvent(
+                        deployment,
+                        EventRecorder.Type.Warning,
+                        EventRecorder.Reason.ValidationError,
+                        EventRecorder.Component.Operator,
+                        validationError.get());
                 return ReconciliationUtils.applyValidationErrorAndResetSpec(
                         deployment, validationError.get());
             }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/CommonStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/CommonStatus.java
@@ -27,6 +27,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.apache.commons.lang3.StringUtils;
 
 /** Last observed common status of the Flink deployment/Flink SessionJob. */
 @Experimental
@@ -54,7 +55,9 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
         var reconciliationStatus = getReconciliationStatus();
 
         if (reconciliationStatus.isFirstDeployment()) {
-            return ResourceLifecycleState.CREATED;
+            return StringUtils.isEmpty(error)
+                    ? ResourceLifecycleState.CREATED
+                    : ResourceLifecycleState.FAILED;
         }
 
         switch (reconciliationStatus.getState()) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -122,6 +122,7 @@ public class EventRecorder {
         StatusChanged,
         SavepointError,
         Cleanup,
-        Missing
+        Missing,
+        ValidationError
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationStatus;
 import org.apache.flink.kubernetes.operator.crd.status.TaskManagerInfo;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
+import org.apache.flink.kubernetes.operator.metrics.lifecycle.ResourceLifecycleState;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.deployment.AbstractFlinkResourceReconciler;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
@@ -61,9 +62,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_JOB_UPGRADE_LAST_STATE_FALLBACK_ENABLED;
+import static org.apache.flink.kubernetes.operator.utils.EventRecorder.Reason.ValidationError;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -575,16 +578,21 @@ public class FlinkDeploymentControllerTest {
                         .getState());
         appCluster.getSpec().setLogConfiguration(Map.of("invalid", "conf"));
         testController.reconcile(appCluster, TestUtils.createEmptyContext());
-        assertEquals(1, testController.events().size());
+        assertEquals(2, testController.events().size());
+        testController.events().remove();
         assertEquals(
                 EventRecorder.Reason.Submit,
-                EventRecorder.Reason.valueOf(testController.events().poll().getReason()));
+                EventRecorder.Reason.valueOf(testController.events().remove().getReason()));
         testController.reconcile(appCluster, context);
         testController.reconcile(appCluster, context);
-        assertEquals(1, testController.events().size());
+        var statusEvents =
+                testController.events().stream()
+                        .filter(e -> !e.getReason().equals(ValidationError.name()))
+                        .collect(Collectors.toList());
+        assertEquals(1, statusEvents.size());
         assertEquals(
                 EventRecorder.Reason.StatusChanged,
-                EventRecorder.Reason.valueOf(testController.events().poll().getReason()));
+                EventRecorder.Reason.valueOf(statusEvents.get(0).getReason()));
 
         assertEquals(
                 JobManagerDeploymentStatus.READY,
@@ -862,6 +870,23 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 appCluster.getStatus().getReconciliationStatus().getLastReconciledSpec(),
                 appCluster.getStatus().getReconciliationStatus().getLastStableSpec());
+    }
+
+    @Test
+    public void testValidationError() throws Exception {
+        assertTrue(testController.events().isEmpty());
+        var flinkDeployment = TestUtils.buildApplicationCluster();
+        flinkDeployment.getSpec().getJob().setParallelism(-1);
+        testController.reconcile(flinkDeployment, context);
+
+        assertEquals(1, testController.events().size());
+        assertEquals(
+                ResourceLifecycleState.FAILED, flinkDeployment.getStatus().getLifecycleState());
+
+        var event = testController.events().remove();
+        assertEquals("Warning", event.getType());
+        assertEquals("ValidationError", event.getReason());
+        assertTrue(event.getMessage().startsWith("Job parallelism "));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Trigger Warning event on validation error. This is very useful in cases where the webhook is not enabled.

![image](https://user-images.githubusercontent.com/5880972/183505832-dd919d0d-05a5-4a00-aaf1-39791f0ba535.png)

## Brief change log

 - Add event triggering to validation logic
 - Improve ResourceLifecycleState in case of failed initial valiadation: `CREATED` -> `FAILED`

## Verifying this change

Extended `FlinkDeploymentControllerTest` to cover the new event triggering.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
