### PR TITLE
[FLINK-29474] Fix global lifecycle metrics group to include resource type

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/LifecycleMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/LifecycleMetrics.java
@@ -160,7 +160,9 @@ public class LifecycleMetrics<CR extends AbstractFlinkResource<?, ?>>
                                 name ->
                                         Tuple2.of(
                                                 createTransitionHistogram(
-                                                        name, operatorMetricGroup),
+                                                        name,
+                                                        operatorMetricGroup.addGroup(
+                                                                cr.getClass().getSimpleName())),
                                                 new ConcurrentHashMap<>())));
 
         this.stateTimeMetrics = new ConcurrentHashMap<>();
@@ -168,7 +170,9 @@ public class LifecycleMetrics<CR extends AbstractFlinkResource<?, ?>>
             stateTimeMetrics.put(
                     state,
                     Tuple2.of(
-                            createStateTimeHistogram(state, operatorMetricGroup),
+                            createStateTimeHistogram(
+                                    state,
+                                    operatorMetricGroup.addGroup(cr.getClass().getSimpleName())),
                             new ConcurrentHashMap<>()));
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

Fix the metric group of the global lifecycle metric histograms to contain resource type and thus avoid collision.

## Brief change log

 - fix metric group
 - add test

## Verifying this change

Added new test to verify the groups

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
