### PR TITLE
[FLINK-29388] Fix to use JobSpec arguments in Standalone Application Mode

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -57,6 +57,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 
 import static org.apache.flink.configuration.DeploymentOptions.SHUTDOWN_ON_APPLICATION_FINISH;
@@ -273,6 +274,12 @@ public class FlinkConfigBuilder {
             if (jobSpec.getEntryClass() != null) {
                 effectiveConfig.set(
                         ApplicationConfiguration.APPLICATION_MAIN_CLASS, jobSpec.getEntryClass());
+            }
+
+            if (jobSpec.getArgs() != null) {
+                effectiveConfig.set(
+                        ApplicationConfiguration.APPLICATION_ARGS,
+                        Arrays.asList(jobSpec.getArgs()));
             }
         } else {
             effectiveConfig.set(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -300,9 +300,11 @@ public class FlinkConfigBuilderTest {
 
     @Test
     public void testApplyJobOrSessionSpec() throws Exception {
-        flinkDeployment.getSpec().getJob().setAllowNonRestoredState(true);
+        FlinkDeployment deploymentClone = ReconciliationUtils.clone(flinkDeployment);
+        deploymentClone.getSpec().getJob().setAllowNonRestoredState(true);
+        deploymentClone.getSpec().getJob().setArgs(new String[] {"--test", "123"});
         var configuration =
-                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                new FlinkConfigBuilder(deploymentClone, new Configuration())
                         .applyJobOrSessionSpec()
                         .build();
         Assertions.assertTrue(
@@ -313,8 +315,11 @@ public class FlinkConfigBuilderTest {
         Assertions.assertEquals(SAMPLE_JAR, configuration.get(PipelineOptions.JARS).get(0));
         Assertions.assertEquals(
                 Integer.valueOf(2), configuration.get(CoreOptions.DEFAULT_PARALLELISM));
+        Assertions.assertEquals(
+                List.of("--test", "123"),
+                configuration.get(ApplicationConfiguration.APPLICATION_ARGS));
 
-        var dep = ReconciliationUtils.clone(flinkDeployment);
+        var dep = ReconciliationUtils.clone(deploymentClone);
         dep.getSpec().setTaskManager(new TaskManagerSpec());
         dep.getSpec().getTaskManager().setReplicas(3);
         dep.getSpec().getFlinkConfiguration().put(TaskManagerOptions.NUM_TASK_SLOTS.key(), "4");

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
@@ -85,6 +85,11 @@ public class CmdStandaloneJobManagerDecorator extends AbstractKubernetesStepDeco
             args.add(allowNonRestoredState.toString());
         }
 
+        List<String> jobSpecArgs = kubernetesJobManagerParameters.getJobSpecArgs();
+        if (jobSpecArgs != null) {
+            args.addAll(kubernetesJobManagerParameters.getJobSpecArgs());
+        }
+
         return args;
     }
 }

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -91,5 +92,12 @@ public class StandaloneKubernetesJobManagerParameters extends KubernetesJobManag
 
     public boolean isPipelineClasspathDefined() {
         return flinkConfig.contains(PipelineOptions.CLASSPATHS);
+    }
+
+    public List<String> getJobSpecArgs() {
+        if (flinkConfig.contains(ApplicationConfiguration.APPLICATION_ARGS)) {
+            return flinkConfig.get(ApplicationConfiguration.APPLICATION_ARGS);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Pass JobSpec `args` through to Flink in Standalone mode.

## Brief change log

  - Add JobSpec args to flinkConfig in `FlinkConfigBuilder`
  - Add a getter in `StandaloneKubernetesJobManagerParameters` that is used in `KubernetesStandaloneClusterDescriptor` to get the JobSpec args


## Verifying this change

This change added tests and can be verified as follows:

  - Added test to make sure that the `FlinkConfigBuilder` appends JobSpec args to the `flinkConfig`
  - Added test to make sure that the `KubernetesStandaloneClusterDescriptor` appends JobSpec args

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
  
  Co-authored-by: Tommy Gunnarsson <tgun89@users.noreply.github.com>
