### PR TITLE
[FLINK-28554] Add subPaths for conf files to allow readOnlyRootFilesystem operation

### DIFF
--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -86,7 +86,14 @@ spec:
             {{- toYaml .Values.operatorSecurityContext | nindent 12 }}
           volumeMounts:
             - name: flink-operator-config-volume
-              mountPath: /opt/flink/conf
+              mountPath: /opt/flink/conf/flink-conf.yaml
+              subPath: flink-conf.yaml
+            - name: flink-operator-config-volume
+              mountPath: /opt/flink/conf/log4j-operator.properties
+              subPath: log4j-operator.properties
+            - name: flink-operator-config-volume
+              mountPath: /opt/flink/conf/log4j-console.properties
+              subPath: log4j-console.properties
             {{- if .Values.operatorVolumeMounts.create }}
                 {{- toYaml .Values.operatorVolumeMounts.data | nindent 12 }}
             {{- end }}
@@ -130,7 +137,14 @@ spec:
             mountPath: "/certs"
             readOnly: true
           - name: flink-operator-config-volume
-            mountPath: /opt/flink/conf
+            mountPath: /opt/flink/conf/flink-conf.yaml
+            subPath: flink-conf.yaml
+          - name: flink-operator-config-volume
+            mountPath: /opt/flink/conf/log4j-operator.properties
+            subPath: log4j-operator.properties
+          - name: flink-operator-config-volume
+            mountPath: /opt/flink/conf/log4j-console.properties
+            subPath: log4j-console.properties
         {{- end }}
       volumes:
         - name: flink-operator-config-volume


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request adds subPaths for each flink config file volume mount. Introducing subPaths in the template makes it possible use emptyDirs for mounting the config files which in return allows to enable `readOnlyRootFilesystem: true` for the operator. Without emptyDir volumes for the configs the operator refuses to start with readOnlyRootFilesystem enabled.

## Brief change log

* Add subPaths for conf files to allow readOnlyRootFilesystem operation

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
