### PR TITLE
FLINK-29536 - Add WATCH_NAMESPACE env var to operator

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EnvUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EnvUtils.java
@@ -55,6 +55,7 @@ public class EnvUtils {
     public static final String ENV_HOSTNAME = "HOSTNAME";
     public static final String ENV_OPERATOR_NAME = "OPERATOR_NAME";
     public static final String ENV_OPERATOR_NAMESPACE = "OPERATOR_NAMESPACE";
+    public static final String ENV_WATCH_NAMESPACES = "WATCH_NAMESPACES";
 
     private static final String PROP_FILE = ".flink-kubernetes-operator.version.properties";
     private static final String FAIL_MESSAGE =

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -82,10 +82,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: WATCH_NAMESPACES
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.annotations['olm.targetNamespaces']
             - name: OPERATOR_NAME
               value: {{ include "flink-operator.name" . }}
             - name: FLINK_CONF_DIR
@@ -164,10 +160,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: WATCH_NAMESPACES
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.annotations['olm.targetNamespaces']
           securityContext:
             {{- toYaml .Values.webhookSecurityContext | nindent 12 }}
           volumeMounts:

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -79,7 +79,13 @@ spec:
           {{- end }}
           env:
             - name: OPERATOR_NAMESPACE
-              value: {{ .Release.Namespace }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: WATCH_NAMESPACES
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['olm.targetNamespaces']
             - name: OPERATOR_NAME
               value: {{ include "flink-operator.name" . }}
             - name: FLINK_CONF_DIR
@@ -155,7 +161,13 @@ spec:
             - name: FLINK_PLUGINS_DIR
               value: /opt/flink/plugins
             - name: OPERATOR_NAMESPACE
-              value: {{ .Release.Namespace }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: WATCH_NAMESPACES
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['olm.targetNamespaces']
           securityContext:
             {{- toYaml .Values.webhookSecurityContext | nindent 12 }}
           volumeMounts:

--- a/helm/flink-kubernetes-operator/templates/webhook.yaml
+++ b/helm/flink-kubernetes-operator/templates/webhook.yaml
@@ -85,7 +85,7 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/flink-operator-serving-cert
   name: flink-operator-{{ .Release.Namespace }}-webhook-configuration
 webhooks:
-- name: flinkoperator.flink.apache.org
+- name: validationwebhook.flink.apache.org
   admissionReviewVersions: ["v1"]
   clientConfig:
     service:
@@ -94,7 +94,7 @@ webhooks:
       path: /validate
   failurePolicy: Fail
   rules:
-  - apiGroups: ["*"]
+  - apiGroups: ["flink.apache.org"]
     apiVersions: ["*"]
     scope: "Namespaced"
     operations:
@@ -121,7 +121,7 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/flink-operator-serving-cert
   name: flink-operator-{{ .Release.Namespace }}-webhook-configuration
 webhooks:
-  - name: flinkoperator.flink.apache.org
+  - name: mutationwebhook.flink.apache.org
     admissionReviewVersions: ["v1"]
     clientConfig:
       service:
@@ -130,7 +130,7 @@ webhooks:
         path: /mutate
     failurePolicy: Fail
     rules:
-      - apiGroups: ["*"]
+      - apiGroups: ["flink.apache.org"]
         apiVersions: ["*"]
         scope: "Namespaced"
         operations:


### PR DESCRIPTION
## What is the purpose of the change

OLM currently provides the ability to install an operator either into a single namespace or all namespaces (though multiple namespaces may come later). The only way to determine what namespace the operator is targeted to watch for CR's is by looking at the annotations that olm injects into the operator deployment i.e. `olm.targetNamespaces`. By adding the WATCH_NAMESPACE env var that references this annotation we will be able to get the operator to correctly monitor the targeted namespace. N.b. if the operator is installed to watch all namespaces then the annotation is just an empty string

## Brief change log

- Add the WATCH_NAMESPACE env var to EnvUtils
- Override Flink config to use this env var if it is defined i.e. not empty
- Modified helm charts so that the env vars for the pod use the deployments annotations
- Added tests to FlinkConfigManagerTest to test the env var changes

## Verifying this change

This change added tests and can be verified as follows:

- Manually installed the helm charts to ensure the default behaviour was not modified
- Generated an OLM bundle with the changes and tested in both single and all namespaces to ensure that the operator was set to watch the correct namespace

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes, added moquito to test env var changes)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented?  (not documented). Though once we have automated olm it will become part of that documentation work
