### PR TITLE
[FLINK-28892] Update NOTICE for flink-kubernetes-operator 1.1.1

### DIFF
--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -21,9 +21,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.guava:guava:31.0.1-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 - com.google.j2objc:j2objc-annotations:1.3
-- com.squareup.okhttp3:logging-interceptor:3.12.12
-- com.squareup.okhttp3:okhttp:3.12.12
-- com.squareup.okio:okio:1.15.0
+- com.squareup.okhttp3:logging-interceptor:4.10.0
+- com.squareup.okhttp3:okhttp:4.10.0
+- com.squareup.okio:okio-jvm:3.0.0
 - com.squareup:javapoet:1.13.0
 - com.twitter:chill-java:0.7.6
 - commons-cli:commons-cli:1.5.0
@@ -67,7 +67,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.fabric8:openshift-model:5.12.2
 - io.fabric8:zjsonpatch:0.3.0
 - io.javaoperatorsdk:operator-framework-core:3.0.3
-- io.javaoperatorsdk:operator-framework-framework-core:0.2.0
 - io.javaoperatorsdk:operator-framework:3.0.3
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-lang3:3.12.0
@@ -77,6 +76,11 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.logging.log4j:log4j-core:2.17.1
 - org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
 - org.javassist:javassist:3.24.0-GA
+- org.jetbrains.kotlin:kotlin-stdlib-common:1.5.31
+- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10
+- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.10
+- org.jetbrains.kotlin:kotlin-stdlib:1.6.20
+- org.jetbrains:annotations:13.0
 - org.lz4:lz4-java:1.8.0
 - org.objenesis:objenesis:2.1
 - org.slf4j:slf4j-api:1.7.36


### PR DESCRIPTION
# What is the purpose of the change

[FLINK-28892] Update NOTICE for flink-kubernetes-operator 1.1.1

# Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

# Documentation

  - Does this pull request introduce a new feature? (no)

