### PR TITLE
[FLINK-29384] Bump snakeyaml version to 1.32

### DIFF
--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -47,6 +47,20 @@ under the License.
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <version>${fabric8.version}</version>
+            <!-- FLINK-29384, can be removed when fabric8 pulls snakeyaml 1.32+ -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- FLINK-29384, can be removed when fabric8 pulls snakeyaml 1.32+ -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
         </dependency>
 
         <dependency>

--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -62,7 +62,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.objenesis:objenesis:2.1
 - org.slf4j:slf4j-api:1.7.36
 - org.xerial.snappy:snappy-java:1.1.8.3
-- org.yaml:snakeyaml:1.30
+- org.yaml:snakeyaml:1.32
 
 This project bundles the following dependencies under the BSD License.
 See bundled license files for details.

--- a/flink-kubernetes-shaded/pom.xml
+++ b/flink-kubernetes-shaded/pom.xml
@@ -54,6 +54,19 @@ under the License.
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- FLINK-29384, Since the transitive snakeyaml that we are filtering out from
+            flink-kubernetes was relocated we have to bundle a relocated new version -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>
@@ -80,6 +93,12 @@ under the License.
                                     <pattern>io.fabric8</pattern>
                                     <shadedPattern>org.apache.flink.kubernetes.shaded.io.fabric8</shadedPattern>
                                 </relocation>
+                                <!-- FLINK-29384, Since the transitive snakeyaml that we are filtering out from
+                                    flink-kubernetes was relocated we have to bundle a relocated new version -->
+                                <relocation>
+                                    <pattern>org.yaml.snakeyaml</pattern>
+                                    <shadedPattern>org.apache.flink.kubernetes.shaded.org.yaml.snakeyaml</shadedPattern>
+                                </relocation>
                             </relocations>
                             <filters>
                                 <filter>
@@ -88,6 +107,7 @@ under the License.
                                         <exclude>META-INF/DEPENDENCIES</exclude>
                                         <exclude>META-INF/LICENSE</exclude>
                                         <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>org/apache/flink/kubernetes/shaded/org/yaml/snakeyaml/**</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/flink-kubernetes-standalone/pom.xml
+++ b/flink-kubernetes-standalone/pom.xml
@@ -38,6 +38,20 @@ under the License.
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
             <version>${fabric8.version}</version>
+            <!-- FLINK-29384, can be removed when fabric8 pulls snakeyaml 1.32+ -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- FLINK-29384, can be removed when fabric8 pulls snakeyaml 1.32+ -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,8 @@ under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <okhttp.version>4.10.0</okhttp.version>
+
+        <snakeyaml.version>1.32</snakeyaml.version>
     </properties>
 
     <dependencyManagement>
@@ -96,7 +98,7 @@ under the License.
                 <artifactId>jackson-bom</artifactId>
                 <type>pom</type>
                 <scope>import</scope>
-                <version>2.13.2.20220328</version>
+                <version>2.13.4</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Also bumped the jackson version as snakeyaml is only transitively pulled by jackson to keep the versions closer and more up to date.