### PR TITLE
[FLINK-28694] Set pipeline.name to resource name by default for application deployments

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -136,6 +136,9 @@ public class FlinkConfigBuilder {
         setDefaultConf(CANCEL_ENABLE, false);
 
         if (spec.getJob() != null) {
+            // Set 'pipeline.name' to resource name by default for application deployments.
+            setDefaultConf(PipelineOptions.NAME, clusterId);
+
             // With last-state upgrade mode, set the default value of
             // 'execution.checkpointing.interval'
             // to 5 minutes when HA is enabled.

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -121,6 +121,8 @@ public class FlinkConfigBuilderTest {
                 KubernetesConfigOptions.ServiceExposedType.ClusterIP,
                 configuration.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE));
         Assertions.assertEquals(false, configuration.get(WebOptions.CANCEL_ENABLE));
+        Assertions.assertEquals(
+                flinkDeployment.getMetadata().getName(), configuration.get(PipelineOptions.NAME));
 
         FlinkDeployment deployment = ReconciliationUtils.clone(flinkDeployment);
         deployment


### PR DESCRIPTION
## What is the purpose of the change

`pipeline.name` should be set to the resource name by default for application deployments.

## Brief change log

  - Sets the `pipeline.name` with the resource name in `applyFlinkConfiguration`.

## Verifying this change

  - Updates the `FlinkConfigBuilder#testApplyFlinkConfiguration` to verify whether the default value of `pipeline.name` is the resource name.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / **no**)
  - Core observer or reconciler logic that is regularly executed: (yes / **no**)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)