### PR TITLE
[FLINK-28966] Check backward compatibility against both 1.1.0 and 1.0…

### DIFF
--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -364,8 +364,10 @@ under the License.
                                 <java classname="org.apache.flink.kubernetes.operator.validation.CrdCompatibilityChecker"
                                       fork="true" failonerror="true">
                                     <classpath refid="maven.compile.classpath"/>
-                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.0/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
                                     <arg value="file://${rootDir}/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
+                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.0/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
+                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.1/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
+                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.1.0/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
                                 </java>
                             </target>
                         </configuration>
@@ -381,8 +383,10 @@ under the License.
                                 <java classname="org.apache.flink.kubernetes.operator.validation.CrdCompatibilityChecker"
                                       fork="true" failonerror="true">
                                     <classpath refid="maven.compile.classpath"/>
-                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.0/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
                                     <arg value="file://${rootDir}/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
+                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.0/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
+                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.1/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
+                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.1.0/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
                                 </java>
                             </target>
                         </configuration>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/CrdCompatibilityChecker.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/CrdCompatibilityChecker.java
@@ -51,7 +51,14 @@ public class CrdCompatibilityChecker {
     private static final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
 
     public static void main(String[] args) throws IOException {
-        checkObjectCompatibility("", getSchema(args[0]), getSchema(args[1]));
+
+        for (int i = 1; i < args.length; i++) {
+            String actualSchema = args[0];
+            String oldSchema = args[i];
+            logger.info("New schema: {}", actualSchema);
+            logger.info("Old schema: {}", oldSchema);
+            checkObjectCompatibility("", getSchema(oldSchema), getSchema(actualSchema));
+        }
         System.out.println("Successful validation!");
     }
 
@@ -80,9 +87,9 @@ public class CrdCompatibilityChecker {
                     checkObjectCompatibility(fieldPath, oldProps.get(field), newProps.get(field));
                 }
             }
-            logger.info("Successfully validated property names for {}", path);
+            logger.debug("Successfully validated property names for {}", path);
         } else {
-            logger.info("Successfully validated type for {}", path);
+            logger.debug("Successfully validated type for {}", path);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change
Check CRD compatibility against all released versions. 

## Brief change log

Modified the current logic to test against multiple versions:
```
 <execution>
    <id>deployment-crd-compatibility-check</id>
    <phase>package</phase>
    <goals>
        <goal>run</goal>
    </goals>
    <configuration>
        <target>
            <java classname="org.apache.flink.kubernetes.operator.validation.CrdCompatibilityChecker"
                  fork="true" failonerror="true">
                <classpath refid="maven.compile.classpath"/>
                <arg value="file://${rootDir}/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
                <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.0/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
                <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.1/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
                <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.1.0/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
            </java>
        </target>
    </configuration>
</execution>
<execution>
    <id>sessionjob-crd-compatibility-check</id>
    <phase>package</phase>
    <goals>
        <goal>run</goal>
    </goals>
    <configuration>
        <target>
            <java classname="org.apache.flink.kubernetes.operator.validation.CrdCompatibilityChecker"
                  fork="true" failonerror="true">
                <classpath refid="maven.compile.classpath"/>
                <arg value="file://${rootDir}/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
                <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.0/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
                <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.1/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
                <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.1.0/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
            </java>
        </target>
    </configuration>
</execution>
```
## Verifying this change

Manually verified:

```
[INFO] --- maven-antrun-plugin:1.8:run (deployment-crd-compatibility-check) @ flink-kubernetes-operator ---
[INFO] Executing tasks

main:
     [java] 2022-09-19 18:29:37,903 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] New schema: file:///Users/morhidi/Work/flink-kubernetes-operator/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
     [java] 2022-09-19 18:29:37,906 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] Old schema: https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.0/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
     [java] 2022-09-19 18:29:40,526 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] New schema: file:///Users/morhidi/Work/flink-kubernetes-operator/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
     [java] 2022-09-19 18:29:40,528 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] Old schema: https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.1/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
     [java] 2022-09-19 18:29:41,853 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] New schema: file:///Users/morhidi/Work/flink-kubernetes-operator/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
     [java] 2022-09-19 18:29:41,854 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] Old schema: https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.1.0/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
     [java] Successful validation!
[INFO] Executed tasks
[INFO]
[INFO] --- maven-antrun-plugin:1.8:run (sessionjob-crd-compatibility-check) @ flink-kubernetes-operator ---
[INFO] Executing tasks

main:
     [java] 2022-09-19 18:29:44,315 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] New schema: file:///Users/morhidi/Work/flink-kubernetes-operator/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
     [java] 2022-09-19 18:29:44,318 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] Old schema: https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.0/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
     [java] 2022-09-19 18:29:45,462 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] New schema: file:///Users/morhidi/Work/flink-kubernetes-operator/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
     [java] 2022-09-19 18:29:45,463 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] Old schema: https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.0.1/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
     [java] 2022-09-19 18:29:45,789 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] New schema: file:///Users/morhidi/Work/flink-kubernetes-operator/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
     [java] 2022-09-19 18:29:45,789 o.a.f.k.o.v.CrdCompatibilityChecker [INFO ] [.] Old schema: https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.1.0/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
     [java] Successful validation!
[INFO] Executed tasks
```
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no