### PR TITLE
[docs] Add an example about how to enable Prometheus for FlinkDeployment

### DIFF
--- a/docs/content/docs/operations/metrics-logging.md
+++ b/docs/content/docs/operations/metrics-logging.md
@@ -113,7 +113,7 @@ defaultConfiguration:
     kubernetes.operator.metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
     kubernetes.operator.metrics.reporter.prom.port: 9999
 ```
-Some metric reporters, including the Prometheus, needs a port to be exposed on the container. This can be achieved be defining a value for the otherwise empty `metrics.port` variable.
+Some metric reporters, including the Prometheus, need a port to be exposed on the container. This can be achieved be defining a value for the otherwise empty `metrics.port` variable.
 Either in the `values.yaml` file:
 ```yaml
 metrics:
@@ -193,4 +193,16 @@ spec:
       rootLogger.level = DEBUG
       rootLogger.appenderRef.file.ref = LogFile
       ...
+```
+
+### FlinkDeployment Prometheus Configuration
+
+The following example shows how to enable the Prometheus metric reporter for the FlinkDeployment:
+
+```yaml
+spec:
+  ...
+  flinkConfiguration:
+    metrics.reporter.prom.class: org.apache.flink.metrics.prometheus.PrometheusReporter
+    metrics.reporter.prom.port: 9249-9250
 ```


### PR DESCRIPTION
 
## What is the purpose of the change

Add docs about how to enable Prometheus for `FlinkDeployment`

## Brief change log
 
## Verifying this change
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
