### PR TITLE
[docs] Prometheus/Grafana credentials via command

### DIFF
--- a/docs/content/docs/operations/metrics-logging.md
+++ b/docs/content/docs/operations/metrics-logging.md
@@ -134,6 +134,12 @@ The Grafana dashboard can be accessed through port-forwarding:
 ```shell
 kubectl port-forward deployment/prometheus-grafana 3000
 ```
+The credentials for the dashboard can be retrieved by:
+```bash
+kubectl get secret prometheus-grafana -o jsonpath="{.data.admin-user}" | base64 --decode ; echo
+kubectl get secret prometheus-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
+```
+
 To enable the operator metrics in Prometheus create a `pod-monitor.yaml` file with the following content:
 ```yaml
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
## What is the purpose of the change

Provide an option to retrieve credentials for local prometheus/grafana setup

## Brief change log
  - Documentation updated
## Verifying this change
Manually
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no