### PR TITLE
[FLINK-29159] Harden initial deployment logic

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/CommonStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/CommonStatus.java
@@ -54,7 +54,7 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
     public ResourceLifecycleState getLifecycleState() {
         var reconciliationStatus = getReconciliationStatus();
 
-        if (reconciliationStatus.isFirstDeployment()) {
+        if (reconciliationStatus.isBeforeFirstDeployment()) {
             return StringUtils.isEmpty(error)
                     ? ResourceLifecycleState.CREATED
                     : ResourceLifecycleState.FAILED;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/ReconciliationStatus.java
@@ -98,7 +98,7 @@ public abstract class ReconciliationStatus<SPEC extends AbstractFlinkSpec> {
     }
 
     @JsonIgnore
-    public boolean isFirstDeployment() {
+    public boolean isBeforeFirstDeployment() {
         return lastReconciledSpec == null;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractDeploymentObserver.java
@@ -76,7 +76,7 @@ public abstract class AbstractDeploymentObserver implements Observer<FlinkDeploy
         var reconciliationStatus = status.getReconciliationStatus();
 
         // Nothing has been launched so skip observing
-        if (reconciliationStatus.isFirstDeployment()
+        if (reconciliationStatus.isBeforeFirstDeployment()
                 || reconciliationStatus.getState() == ReconciliationState.ROLLING_BACK) {
             return;
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserver.java
@@ -98,7 +98,7 @@ public class SessionJobObserver implements Observer<FlinkSessionJob> {
 
     @Override
     public void observe(FlinkSessionJob flinkSessionJob, Context<?> context) {
-        if (flinkSessionJob.getStatus().getReconciliationStatus().isFirstDeployment()) {
+        if (flinkSessionJob.getStatus().getReconciliationStatus().isBeforeFirstDeployment()) {
             return;
         }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -107,6 +107,9 @@ public class ReconciliationUtils {
 
         // Clear errors
         status.setError("");
+        reconciliationStatus.setReconciliationTimestamp(System.currentTimeMillis());
+        reconciliationStatus.setState(
+                upgrading ? ReconciliationState.UPGRADING : ReconciliationState.DEPLOYED);
 
         if (spec.getJob() != null) {
             // For jobs we have to adjust the reconciled spec
@@ -135,10 +138,6 @@ public class ReconciliationUtils {
         } else {
             reconciliationStatus.serializeAndSetLastReconciledSpec(spec, target);
         }
-
-        reconciliationStatus.setReconciliationTimestamp(System.currentTimeMillis());
-        reconciliationStatus.setState(
-                upgrading ? ReconciliationState.UPGRADING : ReconciliationState.DEPLOYED);
     }
 
     public static <SPEC extends AbstractFlinkSpec> void updateLastReconciledSavepointTriggerNonce(
@@ -451,6 +450,7 @@ public class ReconciliationUtils {
 
         if (lastSpecWithMeta.f1.isFirstDeployment()) {
             reconStatus.setLastReconciledSpec(null);
+            reconStatus.setState(ReconciliationState.UPGRADING);
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -99,7 +99,7 @@ public abstract class AbstractFlinkResourceReconciler<
 
         // If this is the first deployment for the resource we simply submit the job and return.
         // No further logic is required at this point.
-        if (reconciliationStatus.isFirstDeployment()) {
+        if (reconciliationStatus.isBeforeFirstDeployment()) {
             LOG.info("Deploying for the first time");
 
             // Before we try to submit the job we record the current spec in the status so we can

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -285,7 +285,7 @@ public class DefaultValidator implements FlinkResourceValidator {
             FlinkDeployment deployment, Map<String, String> effectiveConfig) {
         FlinkDeploymentSpec newSpec = deployment.getSpec();
 
-        if (deployment.getStatus().getReconciliationStatus().isFirstDeployment()) {
+        if (deployment.getStatus().getReconciliationStatus().isBeforeFirstDeployment()) {
             if (newSpec.getJob() != null && !newSpec.getJob().getState().equals(JobState.RUNNING)) {
                 return Optional.of("Job must start in running state");
             }
@@ -417,7 +417,7 @@ public class DefaultValidator implements FlinkResourceValidator {
     private Optional<String> validateSpecChange(FlinkSessionJob sessionJob) {
         FlinkSessionJobSpec newSpec = sessionJob.getSpec();
 
-        if (sessionJob.getStatus().getReconciliationStatus().isFirstDeployment()) {
+        if (sessionJob.getStatus().getReconciliationStatus().isBeforeFirstDeployment()) {
             // New job
             if (newSpec.getJob() != null && !newSpec.getJob().getState().equals(JobState.RUNNING)) {
                 return Optional.of("Job must start in running state");

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -477,6 +477,10 @@ public class ApplicationObserverTest {
         var reconStatus = status.getReconciliationStatus();
 
         // New deployment
+        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(
+                deployment,
+                new FlinkConfigManager(new Configuration())
+                        .getDeployConfig(deployment.getMetadata(), deployment.getSpec()));
         ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
 
         // Test regular upgrades
@@ -528,9 +532,12 @@ public class ApplicationObserverTest {
                 deployment,
                 new FlinkConfigManager(new Configuration())
                         .getDeployConfig(deployment.getMetadata(), deployment.getSpec()));
+        var reconStatus = deployment.getStatus().getReconciliationStatus();
 
-        assertFalse(deployment.getStatus().getReconciliationStatus().isFirstDeployment());
+        assertTrue(reconStatus.deserializeLastReconciledSpecWithMeta().f1.isFirstDeployment());
+        assertFalse(reconStatus.isBeforeFirstDeployment());
+
         observer.observe(deployment, TestUtils.createEmptyContext());
-        assertTrue(deployment.getStatus().getReconciliationStatus().isFirstDeployment());
+        assertTrue(reconStatus.isBeforeFirstDeployment());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/SessionJobObserverTest.java
@@ -352,8 +352,8 @@ public class SessionJobObserverTest {
 
         ReconciliationUtils.updateStatusBeforeDeploymentAttempt(sessionJob, new Configuration());
 
-        assertFalse(sessionJob.getStatus().getReconciliationStatus().isFirstDeployment());
+        assertFalse(sessionJob.getStatus().getReconciliationStatus().isBeforeFirstDeployment());
         observer.observe(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
-        assertTrue(sessionJob.getStatus().getReconciliationStatus().isFirstDeployment());
+        assertTrue(sessionJob.getStatus().getReconciliationStatus().isBeforeFirstDeployment());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -102,16 +102,37 @@ public class ApplicationReconcilerTest {
         reconciler.reconcile(deployment, context);
         var runningJobs = flinkService.listJobs();
         verifyAndSetRunningJobsToStatus(deployment, runningJobs);
+        assertTrue(
+                deployment
+                        .getStatus()
+                        .getReconciliationStatus()
+                        .deserializeLastReconciledSpecWithMeta()
+                        .f1
+                        .isFirstDeployment());
 
         // Test stateless upgrade
         FlinkDeployment statelessUpgrade = ReconciliationUtils.clone(deployment);
         statelessUpgrade.getSpec().getJob().setUpgradeMode(UpgradeMode.STATELESS);
         statelessUpgrade.getSpec().getFlinkConfiguration().put("new", "conf");
         reconciler.reconcile(statelessUpgrade, context);
+        assertFalse(
+                statelessUpgrade
+                        .getStatus()
+                        .getReconciliationStatus()
+                        .deserializeLastReconciledSpecWithMeta()
+                        .f1
+                        .isFirstDeployment());
 
         assertEquals(0, flinkService.getRunningCount());
 
         reconciler.reconcile(statelessUpgrade, context);
+        assertFalse(
+                statelessUpgrade
+                        .getStatus()
+                        .getReconciliationStatus()
+                        .deserializeLastReconciledSpecWithMeta()
+                        .f1
+                        .isFirstDeployment());
 
         runningJobs = flinkService.listJobs();
         assertEquals(1, flinkService.getRunningCount());


### PR DESCRIPTION
## What is the purpose of the change

Fixes a small flaw in the initialDeployment logic that made it useless after the job was actually submitted. This also simplifies code in other places.

## Brief change log

  - *Rename ReconStatus#isFirstDeployment to isBeforeFirstDeployment to better reflect logic*
  - *Fix reconciliation metadata isFirstDeployment computation*
  - *Add some tests*

## Verifying this change

Partly covered by existing tests + new tests added for the fixed logic

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes
  
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
