### PR TITLE
[FLINK-29507] Make e2e tests independent of the current directory

### DIFF
--- a/e2e-tests/test_application_kubernetes_ha.sh
+++ b/e2e-tests/test_application_kubernetes_ha.sh
@@ -17,13 +17,14 @@
 # limitations under the License.
 ################################################################################
 
-source "$(dirname "$0")"/utils.sh
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_DIR}/utils.sh"
 
 CLUSTER_ID="flink-example-statemachine"
-APPLICATION_YAML="e2e-tests/data/flinkdep-cr.yaml"
+APPLICATION_YAML="${SCRIPT_DIR}/data/flinkdep-cr.yaml"
 TIMEOUT=300
 
-on_exit cleanup_and_exit $APPLICATION_YAML $TIMEOUT $CLUSTER_ID
+on_exit cleanup_and_exit "$APPLICATION_YAML" $TIMEOUT $CLUSTER_ID
 
 retry_times 5 30 "kubectl apply -f $APPLICATION_YAML" || exit 1
 

--- a/e2e-tests/test_application_operations.sh
+++ b/e2e-tests/test_application_operations.sh
@@ -20,14 +20,15 @@
 # This script tests the application job operations:
 # 1. Trigger savepoint
 # 2. last state mode upgrade
-source "$(dirname "$0")"/utils.sh
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_DIR}/utils.sh"
 
 CLUSTER_ID="flink-example-statemachine"
-APPLICATION_YAML="e2e-tests/data/flinkdep-cr.yaml"
+APPLICATION_YAML="${SCRIPT_DIR}/data/flinkdep-cr.yaml"
 APPLICATION_IDENTIFIER="flinkdep/$CLUSTER_ID"
 TIMEOUT=300
 
-on_exit cleanup_and_exit $APPLICATION_YAML $TIMEOUT $CLUSTER_ID
+on_exit cleanup_and_exit "$APPLICATION_YAML" $TIMEOUT $CLUSTER_ID
 
 retry_times 5 30 "kubectl apply -f $APPLICATION_YAML" || exit 1
 

--- a/e2e-tests/test_multi_sessionjob.sh
+++ b/e2e-tests/test_multi_sessionjob.sh
@@ -16,15 +16,16 @@
 # limitations under the License.
 #
 
-source "$(dirname "$0")"/utils.sh
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_DIR}/utils.sh"
 
 CLUSTER_ID="session-cluster-1"
-APPLICATION_YAML="e2e-tests/data/multi-sessionjob.yaml"
+APPLICATION_YAML="${SCRIPT_DIR}/data/multi-sessionjob.yaml"
 TIMEOUT=300
 SESSION_CLUSTER_IDENTIFIER="flinkdep/session-cluster-1"
 SESSION_JOB_IDENTIFIER="sessionjob/flink-example-statemachine"
 
-on_exit cleanup_and_exit $APPLICATION_YAML $TIMEOUT $CLUSTER_ID
+on_exit cleanup_and_exit "$APPLICATION_YAML" $TIMEOUT $CLUSTER_ID
 
 create_namespace flink
 retry_times 5 30 "kubectl apply -f $APPLICATION_YAML" || exit 1

--- a/e2e-tests/test_sessionjob_kubernetes_ha.sh
+++ b/e2e-tests/test_sessionjob_kubernetes_ha.sh
@@ -16,15 +16,16 @@
 # limitations under the License.
 #
 
-source "$(dirname "$0")"/utils.sh
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_DIR}/utils.sh"
 
 CLUSTER_ID="session-cluster-1"
-APPLICATION_YAML="e2e-tests/data/sessionjob-cr.yaml"
+APPLICATION_YAML="${SCRIPT_DIR}/data/sessionjob-cr.yaml"
 TIMEOUT=300
 SESSION_CLUSTER_IDENTIFIER="flinkdep/session-cluster-1"
 SESSION_JOB_IDENTIFIER="sessionjob/flink-example-statemachine"
 
-on_exit cleanup_and_exit $APPLICATION_YAML $TIMEOUT $CLUSTER_ID
+on_exit cleanup_and_exit "$APPLICATION_YAML" $TIMEOUT $CLUSTER_ID
 
 retry_times 5 30 "kubectl apply -f $APPLICATION_YAML" || exit 1
 

--- a/e2e-tests/test_sessionjob_operations.sh
+++ b/e2e-tests/test_sessionjob_operations.sh
@@ -20,17 +20,18 @@
 # This script tests the session job operations:
 # 1. Trigger savepoint
 # 2. savepoint mode upgrade
-source "$(dirname "$0")"/utils.sh
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_DIR}/utils.sh"
 
 CLUSTER_ID="session-cluster-1"
-APPLICATION_YAML="e2e-tests/data/sessionjob-cr.yaml"
+APPLICATION_YAML="${SCRIPT_DIR}/data/sessionjob-cr.yaml"
 TIMEOUT=300
 SESSION_CLUSTER_IDENTIFIER="flinkdep/$CLUSTER_ID"
 SESSION_JOB_NAME="flink-example-statemachine"
 SESSION_JOB_IDENTIFIER="sessionjob/$SESSION_JOB_NAME"
 OPERATOR_POD_LABEL="app.kubernetes.io/name=flink-kubernetes-operator"
 
-on_exit cleanup_and_exit $APPLICATION_YAML $TIMEOUT $CLUSTER_ID
+on_exit cleanup_and_exit "$APPLICATION_YAML" $TIMEOUT $CLUSTER_ID
 
 retry_times 5 30 "kubectl apply -f $APPLICATION_YAML" || exit 1
 


### PR DESCRIPTION
## What is the purpose of the change

Currently e2e tests can be executed only from the main directory of the operator repo. In this PR I've made it current directory independent.

## Brief change log

I've made e2e tests current directory independent.

## Verifying this change

Executing all e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
