### PR TITLE
[FLINK-29194] Add logging for ResourceListener

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/AuditUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/AuditUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.listener;
+
+import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.crd.status.CommonStatus;
+
+import io.fabric8.kubernetes.api.model.Event;
+import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Responsible for logging resource event/status updates. */
+public class AuditUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(AuditUtils.class);
+
+    public static <R extends AbstractFlinkResource<?, S>, S extends CommonStatus<?>>
+            void logContext(FlinkResourceListener.StatusUpdateContext<R, S> ctx) {
+        LOG.info(format(ctx.getNewStatus()));
+    }
+
+    public static <R extends AbstractFlinkResource<?, ?>> void logContext(
+            FlinkResourceListener.ResourceEventContext<R> ctx) {
+        LOG.info(format(ctx.getEvent()));
+    }
+
+    private static String format(@NonNull CommonStatus<?> status) {
+        return String.format(
+                ">>> Status | %-7s | %-15s | %s ",
+                StringUtils.isEmpty(status.getError()) ? "Info" : "Error",
+                status.getLifecycleState(),
+                StringUtils.isEmpty(status.getError())
+                        ? status.getLifecycleState().getDescription()
+                        : status.getError());
+    }
+
+    private static String format(@NonNull Event event) {
+        return String.format(
+                ">>> Event  | %-7s | %-15s | %s",
+                event.getType().equals("Normal") ? "Info" : event.getType(),
+                event.getReason().toUpperCase(),
+                event.getMessage());
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/ListenerUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/ListenerUtils.java
@@ -26,7 +26,6 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DelegatingConfiguration;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
-import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +44,7 @@ import java.util.regex.Pattern;
 /** Flink resource listener utilities. */
 public class ListenerUtils {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FlinkUtils.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ListenerUtils.class);
 
     private static final String PREFIX = "kubernetes.operator.plugins.listeners.";
     private static final String SUFFIX = ".class";

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/ResourceLifecycleState.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/ResourceLifecycleState.java
@@ -17,25 +17,31 @@
 
 package org.apache.flink.kubernetes.operator.metrics.lifecycle;
 
+import lombok.Getter;
+
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
 /** Enum encapsulating the lifecycle state of a Flink resource. */
 public enum ResourceLifecycleState {
-    CREATED(false),
-    SUSPENDED(true),
-    UPGRADING(false),
-    DEPLOYED(false),
-    STABLE(true),
-    ROLLING_BACK(false),
-    ROLLED_BACK(true),
-    FAILED(true);
+    CREATED(false, "The resource was created in Kubernetes but not yet handled by the operator"),
+    SUSPENDED(true, "The resource (job) has been suspended"),
+    UPGRADING(false, "The resource is being upgraded"),
+    DEPLOYED(
+            false,
+            "The resource is deployed/submitted to Kubernetes, but it’s not yet considered to be stable and might be rolled back in the future"),
+    STABLE(true, "The resource deployment is considered to be stable and won’t be rolled back"),
+    ROLLING_BACK(false, "The resource is being rolled back to the last stable spec"),
+    ROLLED_BACK(true, "The resource is deployed with the last stable spec"),
+    FAILED(true, "The job terminally failed");
 
     private final boolean terminal;
+    @Getter private final String description;
 
-    ResourceLifecycleState(boolean terminal) {
+    ResourceLifecycleState(boolean terminal, String description) {
         this.terminal = terminal;
+        this.description = description;
     }
 
     public Set<ResourceLifecycleState> getClearedStatesAfterTransition(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.CommonStatus;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
+import org.apache.flink.kubernetes.operator.listener.AuditUtils;
 import org.apache.flink.kubernetes.operator.listener.FlinkResourceListener;
 import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 
@@ -196,6 +197,7 @@ public class StatusRecorder<
                                     listener.onSessionJobStatusUpdate(ctx);
                                 }
                             });
+                    AuditUtils.logContext(ctx);
                 };
 
         return new StatusRecorder<>(kubernetesClient, metricManager, consumer);

--- a/flink-kubernetes-operator/src/main/resources/log4j2.properties
+++ b/flink-kubernetes-operator/src/main/resources/log4j2.properties
@@ -27,3 +27,6 @@ appender.console.layout.pattern = %style{%d}{yellow} %style{%-30c{1.}}{cyan} %hi
 
 logger.conf.name = org.apache.flink.configuration.GlobalConfiguration
 logger.conf.level = WARN
+
+logger.event.name = org.apache.flink.kubernetes.operator.listener.AuditUtils
+logger.event.level = INFO


### PR DESCRIPTION
## What is the purpose of the change

Being able to tell what status updates and events are being sent via the ResourceListener interfaces. It allows easy tail/grep for related messages reported under a specific resource.

## Brief change log
- Added `Unified audit logging for StatusRecorder/EventRecorder`
- Added `description for ResourceLifecycleState`
- Minor fix in EventRecorded to avoid creating redundant `ctx` objects if multiple ResourceListeners are registered.
## Verifying this change

Manual verification:
```
2022-09-07 06:53:23,661 o.a.f.k.o.l.AuditUtils         [INFO ] [default.basic-example] >>> Event  | Info    | SPECCHANGED     | UPGRADE change(s) detected (FlinkDeploymentSpec[serviceAccount=flink] differs from FlinkDeploymentSpec[serviceAccount=flinkk]), starting reconciliation.
2022-09-07 06:53:23,680 o.a.f.k.o.l.AuditUtils         [INFO ] [default.basic-example] >>> Event  | Info    | SUSPENDED       | Suspending existing deployment.
2022-09-07 06:53:24,849 o.a.f.k.o.l.AuditUtils         [INFO ] [default.basic-example] >>> Status | Info    | UPGRADING       | The resource is being upgraded 
2022-09-07 06:53:24,868 o.a.f.k.o.l.AuditUtils         [INFO ] [default.basic-example] >>> Status | Info    | UPGRADING       | The resource is being upgraded 
2022-09-07 06:53:24,884 o.a.f.k.o.l.AuditUtils         [INFO ] [default.basic-example] >>> Event  | Info    | SUBMIT          | Starting deployment
2022-09-07 06:53:25,126 o.a.f.k.o.l.AuditUtils         [INFO ] [default.basic-example] >>> Status | Info    | DEPLOYED        | The resource is deployed/submitted to Kubernetes, but it’s not yet considered to be stable and might be rolled back in the future 
```
## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation
  - Does this pull request introduce a new feature? no
