### PR TITLE
[FLINK-29694] Support tolerations in helm template for flink operator deployment

### DIFF
--- a/docs/content/docs/operations/helm.md
+++ b/docs/content/docs/operations/helm.md
@@ -70,6 +70,7 @@ The configurable parameters of the Helm chart and which default values as detail
 | operatorPod.env | Custom env to be added to the operator pod. | |
 | operatorPod.dnsPolicy | DNS policy to be used by the operator pod. | |
 | operatorPod.dnsConfig | DNS configuration to be used by the operator pod. | |
+| operatorPod.tolerations | Custom tolerations to be added to the operator pod. | |
 | operatorServiceAccount.create | Whether to enable operator service account to create for flink-kubernetes-operator. | true |
 | operatorServiceAccount.annotations | The annotations of operator service account. | |
 | operatorServiceAccount.name | The name of operator service account. | flink-operator |

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -52,6 +52,10 @@ spec:
       {{- if .Values.operatorPod.nodeSelector }}
       nodeSelector: {{ toYaml .Values.operatorPod.nodeSelector | nindent 8 }}
       {{- end }}
+      {{- with .Values.operatorPod.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -60,6 +60,9 @@ operatorPod:
   # Node labels for operator pod assignment
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   nodeSelector: {}
+  # Node tolerations for operator pod assignment
+  # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+  tolerations: []
 
 
 operatorServiceAccount:


### PR DESCRIPTION
## What is the purpose of the change

Support for `tolerations` in helm chart to allow operator pod to tolerate nodes with taints

## Brief change log

  - Add tolerations in operator deployment manifest

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

Tested with `helm template` to ensure `tolerations` is added to the operator's deploymentSpec when `tolerations` is set in the `values.yaml` file

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
