### PR TITLE
[FLINK-29393] Upgrade Kubernetes operator examples to use 1.15.2 Flink base image

### DIFF
--- a/examples/basic-session-deployment-and-job.yaml
+++ b/examples/basic-session-deployment-and-job.yaml
@@ -40,7 +40,7 @@ metadata:
 spec:
   deploymentName: basic-session-deployment-example
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.1/flink-examples-streaming_2.12-1.15.1-TopSpeedWindowing.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.2/flink-examples-streaming_2.12-1.15.2-TopSpeedWindowing.jar
     parallelism: 4
     upgradeMode: stateless
 
@@ -52,7 +52,7 @@ metadata:
 spec:
   deploymentName: basic-session-deployment-example
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.1/flink-examples-streaming_2.12-1.15.1.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.2/flink-examples-streaming_2.12-1.15.2.jar
     parallelism: 2
     upgradeMode: stateless
     entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample

--- a/examples/flink-sql-runner-example/Dockerfile
+++ b/examples/flink-sql-runner-example/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 
-FROM flink:1.15.1
+FROM flink:1.15
 
 RUN mkdir /opt/flink/usrlib
 ADD target/flink-sql-runner-example-*.jar /opt/flink/usrlib/sql-runner.jar

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -73,7 +73,7 @@ spec:
             - /bin/sh
             - -c
             - "wget -O /opt/flink/downloads/flink-examples-streaming.jar \
-              https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.1/flink-examples-streaming_2.12-1.15.1.jar"
+              https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.15.2/flink-examples-streaming_2.12-1.15.2.jar"
   taskManager:
     resource:
       memory: "2048m"


### PR DESCRIPTION
## What is the purpose of the change

There were several places where 1.15.1 was hardcoded. In this PR I've changed them to the latest 1.15.2.

## Brief change log

Changed version from 1.15.1 to 1.15.2.

## Verifying this change

* Manually checked jar URIs.
* Existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
