### PR TITLE
[FLINK-28979] Add owner reference to flink deployment object

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.reconciler.deployment;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
@@ -433,13 +434,13 @@ public abstract class AbstractFlinkResourceReconciler<
 
     private void setOwnerReference(CR owner, Configuration deployConfig) {
         final Map<String, String> ownerReference =
-            Map.of(
-                    "apiVersion", owner.getApiVersion(),
-                    "kind", owner.getKind(),
-                    "name", owner.getMetadata().getName(),
-                    "uid", owner.getMetadata().getUid(),
-                    "blockOwnerDeletion", "false",
-                    "controller", "false");
+                Map.of(
+                        "apiVersion", owner.getApiVersion(),
+                        "kind", owner.getKind(),
+                        "name", owner.getMetadata().getName(),
+                        "uid", owner.getMetadata().getUid(),
+                        "blockOwnerDeletion", "false",
+                        "controller", "false");
         deployConfig.set(
                 KubernetesConfigOptions.JOB_MANAGER_OWNER_REFERENCE, List.of(ownerReference));
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -100,6 +100,8 @@ public abstract class AbstractFlinkResourceReconciler<
             return;
         }
 
+        setOwnerReference(cr, deployConfig);
+
         // If this is the first deployment for the resource we simply submit the job and return.
         // No further logic is required at this point.
         if (reconciliationStatus.isFirstDeployment()) {
@@ -109,8 +111,6 @@ public abstract class AbstractFlinkResourceReconciler<
             // handle subsequent deployment and status update errors
             ReconciliationUtils.updateStatusBeforeDeploymentAttempt(cr, deployConfig);
             statusRecorder.patchAndCacheStatus(cr);
-
-            setOwnerReference(cr, deployConfig);
 
             deploy(
                     cr,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -100,8 +100,6 @@ public abstract class AbstractFlinkResourceReconciler<
             return;
         }
 
-        setOwnerReference(cr, deployConfig);
-
         // If this is the first deployment for the resource we simply submit the job and return.
         // No further logic is required at this point.
         if (reconciliationStatus.isFirstDeployment()) {
@@ -432,7 +430,7 @@ public abstract class AbstractFlinkResourceReconciler<
         return false;
     }
 
-    private void setOwnerReference(CR owner, Configuration deployConfig) {
+    protected void setOwnerReference(CR owner, Configuration deployConfig) {
         final Map<String, String> ownerReference =
                 Map.of(
                         "apiVersion", owner.getApiVersion(),

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -170,6 +170,7 @@ public class ApplicationReconciler
             deployConfig.removeConfig(SavepointConfigOptions.SAVEPOINT_PATH);
         }
 
+        setOwnerReference(relatedResource, deployConfig);
         setRandomJobResultStorePath(deployConfig);
 
         if (status.getJobManagerDeploymentStatus() != JobManagerDeploymentStatus.MISSING) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -129,6 +129,7 @@ public class SessionReconciler
             Optional<String> savepoint,
             boolean requireHaMetadata)
             throws Exception {
+        setOwnerReference(cr, deployConfig);
         flinkService.submitSessionCluster(deployConfig);
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
         IngressUtils.updateIngressRules(cr.getMetadata(), spec, deployConfig, kubernetesClient);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -120,6 +120,7 @@ public class TestUtils {
                         .withName(name)
                         .withNamespace(namespace)
                         .withCreationTimestamp(Instant.now().toString())
+                        .withUid(UUID.randomUUID().toString())
                         .build());
         deployment.setSpec(getTestFlinkDeploymentSpec(version));
         return deployment;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec;
@@ -248,6 +249,16 @@ public class TestUtils {
         deployment.setSpec(spec);
         deployment.setStatus(status);
         return deployment;
+    }
+
+    public static Map<String, String> generateTestOwnerReferenceMap(AbstractFlinkResource owner) {
+        return Map.of(
+                "apiVersion", owner.getApiVersion(),
+                "kind", owner.getKind(),
+                "name", owner.getMetadata().getName(),
+                "uid", owner.getMetadata().getUid(),
+                "blockOwnerDeletion", "false",
+                "controller", "false");
     }
 
     public static <T extends HasMetadata> Context<T> createContextWithDeployment(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -572,8 +572,7 @@ public class ApplicationReconcilerTest {
             assertFalse(StringUtils.isBlank(deployment.getStatus().getJobStatus().getJobId()));
         }
     }
-    
-    
+
     @Test
     public void testSetOwnerReference() throws Exception {
         FlinkDeployment flinkApp = TestUtils.buildApplicationCluster();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.TestingStatusRecorder;
@@ -58,6 +59,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -656,5 +658,24 @@ public class ApplicationReconcilerTest {
                         .getJob()
                         .getState());
         assertEquals(4, flinkService.getDesiredReplicas());
+    }
+
+    @Test
+    public void testSetOwnerReference() throws Exception {
+        FlinkDeployment flinkApp = TestUtils.buildApplicationCluster();
+        ObjectMeta deployMeta = flinkApp.getMetadata();
+        FlinkDeploymentStatus status = flinkApp.getStatus();
+        FlinkDeploymentSpec spec = flinkApp.getSpec();
+        Configuration deployConfig = configManager.getDeployConfig(deployMeta, spec);
+
+        status.getJobStatus().setState(org.apache.flink.api.common.JobStatus.FINISHED.name());
+        status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+        reconciler.deploy(flinkApp, spec, status, context, deployConfig, Optional.empty(), false);
+
+        final List<Map<String, String>> expectedOwnerReferences =
+                List.of(TestUtils.generateTestOwnerReferenceMap(flinkApp));
+        List<Map<String, String>> or =
+                deployConfig.get(KubernetesConfigOptions.JOB_MANAGER_OWNER_REFERENCE);
+        Assertions.assertEquals(expectedOwnerReferences, or);
     }
 }

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesTaskManagerFactory.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesTaskManagerFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorato
 import org.apache.flink.kubernetes.kubeclient.decorators.KerberosMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.MountSecretsDecorator;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesOwnerReference;
 import org.apache.flink.kubernetes.operator.kubeclient.decorators.CmdStandaloneTaskManagerDecorator;
 import org.apache.flink.kubernetes.operator.kubeclient.decorators.InitStandaloneTaskManagerDecorator;
 import org.apache.flink.kubernetes.operator.kubeclient.parameters.StandaloneKubernetesTaskManagerParameters;
@@ -35,6 +36,8 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+
+import java.util.stream.Collectors;
 
 /** Utility class for constructing the TaskManager Deployment when deploying in standalone mode. */
 public class StandaloneKubernetesTaskManagerFactory {
@@ -74,6 +77,10 @@ public class StandaloneKubernetesTaskManagerFactory {
                                 kubernetesTaskManagerParameters.getClusterId()))
                 .withAnnotations(kubernetesTaskManagerParameters.getAnnotations())
                 .withLabels(kubernetesTaskManagerParameters.getLabels())
+                .withOwnerReferences(
+                        kubernetesTaskManagerParameters.getOwnerReference().stream()
+                                .map(e -> KubernetesOwnerReference.fromMap(e).getInternalResource())
+                                .collect(Collectors.toList()))
                 .endMetadata()
                 .editOrNewSpec()
                 .withReplicas(kubernetesTaskManagerParameters.getReplicas())

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesTaskManagerParameters.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesTaskManagerParameters.java
@@ -135,4 +135,11 @@ public class StandaloneKubernetesTaskManagerParameters extends AbstractKubernete
     public double getCpuLimitFactor() {
         return flinkConfig.get(KubernetesConfigOptions.TASK_MANAGER_CPU_LIMIT_FACTOR);
     }
+
+    // Temporally share job manager owner reference config options
+    public List<Map<String, String>> getOwnerReference() {
+        return flinkConfig
+                .getOptional(KubernetesConfigOptions.JOB_MANAGER_OWNER_REFERENCE)
+                .orElse(Collections.emptyList());
+    }
 }

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesJobManagerFactoryTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerSpecification;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesOwnerReference;
 import org.apache.flink.kubernetes.kubeclient.services.HeadlessClusterIPService;
 import org.apache.flink.kubernetes.operator.kubeclient.parameters.ParametersTestBase;
 import org.apache.flink.kubernetes.operator.kubeclient.parameters.StandaloneKubernetesJobManagerParameters;
@@ -36,6 +37,7 @@ import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -89,6 +91,12 @@ public class StandaloneKubernetesJobManagerFactoryTest extends ParametersTestBas
         assertEquals(expectedLabels, deploymentMetadata.getLabels());
 
         assertEquals(userAnnotations, deploymentMetadata.getAnnotations());
+
+        final List<OwnerReference> expectedOwnerReferences =
+                List.of(
+                        KubernetesOwnerReference.fromMap(flinkDeploymentOwnerReference)
+                                .getInternalResource());
+        assertEquals(expectedOwnerReferences, deploymentMetadata.getOwnerReferences());
     }
 
     @Test

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesTaskManagerFactoryTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.kubeclient.factory;
 
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesOwnerReference;
 import org.apache.flink.kubernetes.operator.kubeclient.parameters.ParametersTestBase;
 import org.apache.flink.kubernetes.operator.kubeclient.parameters.StandaloneKubernetesTaskManagerParameters;
 import org.apache.flink.kubernetes.operator.kubeclient.utils.TestUtils;
