### PR TITLE
[FLINK-29713] Kubernetes operator should restart failed jobs

### DIFF
--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -241,6 +241,21 @@ In order this feature to work one must enable [recovery of missing job deploymen
 At the moment deployment is considered unhealthy when Flink's restarts count reaches `kubernetes.operator.cluster.health-check.restarts.threshold` (default: `64`)
 within time window of `kubernetes.operator.cluster.health-check.restarts.window` (default: 2 minutes).
 
+## Restart failed job deployments
+
+The operator can restart a failed Flink cluster deployment. This could be useful in cases when the job main task is
+able to reconfigure the job to handle these failures.
+
+For example a job could dynamically create the DAG based on some job configuration which job configuration could
+change over time. When a task detects a record which could not be handled with the current configuration then the task
+should throw a `SuppressRestartsException` to fail the job. If `kubernetes.operator.cluster.restart.failed` is set to 
+`true` (default: `false`) then the operator detects the failed job and restarts it. When the job restarts then it reads
+the new job configuration and creates the new DAG based on this new configuration. The new deployment could handle the
+incoming records and no manual intervention is needed.
+
+When this configuration is set to `true` then at the moment when the deployment status is set to `FAILED` the kubernetes
+operator will delete the current deployment and redeploys the application using the latest successful checkpoint.
+
 ## Application upgrade rollbacks (Experimental)
 
 The operator supports upgrade rollbacks as an experimental feature.

--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -243,18 +243,12 @@ within time window of `kubernetes.operator.cluster.health-check.restarts.window`
 
 ## Restart failed job deployments
 
-The operator can restart a failed Flink cluster deployment. This could be useful in cases when the job main task is
+The operator can restart a failed Flink job. This could be useful in cases when the job main task is
 able to reconfigure the job to handle these failures.
 
-For example a job could dynamically create the DAG based on some job configuration which job configuration could
-change over time. When a task detects a record which could not be handled with the current configuration then the task
-should throw a `SuppressRestartsException` to fail the job. If `kubernetes.operator.cluster.restart.failed` is set to 
-`true` (default: `false`) then the operator detects the failed job and restarts it. When the job restarts then it reads
-the new job configuration and creates the new DAG based on this new configuration. The new deployment could handle the
-incoming records and no manual intervention is needed.
-
-When this configuration is set to `true` then at the moment when the deployment status is set to `FAILED` the kubernetes
-operator will delete the current deployment and redeploys the application using the latest successful checkpoint.
+When `kubernetes.operator.job.restart.failed` is set to `true` then at the moment when the job status is
+set to `FAILED` the kubernetes operator will delete the current job and redeploy the job using the
+latest successful checkpoint.
 
 ## Application upgrade rollbacks (Experimental)
 

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -27,6 +27,12 @@
             <td>The duration of the time window where job restart count measured.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.cluster.restart.failed</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to restart healthy clusters on failed jobs.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.deployment.readiness.timeout</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -27,12 +27,6 @@
             <td>The duration of the time window where job restart count measured.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.cluster.restart.failed</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to restart healthy clusters on failed jobs.</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.deployment.readiness.timeout</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
@@ -49,6 +43,12 @@
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Whether to enable recovery of missing/deleted jobmanager deployments.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.job.restart.failed</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to restart failed jobs.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.upgrade.ignore-pending-savepoint</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -27,6 +27,12 @@
             <td>The duration of the time window where job restart count measured.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.cluster.restart.failed</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to restart healthy clusters on failed jobs.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.config.cache.size</h5></td>
             <td style="word-wrap: break-word;">1000</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -27,12 +27,6 @@
             <td>The duration of the time window where job restart count measured.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.cluster.restart.failed</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Whether to restart healthy clusters on failed jobs.</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.config.cache.size</h5></td>
             <td style="word-wrap: break-word;">1000</td>
             <td>Integer</td>
@@ -103,6 +97,12 @@
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Whether to enable recovery of missing/deleted jobmanager deployments.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.job.restart.failed</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to restart failed jobs.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.upgrade.ignore-pending-savepoint</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -339,4 +339,11 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "The threshold which is checked against job restart count within a configured window. "
                                     + "If the restart count is reaching the threshold then full cluster restart is initiated.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> OPERATOR_CLUSTER_RESTART_FAILED =
+            operatorConfig("cluster.restart.failed")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether to restart healthy clusters on failed jobs.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -341,9 +341,9 @@ public class KubernetesOperatorConfigOptions {
                                     + "If the restart count is reaching the threshold then full cluster restart is initiated.");
 
     @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<Boolean> OPERATOR_CLUSTER_RESTART_FAILED =
-            operatorConfig("cluster.restart.failed")
+    public static final ConfigOption<Boolean> OPERATOR_JOB_RESTART_FAILED =
+            operatorConfig("job.restart.failed")
                     .booleanType()
                     .defaultValue(false)
-                    .withDescription("Whether to restart healthy clusters on failed jobs.");
+                    .withDescription("Whether to restart failed jobs.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -246,7 +246,7 @@ public abstract class AbstractJobReconciler<
         if (jobStatus == org.apache.flink.api.common.JobStatus.FAILED
                 && observeConfig.getBoolean(OPERATOR_JOB_RESTART_FAILED)) {
             LOG.info("Stopping failed Flink job...");
-            removeFailedJob(resource, context, observeConfig);
+            cleanupAfterFailedJob(resource, context, observeConfig);
             resource.getStatus().setError("");
             resubmitJob(resource, context, observeConfig, false);
             return true;
@@ -289,6 +289,6 @@ public abstract class AbstractJobReconciler<
      * @param observeConfig Observe configuration.
      * @throws Exception Error during cancellation.
      */
-    protected abstract void removeFailedJob(
+    protected abstract void cleanupAfterFailedJob(
             CR resource, Context<?> ctx, Configuration observeConfig) throws Exception;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -246,7 +246,7 @@ public abstract class AbstractJobReconciler<
         if (jobStatus == org.apache.flink.api.common.JobStatus.FAILED
                 && observeConfig.getBoolean(OPERATOR_JOB_RESTART_FAILED)) {
             LOG.info("Stopping failed Flink job...");
-            cancelJob(resource, context, UpgradeMode.LAST_STATE, observeConfig);
+            removeFailedJob(resource, context, observeConfig);
             resource.getStatus().setError("");
             resubmitJob(resource, context, observeConfig, false);
             return true;
@@ -281,4 +281,14 @@ public abstract class AbstractJobReconciler<
     protected abstract void cancelJob(
             CR resource, Context<?> ctx, UpgradeMode upgradeMode, Configuration observeConfig)
             throws Exception;
+
+    /**
+     * Removes a failed job.
+     *
+     * @param resource The failed job.
+     * @param observeConfig Observe configuration.
+     * @throws Exception Error during cancellation.
+     */
+    protected abstract void removeFailedJob(
+            CR resource, Context<?> ctx, Configuration observeConfig) throws Exception;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -245,10 +245,10 @@ public abstract class AbstractJobReconciler<
                         resource.getStatus().getJobStatus().getState());
         if (jobStatus == org.apache.flink.api.common.JobStatus.FAILED
                 && observeConfig.getBoolean(OPERATOR_JOB_RESTART_FAILED)) {
-            LOG.info("Stopping failed Flink Cluster deployment...");
+            LOG.info("Stopping failed Flink job...");
             cancelJob(resource, context, UpgradeMode.LAST_STATE, observeConfig);
             resource.getStatus().setError("");
-            resubmitJmDeployment(resource, context, observeConfig, false);
+            resubmitJob(resource, context, observeConfig, false);
             return true;
         } else {
             return SavepointUtils.triggerSavepointIfNeeded(
@@ -256,10 +256,10 @@ public abstract class AbstractJobReconciler<
         }
     }
 
-    protected void resubmitJmDeployment(
+    protected void resubmitJob(
             CR deployment, Context<?> ctx, Configuration observeConfig, boolean requireHaMetadata)
             throws Exception {
-        LOG.info("Resubmitting Flink Cluster deployment...");
+        LOG.info("Resubmitting Flink job...");
         SPEC specToRecover = ReconciliationUtils.getDeployedSpec(deployment);
         restoreJob(
                 deployment,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -237,7 +237,7 @@ public class ApplicationReconciler
     }
 
     @Override
-    protected void removeFailedJob(
+    protected void cleanupAfterFailedJob(
             FlinkDeployment deployment, Context<?> ctx, Configuration observeConfig) {
         // The job has already stopped. Delete the deployment and we are ready.
         flinkService.deleteClusterDeployment(
@@ -275,7 +275,7 @@ public class ApplicationReconciler
         boolean shouldRecoverDeployment = shouldRecoverDeployment(observeConfig, deployment);
         if (shouldRestartJobBecauseUnhealthy || shouldRecoverDeployment) {
             if (shouldRestartJobBecauseUnhealthy) {
-                removeFailedJob(deployment, ctx, observeConfig);
+                cleanupAfterFailedJob(deployment, ctx, observeConfig);
             }
             resubmitJob(deployment, ctx, observeConfig, true);
             return true;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -236,6 +236,14 @@ public class ApplicationReconciler
         flinkService.cancelJob(deployment, upgradeMode, observeConfig);
     }
 
+    @Override
+    protected void removeFailedJob(
+            FlinkDeployment deployment, Context<?> ctx, Configuration observeConfig) {
+        // The job has already stopped. Delete the deployment and we are ready.
+        flinkService.deleteClusterDeployment(
+                deployment.getMetadata(), deployment.getStatus(), false);
+    }
+
     // Workaround for https://issues.apache.org/jira/browse/FLINK-27569
     private static void setRandomJobResultStorePath(Configuration effectiveConfig) {
         if (effectiveConfig.contains(HighAvailabilityOptions.HA_STORAGE_PATH)) {
@@ -267,7 +275,7 @@ public class ApplicationReconciler
         boolean shouldRecoverDeployment = shouldRecoverDeployment(observeConfig, deployment);
         if (shouldRestartJobBecauseUnhealthy || shouldRecoverDeployment) {
             if (shouldRestartJobBecauseUnhealthy) {
-                cancelJob(deployment, ctx, UpgradeMode.LAST_STATE, observeConfig);
+                removeFailedJob(deployment, ctx, observeConfig);
             }
             resubmitJob(deployment, ctx, observeConfig, true);
             return true;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -18,7 +18,6 @@
 package org.apache.flink.kubernetes.operator.reconciler.deployment;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.PipelineOptionsInternal;
@@ -55,7 +54,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CLUSTER_HEALTH_CHECK_ENABLED;
-import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CLUSTER_RESTART_FAILED;
 
 /** Reconciler Flink Application deployments. */
 public class ApplicationReconciler
@@ -264,15 +262,6 @@ public class ApplicationReconciler
             return true;
         }
 
-        if (JobStatus.valueOf(deployment.getStatus().getJobStatus().getState()) == JobStatus.FAILED
-                && observeConfig.getBoolean(OPERATOR_CLUSTER_RESTART_FAILED)) {
-            LOG.info("Stopping failed Flink Cluster deployment...");
-            cancelJob(deployment, ctx, UpgradeMode.LAST_STATE, observeConfig);
-            deployment.getStatus().setError("");
-            resubmitJmDeployment(deployment, ctx, observeConfig, false);
-            return true;
-        }
-
         boolean shouldRestartJobBecauseUnhealthy =
                 shouldRestartJobBecauseUnhealthy(deployment, observeConfig);
         boolean shouldRecoverDeployment = shouldRecoverDeployment(observeConfig, deployment);
@@ -285,23 +274,6 @@ public class ApplicationReconciler
         }
 
         return false;
-    }
-
-    private void resubmitJmDeployment(
-            FlinkDeployment deployment,
-            Context<?> ctx,
-            Configuration observeConfig,
-            boolean requireHaMetadata)
-            throws Exception {
-        LOG.info("Resubmitting Flink Cluster deployment...");
-        FlinkDeploymentSpec specToRecover = ReconciliationUtils.getDeployedSpec(deployment);
-        restoreJob(
-                deployment,
-                specToRecover,
-                deployment.getStatus(),
-                ctx,
-                observeConfig,
-                requireHaMetadata);
     }
 
     private boolean shouldRestartJobBecauseUnhealthy(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -269,7 +269,7 @@ public class ApplicationReconciler
             if (shouldRestartJobBecauseUnhealthy) {
                 cancelJob(deployment, ctx, UpgradeMode.LAST_STATE, observeConfig);
             }
-            resubmitJmDeployment(deployment, ctx, observeConfig, true);
+            resubmitJob(deployment, ctx, observeConfig, true);
             return true;
         }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -127,6 +127,13 @@ public class SessionJobReconciler
     }
 
     @Override
+    protected void removeFailedJob(
+            FlinkSessionJob resource, Context<?> ctx, Configuration observeConfig)
+            throws Exception {
+        // The job has already stopped, nothing to clean up.
+    }
+
+    @Override
     public DeleteControl cleanupInternal(FlinkSessionJob sessionJob, Context<?> context) {
         Optional<FlinkDeployment> flinkDepOptional =
                 context.getSecondaryResource(FlinkDeployment.class);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -127,7 +127,7 @@ public class SessionJobReconciler
     }
 
     @Override
-    protected void removeFailedJob(
+    protected void cleanupAfterFailedJob(
             FlinkSessionJob resource, Context<?> ctx, Configuration observeConfig)
             throws Exception {
         // The job has already stopped, nothing to clean up.

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -46,7 +46,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.function.Predicate;
 
 /** Flink Utility methods used by the operator. */
 public class FlinkUtils {
@@ -148,7 +147,8 @@ public class FlinkUtils {
                         .list()
                         .getItems();
 
-        return configMaps.stream().anyMatch(Predicate.not(ConfigMap::isMarkedForDeletion));
+        return configMaps.stream()
+                .anyMatch(map -> !map.isMarkedForDeletion() && map.getData() != null);
     }
 
     private static boolean isJobGraphKey(Map.Entry<String, String> entry) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
@@ -38,7 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CLUSTER_RESTART_FAILED;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_JOB_RESTART_FAILED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -56,7 +56,7 @@ public class FailedDeploymentRestartTest {
     @BeforeEach
     public void setup() {
         var configuration = new Configuration();
-        configuration.set(OPERATOR_CLUSTER_RESTART_FAILED, true);
+        configuration.set(OPERATOR_JOB_RESTART_FAILED, true);
         configManager = new FlinkConfigManager(configuration);
         flinkService = new TestingFlinkService(kubernetesClient);
         context = flinkService.getContext();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.controller;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.crd.spec.FlinkVersion;
+import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
+import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CLUSTER_RESTART_FAILED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/** @link Unhealthy deployment restart tests */
+@EnableKubernetesMockClient(crud = true)
+public class FailedDeploymentRestartTest {
+    private FlinkConfigManager configManager;
+
+    private TestingFlinkService flinkService;
+    private Context<FlinkDeployment> context;
+    private TestingFlinkDeploymentController testController;
+
+    private KubernetesClient kubernetesClient;
+
+    @BeforeEach
+    public void setup() {
+        var configuration = new Configuration();
+        configuration.set(OPERATOR_CLUSTER_RESTART_FAILED, true);
+        configManager = new FlinkConfigManager(configuration);
+        flinkService = new TestingFlinkService(kubernetesClient);
+        context = flinkService.getContext();
+        testController =
+                new TestingFlinkDeploymentController(configManager, kubernetesClient, flinkService);
+        kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
+    }
+
+    @ParameterizedTest
+    @MethodSource("applicationTestParams")
+    public void verifyFailedApplicationRecovery(FlinkVersion flinkVersion, UpgradeMode upgradeMode)
+            throws Exception {
+        FlinkDeployment appCluster = TestUtils.buildApplicationCluster(flinkVersion);
+        appCluster.getSpec().getJob().setUpgradeMode(upgradeMode);
+
+        // Start a healthy deployment
+        testController.reconcile(appCluster, context);
+        testController.reconcile(appCluster, context);
+        testController.reconcile(appCluster, context);
+        assertEquals(
+                JobManagerDeploymentStatus.READY,
+                appCluster.getStatus().getJobManagerDeploymentStatus());
+        assertEquals("RUNNING", appCluster.getStatus().getJobStatus().getState());
+
+        // Make deployment unhealthy
+        flinkService.markApplicationJobFailedWithError(
+                flinkService.listJobs().get(0).f1.getJobId(), "Failed job");
+        testController.reconcile(appCluster, context);
+        assertEquals(
+                JobManagerDeploymentStatus.DEPLOYING,
+                appCluster.getStatus().getJobManagerDeploymentStatus());
+
+        // After restart the deployment is healthy again
+        testController.reconcile(appCluster, context);
+        testController.reconcile(appCluster, context);
+        assertEquals(
+                JobManagerDeploymentStatus.READY,
+                appCluster.getStatus().getJobManagerDeploymentStatus());
+        assertEquals("RUNNING", appCluster.getStatus().getJobStatus().getState());
+        assertEquals(
+                appCluster.getSpec(),
+                appCluster.getStatus().getReconciliationStatus().deserializeLastReconciledSpec());
+    }
+
+    private static Stream<Arguments> applicationTestParams() {
+        List<Arguments> args = new ArrayList<>();
+        for (FlinkVersion version : FlinkVersion.values()) {
+            for (UpgradeMode upgradeMode : UpgradeMode.values()) {
+                args.add(arguments(version, upgradeMode));
+            }
+        }
+        return args.stream();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

It would be good to have the possibility to restart the Flink Application if it goes to `FAILED` state.
This could be used to restart, and reconfigure the job dynamically in the application `main` method if the current application can not handle the incoming data.

## Brief change log

  - Creates a new configuration `cluster.restart.failed` with the default `false`
  - If the Application state is `FAILED` and the configuration is set to `true` then the application is removed and redeployed

## Verifying this change
This change added tests and can be verified as follows:
  - Added tests where the configuration is turned on, and the application is redeployed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
