### PR TITLE
[FLINK-29619] Remove redundant MeterView updater thread from KubernetesClientMetrics

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesClientMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesClientMetrics.java
@@ -32,8 +32,6 @@ import okhttp3.Response;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 /** Kubernetes client metrics. */
 public class KubernetesClientMetrics implements Interceptor {
@@ -90,9 +88,6 @@ public class KubernetesClientMetrics implements Interceptor {
         this.responseLatency =
                 responseMetricGroup.histogram(
                         HISTO, OperatorMetricUtils.createHistogram(flinkOperatorConfiguration));
-
-        Executors.newSingleThreadScheduledExecutor()
-                .scheduleAtFixedRate(this::updateMeters, 0, 1, TimeUnit.SECONDS);
     }
 
     @Override
@@ -139,11 +134,5 @@ public class KubernetesClientMetrics implements Interceptor {
                 key ->
                         OperatorMetricUtils.synchronizedCounter(
                                 responseMetricGroup.addGroup(key).counter(COUNTER)));
-    }
-
-    private void updateMeters() {
-        this.requestRateMeter.update();
-        this.requestFailedRateMeter.update();
-        this.responseRateMeter.update();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesClientMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesClientMetricsTest.java
@@ -22,9 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
-import org.apache.flink.metrics.testutils.MetricListener;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
@@ -53,7 +51,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestMethodOrder(OrderAnnotation.class)
 public class KubernetesClientMetricsTest {
     private KubernetesMockServer mockServer;
-    private final MetricListener listener = new MetricListener();
 
     private static final String REQUEST_COUNTER_ID =
             String.join(".", KUBE_CLIENT_GROUP, HTTP_REQUEST_GROUP, COUNTER);
@@ -83,65 +80,154 @@ public class KubernetesClientMetricsTest {
     @Test
     @Order(1)
     public void testMetricsDisabled() {
+        var configuration = new Configuration();
+        configuration.set(
+                KubernetesOperatorMetricOptions.OPERATOR_KUBERNETES_CLIENT_METRICS_ENABLED, false);
+        var flinkConfigManager = new FlinkConfigManager(configuration);
+        var listener = new TestingMetricListener(flinkConfigManager.getDefaultConfig());
+        var kubernetesClient =
+                KubernetesClientUtils.getKubernetesClient(
+                        flinkConfigManager.getOperatorConfiguration(),
+                        listener.getMetricGroup(),
+                        mockServer.createClient().getConfiguration());
+
         var deployment = TestUtils.buildApplicationCluster();
-        KubernetesClient noMetricsClient = getKubernetesClient(false);
-        noMetricsClient.resource(deployment).get();
-        assertFalse(listener.getCounter(REQUEST_COUNTER_ID).isPresent());
-        assertFalse(listener.getMeter(REQUEST_METER_ID).isPresent());
-        assertFalse(listener.getCounter(REQUEST_FAILED_COUNTER_ID).isPresent());
-        assertFalse(listener.getMeter(REQUEST_FAILED_METER_ID).isPresent());
-        assertFalse(listener.getCounter(RESPONSE_COUNTER_ID).isPresent());
-        assertFalse(listener.getMeter(RESPONSE_METER_ID).isPresent());
-        assertFalse(listener.getHistogram(RESPONSE_LATENCY_ID).isPresent());
-        assertFalse(listener.getHistogram(RESPONSE_LATENCY_ID).isPresent());
+        kubernetesClient.resource(deployment).get();
+        assertFalse(listener.getCounter(listener.getMetricId(REQUEST_COUNTER_ID)).isPresent());
+        assertFalse(listener.getMeter(listener.getMetricId(REQUEST_METER_ID)).isPresent());
+        assertFalse(
+                listener.getCounter(listener.getMetricId(REQUEST_FAILED_COUNTER_ID)).isPresent());
+        assertFalse(listener.getMeter(listener.getMetricId(REQUEST_FAILED_METER_ID)).isPresent());
+        assertFalse(listener.getCounter(listener.getMetricId(RESPONSE_COUNTER_ID)).isPresent());
+        assertFalse(listener.getMeter(listener.getMetricId(RESPONSE_METER_ID)).isPresent());
+        assertFalse(listener.getHistogram(listener.getMetricId(RESPONSE_LATENCY_ID)).isPresent());
+        assertFalse(listener.getHistogram(listener.getMetricId(RESPONSE_LATENCY_ID)).isPresent());
     }
 
     @Test
     @Order(2)
     public void testMetricsEnabled() {
-        KubernetesClient kubernetesClient = getKubernetesClient(true);
+        var flinkConfigManager = new FlinkConfigManager(new Configuration());
+        var listener = new TestingMetricListener(flinkConfigManager.getDefaultConfig());
+        var kubernetesClient =
+                KubernetesClientUtils.getKubernetesClient(
+                        flinkConfigManager.getOperatorConfiguration(),
+                        listener.getMetricGroup(),
+                        mockServer.createClient().getConfiguration());
+
         var deployment = TestUtils.buildApplicationCluster();
-        assertEquals(0, listener.getCounter(REQUEST_COUNTER_ID).get().getCount());
-        assertEquals(0.0, listener.getMeter(REQUEST_METER_ID).get().getRate());
-        assertEquals(0, listener.getCounter(REQUEST_FAILED_COUNTER_ID).get().getCount());
-        assertEquals(0.0, listener.getMeter(REQUEST_FAILED_METER_ID).get().getRate());
-        assertEquals(0, listener.getCounter(RESPONSE_COUNTER_ID).get().getCount());
-        assertEquals(0.0, listener.getMeter(RESPONSE_METER_ID).get().getRate());
-        assertEquals(0, listener.getHistogram(RESPONSE_LATENCY_ID).get().getStatistics().getMin());
-        assertEquals(0, listener.getHistogram(RESPONSE_LATENCY_ID).get().getStatistics().getMax());
+        assertEquals(
+                0, listener.getCounter(listener.getMetricId(REQUEST_COUNTER_ID)).get().getCount());
+        assertEquals(
+                0.0, listener.getMeter(listener.getMetricId(REQUEST_METER_ID)).get().getRate());
+        assertEquals(
+                0,
+                listener.getCounter(listener.getMetricId(REQUEST_FAILED_COUNTER_ID))
+                        .get()
+                        .getCount());
+        assertEquals(
+                0.0,
+                listener.getMeter(listener.getMetricId(REQUEST_FAILED_METER_ID)).get().getRate());
+        assertEquals(
+                0, listener.getCounter(listener.getMetricId(RESPONSE_COUNTER_ID)).get().getCount());
+        assertEquals(
+                0.0, listener.getMeter(listener.getMetricId(RESPONSE_METER_ID)).get().getRate());
+        assertEquals(
+                0,
+                listener.getHistogram(listener.getMetricId(RESPONSE_LATENCY_ID))
+                        .get()
+                        .getStatistics()
+                        .getMin());
+        assertEquals(
+                0,
+                listener.getHistogram(listener.getMetricId(RESPONSE_LATENCY_ID))
+                        .get()
+                        .getStatistics()
+                        .getMax());
 
         kubernetesClient.resource(deployment).createOrReplace();
-        assertEquals(1, listener.getCounter(REQUEST_COUNTER_ID).get().getCount());
-        assertEquals(1, listener.getCounter(REQUEST_POST_COUNTER_ID).get().getCount());
-        assertEquals(1, listener.getCounter(RESPONSE_COUNTER_ID).get().getCount());
-        assertEquals(1, listener.getCounter(RESPONSE_200_COUNTER_ID).get().getCount());
-        assertTrue(listener.getHistogram(RESPONSE_LATENCY_ID).get().getStatistics().getMin() > 0);
-        assertTrue(listener.getHistogram(RESPONSE_LATENCY_ID).get().getStatistics().getMax() > 0);
+        assertEquals(
+                1, listener.getCounter(listener.getMetricId(REQUEST_COUNTER_ID)).get().getCount());
+        assertEquals(
+                1,
+                listener.getCounter(listener.getMetricId(REQUEST_POST_COUNTER_ID))
+                        .get()
+                        .getCount());
+        assertEquals(
+                1, listener.getCounter(listener.getMetricId(RESPONSE_COUNTER_ID)).get().getCount());
+        assertEquals(
+                1,
+                listener.getCounter(listener.getMetricId(RESPONSE_200_COUNTER_ID))
+                        .get()
+                        .getCount());
+        assertTrue(
+                listener.getHistogram(listener.getMetricId(RESPONSE_LATENCY_ID))
+                                .get()
+                                .getStatistics()
+                                .getMin()
+                        > 0);
+        assertTrue(
+                listener.getHistogram(listener.getMetricId(RESPONSE_LATENCY_ID))
+                                .get()
+                                .getStatistics()
+                                .getMax()
+                        > 0);
 
         kubernetesClient.resource(deployment).delete();
-        assertEquals(1, listener.getCounter(REQUEST_DELETE_COUNTER_ID).get().getCount());
+        assertEquals(
+                1,
+                listener.getCounter(listener.getMetricId(REQUEST_DELETE_COUNTER_ID))
+                        .get()
+                        .getCount());
 
         kubernetesClient.resource(deployment).delete();
-        assertEquals(2, listener.getCounter(REQUEST_DELETE_COUNTER_ID).get().getCount());
-        assertEquals(1, listener.getCounter(RESPONSE_404_COUNTER_ID).get().getCount());
+        assertEquals(
+                2,
+                listener.getCounter(listener.getMetricId(REQUEST_DELETE_COUNTER_ID))
+                        .get()
+                        .getCount());
+        assertEquals(
+                1,
+                listener.getCounter(listener.getMetricId(RESPONSE_404_COUNTER_ID))
+                        .get()
+                        .getCount());
         Awaitility.await()
                 .atMost(1, TimeUnit.MINUTES)
                 .until(
                         () -> {
                             kubernetesClient.resource(deployment).createOrReplace();
-                            return listener.getMeter(REQUEST_METER_ID).get().getRate() > 0.1
-                                    && listener.getMeter(RESPONSE_METER_ID).get().getRate() > 0.1;
+                            return listener.getMeter(listener.getMetricId(REQUEST_METER_ID))
+                                                    .get()
+                                                    .getRate()
+                                            > 0.01
+                                    && listener.getMeter(listener.getMetricId(RESPONSE_METER_ID))
+                                                    .get()
+                                                    .getRate()
+                                            > 0.01;
                         });
     }
 
     @Test
     @Order(3)
     public void testAPIServerIsDown() {
+        var flinkConfigManager = new FlinkConfigManager(new Configuration());
+        var listener = new TestingMetricListener(flinkConfigManager.getDefaultConfig());
+        var kubernetesClient =
+                KubernetesClientUtils.getKubernetesClient(
+                        flinkConfigManager.getOperatorConfiguration(),
+                        listener.getMetricGroup(),
+                        mockServer.createClient().getConfiguration());
+
         var deployment = TestUtils.buildApplicationCluster();
-        KubernetesClient kubernetesClient = getKubernetesClient(true);
         mockServer.shutdown();
-        assertEquals(0, listener.getCounter(REQUEST_FAILED_COUNTER_ID).get().getCount());
-        assertEquals(0.0, listener.getMeter(REQUEST_FAILED_METER_ID).get().getRate());
+        assertEquals(
+                0,
+                listener.getCounter(listener.getMetricId(REQUEST_FAILED_COUNTER_ID))
+                        .get()
+                        .getCount());
+        assertEquals(
+                0.0,
+                listener.getMeter(listener.getMetricId(REQUEST_FAILED_METER_ID)).get().getRate());
         Awaitility.await()
                 .atMost(1, TimeUnit.MINUTES)
                 .until(
@@ -149,22 +235,18 @@ public class KubernetesClientMetricsTest {
                             assertThrows(
                                     KubernetesClientException.class,
                                     () -> kubernetesClient.resource(deployment).createOrReplace());
-                            return listener.getCounter(REQUEST_FAILED_COUNTER_ID).get().getCount()
+                            return listener.getCounter(
+                                                            listener.getMetricId(
+                                                                    REQUEST_FAILED_COUNTER_ID))
+                                                    .get()
+                                                    .getCount()
                                             > 0
-                                    && listener.getMeter(REQUEST_FAILED_METER_ID).get().getRate()
-                                            > 0.1;
+                                    && listener.getMeter(
+                                                            listener.getMetricId(
+                                                                    REQUEST_FAILED_METER_ID))
+                                                    .get()
+                                                    .getRate()
+                                            > 0.01;
                         });
-    }
-
-    private KubernetesClient getKubernetesClient(boolean enableMetrics) {
-        var configuration = new Configuration();
-        configuration.setBoolean(
-                KubernetesOperatorMetricOptions.OPERATOR_KUBERNETES_CLIENT_METRICS_ENABLED,
-                enableMetrics);
-        var configManager = new FlinkConfigManager(configuration);
-        return KubernetesClientUtils.getKubernetesClient(
-                configManager.getOperatorConfiguration(),
-                listener.getMetricGroup(),
-                mockServer.createClient().getConfiguration());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The `KubernetesClientMetrics` class has a redundant background thread that periodically updates the `MeterView` metrics. However the `MetricRegistryImpl` already has a built in solution for this.

## Brief change log
  - Removed the periodic updater from `KubernetesClientMetrics`
  - Updated the `TestingMetricListener` to follow the logic implemented in `MetricRegistryImpl`
  - Updated the `KubernetesClientMetricsTest` to use the `TestingMetricListener`
## Verifying this change
  - Covered by existing unit tests
  - Verified manually
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
