### PR TITLE
[FLINK-29633] Pass fromSavepoint argument

### DIFF
--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
@@ -80,9 +80,8 @@ public class CmdStandaloneJobManagerDecorator extends AbstractKubernetesStepDeco
         }
 
         Boolean allowNonRestoredState = kubernetesJobManagerParameters.getAllowNonRestoredState();
-        if (allowNonRestoredState != null) {
+        if (allowNonRestoredState != null && allowNonRestoredState) {
             args.add("--allowNonRestoredState");
-            args.add(allowNonRestoredState.toString());
         }
 
         String savepointPath = kubernetesJobManagerParameters.getSavepointPath();

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
@@ -85,6 +85,12 @@ public class CmdStandaloneJobManagerDecorator extends AbstractKubernetesStepDeco
             args.add(allowNonRestoredState.toString());
         }
 
+        String savepointPath = kubernetesJobManagerParameters.getSavepointPath();
+        if (savepointPath != null) {
+            args.add("--fromSavepoint");
+            args.add(savepointPath);
+        }
+
         List<String> jobSpecArgs = kubernetesJobManagerParameters.getJobSpecArgs();
         if (jobSpecArgs != null) {
             args.addAll(kubernetesJobManagerParameters.getJobSpecArgs());

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
@@ -90,6 +90,13 @@ public class StandaloneKubernetesJobManagerParameters extends KubernetesJobManag
         return null;
     }
 
+    public String getSavepointPath() {
+        if (flinkConfig.contains(SavepointConfigOptions.SAVEPOINT_PATH)) {
+            return flinkConfig.get(SavepointConfigOptions.SAVEPOINT_PATH);
+        }
+        return null;
+    }
+
     public boolean isPipelineClasspathDefined() {
         return flinkConfig.contains(PipelineOptions.CLASSPATHS);
     }

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
@@ -75,7 +75,7 @@ public class CmdStandaloneJobManagerDecoratorTest {
                 StandaloneKubernetesConfigOptionsInternal.CLUSTER_MODE,
                 StandaloneKubernetesConfigOptionsInternal.ClusterMode.APPLICATION);
         configuration.set(ApplicationConfiguration.APPLICATION_MAIN_CLASS, testMainClass);
-        configuration.set(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, false);
+        configuration.set(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, true);
         configuration.set(SavepointConfigOptions.SAVEPOINT_PATH, "/tmp/savepoint/path");
 
         FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
@@ -86,7 +86,6 @@ public class CmdStandaloneJobManagerDecoratorTest {
                 containsInAnyOrder(
                         CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG,
                         "--allowNonRestoredState",
-                        "false",
                         "--fromSavepoint",
                         "/tmp/savepoint/path",
                         "--job-classname",

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
@@ -76,6 +76,7 @@ public class CmdStandaloneJobManagerDecoratorTest {
                 StandaloneKubernetesConfigOptionsInternal.ClusterMode.APPLICATION);
         configuration.set(ApplicationConfiguration.APPLICATION_MAIN_CLASS, testMainClass);
         configuration.set(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, false);
+        configuration.set(SavepointConfigOptions.SAVEPOINT_PATH, "/tmp/savepoint/path");
 
         FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
         assertThat(
@@ -86,6 +87,8 @@ public class CmdStandaloneJobManagerDecoratorTest {
                         CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG,
                         "--allowNonRestoredState",
                         "false",
+                        "--fromSavepoint",
+                        "/tmp/savepoint/path",
                         "--job-classname",
                         testMainClass));
     }


### PR DESCRIPTION
## What is the purpose of the change

Passing `initialSavepointPath` from the JobSpec as a `fromSavepoint` argument in the standalone mode.

## Brief change log

- Updated `StandaloneKubernetesJobManagerParameters` to include savepoint path.
- Updated `CmdStandaloneJobManagerDecorator` to pass that as `fromSavepoint`.
- Also dropping the boolean parameter for the `allowNonRestoredState` flag: Flink may not parse it properly.

## Verifying this change

- Modified `CmdStandaloneJobManagerDecoratorTest` to confirm the argument is passed properly.
- Confirmed it's working after deploying to an internal staging environment.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
