### PR TITLE
[FLINK-29109] Avoid checkpoint path conflicts (Flink < 1.16)

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -24,6 +24,7 @@ import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder;
@@ -150,6 +151,9 @@ public class TestingFlinkService extends AbstractFlinkService {
             throw new Exception("Cannot submit 2 application clusters at the same time");
         }
         JobID jobID = new JobID();
+        if (conf.contains(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID)) {
+            jobID = JobID.fromHexString(conf.get(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID));
+        }
         JobStatusMessage jobStatusMessage =
                 new JobStatusMessage(
                         jobID,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -17,11 +17,13 @@
 
 package org.apache.flink.kubernetes.operator.reconciler.deployment;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.configuration.SchedulerExecutionMode;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
@@ -103,6 +105,9 @@ public class ApplicationReconcilerTest {
         var runningJobs = flinkService.listJobs();
         verifyAndSetRunningJobsToStatus(deployment, runningJobs);
 
+        JobID jobId = runningJobs.get(0).f1.getJobId();
+        verifyJobId(deployment, runningJobs.get(0).f1, runningJobs.get(0).f2, jobId);
+
         // Test stateless upgrade
         FlinkDeployment statelessUpgrade = ReconciliationUtils.clone(deployment);
         statelessUpgrade.getSpec().getJob().setUpgradeMode(UpgradeMode.STATELESS);
@@ -117,10 +122,11 @@ public class ApplicationReconcilerTest {
         assertEquals(1, flinkService.getRunningCount());
         assertNull(runningJobs.get(0).f0);
 
-        deployment
-                .getStatus()
-                .getJobStatus()
-                .setJobId(runningJobs.get(0).f1.getJobId().toHexString());
+        assertNotEquals(
+                runningJobs.get(0).f2.get(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID), jobId);
+        jobId = runningJobs.get(0).f1.getJobId();
+
+        deployment.getStatus().getJobStatus().setJobId(jobId.toHexString());
 
         // Test stateful upgrade
         FlinkDeployment statefulUpgrade = ReconciliationUtils.clone(deployment);
@@ -144,6 +150,8 @@ public class ApplicationReconcilerTest {
                         .getSavepointInfo()
                         .getLastSavepoint()
                         .getTriggerType());
+
+        verifyJobId(deployment, runningJobs.get(0).f1, runningJobs.get(0).f2, jobId);
 
         deployment.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
         deployment.getSpec().setRestartNonce(100L);
@@ -187,6 +195,19 @@ public class ApplicationReconcilerTest {
 
         assertEquals(1, flinkService.getRunningCount());
         assertEquals("finished_sp", runningJobs.get(0).f0);
+        verifyJobId(deployment, runningJobs.get(0).f1, runningJobs.get(0).f2, jobId);
+    }
+
+    private void verifyJobId(
+            FlinkDeployment deployment, JobStatusMessage status, Configuration conf, JobID jobId) {
+        if (deployment.getSpec().getFlinkVersion().isNewerVersionThan(FlinkVersion.v1_15)) {
+            assertNull(conf.get(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID));
+        } else {
+            // jobId set by operator
+            assertEquals(jobId, status.getJobId());
+            assertEquals(
+                    conf.get(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID), jobId.toHexString());
+        }
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Automatically set jobId for Flink version < 1.16 to avoid conflicts in checkpoint path (and other jobId based effects).

## Brief change log

* Set a jobId when no jobID is defined by user and Flink version is < 1.16.
* Rotate jobId when upgrade mode is stateless

## Verifying this change

This change added tests and can be verified as follows:

Manual verification:
* No jobId set in Flink config
  * Set upgrade mode to stateless. Trigger CR changes and check that every redeploy uses a new ID.
  * Set upgrade mode to last_state. Trigger CR changes and check that ID does not change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / **no**)
  - Core observer or reconciler logic that is regularly executed: (**yes** / no)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
