### PR TITLE
[FLINK-29251] Send CREATED status and Cancel event via FlinkResourceListener

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -84,7 +84,14 @@ public class FlinkDeploymentController
 
     @Override
     public DeleteControl cleanup(FlinkDeployment flinkApp, Context context) {
-        LOG.info("Deleting FlinkDeployment");
+        String msg = "Cleaning up " + FlinkDeployment.class.getSimpleName();
+        LOG.info(msg);
+        eventRecorder.triggerEvent(
+                flinkApp,
+                EventRecorder.Type.Normal,
+                EventRecorder.Reason.Cleanup,
+                EventRecorder.Component.Operator,
+                msg);
         statusRecorder.updateStatusFromCache(flinkApp);
         try {
             observerFactory.getOrCreate(flinkApp).observe(flinkApp, context);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -107,7 +107,14 @@ public class FlinkSessionJobController
 
     @Override
     public DeleteControl cleanup(FlinkSessionJob sessionJob, Context context) {
-        LOG.info("Deleting FlinkSessionJob");
+        String msg = "Cleaning up " + FlinkSessionJob.class.getSimpleName();
+        LOG.info(msg);
+        eventRecorder.triggerEvent(
+                sessionJob,
+                EventRecorder.Type.Normal,
+                EventRecorder.Reason.Cleanup,
+                EventRecorder.Component.Operator,
+                msg);
         statusRecorder.removeCachedStatus(sessionJob);
         return reconciler.cleanup(sessionJob, context);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -147,7 +147,7 @@ public abstract class JobStatusObserver<CTX> {
             eventRecorder.triggerEvent(
                     resource,
                     EventRecorder.Type.Normal,
-                    EventRecorder.Reason.StatusChanged,
+                    EventRecorder.Reason.JobStatusChanged,
                     EventRecorder.Component.Job,
                     message);
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -187,7 +187,7 @@ public class SessionReconciler
             if (eventRecorder.triggerEvent(
                     deployment,
                     EventRecorder.Type.Warning,
-                    EventRecorder.Reason.Cleanup,
+                    EventRecorder.Reason.CleanupFailed,
                     EventRecorder.Component.Operator,
                     error)) {
                 LOG.warn(error);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -121,9 +121,10 @@ public class EventRecorder {
         SpecChanged,
         Rollback,
         Submit,
-        StatusChanged,
+        JobStatusChanged,
         SavepointError,
         Cleanup,
+        CleanupFailed,
         Missing,
         ValidationError
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
@@ -27,6 +27,7 @@ import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.listener.AuditUtils;
 import org.apache.flink.kubernetes.operator.listener.FlinkResourceListener;
 import org.apache.flink.kubernetes.operator.metrics.MetricManager;
+import org.apache.flink.kubernetes.operator.metrics.lifecycle.ResourceLifecycleState;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -140,6 +141,9 @@ public class StatusRecorder<
         } else {
             // Initialize cache with current status copy
             statusCache.put(key, objectMapper.convertValue(resource.getStatus(), ObjectNode.class));
+            if (ResourceLifecycleState.CREATED.equals(resource.getStatus().getLifecycleState())) {
+                statusUpdateListener.accept(resource, resource.getStatus());
+            }
         }
         metricManager.onUpdate(resource);
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -117,7 +117,7 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 appCluster.getStatus().getJobStatus().getState());
-        assertEquals(2, testController.getInternalStatusUpdateCount());
+        assertEquals(3, testController.getInternalStatusUpdateCount());
         assertFalse(updateControl.isUpdateStatus());
         assertEquals(
                 Optional.of(
@@ -140,7 +140,7 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 org.apache.flink.api.common.JobStatus.RECONCILING.name(),
                 appCluster.getStatus().getJobStatus().getState());
-        assertEquals(3, testController.getInternalStatusUpdateCount());
+        assertEquals(4, testController.getInternalStatusUpdateCount());
         assertFalse(updateControl.isUpdateStatus());
         assertEquals(
                 Optional.of(
@@ -154,7 +154,7 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 org.apache.flink.api.common.JobStatus.RUNNING.name(),
                 appCluster.getStatus().getJobStatus().getState());
-        assertEquals(4, testController.getInternalStatusUpdateCount());
+        assertEquals(5, testController.getInternalStatusUpdateCount());
         assertFalse(updateControl.isUpdateStatus());
         assertEquals(
                 Optional.of(
@@ -169,7 +169,7 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 org.apache.flink.api.common.JobStatus.RUNNING.name(),
                 appCluster.getStatus().getJobStatus().getState());
-        assertEquals(4, testController.getInternalStatusUpdateCount());
+        assertEquals(5, testController.getInternalStatusUpdateCount());
         assertFalse(updateControl.isUpdateStatus());
         assertEquals(
                 Optional.of(
@@ -195,7 +195,7 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 org.apache.flink.api.common.JobStatus.RUNNING.name(),
                 appCluster.getStatus().getJobStatus().getState());
-        assertEquals(5, testController.getInternalStatusUpdateCount());
+        assertEquals(6, testController.getInternalStatusUpdateCount());
         assertFalse(updateControl.isUpdateStatus());
 
         reconciliationStatus = appCluster.getStatus().getReconciliationStatus();
@@ -482,7 +482,7 @@ public class FlinkDeploymentControllerTest {
 
         assertEquals(1, testController.events().size());
         assertEquals(
-                EventRecorder.Reason.StatusChanged,
+                EventRecorder.Reason.JobStatusChanged,
                 EventRecorder.Reason.valueOf(testController.events().poll().getReason()));
 
         // Upgrade job
@@ -530,7 +530,7 @@ public class FlinkDeploymentControllerTest {
         testController.reconcile(appCluster, context);
         assertEquals(1, testController.events().size());
         assertEquals(
-                EventRecorder.Reason.StatusChanged,
+                EventRecorder.Reason.JobStatusChanged,
                 EventRecorder.Reason.valueOf(testController.events().poll().getReason()));
 
         // Suspend job
@@ -592,7 +592,7 @@ public class FlinkDeploymentControllerTest {
                         .collect(Collectors.toList());
         assertEquals(1, statusEvents.size());
         assertEquals(
-                EventRecorder.Reason.StatusChanged,
+                EventRecorder.Reason.JobStatusChanged,
                 EventRecorder.Reason.valueOf(statusEvents.get(0).getReason()));
 
         assertEquals(


### PR DESCRIPTION
## What is the purpose of the change
- Send initial CREATED status update
- Send Events when cancelling resources

## Brief change log
- Modified the `StatusRecorder`, `FlinkDeploymentController`, `FlinkSessionJobController` with the changes
- Some minor fixes

## Verifying this change
Unit tests were updated `FlinkDeploymentControllerTest`, `FlinkResourceListenerTest`

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
