### PR TITLE
[FLINK-29383] Add PrinterColumn annotation for status fields

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/JobStatus.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.crd.status;
 
 import org.apache.flink.annotation.Experimental;
 
+import io.fabric8.kubernetes.model.annotation.PrinterColumn;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -38,6 +39,7 @@ public class JobStatus {
     private String jobId;
 
     /** Last observed state of the job. */
+    @PrinterColumn(name = "Job Status")
     private String state;
 
     /** Start time of the job. */

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
@@ -25,6 +25,7 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationMetadata;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.fabric8.kubernetes.model.annotation.PrinterColumn;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -50,6 +51,7 @@ public abstract class ReconciliationStatus<SPEC extends AbstractFlinkSpec> {
     private String lastStableSpec;
 
     /** Deployment state of the last reconciled spec. */
+    @PrinterColumn(name = "Reconciliation Status")
     private ReconciliationState state = ReconciliationState.UPGRADING;
 
     @JsonIgnore

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -13,7 +13,16 @@ spec:
     singular: flinkdeployment
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Last observed state of the job.
+      jsonPath: .status.jobStatus.state
+      name: Job Status
+      type: string
+    - description: Deployment state of the last reconciled spec.
+      jsonPath: .status.reconciliationStatus.state
+      name: Reconciliation Status
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -13,7 +13,16 @@ spec:
     singular: flinksessionjob
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Last observed state of the job.
+      jsonPath: .status.jobStatus.state
+      name: Job Status
+      type: string
+    - description: Deployment state of the last reconciled spec.
+      jsonPath: .status.reconciliationStatus.state
+      name: Reconciliation Status
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         properties:


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add `PrinterColumn` annotation to the state fields, so that we can use `k get flinksession -o wide` to see session job list with status fields.

## Brief change log

- Add `@PrinterColumn` annotation to the state fields

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

I think the generated CRDs have covered the change 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (yes / no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
