### PR TITLE
[hotfix] Change default Helm operator configs to align with Flink

### DIFF
--- a/helm/flink-kubernetes-operator/conf/flink-conf.yaml
+++ b/helm/flink-kubernetes-operator/conf/flink-conf.yaml
@@ -17,8 +17,8 @@
 ################################################################################
 
 # Flink job/cluster related configs
-taskmanager.numberOfTaskSlots: 2
-parallelism.default: 2
+taskmanager.numberOfTaskSlots: 1
+parallelism.default: 1
 
 # Flink operator related configs
 # kubernetes.operator.reconcile.interval: 60 s


### PR DESCRIPTION
## What is the purpose of the change

Minor change based on mailng list discussion to align default confs with Flink for subtask number and parallelism.