### PR TITLE
[FLINK-28734][helm] Configurable role(binding) names

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
@@ -49,7 +49,7 @@ public class FlinkOperatorITCase {
 
     private static final String TEST_NAMESPACE = "flink-operator-test";
     private static final String SERVICE_ACCOUNT = "flink-operator";
-    private static final String CLUSTER_ROLE_BINDING = "flink-operator-cluster-role-binding";
+    private static final String CLUSTER_ROLE_BINDING = "flink-operator-role-binding";
     private static final String FLINK_VERSION = "1.15.1";
     private static final String IMAGE = String.format("flink:%s", FLINK_VERSION);
     private static final Logger LOG = LoggerFactory.getLogger(FlinkOperatorITCase.class);

--- a/helm/flink-kubernetes-operator/templates/_helpers.tpl
+++ b/helm/flink-kubernetes-operator/templates/_helpers.tpl
@@ -134,7 +134,18 @@ Create the name of the job service account to use
 {{- end }}
 {{- end }}
 
-{{- define "validating-webhook-enabled" -}}
+{{/*
+Determine role scope based on name
+*/}}
+{{- define "flink-operator.roleScope" -}}
+{{- if contains ":" .role  }}
+{{- printf "ClusterRole" }}
+{{- else }}
+{{- printf "Role" }}
+{{- end }}
+{{- end }}
+
+{{- define "flink-operator.validating-webhook-enabled" -}}
 {{- if hasKey .Values.webhook "validator" }}
 {{- if .Values.webhook.validator.create }}
 {{- printf "true" }}
@@ -150,7 +161,7 @@ Create the name of the job service account to use
 {{- end }}
 {{- end }}
 
-{{- define "mutating-webhook-enabled" -}}
+{{- define "flink-operator.mutating-webhook-enabled" -}}
 {{- if hasKey .Values.webhook "mutator" }}
 {{- if .Values.webhook.mutator.create }}
 {{- printf "true" }}
@@ -166,8 +177,8 @@ Create the name of the job service account to use
 {{- end }}
 {{- end }}
 
-{{- define "webhook-enabled" -}}
-{{- if or (eq (include "validating-webhook-enabled" .) "true") (eq (include "mutating-webhook-enabled" .) "true") }}
+{{- define "flink-operator.webhook-enabled" -}}
+{{- if or (eq (include "flink-operator.validating-webhook-enabled" .) "true") (eq (include "flink-operator.mutating-webhook-enabled" .) "true") }}
 {{- printf "true" }}
 {{- else }}
 {{- printf "false" }}

--- a/helm/flink-kubernetes-operator/templates/_helpers.tpl
+++ b/helm/flink-kubernetes-operator/templates/_helpers.tpl
@@ -68,6 +68,51 @@ app.kubernetes.io/name: {{ include "flink-operator.name" . }}
 {{- end }}
 
 {{/*
+Create the name of the operator role to use
+*/}}
+{{- define "flink-operator.roleName" -}}
+{{- if .Values.rbac.operatorRole.create }}
+{{- default (include "flink-operator.fullname" .) .Values.rbac.operatorRole.name }}
+{{- else }}
+{{- default "default" .Values.rbac.operatorRole.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the operator role binding to use
+*/}}
+{{- define "flink-operator.roleBindingName" -}}
+{{- if .Values.rbac.operatorRoleBinding.create }}
+{{- default (include "flink-operator.fullname" .) .Values.rbac.operatorRoleBinding.name }}
+{{- else }}
+{{- default "default" .Values.rbac.operatorRoleBinding.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the job role to use
+*/}}
+{{- define "flink-operator.jobRoleName" -}}
+{{- if .Values.rbac.jobRoleBinding.create }}
+{{- default (include "flink-operator.fullname" .) .Values.rbac.jobRole.name }}
+{{- else }}
+{{- default "default" .Values.rbac.jobRole.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the job role to use
+*/}}
+{{- define "flink-operator.jobRoleBindingName" -}}
+{{- if .Values.rbac.jobRole.create }}
+{{- default (include "flink-operator.fullname" .) .Values.rbac.jobRoleBinding.name }}
+{{- else }}
+{{- default "default" .Values.rbac.jobRoleBinding.name }}
+{{- end }}
+{{- end }}
+
+
+{{/*
 Create the name of the operator service account to use
 */}}
 {{- define "flink-operator.serviceAccountName" -}}

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -116,7 +116,7 @@ spec:
               path: /
               port: health-port
           {{- end }}
-        {{- if eq (include "webhook-enabled" .) "true" }}
+        {{- if eq (include "flink-operator.webhook-enabled" .) "true" }}
         - name: flink-webhook
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -179,7 +179,7 @@ spec:
         {{- if .Values.operatorVolumes.create }}
               {{- toYaml .Values.operatorVolumes.data | nindent 8 }}
         {{- end }}
-        {{- if eq (include "webhook-enabled" .) "true" }}
+        {{- if eq (include "flink-operator.webhook-enabled" .) "true" }}
         - name: keystore
           secret:
             secretName: webhook-server-cert

--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -133,7 +133,7 @@ metadata:
   labels:
     {{- include "flink-operator.labels" $ | nindent 4 }}
 roleRef:
-  kind: Role
+  kind: {{ $role := include "flink-operator.roleName" $ }}{{ include "flink-operator.roleScope" (dict "role" $role)}}
   name: {{ include "flink-operator.roleName" $ }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
@@ -153,7 +153,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
 roleRef:
-  kind: Role
+  kind: {{ $role := include "flink-operator.jobRoleName" $ }}{{ include "flink-operator.roleScope" (dict "role" $role)}}
   name: {{ include "flink-operator.jobRoleName" $ }}
   apiGroup: rbac.authorization.k8s.io
 subjects:

--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -100,46 +100,53 @@ Namespaced scoped RBAC.
 */}}
 {{- if .Values.watchNamespaces }}
 {{- range .Values.watchNamespaces }}
