### PR TITLE
[FLINK-29744] Throw DeploymentFailedException on ImagePullBackOff

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
 public class DeploymentFailedException extends RuntimeException {
 
     public static final String REASON_CRASH_LOOP_BACKOFF = "CrashLoopBackOff";
+    public static final String REASON_IMAGE_PULL_BACKOFF = "ImagePullBackOff";
 
     private static final long serialVersionUID = -1070179896083579221L;
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -38,7 +38,6 @@ import org.apache.flink.kubernetes.operator.crd.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.crd.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.crd.status.JobManagerDeploymentStatus;
-import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
@@ -219,12 +218,12 @@ public class TestUtils {
         return pod;
     }
 
-    public static PodList createFailedPodList(String crashLoopMessage) {
+    public static PodList createFailedPodList(String crashLoopMessage, String reason) {
         ContainerStatus cs =
                 new ContainerStatusBuilder()
                         .withNewState()
                         .withNewWaiting()
-                        .withReason(DeploymentFailedException.REASON_CRASH_LOOP_BACKOFF)
+                        .withReason(reason)
                         .withMessage(crashLoopMessage)
                         .endWaiting()
                         .endState()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -624,7 +624,9 @@ public class ApplicationObserverTest {
                 deployment.getStatus().getJobManagerDeploymentStatus());
         // simulate deployment failure
         String podFailedMessage = "list jobs error";
-        flinkService.setJmPodList(TestUtils.createFailedPodList(podFailedMessage));
+        flinkService.setJmPodList(
+                TestUtils.createFailedPodList(
+                        podFailedMessage, DeploymentFailedException.REASON_CRASH_LOOP_BACKOFF));
         flinkService.setPortReady(false);
         Exception exception =
                 assertThrows(


### PR DESCRIPTION
## What is the purpose of the change

Handle cases when pod is unable to pull images. (a.k.a `ImagePullBackOff`)

## Brief change log

Code is already handling `CrashLoopBackOff` this PR adds extra `ImagePullBackOff ` handling.

## Verifying this change

Added parameterized `FlinkDeploymentControllerTest.verifyInProgressDeploymentWithBackoff()`
## Documentation

  - Does this pull request introduce a new feature? no
