### PR TITLE
[FLINK-29140] Bump Flink version to 1.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@ under the License.
         <fabric8.version>5.12.3</fabric8.version>
         <lombok.version>1.18.22</lombok.version>
 
-        <flink.version>1.15.1</flink.version>
+        <flink.version>1.15.2</flink.version>
 
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.1</log4j.version>


### PR DESCRIPTION
## What is the purpose of the change

This PR bumps Flink version to 1.15.2.

## Brief change log

Bump Flink version to 1.15.2.

## Verifying this change

Existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
