### PR TITLE
[FLINK-28272] Handle TLS Certificate Renewal in Webhook

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/fs/FileSystemWatchService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/fs/FileSystemWatchService.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.fs;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.WatchEvent;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+
+import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
+import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
+import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
+
+/** Service which is able to watch local filesystem directories. */
+public class FileSystemWatchService extends Thread {
+    private static final Logger LOG = LoggerFactory.getLogger(FileSystemWatchService.class);
+
+    private final String directoryPath;
+
+    public FileSystemWatchService(String directoryPath) {
+        if (!new File(directoryPath).isDirectory()) {
+            throw new IllegalArgumentException("Directory must exists: " + directoryPath);
+        }
+        this.directoryPath = directoryPath;
+    }
+
+    @Override
+    public void run() {
+        try (WatchService watcher = FileSystems.getDefault().newWatchService()) {
+            LOG.info("Starting watching path: " + directoryPath);
+            Path realDirectoryPath = Paths.get(directoryPath).toRealPath();
+            LOG.info("Path is resolved to real path: " + realDirectoryPath);
+            realDirectoryPath.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+            onWatchStarted(realDirectoryPath);
+
+            while (true) {
+                LOG.debug("Taking watch key");
+                WatchKey watchKey = watcher.take();
+                LOG.debug("Watch key arrived");
+                for (WatchEvent<?> watchEvent : watchKey.pollEvents()) {
+                    LOG.debug("Watch event count: " + watchEvent.count());
+                    if (watchEvent.kind() == OVERFLOW) {
+                        LOG.error("Filesystem events may have been lost or discarded");
+                        Thread.yield();
+                    } else if (watchEvent.kind() == ENTRY_CREATE) {
+                        onFileOrDirectoryCreated((Path) watchEvent.context());
+                    } else if (watchEvent.kind() == ENTRY_DELETE) {
+                        onFileOrDirectoryDeleted((Path) watchEvent.context());
+                    } else if (watchEvent.kind() == ENTRY_MODIFY) {
+                        onFileOrDirectoryModified((Path) watchEvent.context());
+                    } else {
+                        throw new IllegalStateException("Invalid event kind: " + watchEvent.kind());
+                    }
+                }
+                watchKey.reset();
+            }
+        } catch (InterruptedException e) {
+            LOG.info("Filesystem watcher interrupted");
+        } catch (Exception e) {
+            LOG.error("Filesystem watcher received exception and stopped: " + e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void onWatchStarted(Path realDirectoryPath) {}
+
+    protected void onFileOrDirectoryCreated(Path relativePath) {}
+
+    protected void onFileOrDirectoryDeleted(Path relativePath) {}
+
+    protected void onFileOrDirectoryModified(Path relativePath) {}
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/ssl/ReloadableSslContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/ssl/ReloadableSslContext.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.ssl;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http2.Http2SecurityUtil;
+import org.apache.flink.shaded.netty4.io.netty.handler.ssl.ApplicationProtocolNegotiator;
+import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContext;
+import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContextBuilder;
+import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SupportedCipherSuiteFilter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSessionContext;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.security.KeyStore;
+import java.util.List;
+
+/** SSL context which is able to reload keystore. */
+public class ReloadableSslContext extends SslContext {
+    private static final Logger LOG = LoggerFactory.getLogger(ReloadableSslContext.class);
+
+    private final String keystorePath;
+    private final String keystoreType;
+    private final String keystorePassword;
+    private volatile SslContext sslContext;
+
+    public ReloadableSslContext(String keystorePath, String keystoreType, String keystorePassword)
+            throws Exception {
+        this.keystorePath = keystorePath;
+        this.keystoreType = keystoreType;
+        this.keystorePassword = keystorePassword;
+        loadContext();
+    }
+
+    @Override
+    public boolean isClient() {
+        return sslContext.isClient();
+    }
+
+    @Override
+    public List<String> cipherSuites() {
+        return sslContext.cipherSuites();
+    }
+
+    @Override
+    public ApplicationProtocolNegotiator applicationProtocolNegotiator() {
+        return sslContext.applicationProtocolNegotiator();
+    }
+
+    @Override
+    public SSLEngine newEngine(ByteBufAllocator byteBufAllocator) {
+        return sslContext.newEngine(byteBufAllocator);
+    }
+
+    @Override
+    public SSLEngine newEngine(ByteBufAllocator byteBufAllocator, String s, int i) {
+        return sslContext.newEngine(byteBufAllocator, s, i);
+    }
+
+    @Override
+    public SSLSessionContext sessionContext() {
+        return sslContext.sessionContext();
+    }
+
+    public void reload() throws Exception {
+        loadContext();
+    }
+
+    private void loadContext() throws Exception {
+        LOG.info("Creating keystore with type: " + keystoreType);
+        KeyStore keyStore = KeyStore.getInstance(keystoreType);
+        LOG.info("Loading keystore from file: " + keystorePath);
+        try (InputStream keyStoreFile = Files.newInputStream(new File(keystorePath).toPath())) {
+            keyStore.load(keyStoreFile, keystorePassword.toCharArray());
+        }
+        final KeyManagerFactory kmf =
+                KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        LOG.info("Initializing key manager with keystore and password");
+        kmf.init(keyStore, keystorePassword.toCharArray());
+
+        sslContext =
+                SslContextBuilder.forServer(kmf)
+                        .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
+                        .build();
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/fs/FileSystemWatchServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/fs/FileSystemWatchServiceTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.fs;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/** Test for filesystem watch service. */
+class FileSystemWatchServiceTest {
+    private static final Logger LOG = LoggerFactory.getLogger(FileSystemWatchServiceTest.class);
+
+    private @TempDir Path tmpDir;
+    private String fileName;
+    private Path fileFullPath;
+    private CountDownLatch watchStartedLatch;
+    private CountDownLatch watchEventArrivedLatch;
+    private FileSystemWatchService fileSystemWatchService;
+
+    @BeforeEach
+    public void beforeEach() {
+        fileName = UUID.randomUUID().toString();
+        fileFullPath = Paths.get(tmpDir.toString(), fileName);
+        watchStartedLatch = new CountDownLatch(1);
+        watchEventArrivedLatch = new CountDownLatch(1);
+        fileSystemWatchService = null;
+    }
+
+    @AfterEach
+    public void afterEach() throws InterruptedException {
+        if (fileSystemWatchService != null) {
+            fileSystemWatchService.interrupt();
+            fileSystemWatchService.join(10_000);
+            fileSystemWatchService = null;
+        }
+    }
+
+    @Test
+    public void testMissingDirectory() {
+        Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                    new FileSystemWatchService("/intentionally/missing/directory");
+                });
+    }
+
+    @Test
+    public void testFileCreateEvent() throws Exception {
+        FileSystemWatchService fileSystemWatchService =
+                new FileSystemWatchService(tmpDir.toString()) {
+                    @Override
+                    protected void onWatchStarted(Path realDirectoryPath) {
+                        watchStartedLatch.countDown();
+                    }
+
+                    @Override
+                    protected void onFileOrDirectoryCreated(Path relativePath) {
+                        if (relativePath.toString().equals(fileName)) {
+                            watchEventArrivedLatch.countDown();
+                        }
+                    }
+                };
+        fileSystemWatchService.start();
+        Assertions.assertTrue(watchStartedLatch.await(10, TimeUnit.SECONDS));
+
+        Files.createFile(Paths.get(tmpDir.toString(), fileName));
+
+        Assertions.assertTrue(watchEventArrivedLatch.await(1, TimeUnit.MINUTES));
+    }
+
+    @Test
+    public void testFileDeleteEvent() throws Exception {
+        Files.createFile(fileFullPath);
+        Assertions.assertEquals(1, Files.list(tmpDir).count());
+        FileSystemWatchService fileSystemWatchService =
+                new FileSystemWatchService(tmpDir.toString()) {
+                    @Override
+                    protected void onWatchStarted(Path realDirectoryPath) {
+                        LOG.info("onWatchStarted");
+                        watchStartedLatch.countDown();
+                    }
+
+                    @Override
+                    protected void onFileOrDirectoryDeleted(Path relativePath) {
+                        LOG.info("onFileOrDirectoryDeleted");
+                        if (relativePath.toString().equals(fileName)) {
+                            watchEventArrivedLatch.countDown();
+                        }
+                    }
+                };
+        fileSystemWatchService.start();
+        Assertions.assertTrue(watchStartedLatch.await(10, TimeUnit.SECONDS));
+
+        Files.delete(fileFullPath);
+
+        Assertions.assertEquals(0, Files.list(tmpDir).count());
+        Assertions.assertTrue(watchEventArrivedLatch.await(1, TimeUnit.MINUTES));
+    }
+
+    @Test
+    public void testFileModifyEvent() throws Exception {
+        writeFile("1");
+
+        FileSystemWatchService fileSystemWatchService =
+                new FileSystemWatchService(tmpDir.toString()) {
+                    @Override
+                    protected void onWatchStarted(Path realDirectoryPath) {
+                        watchStartedLatch.countDown();
+                    }
+
+                    @Override
+                    protected void onFileOrDirectoryModified(Path relativePath) {
+                        if (relativePath.toString().equals(fileName)) {
+                            watchEventArrivedLatch.countDown();
+                        }
+                    }
+                };
+        fileSystemWatchService.start();
+        Assertions.assertTrue(watchStartedLatch.await(10, TimeUnit.SECONDS));
+
+        writeFile("2");
+
+        Assertions.assertTrue(watchEventArrivedLatch.await(1, TimeUnit.MINUTES));
+    }
+
+    private void writeFile(String content) throws IOException {
+        Files.write(
+                fileFullPath,
+                content.getBytes(),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

At the moment SSL context is not realoading the certificate when changed. In this PR I've added this functionality.

## Brief change log

* `FsWatchService` added with tests in `FsWatchServiceTest`
* `ReloadableSslContext` added
* Additional logging to see more

## Verifying this change

* Newly added unit tests
* Manually: https://gist.github.com/gaborgsomogyi/014054be6ef40326a2ade870f5f3dd02

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
