### PR TITLE
[FLINK-29086] Fix the Helm chart's pod env params reference

### DIFF
--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -84,8 +84,8 @@ spec:
             - name: JVM_ARGS
               value: {{ .Values.jvmArgs.operator }}
             {{- range $k, $v := .Values.operatorPod.env }}
-            - name: {{ $v.name }}
-              value: {{ $v.value }}
+            - name: {{ $v.name | quote }}
+              value: {{ $v.value | quote }}
             {{- end }}
           securityContext:
             {{- toYaml .Values.operatorSecurityContext | nindent 12 }}


### PR DESCRIPTION
 

## Contribution Checklist


## What is the purpose of the change

Fix the Helm chart's env vars params


## Brief change log

## Verifying this change


Helm chart small fix

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
