### PR TITLE
[FLINK-29392] Trigger error when session job is lost without HA

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -86,6 +86,7 @@ public abstract class JobStatusObserver<CTX> {
                     filterTargetJob(jobStatus, clusterJobStatuses);
 
             if (targetJobStatusMessage.isEmpty()) {
+                LOG.warn("No matching jobs found on the cluster");
                 ifRunningMoveToReconciling(jobStatus, previousJobStatus);
                 // We could list the jobs but cannot find the one for this resource
                 if (resource instanceof FlinkDeployment) {
@@ -101,6 +102,7 @@ public abstract class JobStatusObserver<CTX> {
             ReconciliationUtils.checkAndUpdateStableSpec(resource.getStatus());
             return true;
         } else {
+            LOG.debug("No jobs found on the cluster");
             // No jobs found on the cluster, it is possible that the jobmanager is still starting up
             ifRunningMoveToReconciling(jobStatus, previousJobStatus);
 
@@ -140,7 +142,6 @@ public abstract class JobStatusObserver<CTX> {
      * We found a job on an application cluster that doesn't match the expected job. Trigger error.
      *
      * @param deployment Application deployment.
-     * @param conf Flink config.
      */
     private void setUnknownJobError(FlinkDeployment deployment) {
         deployment

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -75,26 +75,35 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
         var status = flinkApp.getStatus();
         var reconciliationStatus = status.getReconciliationStatus();
 
-        // Nothing has been launched so skip observing
-        if (reconciliationStatus.isBeforeFirstDeployment()
-                || reconciliationStatus.getState() == ReconciliationState.ROLLING_BACK) {
+        if (reconciliationStatus.isBeforeFirstDeployment()) {
+            logger.debug("Skipping observe before first deployment");
             return;
         }
 
+        if (reconciliationStatus.getState() == ReconciliationState.ROLLING_BACK) {
+            logger.debug("Skipping observe during rollback operation");
+            return;
+        }
+
+        // We are in the middle or possibly right after an upgrade
         if (reconciliationStatus.getState() == ReconciliationState.UPGRADING) {
+            // We must check if the upgrade went through without the status upgrade for some reason
             checkIfAlreadyUpgraded(flinkApp, context);
             if (reconciliationStatus.getState() == ReconciliationState.UPGRADING) {
                 ReconciliationUtils.clearLastReconciledSpecIfFirstDeploy(flinkApp);
+                logger.debug("Skipping observe before resource is deployed during upgrade");
                 return;
             }
         }
 
         Configuration observeConfig = configManager.getObserveConfig(flinkApp);
         if (!isJmDeploymentReady(flinkApp)) {
+            // Only observe the JM if we think it's in bad state
             observeJmDeployment(flinkApp, context, observeConfig);
         }
 
         if (isJmDeploymentReady(flinkApp)) {
+            // Only observe session/application if JM is ready
             observeFlinkCluster(flinkApp, context, observeConfig);
         }
 
@@ -126,7 +135,7 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
                 deploymentStatus.getJobManagerDeploymentStatus();
 
         if (isSuspendedJob(flinkApp)) {
-            logger.debug("Skipping observe step for suspended application deployments.");
+            logger.debug("Skipping observe step for suspended application deployments");
             return;
         }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
@@ -69,6 +69,7 @@ public class ApplicationObserver extends AbstractDeploymentObserver {
     protected void observeFlinkCluster(
             FlinkDeployment flinkApp, Context<?> context, Configuration deployedConfig) {
 
+        logger.debug("Observing application cluster");
         boolean jobFound =
                 jobStatusObserver.observe(
                         flinkApp,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
@@ -43,6 +43,7 @@ public class SessionObserver extends AbstractDeploymentObserver {
             FlinkDeployment deployment, Context<?> context, Configuration deployedConfig) {
         // Check if session cluster can serve rest calls following our practice in JobObserver
         try {
+            logger.debug("Observing session cluster");
             flinkService.listJobs(deployedConfig);
             var rs = deployment.getStatus().getReconciliationStatus();
             if (rs.getState() == ReconciliationState.DEPLOYED) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -20,7 +20,6 @@ package org.apache.flink.kubernetes.operator.controller;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.TestingFlinkServiceFactory;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
-import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.metrics.MetricManager;
@@ -28,6 +27,7 @@ import org.apache.flink.kubernetes.operator.observer.deployment.ObserverFactory;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.deployment.ReconcilerFactory;
 import org.apache.flink.kubernetes.operator.service.FlinkServiceFactory;
+import org.apache.flink.kubernetes.operator.utils.EventCollector;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
@@ -46,7 +46,6 @@ import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import org.junit.jupiter.api.Assertions;
 
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
 import java.util.function.BiConsumer;
@@ -121,15 +120,6 @@ public class TestingFlinkDeploymentController
     public Map<String, EventSource> prepareEventSources(
             EventSourceContext<FlinkDeployment> eventSourceContext) {
         throw new UnsupportedOperationException();
-    }
-
-    private static class EventCollector implements BiConsumer<AbstractFlinkResource<?, ?>, Event> {
-        private Queue<Event> events = new LinkedList<>();
-
-        @Override
-        public void accept(AbstractFlinkResource<?, ?> abstractFlinkResource, Event event) {
-            events.add(event);
-        }
     }
 
     public Queue<Event> events() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.observer.sessionjob;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
@@ -30,9 +31,11 @@ import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
+import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.sessionjob.SessionJobReconciler;
 import org.apache.flink.kubernetes.operator.service.FlinkServiceFactory;
+import org.apache.flink.kubernetes.operator.utils.EventCollector;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
@@ -40,6 +43,7 @@ import org.apache.flink.runtime.client.JobStatusMessage;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,10 +63,12 @@ public class SessionJobObserverTest {
     private SessionJobObserver observer;
     private SessionJobReconciler reconciler;
 
+    private EventCollector eventCollector = new EventCollector();
+
     @BeforeEach
     public void before() {
         kubernetesClient.resource(TestUtils.buildSessionJob()).createOrReplace();
-        var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
+        var eventRecorder = new EventRecorder(kubernetesClient, eventCollector);
         var statusRecorder = new TestingStatusRecorder<FlinkSessionJob, FlinkSessionJobStatus>();
         flinkService = new TestingFlinkService();
         FlinkServiceFactory flinkServiceFactory = new TestingFlinkServiceFactory(flinkService);
@@ -137,6 +143,32 @@ public class SessionJobObserverTest {
         observer.observe(sessionJob, readyContext);
         Assertions.assertEquals(
                 JobStatus.RUNNING.name(), sessionJob.getStatus().getJobStatus().getState());
+
+        // test error behaviour if job not present
+        flinkService.clear();
+
+        eventCollector.events.clear();
+
+        // With HA enabled no error should be triggered
+        observer.observe(sessionJob2, readyContext);
+        Assertions.assertEquals(
+                JobStatus.RECONCILING.name(), sessionJob2.getStatus().getJobStatus().getState());
+        Assertions.assertTrue(StringUtils.isEmpty(sessionJob2.getStatus().getError()));
+        Assertions.assertTrue(eventCollector.events.isEmpty());
+
+        // With HA disabled we expect an error status and event
+        sessionJob2
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(HighAvailabilityOptions.HA_MODE.key(), "NONE");
+        observer.observe(sessionJob2, readyContext);
+        Assertions.assertEquals(
+                JobStatus.RECONCILING.name(), sessionJob2.getStatus().getJobStatus().getState());
+        Assertions.assertEquals(
+                JobStatusObserver.MISSING_SESSION_JOB_ERR, sessionJob2.getStatus().getError());
+        Assertions.assertEquals(
+                JobStatusObserver.MISSING_SESSION_JOB_ERR,
+                eventCollector.events.peek().getMessage());
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventCollector.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventCollector.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
+
+import io.fabric8.kubernetes.api.model.Event;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.function.BiConsumer;
+
+/** Simple consumer that collects triggered events for tests. */
+public class EventCollector implements BiConsumer<AbstractFlinkResource<?, ?>, Event> {
+
+    public final Queue<Event> events = new LinkedList<>();
+
+    @Override
+    public void accept(AbstractFlinkResource<?, ?> abstractFlinkResource, Event event) {
+        events.add(event);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix a bug where without HA a deployed SessionJob could be lost without any errors triggered.

## Brief change log

  - *Detect when a session job is completely lost*
  - *Trigger error event and set error status*
  - *Add tests*

## Verifying this change

SessionJobObserverTest have been extended to cover the expected cases for HA/non-HA configs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
