### PR TITLE
[FLINK-29413] Make it possible to associate triggered and completed savepoints

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -274,6 +274,19 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | timeStamp | long | Millisecond timestamp at the start of the savepoint operation. |
 | location | java.lang.String | External pointer of the savepoint can be used to recover jobs. |
 | triggerType | org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType | Savepoint trigger mechanism. |
+| formatType | org.apache.flink.kubernetes.operator.crd.status.SavepointFormatType |  |
+| triggerNonce | java.lang.Long | Nonce value used when the savepoint was triggered manually {@link SavepointTriggerType#MANUAL}, defaults to 0. |
+
+### SavepointFormatType
+**Class**: org.apache.flink.kubernetes.operator.crd.status.SavepointFormatType
+
+**Description**: Savepoint format type.
+
+| Value | Docs |
+| ----- | ---- |
+| CANONICAL | A canonical, common for all state backends format. |
+| NATIVE | A format specific for the chosen state backend. |
+| UNKNOWN | Savepoint format unknown, if the savepoint was not triggered by the operator. |
 
 ### SavepointInfo
 **Class**: org.apache.flink.kubernetes.operator.crd.status.SavepointInfo
@@ -286,6 +299,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | triggerId | java.lang.String | Trigger id of a pending savepoint operation. |
 | triggerTimestamp | long | Trigger timestamp of a pending savepoint operation. |
 | triggerType | org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType | Savepoint trigger mechanism. |
+| formatType | org.apache.flink.kubernetes.operator.crd.status.SavepointFormatType |  |
 | savepointHistory | java.util.List<org.apache.flink.kubernetes.operator.crd.status.Savepoint> | List of recent savepoints. |
 | lastPeriodicSavepointTimestamp | long | Trigger timestamp of last periodic savepoint operation. |
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/Savepoint.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/Savepoint.java
@@ -19,14 +19,12 @@ package org.apache.flink.kubernetes.operator.crd.status;
 
 import org.apache.flink.annotation.Experimental;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** Represents information about a finished savepoint. */
 @Experimental
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class Savepoint {
     /** Millisecond timestamp at the start of the savepoint operation. */
@@ -38,7 +36,42 @@ public class Savepoint {
     /** Savepoint trigger mechanism. */
     private SavepointTriggerType triggerType = SavepointTriggerType.UNKNOWN;
 
-    public static Savepoint of(String location, SavepointTriggerType type) {
-        return new Savepoint(System.currentTimeMillis(), location, type);
+    private SavepointFormatType formatType = SavepointFormatType.UNKNOWN;
+
+    /**
+     * Nonce value used when the savepoint was triggered manually {@link
+     * SavepointTriggerType#MANUAL}, defaults to 0.
+     */
+    private Long triggerNonce = 0L;
+
+    public Savepoint(
+            long timeStamp,
+            String location,
+            SavepointTriggerType triggerType,
+            SavepointFormatType formatType,
+            Long triggerNonce) {
+        this.timeStamp = timeStamp;
+        this.location = location;
+        this.triggerType = triggerType;
+        this.formatType = formatType;
+        setTriggerNonce(triggerNonce);
+    }
+
+    public static Savepoint of(String location, SavepointTriggerType triggerType) {
+        return new Savepoint(
+                System.currentTimeMillis(), location, triggerType, SavepointFormatType.UNKNOWN, 0L);
+    }
+
+    public static Savepoint of(
+            String location, SavepointTriggerType triggerType, SavepointFormatType formatType) {
+        return new Savepoint(System.currentTimeMillis(), location, triggerType, formatType, 0L);
+    }
+
+    public void setTriggerNonce(Long triggerNonce) {
+        if (triggerNonce == null) {
+            this.triggerNonce = 0L;
+        } else {
+            this.triggerNonce = triggerNonce;
+        }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointFormatType.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointFormatType.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.crd.status;
+
+/** Savepoint format type. */
+public enum SavepointFormatType {
+
+    /** A canonical, common for all state backends format. */
+    CANONICAL,
+    /** A format specific for the chosen state backend. */
+    NATIVE,
+    /** Savepoint format unknown, if the savepoint was not triggered by the operator. */
+    UNKNOWN
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointInfo.java
@@ -46,16 +46,20 @@ public class SavepointInfo {
     /** Savepoint trigger mechanism. */
     private SavepointTriggerType triggerType = SavepointTriggerType.UNKNOWN;
 
+    private SavepointFormatType formatType = SavepointFormatType.UNKNOWN;
+
     /** List of recent savepoints. */
     private List<Savepoint> savepointHistory = new ArrayList<>();
 
     /** Trigger timestamp of last periodic savepoint operation. */
     private long lastPeriodicSavepointTimestamp = 0L;
 
-    public void setTrigger(String triggerId, SavepointTriggerType triggerType) {
+    public void setTrigger(
+            String triggerId, SavepointTriggerType triggerType, SavepointFormatType formatType) {
         this.triggerId = triggerId;
         this.triggerTimestamp = System.currentTimeMillis();
         this.triggerType = triggerType;
+        this.formatType = formatType;
     }
 
     public void resetTrigger() {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -26,6 +26,7 @@ import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.crd.status.CommonStatus;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
@@ -127,7 +128,11 @@ public class SavepointObserver<
                 new Savepoint(
                         savepointInfo.getTriggerTimestamp(),
                         savepointFetchResult.getLocation(),
-                        savepointInfo.getTriggerType());
+                        savepointInfo.getTriggerType(),
+                        savepointInfo.getFormatType(),
+                        SavepointTriggerType.MANUAL == savepointInfo.getTriggerType()
+                                ? resource.getSpec().getJob().getSavepointTriggerNonce()
+                                : null);
 
         ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(savepointInfo, resource);
         savepointInfo.updateLastSavepoint(savepoint);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -19,8 +19,10 @@ package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
@@ -34,6 +36,8 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
+
+import static org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder.FLINK_VERSION;
 
 /** Savepoint utilities. */
 public class SavepointUtils {
@@ -163,5 +167,16 @@ public class SavepointUtils {
         return SavepointTriggerType.PERIODIC == savepointInfo.getTriggerType()
                 ? "Periodic savepoint failed"
                 : "Savepoint failed for savepointTriggerNonce: " + triggerNonce;
+    }
+
+    public static SavepointFormatType getSavepointFormatType(Configuration configuration) {
+        var savepointFormatType = org.apache.flink.core.execution.SavepointFormatType.CANONICAL;
+        if (configuration.get(FLINK_VERSION) != null
+                && configuration.get(FLINK_VERSION).isNewerVersionThan(FlinkVersion.v1_14)) {
+            savepointFormatType =
+                    configuration.get(
+                            KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_FORMAT_TYPE);
+        }
+        return savepointFormatType;
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -37,6 +37,7 @@ import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointFormatType;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
@@ -44,6 +45,7 @@ import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
 import org.apache.flink.kubernetes.operator.service.AbstractFlinkService;
 import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfigOptionsInternal;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
+import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
@@ -127,6 +129,8 @@ public class TestingFlinkService extends AbstractFlinkService {
     public void clear() {
         jobs.clear();
         sessions.clear();
+        triggerCounter = 0;
+        savepointCounter = 0;
     }
 
     public Set<String> getSessions() {
@@ -253,7 +257,10 @@ public class TestingFlinkService extends AbstractFlinkService {
             SavepointInfo savepointInfo,
             Configuration conf) {
         var triggerId = "trigger_" + triggerCounter++;
-        savepointInfo.setTrigger(triggerId, triggerType);
+
+        var savepointFormatType = SavepointUtils.getSavepointFormatType(conf);
+        savepointInfo.setTrigger(
+                triggerId, triggerType, SavepointFormatType.valueOf(savepointFormatType.name()));
         savepointTriggers.put(triggerId, false);
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptio
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.Savepoint;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointFormatType;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
@@ -63,7 +64,9 @@ public class SavepointObserverTest {
         SavepointInfo spInfo = new SavepointInfo();
         Assertions.assertTrue(spInfo.getSavepointHistory().isEmpty());
 
-        Savepoint sp = new Savepoint(1, "sp1", SavepointTriggerType.MANUAL);
+        Savepoint sp =
+                new Savepoint(
+                        1, "sp1", SavepointTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
         spInfo.updateLastSavepoint(sp);
         observer.cleanupSavepointHistory(spInfo, configManager.getDefaultConfig());
 
@@ -81,7 +84,9 @@ public class SavepointObserverTest {
 
         SavepointInfo spInfo = new SavepointInfo();
 
-        Savepoint sp1 = new Savepoint(1, "sp1", SavepointTriggerType.MANUAL);
+        Savepoint sp1 =
+                new Savepoint(
+                        1, "sp1", SavepointTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
         spInfo.updateLastSavepoint(sp1);
         observer.cleanupSavepointHistory(spInfo, conf);
         Assertions.assertIterableEquals(
@@ -89,7 +94,9 @@ public class SavepointObserverTest {
         Assertions.assertIterableEquals(
                 Collections.emptyList(), flinkService.getDisposedSavepoints());
 
-        Savepoint sp2 = new Savepoint(2, "sp2", SavepointTriggerType.MANUAL);
+        Savepoint sp2 =
+                new Savepoint(
+                        2, "sp2", SavepointTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
         spInfo.updateLastSavepoint(sp2);
         observer.cleanupSavepointHistory(spInfo, conf);
         Assertions.assertIterableEquals(
@@ -110,7 +117,9 @@ public class SavepointObserverTest {
         configManager.updateDefaultConfig(conf);
         SavepointInfo spInfo = new SavepointInfo();
 
-        Savepoint sp1 = new Savepoint(1, "sp1", SavepointTriggerType.MANUAL);
+        Savepoint sp1 =
+                new Savepoint(
+                        1, "sp1", SavepointTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
         spInfo.updateLastSavepoint(sp1);
         observer.cleanupSavepointHistory(spInfo, conf);
         Assertions.assertIterableEquals(
@@ -118,7 +127,9 @@ public class SavepointObserverTest {
         Assertions.assertIterableEquals(
                 Collections.emptyList(), flinkService.getDisposedSavepoints());
 
-        Savepoint sp2 = new Savepoint(2, "sp2", SavepointTriggerType.MANUAL);
+        Savepoint sp2 =
+                new Savepoint(
+                        2, "sp2", SavepointTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
         spInfo.updateLastSavepoint(sp2);
         observer.cleanupSavepointHistory(spInfo, conf);
         Assertions.assertIterableEquals(
@@ -159,5 +170,6 @@ public class SavepointObserverTest {
         assertEquals(savepointInfo.getLastSavepoint(), savepointInfo.getSavepointHistory().get(0));
         assertEquals(
                 SavepointTriggerType.PERIODIC, savepointInfo.getLastSavepoint().getTriggerType());
+        assertEquals(0L, savepointInfo.getLastSavepoint().getTriggerNonce());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -24,10 +24,12 @@ import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.crd.spec.JobState;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.ReconciliationState;
+import org.apache.flink.kubernetes.operator.crd.status.SavepointFormatType;
 import org.apache.flink.kubernetes.operator.crd.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
@@ -46,8 +48,10 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_FORMAT_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -68,6 +72,7 @@ public class ApplicationObserverTest {
     public void before() {
         var eventRecorder = new EventRecorder(kubernetesClient, (r, e) -> {});
         observer = new ApplicationObserver(flinkService, configManager, eventRecorder);
+        flinkService.clear();
     }
 
     @Test
@@ -224,6 +229,8 @@ public class ApplicationObserverTest {
     @Test
     public void observeSavepoint() throws Exception {
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        Long timedOutNonce = 1L;
+        deployment.getSpec().getJob().setSavepointTriggerNonce(timedOutNonce);
         Configuration conf =
                 configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
         flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
@@ -283,17 +290,31 @@ public class ApplicationObserverTest {
                 kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
                         .list().getItems().stream()
                         .filter(e -> e.getReason().contains("SavepointError"))
+                        .filter(
+                                e ->
+                                        e.getMessage()
+                                                .equals(
+                                                        "Savepoint failed for savepointTriggerNonce: "
+                                                                + timedOutNonce))
                         .count());
         assertEquals(
                 1,
                 kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
                         .list().getItems().stream()
                         .filter(e -> e.getReason().contains("SavepointError"))
+                        .filter(
+                                e ->
+                                        e.getMessage()
+                                                .equals(
+                                                        "Savepoint failed for savepointTriggerNonce: "
+                                                                + timedOutNonce))
                         .collect(Collectors.toList())
                         .get(0)
                         .getCount());
 
         // savepoint success
+        Long firstNonce = 123L;
+        deployment.getSpec().getJob().setSavepointTriggerNonce(firstNonce);
         flinkService.triggerSavepoint(
                 deployment.getStatus().getJobStatus().getJobId(),
                 SavepointTriggerType.MANUAL,
@@ -313,9 +334,19 @@ public class ApplicationObserverTest {
                         .getSavepointInfo()
                         .getLastSavepoint()
                         .getLocation());
+        assertEquals(
+                firstNonce,
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .getLastSavepoint()
+                        .getTriggerNonce());
         assertFalse(SavepointUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
 
         // second attempt success
+        Long secondNonce = 456L;
+        deployment.getSpec().getJob().setSavepointTriggerNonce(secondNonce);
         flinkService.triggerSavepoint(
                 deployment.getStatus().getJobStatus().getJobId(),
                 SavepointTriggerType.MANUAL,
@@ -337,9 +368,19 @@ public class ApplicationObserverTest {
                         .getSavepointInfo()
                         .getLastSavepoint()
                         .getLocation());
+        assertEquals(
+                secondNonce,
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .getLastSavepoint()
+                        .getTriggerNonce());
         assertFalse(SavepointUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
 
         // application failure after checkpoint trigger
+        Long thirdNonce = 789L;
+        deployment.getSpec().getJob().setSavepointTriggerNonce(thirdNonce);
         flinkService.triggerSavepoint(
                 deployment.getStatus().getJobStatus().getJobId(),
                 SavepointTriggerType.MANUAL,
@@ -359,6 +400,14 @@ public class ApplicationObserverTest {
                         .getSavepointInfo()
                         .getLastSavepoint()
                         .getLocation());
+        assertEquals(
+                secondNonce,
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .getLastSavepoint()
+                        .getTriggerNonce());
         assertFalse(SavepointUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
 
         assertEquals(
@@ -366,12 +415,24 @@ public class ApplicationObserverTest {
                 kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
                         .list().getItems().stream()
                         .filter(e -> e.getReason().contains("SavepointError"))
+                        .filter(
+                                e ->
+                                        e.getMessage()
+                                                .equals(
+                                                        "Savepoint failed for savepointTriggerNonce: "
+                                                                + thirdNonce))
                         .count());
         assertEquals(
-                2,
+                1,
                 kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
                         .list().getItems().stream()
                         .filter(e -> e.getReason().contains("SavepointError"))
+                        .filter(
+                                e ->
+                                        e.getMessage()
+                                                .equals(
+                                                        "Savepoint failed for savepointTriggerNonce: "
+                                                                + thirdNonce))
                         .collect(Collectors.toList())
                         .get(0)
                         .getCount());
@@ -429,6 +490,118 @@ public class ApplicationObserverTest {
                         .getSavepointInfo()
                         .getSavepointHistory()
                         .size());
+    }
+
+    @Test
+    public void testSavepointFormat() throws Exception {
+        FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        Configuration conf =
+                configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        bringToReadyStatus(deployment);
+        assertTrue(ReconciliationUtils.isJobRunning(deployment.getStatus()));
+
+        // canonical savepoint
+        Long firstNonce = 123L;
+        deployment.getSpec().getJob().setSavepointTriggerNonce(firstNonce);
+        flinkService.triggerSavepoint(
+                deployment.getStatus().getJobStatus().getJobId(),
+                SavepointTriggerType.MANUAL,
+                deployment.getStatus().getJobStatus().getSavepointInfo(),
+                conf);
+
+        observer.observe(deployment, readyContext);
+        observer.observe(deployment, readyContext);
+        assertFalse(SavepointUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
+        assertEquals(
+                firstNonce,
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .getLastSavepoint()
+                        .getTriggerNonce());
+        assertEquals(
+                SavepointFormatType.CANONICAL,
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .getLastSavepoint()
+                        .getFormatType());
+
+        // native savepoint
+        Long secondNonce = 456L;
+        deployment.getSpec().getJob().setSavepointTriggerNonce(secondNonce);
+        deployment
+                .getSpec()
+                .setFlinkConfiguration(
+                        Map.of(
+                                OPERATOR_SAVEPOINT_FORMAT_TYPE.key(),
+                                org.apache.flink.core.execution.SavepointFormatType.NATIVE.name()));
+        conf = configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
+        flinkService.triggerSavepoint(
+                deployment.getStatus().getJobStatus().getJobId(),
+                SavepointTriggerType.MANUAL,
+                deployment.getStatus().getJobStatus().getSavepointInfo(),
+                conf);
+
+        observer.observe(deployment, readyContext);
+        observer.observe(deployment, readyContext);
+        assertFalse(SavepointUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
+        assertEquals(
+                secondNonce,
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .getLastSavepoint()
+                        .getTriggerNonce());
+        assertEquals(
+                SavepointFormatType.NATIVE,
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .getLastSavepoint()
+                        .getFormatType());
+
+        // canonical for flink savepoint
+        Long thirdNonce = 789L;
+        deployment.getSpec().getJob().setSavepointTriggerNonce(thirdNonce);
+        deployment.getSpec().setFlinkVersion(FlinkVersion.v1_14);
+        deployment
+                .getSpec()
+                .setFlinkConfiguration(
+                        Map.of(
+                                OPERATOR_SAVEPOINT_FORMAT_TYPE.key(),
+                                org.apache.flink.core.execution.SavepointFormatType.NATIVE.name()));
+        conf = configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
+        flinkService.triggerSavepoint(
+                deployment.getStatus().getJobStatus().getJobId(),
+                SavepointTriggerType.MANUAL,
+                deployment.getStatus().getJobStatus().getSavepointInfo(),
+                conf);
+
+        observer.observe(deployment, readyContext);
+        observer.observe(deployment, readyContext);
+        assertFalse(SavepointUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
+        assertEquals(
+                thirdNonce,
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .getLastSavepoint()
+                        .getTriggerNonce());
+        assertEquals(
+                SavepointFormatType.CANONICAL,
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .getLastSavepoint()
+                        .getFormatType());
     }
 
     private void bringToReadyStatus(FlinkDeployment deployment) {

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9162,6 +9162,14 @@ spec:
                             - UPGRADE
                             - UNKNOWN
                             type: string
+                          formatType:
+                            enum:
+                            - CANONICAL
+                            - NATIVE
+                            - UNKNOWN
+                            type: string
+                          triggerNonce:
+                            type: integer
                         type: object
                       triggerId:
                         type: string
@@ -9172,6 +9180,12 @@ spec:
                         - MANUAL
                         - PERIODIC
                         - UPGRADE
+                        - UNKNOWN
+                        type: string
+                      formatType:
+                        enum:
+                        - CANONICAL
+                        - NATIVE
                         - UNKNOWN
                         type: string
                       savepointHistory:
@@ -9188,6 +9202,14 @@ spec:
                               - UPGRADE
                               - UNKNOWN
                               type: string
+                            formatType:
+                              enum:
+                              - CANONICAL
+                              - NATIVE
+                              - UNKNOWN
+                              type: string
+                            triggerNonce:
+                              type: integer
                           type: object
                         type: array
                       lastPeriodicSavepointTimestamp:

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -112,6 +112,14 @@ spec:
                             - UPGRADE
                             - UNKNOWN
                             type: string
+                          formatType:
+                            enum:
+                            - CANONICAL
+                            - NATIVE
+                            - UNKNOWN
+                            type: string
+                          triggerNonce:
+                            type: integer
                         type: object
                       triggerId:
                         type: string
@@ -122,6 +130,12 @@ spec:
                         - MANUAL
                         - PERIODIC
                         - UPGRADE
+                        - UNKNOWN
+                        type: string
+                      formatType:
+                        enum:
+                        - CANONICAL
+                        - NATIVE
                         - UNKNOWN
                         type: string
                       savepointHistory:
@@ -138,6 +152,14 @@ spec:
                               - UPGRADE
                               - UNKNOWN
                               type: string
+                            formatType:
+                              enum:
+                              - CANONICAL
+                              - NATIVE
+                              - UNKNOWN
+                              type: string
+                            triggerNonce:
+                              type: integer
                           type: object
                         type: array
                       lastPeriodicSavepointTimestamp:


### PR DESCRIPTION
## What is the purpose of the change

Currently it is not clear how one would associate completed manual savepoints with savepointTriggerNonce-es when using the operator. This makes it difficult to track when a savepoint was completed vs when it was abandoned. This solution adds the `triggerNonce` to the completed checkpoint info for `MANUAL` savepoints. Furthermore, the solution adds the format type too that was used to trigger the savepoint.

## Brief change log

`Savepoint` class was extended by `triggerNonce` and `formatType` fields

## Verifying this change

- the change for `triggerNonce` is covered by changing existing unit test
- the change for `formatType` is covered by a new unit test
Manually by observing the `savepointInfo` in the CR:
```
savepointInfo:
  formatType: CANONICAL
  lastPeriodicSavepointTimestamp: 1664356683858
  lastSavepoint:
    formatType: CANONICAL
    location: file:/flink-data/savepoints/savepoint-000000-1e7bb345adb5
    savepointTriggerNonce: 0
    timeStamp: 1664356683858
    triggerType: PERIODIC
  savepointHistory:
  - formatType: NATIVE
    location: file:/flink-data/savepoints/savepoint-000000-a4d0f7e6c543
    savepointTriggerNonce: 0
    timeStamp: 1664356463272
    triggerType: PERIODIC
  - formatType: NATIVE
    location: file:/flink-data/savepoints/savepoint-000000-72f83aca3cdc
    savepointTriggerNonce: 0
    timeStamp: 1664356526828
    triggerType: PERIODIC
  - formatType: NATIVE
    location: file:/flink-data/savepoints/savepoint-000000-f79dc5960528
    savepointTriggerNonce: 0
    timeStamp: 1664356584902
    triggerType: UPGRADE
  - formatType: NATIVE
    location: file:/flink-data/savepoints/savepoint-000000-b3d031cc2754
    savepointTriggerNonce: 1
    timeStamp: 1664356617207
    triggerType: MANUAL
  - formatType: NATIVE
    location: file:/flink-data/savepoints/savepoint-000000-97f64ec65c39
    savepointTriggerNonce: 0
    timeStamp: 1664356620315
    triggerType: PERIODIC
  - formatType: CANONICAL
    location: file:/flink-data/savepoints/savepoint-000000-1e7bb345adb5
    savepointTriggerNonce: 0
    timeStamp: 1664356683858
    triggerType: PERIODIC
  triggerId: ""
  triggerTimestamp: 0
  triggerType: PERIODIC
```
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
API docs generated automatically
