### PR TITLE
[FLINK-29327][operator] remove operator config from job runtime config before d…

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -184,13 +184,7 @@ public abstract class AbstractFlinkService implements FlinkService {
             throws Exception {
         // we generate jobID in advance to help deduplicate job submission.
         var jobID = FlinkUtils.generateSessionJobFixedJobID(meta);
-        Configuration runtimeConfig = removeOperatorConfigs(conf);
-        runJar(
-                spec.getJob(),
-                jobID,
-                uploadJar(meta, spec, runtimeConfig),
-                runtimeConfig,
-                savepoint);
+        runJar(spec.getJob(), jobID, uploadJar(meta, spec, conf), conf, savepoint);
         LOG.info("Submitted job: {} to session cluster.", jobID);
         return jobID;
     }
@@ -632,7 +626,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                 conf, clusterId, (c, e) -> new StandaloneClientHAServices(restServerAddress));
     }
 
-    protected JarRunResponseBody runJar(
+    private JarRunResponseBody runJar(
             JobSpec job,
             JobID jobID,
             JarUploadResponseBody response,
@@ -674,7 +668,7 @@ public abstract class AbstractFlinkService implements FlinkService {
         }
     }
 
-    protected JarUploadResponseBody uploadJar(
+    private JarUploadResponseBody uploadJar(
             ObjectMeta objectMeta, FlinkSessionJobSpec spec, Configuration conf) throws Exception {
         String targetDir = artifactManager.generateJarDir(objectMeta, spec);
         File jarFile = artifactManager.fetch(spec.getJob().getJarURI(), conf, targetDir);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -73,17 +73,7 @@ public class NativeFlinkService extends AbstractFlinkService {
 
     @Override
     public void submitSessionCluster(Configuration conf) throws Exception {
-        LOG.info("Deploying session cluster");
-        final ClusterClientServiceLoader clusterClientServiceLoader =
-                new DefaultClusterClientServiceLoader();
-        final ClusterClientFactory<String> kubernetesClusterClientFactory =
-                clusterClientServiceLoader.getClusterClientFactory(conf);
-        try (final ClusterDescriptor<String> kubernetesClusterDescriptor =
-                kubernetesClusterClientFactory.createClusterDescriptor(conf)) {
-            kubernetesClusterDescriptor.deploySessionCluster(
-                    kubernetesClusterClientFactory.getClusterSpecification(conf));
-        }
-        LOG.info("Session cluster successfully deployed");
+        submitClusterInternal(removeOperatorConfigs(conf));
     }
 
     @Override
@@ -113,6 +103,20 @@ public class NativeFlinkService extends AbstractFlinkService {
                 .inNamespace(namespace)
                 .withLabels(KubernetesUtils.getJobManagerSelectors(clusterId))
                 .list();
+    }
+
+    protected void submitClusterInternal(Configuration conf) throws Exception {
+        LOG.info("Deploying session cluster");
+        final ClusterClientServiceLoader clusterClientServiceLoader =
+                new DefaultClusterClientServiceLoader();
+        final ClusterClientFactory<String> kubernetesClusterClientFactory =
+                clusterClientServiceLoader.getClusterClientFactory(conf);
+        try (final ClusterDescriptor<String> kubernetesClusterDescriptor =
+                kubernetesClusterClientFactory.createClusterDescriptor(conf)) {
+            kubernetesClusterDescriptor.deploySessionCluster(
+                    kubernetesClusterClientFactory.getClusterSpecification(conf));
+        }
+        LOG.info("Session cluster successfully deployed");
     }
 
     /**

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
@@ -66,14 +66,14 @@ public class StandaloneFlinkService extends AbstractFlinkService {
     @Override
     protected void deployApplicationCluster(JobSpec jobSpec, Configuration conf) throws Exception {
         LOG.info("Deploying application cluster");
-        submitClusterInternal(conf, Mode.APPLICATION);
+        submitClusterInternal(removeOperatorConfigs(conf), Mode.APPLICATION);
         LOG.info("Application cluster successfully deployed");
     }
 
     @Override
     public void submitSessionCluster(Configuration conf) throws Exception {
         LOG.info("Deploying session cluster");
-        submitClusterInternal(conf, Mode.SESSION);
+        submitClusterInternal(removeOperatorConfigs(conf), Mode.SESSION);
         LOG.info("Session cluster successfully deployed");
     }
 
@@ -115,7 +115,7 @@ public class StandaloneFlinkService extends AbstractFlinkService {
                 executorService);
     }
 
-    private void submitClusterInternal(Configuration conf, Mode mode)
+    protected void submitClusterInternal(Configuration conf, Mode mode)
             throws ClusterDeploymentException {
         final String namespace = conf.get(KubernetesConfigOptions.NAMESPACE);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -139,7 +139,7 @@ public class TestingFlinkService extends AbstractFlinkService {
         if (requireHaMetadata) {
             validateHaMetadataExists(conf);
         }
-        deployApplicationCluster(jobSpec, conf);
+        deployApplicationCluster(jobSpec, removeOperatorConfigs(conf));
     }
 
     protected void deployApplicationCluster(JobSpec jobSpec, Configuration conf) throws Exception {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -30,8 +30,6 @@ import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingClusterClient;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
-import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
-import org.apache.flink.kubernetes.operator.crd.spec.FlinkSessionJobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
@@ -48,13 +46,10 @@ import org.apache.flink.runtime.rest.messages.TriggerId;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointTriggerRequestBody;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
-import org.apache.flink.runtime.webmonitor.handlers.JarRunResponseBody;
-import org.apache.flink.runtime.webmonitor.handlers.JarUploadResponseBody;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -344,21 +339,6 @@ public class NativeFlinkServiceTest {
     }
 
     @Test
-    public void testSubmitJobToSessionClusterConfigRemoval() throws Exception {
-        var testingClusterClient =
-                new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
-        Configuration deployConfig = createOperatorConfig();
-        final FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
-
-        var flinkService = (NativeFlinkService) createFlinkService(testingClusterClient);
-        var testingService = new TestingNativeFlinkService(flinkService);
-        testingService.submitJobToSessionCluster(
-                sessionJob.getMetadata(), sessionJob.getSpec(), deployConfig, "");
-        assertFalse(
-                testingService.getRuntimeConfig().containsKey(OPERATOR_HEALTH_PROBE_PORT.key()));
-    }
-
-    @Test
     public void testEffectiveStatus() {
 
         JobDetails allRunning =
@@ -479,24 +459,6 @@ public class NativeFlinkServiceTest {
         @Override
         protected void submitClusterInternal(Configuration conf) throws Exception {
             this.runtimeConfig = conf;
-        }
-
-        @Override
-        protected JarRunResponseBody runJar(
-                JobSpec job,
-                JobID jobID,
-                JarUploadResponseBody response,
-                Configuration conf,
-                String savepoint) {
-            this.runtimeConfig = conf;
-            return new JarRunResponseBody(jobID);
-        }
-
-        @Override
-        protected JarUploadResponseBody uploadJar(
-                ObjectMeta objectMeta, FlinkSessionJobSpec spec, Configuration conf)
-                throws Exception {
-            return new JarUploadResponseBody(objectMeta.getName());
         }
 
         public Configuration getRuntimeConfig() {


### PR DESCRIPTION
## What is the purpose of the change
Remove operator related configs from flink runtime config, so that users will not see any operator related config in web ui.

## Brief change log
  - remove operator configs before deployments in Flink services.

## Verifying this change

This change is a trivial rework / code cleanup with unit test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
