### PR TITLE
[FLINK-29376] Set SHUTDOWN_ON_APPLICATION_FINISH to false only on 1.15 and above

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -150,7 +150,9 @@ public class FlinkConfigBuilder {
             }
 
             // We need to keep the application clusters around for proper operator behaviour
-            effectiveConfig.set(SHUTDOWN_ON_APPLICATION_FINISH, false);
+            if (spec.getFlinkVersion().isNewerVersionThan(FlinkVersion.v1_14)) {
+                effectiveConfig.set(SHUTDOWN_ON_APPLICATION_FINISH, false);
+            }
             if (HighAvailabilityMode.isHighAvailabilityModeActivated(effectiveConfig)) {
                 setDefaultConf(SUBMIT_FAILED_JOB_ON_APPLICATION_ERROR, true);
             }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.IngressSpec;
 import org.apache.flink.kubernetes.operator.crd.spec.KubernetesDeploymentMode;
 import org.apache.flink.kubernetes.operator.crd.spec.TaskManagerSpec;
@@ -51,6 +52,8 @@ import io.fabric8.kubernetes.api.model.Pod;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -60,6 +63,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.configuration.DeploymentOptions.SHUTDOWN_ON_APPLICATION_FINISH;
 import static org.apache.flink.kubernetes.operator.TestUtils.IMAGE;
 import static org.apache.flink.kubernetes.operator.TestUtils.IMAGE_POLICY;
 import static org.apache.flink.kubernetes.operator.TestUtils.SAMPLE_JAR;
@@ -161,6 +165,22 @@ public class FlinkConfigBuilderTest {
                         .applyFlinkConfiguration()
                         .build();
         Assertions.assertEquals(false, configuration.get(WebOptions.CANCEL_ENABLE));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FlinkVersion.class)
+    public void testApplyFlinkConfigurationShouldSetShutdownOnFinishBasedOnFlinkVersion(
+            FlinkVersion flinkVersion) {
+        flinkDeployment.getSpec().setFlinkVersion(flinkVersion);
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyFlinkConfiguration()
+                        .build();
+        if (flinkVersion.isNewerVersionThan(FlinkVersion.v1_14)) {
+            Assertions.assertFalse(configuration.getBoolean(SHUTDOWN_ON_APPLICATION_FINISH));
+        } else {
+            Assertions.assertTrue(configuration.getBoolean(SHUTDOWN_ON_APPLICATION_FINISH));
+        }
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

If the user incorrectly sets a Flink version lower than 1.15 when using 1.15 or above:
```
image: flink:1.15
  flinkVersion: v1_14
```
then a spec change ends-up in exception and restart loop. In this PR we set `SHUTDOWN_ON_APPLICATION_FINISH` to `false` when Flink version is less than 1.15.

## Brief change log

* Set `SHUTDOWN_ON_APPLICATION_FINISH` to false only on 1.15 and above
* Added unit test for all available Flink versions

## Verifying this change

* New unit test
* Manually
  * Deploy app where
  `image: flink:1.15 flinkVersion: v1_14`
  * Wait for RUNNING state
  * Change Flink config
  * Double check that Flink is re-deployed and in RUNNING state again

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
