### PR TITLE
[FLINK-29261] Use FAIL_ON_UNKNOWN_PROPERTIES=false in ReconciliationUtils

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -37,6 +37,7 @@ import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -60,7 +61,8 @@ public class ReconciliationUtils {
 
     public static final String INTERNAL_METADATA_JSON_KEY = "resource_metadata";
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper =
+            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     /**
      * Update status after successful deployment of a new resource spec. Existing reconciliation

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -96,4 +96,24 @@ public class ReconciliationUtilsTest {
                 migrated.f0.getJob().getJarURI());
         assertNull(migrated.f1);
     }
+
+    @Test
+    public void testSpecDeserializationWithUnknownField() throws JsonProcessingException {
+        FlinkDeployment app = TestUtils.buildApplicationCluster();
+        String serialized = ReconciliationUtils.writeSpecWithMeta(app.getSpec(), app);
+        assertEquals(
+                app.getSpec(),
+                ReconciliationUtils.deserializeSpecWithMeta(serialized, FlinkDeploymentSpec.class)
+                        .f0);
+
+        ObjectNode node = (ObjectNode) new ObjectMapper().readTree(serialized);
+        ((ObjectNode) node.get("spec")).put("unknown_field", "unknown_field_value");
+        String serializedWithUnknownField = new ObjectMapper().writeValueAsString(node);
+
+        assertEquals(
+                app.getSpec(),
+                ReconciliationUtils.deserializeSpecWithMeta(
+                                serializedWithUnknownField, FlinkDeploymentSpec.class)
+                        .f0);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change
The operator cannot be downgraded with new CRD, once the CR containing a new field is written to the last reconciled/stable spec.

## Brief change log
The `ObjectMapper` is modified in `ReconciliationUtils`
```
private static final ObjectMapper objectMapper =
            new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
```

## Verifying this change

Added new `ReconciliationUtilsTest.testSpecDeserializationWithUnknownField()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no