### PR TITLE
[FLINK-29110] Use StatefulSet instead of Deployment to deploy JM and …

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -99,11 +99,12 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 **Description**: JobManager spec.
 
-| Parameter | Type | Docs |
-| ----------| ---- | ---- |
-| resource | org.apache.flink.kubernetes.operator.crd.spec.Resource | Resource specification for the JobManager pods. |
-| replicas | int | Number of JobManager replicas. Must be 1 for non-HA deployments. |
-| podTemplate | io.fabric8.kubernetes.api.model.Pod | JobManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. |
+| Parameter | Type | Docs                                                                                          |
+| ----------| ---- |-----------------------------------------------------------------------------------------------|
+| resource | org.apache.flink.kubernetes.operator.crd.spec.Resource | Resource specification for the JobManager pods.                                               |
+| replicas | int | Number of JobManager replicas. Must be 1 for non-HA deployments.                              |
+| podTemplate | io.fabric8.kubernetes.api.model.Pod | JobManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate.              |
+| volumeClaimTemplates | java.util.List<io.fabric8.kubernetes.api.model.PersistentVolumeClaim>| JobManager Volume Claim templates. It will be used to mount custom PVCs by defined templates. | 
 
 ### JobSpec
 **Class**: org.apache.flink.kubernetes.operator.crd.spec.JobSpec
@@ -157,12 +158,12 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 **Description**: TaskManager spec.
 
-| Parameter | Type | Docs |
-| ----------| ---- | ---- |
-| resource | org.apache.flink.kubernetes.operator.crd.spec.Resource | Resource specification for the TaskManager pods. |
-| replicas | java.lang.Integer | Number of TaskManager replicas. If defined, takes precedence over parallelism |
-| podTemplate | io.fabric8.kubernetes.api.model.Pod | TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. |
-
+| Parameter | Type                                                   | Docs                                                                                           |
+| ----------|--------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| resource | org.apache.flink.kubernetes.operator.crd.spec.Resource | Resource specification for the TaskManager pods.                                               |
+| replicas | java.lang.Integer                                      | Number of TaskManager replicas. If defined, takes precedence over parallelism                  |
+| podTemplate | io.fabric8.kubernetes.api.model.Pod                    | TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate.              | 
+| volumeClaimTemplates | java.util.List<io.fabric8.kubernetes.api.model.PersistentVolumeClaim>                                       | TaskManager Volume Claim templates. It will be used to mount custom PVCs by defined templates. | 
 ### UpgradeMode
 **Class**: org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode
 

--- a/examples/advanced-ingress.yaml
+++ b/examples/advanced-ingress.yaml
@@ -42,3 +42,4 @@ spec:
   job:
     jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
     parallelism: 2
+  mode: native

--- a/examples/basic-checkpoint-ha.yaml
+++ b/examples/basic-checkpoint-ha.yaml
@@ -58,3 +58,4 @@ spec:
     upgradeMode: savepoint
     state: running
     savepointTriggerNonce: 0
+  mode: native

--- a/examples/basic-ingress.yaml
+++ b/examples/basic-ingress.yaml
@@ -39,3 +39,4 @@ spec:
   job:
     jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
     parallelism: 2
+  mode: native

--- a/examples/basic-session-deployment-and-job.yaml
+++ b/examples/basic-session-deployment-and-job.yaml
@@ -32,6 +32,7 @@ spec:
       memory: "2048m"
       cpu: 1
   serviceAccount: flink
+  mode: native
 ---
 apiVersion: flink.apache.org/v1beta1
 kind: FlinkSessionJob

--- a/examples/basic-session-deployment-only.yaml
+++ b/examples/basic-session-deployment-only.yaml
@@ -34,3 +34,4 @@ spec:
     resource:
       memory: "2048m"
       cpu: 1
+  mode: native

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -38,3 +38,4 @@ spec:
     jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
     parallelism: 2
     upgradeMode: stateless
+  mode: native

--- a/examples/custom-logging.yaml
+++ b/examples/custom-logging.yaml
@@ -63,3 +63,4 @@ spec:
       logger.zookeeper.level = INFO
       logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
       logger.netty.level = OFF
+  mode: native

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -82,3 +82,4 @@ spec:
     jarURI: local:///opt/flink/downloads/flink-examples-streaming.jar
     entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample
     parallelism: 2
+  mode: native

