### PR TITLE
[FLINK-29695] Create a utility to report the status of the last savep…

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/crd/status/SavepointStatus.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.crd.status;
+
+/** Enum encapsulating the lifecycle state of a Flink resource. */
+public enum SavepointStatus {
+    /** Savepoint is pending, could be in the retry phase in the case of manual savepoint. */
+    PENDING,
+    /** Savepoint is completed successfully. */
+    SUCCEEDED,
+    /** Manual savepoint is abandoned after defined retries. */
+    ABANDONED
+}


### PR DESCRIPTION
…oint


## What is the purpose of the change

https://issues.apache.org/jira/browse/FLINK-29695
Users want to know the status of last savepoint, especially for manually triggered ones, to manage savepoints.
Currently, users can infer the status of the last savepoint (PENDING, SUCCEEDED and ABANDONED) from jobStatus.triggerId, lastSavepoint.triggerNonce, spec.job.savepointTriggerNonce and savepointTriggerNonce from last reconciliation. If the last savepoint is not manually triggered, there is no ABANDONED status, only PENDING or SUCCEEDED.
Creating a utility will encapsulate the internal logic of Flink operator guard against regression by any future version changes.

## Brief change log
- Added SavepointStatus class and getLastSavepointStatus method to SavepointUtils
## Verifying this change
Added verification of savepoint status in existing SavepointOserverTests and ApplicationReconcilerTests for manual and non-manual savepoints for all types of SavepointStatus
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: No
  - Core observer or reconciler logic that is regularly executed: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? No