@@ -28,6 +29,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -74,6 +76,12 @@ public class StandaloneKubernetesTaskManagerFactoryTest extends ParametersTestBa
         assertEquals(expectedLabels, deployment.getMetadata().getLabels());
 
         assertEquals(userAnnotations, deployment.getMetadata().getAnnotations());
+
+        final List<OwnerReference> expectedOwnerReferences =
+                List.of(
+                        KubernetesOwnerReference.fromMap(flinkDeploymentOwnerReference)
+                                .getInternalResource());
+        assertEquals(expectedOwnerReferences, deployment.getMetadata().getOwnerReferences());
     }
 
     @Test

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/ParametersTestBase.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/ParametersTestBase.java
@@ -74,6 +74,9 @@ public class ParametersTestBase {
 
     protected final List<String> templateImagePullSecrets = Arrays.asList("ts1", "ts2", "ts3");
 
+    protected final Map<String, String> flinkDeploymentOwnerReference =
+            TestUtils.generateTestOwnerReferenceMap("FlinkDeployment");
+
     private static final String SECRETS = "ssl-cert:/etc/ssl";
 
     protected FlinkPod createPodTemplate() {
@@ -141,5 +144,8 @@ public class ParametersTestBase {
         flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_NODE_SELECTOR, userNodeSelectors);
         flinkConfig.set(KubernetesConfigOptions.CONTAINER_IMAGE_PULL_SECRETS, userImagePullSecrets);
         flinkConfig.setString(KubernetesConfigOptions.KUBERNETES_SECRETS.key(), SECRETS);
+        flinkConfig.set(
+                KubernetesConfigOptions.JOB_MANAGER_OWNER_REFERENCE,
+                List.of(flinkDeploymentOwnerReference));
     }
 }

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/utils/TestUtils.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/utils/TestUtils.java
@@ -28,6 +28,7 @@ import org.apache.flink.kubernetes.utils.Constants;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /** Testing utilities. */
 public class TestUtils {
@@ -60,6 +61,22 @@ public class TestUtils {
             map.put(keyPrefix + i, valuePrefix + i);
         }
         return map;
+    }
+
+    public static Map<String, String> generateTestOwnerReferenceMap(String kind) {
+        return Map.of(
+                "apiVersion",
+                "flink.apache.org/v1beta1",
+                "kind",
+                kind,
+                "name",
+                CLUSTER_ID,
+                "uid",
+                UUID.randomUUID().toString(),
+                "blockOwnerDeletion",
+                "false",
+                "controller",
+                "false");
     }
 
     public static ClusterSpecification createClusterSpecification() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add owner reference to `FlinkDeployment` object when create `Deployment`


## Brief change log

  - add owner reference to `FlinkDeployment` object when create `Deployment`


## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no

---
**NOTE:** 
With this change, we can see relation of `FlinkDeployment` with other resources in ArgoCD Web UI

**AS-IS:**
![image](https://user-images.githubusercontent.com/41815516/191509471-1c4a2702-610c-41fa-9413-1277257f8fd4.png)

**TO-BE:**
![image](https://user-images.githubusercontent.com/41815516/191508194-de0769ae-a16d-413f-9379-5efce7fe969b.png)