+{{- if $.Values.rbac.operatorRole.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: flink-operator
+  name: {{ include "flink-operator.roleName" $ }}
   namespace: {{ . }}
   labels:
     {{- include "flink-operator.labels" $ | nindent 4 }}
 {{- template "flink-operator.rbacRules" $ }}
+{{- end }}
 ---
+{{- if $.Values.rbac.jobRole.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: flink
+  name: {{ include "flink-operator.jobRoleName" $ }}
   namespace: {{ . }}
   labels:
     {{- include "flink-operator.labels" $ | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": keep
 {{- template "flink-operator.jobRbacRules" $ }}
+{{- end }}
 ---
+{{- if $.Values.rbac.operatorRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: flink-operator-role-binding
+  name: {{ include "flink-operator.roleBindingName" $ }}
   namespace: {{ . }}
   labels:
     {{- include "flink-operator.labels" $ | nindent 4 }}
 roleRef:
   kind: Role
-  name: flink-operator
+  name: {{ include "flink-operator.roleName" $ }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: {{ include "flink-operator.serviceAccountName" $ }}
     namespace: {{ $.Release.Namespace }}
+{{- end }}
 ---
+{{- if $.Values.rbac.jobRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: flink-role-binding
+  name: {{ include "flink-operator.jobRoleBindingName" $ }}
   namespace: {{ . }}
   labels:
     {{- include "flink-operator.labels" $ | nindent 4 }}
@@ -147,12 +154,13 @@ metadata:
     "helm.sh/resource-policy": keep
 roleRef:
   kind: Role
-  name: flink
+  name: {{ include "flink-operator.jobRoleName" $ }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: {{ include "flink-operator.jobServiceAccountName" $ }}
     namespace: {{ . }}
+{{- end }}
 ---
 {{- end }}
 {{ else }}
@@ -160,46 +168,53 @@ subjects:
 Cluster scoped RBAC.
 */}}
 ---
+{{- if .Values.rbac.operatorRole.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: flink-operator
+  name: {{ include "flink-operator.roleName" $ }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
 {{- template "flink-operator.rbacRules" $ }}
+{{- end }}
 ---
+{{- if .Values.rbac.jobRole.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: flink
+  name: {{ include "flink-operator.jobRoleName" $ }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
   annotations:
     "helm.sh/resource-policy": keep
 {{- template "flink-operator.jobRbacRules" $ }}
+{{- end }}
 ---
+{{- if .Values.rbac.operatorRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: flink-operator-cluster-role-binding
+  name: {{ include "flink-operator.roleBindingName" $ }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
 roleRef:
   kind: ClusterRole
-  name: flink-operator
+  name: {{ include "flink-operator.roleName" $ }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: {{ include "flink-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 ---
+{{- if .Values.rbac.jobRoleBinding.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: flink-role-binding
+  name: {{ include "flink-operator.jobRoleBindingName" $ }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "flink-operator.labels" . | nindent 4 }}
@@ -207,11 +222,12 @@ metadata:
     "helm.sh/resource-policy": keep
 roleRef:
   kind: Role
-  name: flink
+  name: {{ include "flink-operator.jobRoleName" $ }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount
     name: {{ include "flink-operator.jobServiceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/flink-kubernetes-operator/templates/webhook.yaml
+++ b/helm/flink-kubernetes-operator/templates/webhook.yaml
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 ---
-{{- if eq (include "webhook-enabled" .) "true" }}
+{{- if eq (include "flink-operator.webhook-enabled" .) "true" }}
 ---
 apiVersion: v1
 kind: Service
@@ -76,7 +76,7 @@ metadata:
 spec:
   selfSigned: {}
 {{- end }}
-{{- if eq (include "validating-webhook-enabled" .) "true" }}
+{{- if eq (include "flink-operator.validating-webhook-enabled" .) "true" }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -112,7 +112,7 @@ webhooks:
         values: [{{- range .Values.watchNamespaces }}{{ . | quote }},{{- end}}]
   {{- end }}
 {{- end }}
-{{- if eq (include "mutating-webhook-enabled" .) "true" }}
+{{- if eq (include "flink-operator.mutating-webhook-enabled" .) "true" }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -36,6 +36,18 @@ rbac:
   # Set create to true if you are using NodePort type.
   nodesRule:
     create: false
+  operatorRole:
+    create: true
+    name: "flink-operator"
+  operatorRoleBinding:
+    create: true
+    name: "flink-operator-role-binding"
+  jobRole:
+    create: true
+    name: "flink"
+  jobRoleBinding:
+    create: true
+    name: "flink-role-binding"
 
 operatorPod:
   annotations: {}


### PR DESCRIPTION
## What is the purpose of the change

The names of the roles and rolebindings in the helm chart are not yet configurable. In this PR it's made configurable.

## Brief change log

* Configurable role(binding) names
* Added option to bind rolebinding to clusterrole

## Verifying this change

Manually on minikube.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not applicable