--- a/examples/standalone_pvc.yaml
+++ b/examples/standalone_pvc.yaml
@@ -1,0 +1,81 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+kind: FlinkDeployment
+metadata:
+  namespace: default
+  name: basic-example
+spec:
+  image: flink:1.15.1
+  flinkVersion: v1_15
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "2"
+  serviceAccount: flink
+  jobManager:
+    replicas: 1
+    resource:
+      memory: "2048m"
+      cpu: 1
+    volumeClaimTemplates:
+      - metadata:
+          name: log
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          ### Please override with custom supported storageClassName
+          storageClassName: "alicloud-local-lvm"
+          resources:
+            requests:
+              storage: 10Gi
+    podTemplate:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: job-manager-pod-template
+      spec:
+        containers:
+          - name: flink-main-container
+            volumeMounts:
+              - name: log
+                mountPath: /opt/flink/log
+  taskManager:
+    replicas: 1
+    resource:
+      memory: "2048m"
+      cpu: 1
+    volumeClaimTemplates:
+      - metadata:
+          name: log
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          ### Please override with custom supported storageClassName
+          storageClassName: "alicloud-local-lvm"
+          resources:
+            requests:
+              storage: 10Gi
+    podTemplate:
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: task-manager-pod-template
+      spec:
+        containers:
+          - name: flink-main-container
+            volumeMounts:
+              - name: log
+                mountPath: /opt/flink/log
+  mode: standalone

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -148,6 +148,7 @@ public class FlinkConfigManager {
     public Configuration getDeployConfig(ObjectMeta objectMeta, FlinkDeploymentSpec spec) {
         var conf = getConfig(objectMeta, spec);
         FlinkUtils.setGenerationAnnotation(conf, objectMeta.getGeneration());
+        FlinkUtils.setTaskmanagerGenerationAnnotation(conf, objectMeta.getGeneration());
         return conf;
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobManagerSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/JobManagerSpec.java
@@ -19,11 +19,15 @@ package org.apache.flink.kubernetes.operator.crd.spec;
 
 import org.apache.flink.annotation.Experimental;
 
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /** JobManager spec. */
 @Experimental
@@ -37,6 +41,9 @@ public class JobManagerSpec {
 
     /** Number of JobManager replicas. Must be 1 for non-HA deployments. */
     private int replicas = 1;
+
+    /** Volume Claim Templates for JobManager stateful set. Just for standalone mode. */
+    private List<PersistentVolumeClaim> volumeClaimTemplates = new ArrayList<>();
 
     /** JobManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. */
     private Pod podTemplate;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/TaskManagerSpec.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/spec/TaskManagerSpec.java
@@ -19,12 +19,16 @@ package org.apache.flink.kubernetes.operator.crd.spec;
 
 import org.apache.flink.annotation.Experimental;
 
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.model.annotation.SpecReplicas;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /** TaskManager spec. */
 @Experimental
@@ -38,6 +42,9 @@ public class TaskManagerSpec {
 
     /** Number of TaskManager replicas. If defined, takes precedence over parallelism */
     @SpecReplicas private Integer replicas;
+
+    /** Volume Claim Templates for TaskManager stateful set. Just for standalone mode. */
+    private List<PersistentVolumeClaim> volumeClaimTemplates = new ArrayList<>();
 
     /** TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. */
     private Pod podTemplate;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/FlinkDeploymentException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/FlinkDeploymentException.java
@@ -17,23 +17,19 @@
 
 package org.apache.flink.kubernetes.operator.exception;
 
-import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
-import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
+/** Exception to signal terminal flink deployment failure. */
+public class FlinkDeploymentException extends RuntimeException {
+    public static final String REASON_CRASH_LOOP_BACKOFF = "CrashLoopBackOff";
 
-/** Exception to signal terminal deployment failure. */
-public class DeploymentFailedException extends FlinkDeploymentException {
+    private static final long serialVersionUID = 3641912388482837809L;
+    private final String reason;
 
-    private static final long serialVersionUID = -1070179896083579221L;
-
-    public DeploymentFailedException(DeploymentCondition deployCondition) {
-        super(deployCondition.getMessage(), deployCondition.getReason());
+    public FlinkDeploymentException(String message, String reason) {
+        super(message);
+        this.reason = reason;
     }
 
-    public DeploymentFailedException(ContainerStateWaiting stateWaiting) {
-        super(stateWaiting.getMessage(), stateWaiting.getReason());
-    }
-
-    public DeploymentFailedException(String message, String reason) {
-        super(message, reason);
+    public String getReason() {
+        return reason;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/StatefulSetFailedException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/StatefulSetFailedException.java
@@ -18,22 +18,22 @@
 package org.apache.flink.kubernetes.operator.exception;
 
 import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
-import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetCondition;
 
-/** Exception to signal terminal deployment failure. */
-public class DeploymentFailedException extends FlinkDeploymentException {
+/** Exception to signal terminal statefulSet failure. */
+public class StatefulSetFailedException extends FlinkDeploymentException {
 
-    private static final long serialVersionUID = -1070179896083579221L;
+    private static final long serialVersionUID = 4756119502434252719L;
 
-    public DeploymentFailedException(DeploymentCondition deployCondition) {
+    public StatefulSetFailedException(StatefulSetCondition deployCondition) {
         super(deployCondition.getMessage(), deployCondition.getReason());
     }
 
-    public DeploymentFailedException(ContainerStateWaiting stateWaiting) {
+    public StatefulSetFailedException(ContainerStateWaiting stateWaiting) {
         super(stateWaiting.getMessage(), stateWaiting.getReason());
     }
 
-    public DeploymentFailedException(String message, String reason) {
+    public StatefulSetFailedException(String message, String reason) {
         super(message, reason);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.utils.Constants;
 
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
@@ -58,6 +59,23 @@ public class EventSourceUtils {
                         .followNamespaceChanges(true)
                         .build();
 
+        return new InformerEventSource<>(configuration, context);
+    }
+
+    public static InformerEventSource<StatefulSet, FlinkDeployment>
+            getStatefulSetInformerEventSource(EventSourceContext<FlinkDeployment> context) {
+        final String labelSelector =
+                Map.of(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_JOB_MANAGER)
+                        .entrySet().stream()
+                        .map(Object::toString)
+                        .collect(Collectors.joining(","));
+        var configuration =
+                InformerConfiguration.from(StatefulSet.class, context)
+                        .withLabelSelector(labelSelector)
+                        .withSecondaryToPrimaryMapper(Mappers.fromLabel(Constants.LABEL_APP_KEY))
+                        .withNamespacesInheritedFromController(context)
+                        .followNamespaceChanges(true)
+                        .build();
         return new InformerEventSource<>(configuration, context);
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -187,6 +187,18 @@ public class FlinkUtils {
         conf.set(KubernetesConfigOptions.JOB_MANAGER_ANNOTATIONS, labels);
     }
 
+    public static void setTaskmanagerGenerationAnnotation(Configuration conf, Long generation) {
+        if (generation == null) {
+            return;
+        }
+        var labels =
+                new HashMap<>(
+                        conf.getOptional(KubernetesConfigOptions.TASK_MANAGER_ANNOTATIONS)
+                                .orElse(Collections.emptyMap()));
+        labels.put(CR_GENERATION_LABEL, generation.toString());
+        conf.set(KubernetesConfigOptions.TASK_MANAGER_ANNOTATIONS, labels);
+    }
+
     /**
      * The jobID's lower part is the resource uid, the higher part is the resource generation.
      *

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/diff/SpecDiffTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/diff/SpecDiffTest.java
@@ -132,7 +132,6 @@ public class SpecDiffTest {
         var diff = left.diff(right);
         assertEquals(DiffType.IGNORE, diff.getType());
         assertEquals(0, diff.getNumDiffs());
-
         left = TestUtils.buildSessionJob().getSpec();
         right = ReconciliationUtils.clone(left);
         diff = left.diff(right);

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/Fabric8FlinkStandaloneKubeClient.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/Fabric8FlinkStandaloneKubeClient.java
@@ -20,11 +20,23 @@ package org.apache.flink.kubernetes.operator.kubeclient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.kubeclient.Fabric8FlinkKubeClient;
 import org.apache.flink.kubernetes.operator.utils.StandaloneKubernetesUtils;
+import org.apache.flink.kubernetes.utils.KubernetesUtils;
+import org.apache.flink.util.FlinkRuntimeException;
 
-import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.OwnerReference;
+import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -32,7 +44,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** The Implementation of {@link FlinkStandaloneKubeClient}. */
 public class Fabric8FlinkStandaloneKubeClient extends Fabric8FlinkKubeClient
         implements FlinkStandaloneKubeClient {
-
+    private static final Logger LOG =
+            LoggerFactory.getLogger(Fabric8FlinkStandaloneKubeClient.class);
     private final NamespacedKubernetesClient internalClient;
 
     public Fabric8FlinkStandaloneKubeClient(
@@ -43,29 +56,74 @@ public class Fabric8FlinkStandaloneKubeClient extends Fabric8FlinkKubeClient
         internalClient = checkNotNull(client);
     }
 
+    private void setOwnerReference(StatefulSet statefulSet, List<HasMetadata> resources) {
+        final OwnerReference statefulSetOwnerReference =
+                new OwnerReferenceBuilder()
+                        .withName(statefulSet.getMetadata().getName())
+                        .withApiVersion(statefulSet.getApiVersion())
+                        .withUid(statefulSet.getMetadata().getUid())
+                        .withKind(statefulSet.getKind())
+                        .withController(true)
+                        .withBlockOwnerDeletion(true)
+                        .build();
+        resources.forEach(
+                resource ->
+                        resource.getMetadata()
+                                .setOwnerReferences(
+                                        Collections.singletonList(statefulSetOwnerReference)));
+    }
+
     @Override
-    public void createTaskManagerDeployment(Deployment tmDeployment) {
-        this.internalClient.apps().deployments().create(tmDeployment);
+    public void createJobManagerComponent(
+            StandaloneKubernetesJobManagerSpecification kubernetesJMSpec) {
+        final StatefulSet statefulSet = kubernetesJMSpec.getStatefulSet();
+        final List<HasMetadata> accompanyingResources = kubernetesJMSpec.getAccompanyingResources();
+
+        // create StatefulSet
+        LOG.debug(
+                "Start to create statefulSet with spec {}{}",
+                System.lineSeparator(),
+                KubernetesUtils.tryToGetPrettyPrintYaml(statefulSet));
+        final StatefulSet createdStatefulSet =
+                this.internalClient.apps().statefulSets().create(statefulSet);
+        // Note that we should use the uid of the created StatefulSet for the OwnerReference.
+        setOwnerReference(createdStatefulSet, accompanyingResources);
+
+        this.internalClient.resourceList(accompanyingResources).createOrReplace();
+    }
+
+    @Override
+    public void createTaskManagerStatefulSet(StatefulSet tmStatefulSet) {
+        this.internalClient.apps().statefulSets().create(tmStatefulSet);
     }
 
     @Override
     public void stopAndCleanupCluster(String clusterId) {
         this.internalClient
                 .apps()
-                .deployments()
-                .withName(StandaloneKubernetesUtils.getJobManagerDeploymentName(clusterId))
-                .cascading(true)
+                .statefulSets()
+                .withName(StandaloneKubernetesUtils.getJobManagerStatefulSetName(clusterId))
+                .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                 .delete();
 
         this.internalClient
                 .apps()
-                .deployments()
-                .withName(StandaloneKubernetesUtils.getTaskManagerDeploymentName(clusterId))
-                .cascading(true)
+                .statefulSets()
+                .withName(StandaloneKubernetesUtils.getTaskManagerStatefulSetName(clusterId))
+                .withPropagationPolicy(DeletionPropagation.FOREGROUND)
                 .delete();
     }
 
     public static NamespacedKubernetesClient createNamespacedKubeClient(String namespace) {
         return new DefaultKubernetesClient().inNamespace(namespace);
+    }
+
+    @Override
+    public PersistentVolumeClaim loadVolumeClaimTemplates(File file) {
+        if (!file.exists()) {
+            throw new FlinkRuntimeException(
+                    String.format("Pvc template file %s does not exist.", file));
+        }
+        return this.internalClient.persistentVolumeClaims().load(file).get();
     }
 }

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/StandaloneKubernetesJobManagerSpecification.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/StandaloneKubernetesJobManagerSpecification.java
@@ -17,19 +17,28 @@
 
 package org.apache.flink.kubernetes.operator.kubeclient;
 
-import org.apache.flink.kubernetes.kubeclient.FlinkKubeClient;
-
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 
-import java.io.File;
+import java.util.List;
 
-/** Extension of the FlinkKubeClient that is used for Flink standalone deployments. */
-public interface FlinkStandaloneKubeClient extends FlinkKubeClient {
+/** Composition of the created Kubernetes components that represents a Flink application. */
+public class StandaloneKubernetesJobManagerSpecification {
+    private final StatefulSet statefulSet;
 
-    void createJobManagerComponent(StandaloneKubernetesJobManagerSpecification kubernetesJMSpec);
+    private final List<HasMetadata> accompanyingResources;
 
-    void createTaskManagerStatefulSet(StatefulSet tmStatefulSet);
+    public StandaloneKubernetesJobManagerSpecification(
+            StatefulSet statefulSet, List<HasMetadata> accompanyingResources) {
+        this.statefulSet = statefulSet;
+        this.accompanyingResources = accompanyingResources;
+    }
 
-    PersistentVolumeClaim loadVolumeClaimTemplates(File file);
+    public StatefulSet getStatefulSet() {
+        return statefulSet;
+    }
+
+    public List<HasMetadata> getAccompanyingResources() {
+        return accompanyingResources;
+    }
 }

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesJobManagerFactory.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesJobManagerFactory.java
@@ -18,7 +18,6 @@
 package org.apache.flink.kubernetes.operator.kubeclient.factory;
 
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
-import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerSpecification;
 import org.apache.flink.kubernetes.kubeclient.decorators.EnvSecretsDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator;
@@ -30,6 +29,7 @@ import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator
 import org.apache.flink.kubernetes.kubeclient.decorators.MountSecretsDecorator;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesOwnerReference;
+import org.apache.flink.kubernetes.operator.kubeclient.StandaloneKubernetesJobManagerSpecification;
 import org.apache.flink.kubernetes.operator.kubeclient.decorators.CmdStandaloneJobManagerDecorator;
 import org.apache.flink.kubernetes.operator.kubeclient.decorators.UserLibMountDecorator;
 import org.apache.flink.kubernetes.operator.kubeclient.parameters.StandaloneKubernetesJobManagerParameters;
@@ -39,10 +39,11 @@ import org.apache.flink.util.Preconditions;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,13 +52,15 @@ import java.util.stream.Collectors;
 
 /**
  * Utility class for constructing all the Kubernetes for the JobManager deploying in standalone
- * mode. This can include the Deployment, the ConfigMap(s), and the Service(s).
+ * mode. This can include the StatefulSet, the ConfigMap(s), and the Service(s).
  */
 public class StandaloneKubernetesJobManagerFactory {
-    public static KubernetesJobManagerSpecification buildKubernetesJobManagerSpecification(
-            FlinkPod podTemplate,
-            StandaloneKubernetesJobManagerParameters kubernetesJobManagerParameters)
-            throws IOException {
+    public static StandaloneKubernetesJobManagerSpecification
+            buildKubernetesJobManagerSpecification(
+                    FlinkPod podTemplate,
+                    List<PersistentVolumeClaim> volumeClaims,
+                    StandaloneKubernetesJobManagerParameters kubernetesJobManagerParameters)
+                    throws IOException {
         FlinkPod flinkPod = Preconditions.checkNotNull(podTemplate).copy();
         List<HasMetadata> accompanyingResources = new ArrayList<>();
 
@@ -80,45 +83,59 @@ public class StandaloneKubernetesJobManagerFactory {
             accompanyingResources.addAll(stepDecorator.buildAccompanyingKubernetesResources());
         }
 
-        final Deployment deployment =
-                createJobManagerDeployment(flinkPod, kubernetesJobManagerParameters);
-
-        return new KubernetesJobManagerSpecification(deployment, accompanyingResources);
+        final StatefulSet statefulSet =
+                createJobManagerStatefulSet(flinkPod, volumeClaims, kubernetesJobManagerParameters);
+        return new StandaloneKubernetesJobManagerSpecification(statefulSet, accompanyingResources);
     }
 
-    private static Deployment createJobManagerDeployment(
-            FlinkPod flinkPod, KubernetesJobManagerParameters kubernetesJobManagerParameters) {
+    private static StatefulSet createJobManagerStatefulSet(
+            FlinkPod flinkPod,
+            List<PersistentVolumeClaim> volumeClaims,
+            KubernetesJobManagerParameters kubernetesJobManagerParameters) {
         final Container resolvedMainContainer = flinkPod.getMainContainer();
-
         final Pod resolvedPod =
                 new PodBuilder(flinkPod.getPodWithoutMainContainer())
                         .editOrNewSpec()
                         .addToContainers(resolvedMainContainer)
                         .endSpec()
                         .build();
-        return new DeploymentBuilder()
-                .withApiVersion(Constants.APPS_API_VERSION)
-                .editOrNewMetadata()
-                .withName(
-                        StandaloneKubernetesUtils.getJobManagerDeploymentName(
-                                kubernetesJobManagerParameters.getClusterId()))
-                .withAnnotations(kubernetesJobManagerParameters.getAnnotations())
-                .withLabels(kubernetesJobManagerParameters.getLabels())
-                .withOwnerReferences(
-                        kubernetesJobManagerParameters.getOwnerReference().stream()
-                                .map(e -> KubernetesOwnerReference.fromMap(e).getInternalResource())
-                                .collect(Collectors.toList()))
-                .endMetadata()
-                .editOrNewSpec()
-                .withReplicas(kubernetesJobManagerParameters.getReplicas())
-                .editOrNewTemplate()
-                .withMetadata(resolvedPod.getMetadata())
-                .withSpec(resolvedPod.getSpec())
-                .endTemplate()
-                .editOrNewSelector()
-                .addToMatchLabels(kubernetesJobManagerParameters.getSelectors())
-                .endSelector()
-                .endSpec()
-                .build();
+
+        StatefulSetBuilder statefulSetBuilder =
+                new StatefulSetBuilder()
+                        .withApiVersion(Constants.APPS_API_VERSION)
+                        .editOrNewMetadata()
+                        .withName(
+                                StandaloneKubernetesUtils.getJobManagerStatefulSetName(
+                                        kubernetesJobManagerParameters.getClusterId()))
+                        .withAnnotations(kubernetesJobManagerParameters.getAnnotations())
+                        .withLabels(kubernetesJobManagerParameters.getLabels())
+                        .withOwnerReferences(
+                                kubernetesJobManagerParameters.getOwnerReference().stream()
+                                        .map(
+                                                e ->
+                                                        KubernetesOwnerReference.fromMap(e)
+                                                                .getInternalResource())
+                                        .collect(Collectors.toList()))
+                        .endMetadata()
+                        .editOrNewSpec()
+                        .withServiceName(kubernetesJobManagerParameters.getClusterId())
+                        .withReplicas(kubernetesJobManagerParameters.getReplicas())
+                        .editOrNewTemplate()
+                        .withMetadata(resolvedPod.getMetadata())
+                        .withSpec(resolvedPod.getSpec())
+                        .endTemplate()
+                        .editOrNewSelector()
+                        .addToMatchLabels(kubernetesJobManagerParameters.getSelectors())
+                        .endSelector()
+                        .endSpec();
+        if (null != volumeClaims) {
+            return statefulSetBuilder
+                    .editSpec()
+                    .withVolumeClaimTemplates(volumeClaims)
+                    .endSpec()
+                    .build();
+        } else {
+            return statefulSetBuilder.build();
+        }
     }
 }

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
@@ -26,8 +26,13 @@ import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfi
 import org.apache.flink.kubernetes.operator.utils.StandaloneKubernetesUtils;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -86,5 +91,20 @@ public class StandaloneKubernetesJobManagerParameters extends KubernetesJobManag
             return flinkConfig.get(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE);
         }
         return null;
+    }
+
+    public List<File> getVolumeClaimTemplates() {
+        String templates =
+                flinkConfig.get(StandaloneKubernetesConfigOptionsInternal.JOB_MANAGER_PVC_TEMPLATE);
+        if (StringUtils.isEmpty(templates)) {
+            return null;
+        } else {
+            String[] pvcFiles = templates.split(",");
+            List<File> files = new ArrayList<>();
+            for (String pvcFile : pvcFiles) {
+                files.add(new File(pvcFile));
+            }
+            return files;
+        }
     }
 }

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesTaskManagerParameters.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesTaskManagerParameters.java
@@ -27,7 +27,10 @@ import org.apache.flink.kubernetes.operator.utils.StandaloneKubernetesUtils;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -134,5 +137,21 @@ public class StandaloneKubernetesTaskManagerParameters extends AbstractKubernete
 
     public double getCpuLimitFactor() {
         return flinkConfig.get(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR);
+    }
+
+    public List<File> getVolumeClaimTemplates() {
+        String templates =
+                flinkConfig.get(
+                        StandaloneKubernetesConfigOptionsInternal.TASK_MANAGER_PVC_TEMPLATE);
+        if (StringUtils.isEmpty(templates)) {
+            return null;
+        } else {
+            String[] pvcFiles = templates.split(",");
+            List<File> files = new ArrayList<>();
+            for (String pvcFile : pvcFiles) {
+                files.add(new File(pvcFile));
+            }
+            return files;
+        }
     }
 }

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/standalone/StandaloneKubernetesConfigOptionsInternal.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/standalone/StandaloneKubernetesConfigOptionsInternal.java
@@ -26,6 +26,19 @@ import static org.apache.flink.configuration.ConfigOptions.key;
  * clusters in standalone mode.
  */
 public class StandaloneKubernetesConfigOptionsInternal {
+    public static final ConfigOption<String> JOB_MANAGER_PVC_TEMPLATE =
+            key("kubernetes.pvc-template-file.jobmanager")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Specify a local file that contains the jobmanager pvc template definition. It will be used to mount pvc to jobmanager pod.");
+    public static final ConfigOption<String> TASK_MANAGER_PVC_TEMPLATE =
+            key("kubernetes.pvc-template-file.taskmanager")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Specify a local file that contains the taskmanager pvc template definition. It will be used to mount pvc to taskmanager pod.");
+
     public static final ConfigOption<Integer> KUBERNETES_TASKMANAGER_REPLICAS =
             key("kubernetes.internal.taskmanager.replicas")
                     .intType()

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesTaskManagerFactoryTest.java
@@ -31,7 +31,7 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /** @link StandaloneKubernetesJobManagerFactory unit tests */
 public class StandaloneKubernetesTaskManagerFactoryTest extends ParametersTestBase {
 
-    private Deployment deployment;
+    private StatefulSet statefulSet;
 
     @BeforeEach
     public void setup() {
@@ -56,37 +56,37 @@ public class StandaloneKubernetesTaskManagerFactoryTest extends ParametersTestBa
         StandaloneKubernetesTaskManagerParameters tmParameters =
                 new StandaloneKubernetesTaskManagerParameters(
                         flinkConfig, TestUtils.createClusterSpecification());
-        deployment =
-                StandaloneKubernetesTaskManagerFactory.buildKubernetesTaskManagerDeployment(
-                        podTemplate, tmParameters);
+        statefulSet =
+                StandaloneKubernetesTaskManagerFactory.buildKubernetesTaskManagerStatefulSet(
+                        podTemplate, null, tmParameters);
     }
 
     @Test
     public void testDeploymentMetadata() {
         assertEquals(
-                StandaloneKubernetesUtils.getTaskManagerDeploymentName(TestUtils.CLUSTER_ID),
-                deployment.getMetadata().getName());
+                StandaloneKubernetesUtils.getTaskManagerStatefulSetName(TestUtils.CLUSTER_ID),
+                statefulSet.getMetadata().getName());
 
         final Map<String, String> expectedLabels =
                 new HashMap<>(
                         StandaloneKubernetesUtils.getTaskManagerSelectors(TestUtils.CLUSTER_ID));
         expectedLabels.putAll(userLabels);
-        assertEquals(expectedLabels, deployment.getMetadata().getLabels());
+        assertEquals(expectedLabels, statefulSet.getMetadata().getLabels());
 
-        assertEquals(userAnnotations, deployment.getMetadata().getAnnotations());
+        assertEquals(userAnnotations, statefulSet.getMetadata().getAnnotations());
     }
 
     @Test
     public void testDeploymentSpec() {
-        assertEquals(1, deployment.getSpec().getReplicas());
+        assertEquals(1, statefulSet.getSpec().getReplicas());
         assertEquals(
                 StandaloneKubernetesUtils.getTaskManagerSelectors(TestUtils.CLUSTER_ID),
-                deployment.getSpec().getSelector().getMatchLabels());
+                statefulSet.getSpec().getSelector().getMatchLabels());
     }
 
     @Test
     public void testTemplateMetadata() {
-        final ObjectMeta podMetadata = deployment.getSpec().getTemplate().getMetadata();
+        final ObjectMeta podMetadata = statefulSet.getSpec().getTemplate().getMetadata();
 
         final Map<String, String> expectedLabels =
                 new HashMap<>(
@@ -102,7 +102,7 @@ public class StandaloneKubernetesTaskManagerFactoryTest extends ParametersTestBa
 
     @Test
     public void testTemplateSpec() {
-        final PodSpec podSpec = deployment.getSpec().getTemplate().getSpec();
+        final PodSpec podSpec = statefulSet.getSpec().getTemplate().getSpec();
 
         assertEquals(1, podSpec.getContainers().size());
         assertEquals(TestUtils.SERVICE_ACCOUNT, podSpec.getServiceAccountName());

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/standalone/KubernetesStandaloneClusterDescriptorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/standalone/KubernetesStandaloneClusterDescriptorTest.java
@@ -30,7 +30,7 @@ import org.apache.flink.kubernetes.operator.kubeclient.utils.TestUtils;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.util.concurrent.Executors;
 
-import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
@@ -76,19 +76,19 @@ public class KubernetesStandaloneClusterDescriptorTest {
 
         var clusterClientProvider = clusterDescriptor.deploySessionCluster(clusterSpecification);
 
-        List<Deployment> deployments =
+        List<StatefulSet> statefulSets =
                 kubernetesClient
                         .apps()
-                        .deployments()
+                        .statefulSets()
                         .inNamespace(TestUtils.TEST_NAMESPACE)
                         .list()
                         .getItems();
         String expectedJMDeploymentName = TestUtils.CLUSTER_ID;
         String expectedTMDeploymentName = TestUtils.CLUSTER_ID + "-taskmanager";
 
-        assertEquals(2, deployments.size());
+        assertEquals(2, statefulSets.size());
         assertThat(
-                deployments.stream()
+                statefulSets.stream()
                         .map(d -> d.getMetadata().getName())
                         .collect(Collectors.toList()),
                 containsInAnyOrder(expectedJMDeploymentName, expectedTMDeploymentName));
@@ -100,13 +100,13 @@ public class KubernetesStandaloneClusterDescriptorTest {
                 String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
         assertEquals(flinkConfig.get(RestOptions.BIND_PORT), String.valueOf(Constants.REST_PORT));
 
-        Deployment jmDeployment =
-                deployments.stream()
+        StatefulSet jmStatefulSet =
+                statefulSets.stream()
                         .filter(d -> d.getMetadata().getName().equals(expectedJMDeploymentName))
                         .findFirst()
                         .orElse(null);
         assertTrue(
-                jmDeployment.getSpec().getTemplate().getSpec().getContainers().stream()
+                jmStatefulSet.getSpec().getTemplate().getSpec().getContainers().stream()
                         .anyMatch(c -> c.getArgs().contains("jobmanager")));
 
         var clusterClient = clusterClientProvider.getClusterClient();
@@ -133,19 +133,19 @@ public class KubernetesStandaloneClusterDescriptorTest {
                         clusterSpecification,
                         ApplicationConfiguration.fromConfiguration(flinkConfig));
 
-        List<Deployment> deployments =
+        List<StatefulSet> statefulSets =
                 kubernetesClient
                         .apps()
-                        .deployments()
+                        .statefulSets()
                         .inNamespace(TestUtils.TEST_NAMESPACE)
                         .list()
                         .getItems();
         String expectedJMDeploymentName = TestUtils.CLUSTER_ID;
         String expectedTMDeploymentName = TestUtils.CLUSTER_ID + "-taskmanager";
 
-        assertEquals(2, deployments.size());
+        assertEquals(2, statefulSets.size());
         assertThat(
-                deployments.stream()
+                statefulSets.stream()
                         .map(d -> d.getMetadata().getName())
                         .collect(Collectors.toList()),
                 containsInAnyOrder(expectedJMDeploymentName, expectedTMDeploymentName));
@@ -157,13 +157,13 @@ public class KubernetesStandaloneClusterDescriptorTest {
                 String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
         assertEquals(flinkConfig.get(RestOptions.BIND_PORT), String.valueOf(Constants.REST_PORT));
 
-        Deployment jmDeployment =
-                deployments.stream()
+        StatefulSet jmStatefulSet =
+                statefulSets.stream()
                         .filter(d -> d.getMetadata().getName().equals(expectedJMDeploymentName))
                         .findFirst()
                         .orElse(null);
         assertTrue(
-                jmDeployment.getSpec().getTemplate().getSpec().getContainers().stream()
+                jmStatefulSet.getSpec().getTemplate().getSpec().getContainers().stream()
                         .anyMatch(c -> c.getArgs().contains("standalone-job")));
 
         var clusterClient = clusterClientProvider.getClusterClient();

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -3046,6 +3046,198 @@ spec:
                     type: object
                   replicas:
                     type: integer
+                  volumeClaimTemplates:
+                    items:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            clusterName:
+                              type: string
+                            creationTimestamp:
+                              type: string
+                            deletionGracePeriodSeconds:
+                              type: integer
+                            deletionTimestamp:
+                              type: string
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            generateName:
+                              type: string
+                            generation:
+                              type: integer
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            managedFields:
+                              items:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldsType:
+                                    type: string
+                                  fieldsV1:
+                                    type: object
+                                  manager:
+                                    type: string
+                                  operation:
+                                    type: string
+                                  subresource:
+                                    type: string
+                                  time:
+                                    type: string
+                                type: object
+                              type: array
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            ownerReferences:
+                              items:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  blockOwnerDeletion:
+                                    type: boolean
+                                  controller:
+                                    type: boolean
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  uid:
+                                    type: string
+                                type: object
+                              type: array
+                            resourceVersion:
+                              type: string
+                            selfLink:
+                              type: string
+                            uid:
+                              type: string
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                            dataSourceRef:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                        status:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            allocatedResources:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            capacity:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            conditions:
+                              items:
+                                properties:
+                                  lastProbeTime:
+                                    type: string
+                                  lastTransitionTime:
+                                    type: string
+                                  message:
+                                    type: string
+                                  reason:
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              type: array
+                            phase:
+                              type: string
+                            resizeStatus:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
                   podTemplate:
                     properties:
                       apiVersion:
@@ -6050,6 +6242,198 @@ spec:
                     type: object
                   replicas:
                     type: integer
+                  volumeClaimTemplates:
+                    items:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            clusterName:
+                              type: string
+                            creationTimestamp:
+                              type: string
+                            deletionGracePeriodSeconds:
+                              type: integer
+                            deletionTimestamp:
+                              type: string
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            generateName:
+                              type: string
+                            generation:
+                              type: integer
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            managedFields:
+                              items:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldsType:
+                                    type: string
+                                  fieldsV1:
+                                    type: object
+                                  manager:
+                                    type: string
+                                  operation:
+                                    type: string
+                                  subresource:
+                                    type: string
+                                  time:
+                                    type: string
+                                type: object
+                              type: array
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                            ownerReferences:
+                              items:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  blockOwnerDeletion:
+                                    type: boolean
+                                  controller:
+                                    type: boolean
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                  uid:
+                                    type: string
+                                type: object
+                              type: array
+                            resourceVersion:
+                              type: string
+                            selfLink:
+                              type: string
+                            uid:
+                              type: string
+                          type: object
+                        spec:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                            dataSourceRef:
+                              properties:
+                                apiGroup:
+                                  type: string
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                              type: object
+                            resources:
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                  type: object
+                              type: object
+                            selector:
+                              properties:
+                                matchExpressions:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            storageClassName:
+                              type: string
+                            volumeMode:
+                              type: string
+                            volumeName:
+                              type: string
+                          type: object
+                        status:
+                          properties:
+                            accessModes:
+                              items:
+                                type: string
+                              type: array
+                            allocatedResources:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            capacity:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            conditions:
+                              items:
+                                properties:
+                                  lastProbeTime:
+                                    type: string
+                                  lastTransitionTime:
+                                    type: string
+                                  message:
+                                    type: string
+                                  reason:
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              type: array
+                            phase:
+                              type: string
+                            resizeStatus:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
                   podTemplate:
                     properties:
                       apiVersion:

--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -44,6 +44,8 @@ rules:
     resources:
       - deployments
       - deployments/finalizers
+      - statefulsets
+      - statefulsets/finalizers
       - replicasets
     verbs:
       - "*"
@@ -51,6 +53,7 @@ rules:
       - extensions
     resources:
       - deployments
+      - statefulsets
       - ingresses
     verbs:
       - "*"
@@ -88,6 +91,8 @@ rules:
     resources:
       - deployments
       - deployments/finalizers
+      - statefulsets
+      - statefulsets/finalizers
     verbs:
       - '*'
 {{- end }}


### PR DESCRIPTION
## What is the purpose of the change

This pull request make an improvement for standalone mode to use StatefulSet instead of Deployment to deploy JM and TM to support mount a dynamically-created PersistentVolumeClaim.

## Brief change log
  - Use StatefulSet to instead of Deployment to depoly JM and TM
  - Introduce StandaloneKubernetesJobManagerSpecification to encapsulate JM specification info 
  - Add volumeClaimTemplates for JobManagerSpec and TaskManagerSpec
  - Add JOB_MANAGER_PVC_TEMPLATE and TASK_MANAGER_PVC_TEMPLATE ConfigOption to set jobmanager and taskmanager pvc template file separately.
  - Modify obersving logical for JM and TM StatefulSet.
  - Add statefulset rbac.
  - Modify docs/content/docs/custom-resource/reference.md to describe volumeClaimTemplates settings.
  - Add standalone cluster example with pvc settings.

## Verifying this change

This change is already covered by existing tests, such as .
 - Modified Fabric8FlinkStandaloneKubeClientTest to adapt StatefulSet creating test.
 - Modified KubernetesStandaloneClusterDescriptorTest to adapt StatefulSet to test standalone cluster deploying
 - Modified StandaloneFlinkServiceTest to adapt StatefulSet to test StandaloneFlinkService to deploy standalone cluster.
 - Modified StandaloneKubernetesJobManagerFactoryTest to adapt StatefulSet to test jobmanager spec.
 - Modified StandaloneKubernetesTaskManagerFactoryTest to adapt StatefulSet to test taskmanager spec

This change added tests and can be verified as follows:
  - Added TestUtils.buildStandaloneSessionCluster() and TestUtils.buildStandaloneApplicationCluster() for standalone cluster tests.
  - Added SessionObserverTest.observeStandaloneSessionCluster to verify standalone session cluster observing logical


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes )
  - Core observer or reconciler logic that is regularly executed: (yes )

## Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (docs )