### PR TITLE
[FLINK-29633] Backport to 1.2

### DIFF
--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
@@ -80,9 +80,14 @@ public class CmdStandaloneJobManagerDecorator extends AbstractKubernetesStepDeco
         }
 
         Boolean allowNonRestoredState = kubernetesJobManagerParameters.getAllowNonRestoredState();
-        if (allowNonRestoredState != null) {
+        if (allowNonRestoredState != null && allowNonRestoredState) {
             args.add("--allowNonRestoredState");
-            args.add(allowNonRestoredState.toString());
+        }
+
+        String savepointPath = kubernetesJobManagerParameters.getSavepointPath();
+        if (savepointPath != null) {
+            args.add("--fromSavepoint");
+            args.add(savepointPath);
         }
 
         List<String> jobSpecArgs = kubernetesJobManagerParameters.getJobSpecArgs();

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
@@ -90,6 +90,13 @@ public class StandaloneKubernetesJobManagerParameters extends KubernetesJobManag
         return null;
     }
 
+    public String getSavepointPath() {
+        if (flinkConfig.contains(SavepointConfigOptions.SAVEPOINT_PATH)) {
+            return flinkConfig.get(SavepointConfigOptions.SAVEPOINT_PATH);
+        }
+        return null;
+    }
+
     public boolean isPipelineClasspathDefined() {
         return flinkConfig.contains(PipelineOptions.CLASSPATHS);
     }

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
@@ -75,7 +75,8 @@ public class CmdStandaloneJobManagerDecoratorTest {
                 StandaloneKubernetesConfigOptionsInternal.CLUSTER_MODE,
                 StandaloneKubernetesConfigOptionsInternal.ClusterMode.APPLICATION);
         configuration.set(ApplicationConfiguration.APPLICATION_MAIN_CLASS, testMainClass);
-        configuration.set(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, false);
+        configuration.set(SavepointConfigOptions.SAVEPOINT_IGNORE_UNCLAIMED_STATE, true);
+        configuration.set(SavepointConfigOptions.SAVEPOINT_PATH, "/tmp/savepoint/path");
 
         FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
         assertThat(
@@ -85,7 +86,8 @@ public class CmdStandaloneJobManagerDecoratorTest {
                 containsInAnyOrder(
                         CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG,
                         "--allowNonRestoredState",
-                        "false",
+                        "--fromSavepoint",
+                        "/tmp/savepoint/path",
                         "--job-classname",
                         testMainClass));
     }


### PR DESCRIPTION
Backporting https://github.com/apache/flink-kubernetes-operator/pull/403 to the 1.2 release branch.