### PR TITLE
[FLINK-29302] Add helm chart support for setting dns policy and config

### DIFF
--- a/docs/content/docs/operations/helm.md
+++ b/docs/content/docs/operations/helm.md
@@ -68,6 +68,8 @@ The configurable parameters of the Helm chart and which default values as detail
 | operatorPod.annotations | Custom annotations to be added to the operator pod (but not the deployment). | |
 | operatorPod.labels | Custom labels to be added to the operator pod (but not the deployment). | |
 | operatorPod.env | Custom env to be added to the operator pod. | |
+| operatorPod.dnsPolicy | DNS policy to be used by the operator pod. | |
+| operatorPod.dnsConfig | DNS configuration to be used by the operator pod. | |
 | operatorServiceAccount.create | Whether to enable operator service account to create for flink-kubernetes-operator. | true |
 | operatorServiceAccount.annotations | The annotations of operator service account. | |
 | operatorServiceAccount.name | The name of operator service account. | flink-operator |

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -165,6 +165,15 @@ spec:
             mountPath: /opt/flink/conf/log4j-console.properties
             subPath: log4j-console.properties
         {{- end }}
+      {{- if index (.Values.operatorPod) "dnsPolicy" }}
+      dnsPolicy: {{ .Values.operatorPod.dnsPolicy | quote }}
+      {{- end }}
+      {{- if index (.Values.operatorPod) "dnsConfig" }}
+      dnsConfig:
+        {{- with .Values.operatorPod.dnsConfig }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
       volumes:
         - name: flink-operator-config-volume
           configMap:

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -55,6 +55,9 @@ operatorPod:
   env:
   # - name: ""
   #   value: ""
+  # dnsPolicy: ""
+  # dnsConfig: {}
+
 
 operatorServiceAccount:
   create: true


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request updates the helm chart to add the ability to set `dnsPolicy` and `dnsConfig` of the operator pod.


## Brief change log

  - Support setting `dnsPolicy` and `dnsConfig` of the operator pod

## Verifying this change
Manually verified this change on a Kubernetes cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
