### PR TITLE
[FLINK-29819] Record an error event when savepoint fails within grace…

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -109,17 +109,16 @@ public class SavepointObserver<
                                 + err);
                 ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(
                         savepointInfo, resource);
-                eventRecorder.triggerEvent(
-                        resource,
-                        EventRecorder.Type.Warning,
-                        EventRecorder.Reason.SavepointError,
-                        EventRecorder.Component.Operator,
-                        SavepointUtils.createSavepointError(
-                                savepointInfo,
-                                resource.getSpec().getJob().getSavepointTriggerNonce()));
             } else {
                 LOG.warn("Savepoint failed within grace period, retrying: " + err);
             }
+            eventRecorder.triggerEvent(
+                    resource,
+                    EventRecorder.Type.Warning,
+                    EventRecorder.Reason.SavepointError,
+                    EventRecorder.Component.Operator,
+                    SavepointUtils.createSavepointError(
+                            savepointInfo, resource.getSpec().getJob().getSavepointTriggerNonce()));
             savepointInfo.resetTrigger();
             return;
         }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -262,7 +262,7 @@ public class ApplicationObserverTest {
         observer.observe(deployment, readyContext);
         assertFalse(SavepointUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
         assertEquals(
-                0,
+                1,
                 kubernetesClient
                         .v1()
                         .events()
@@ -298,7 +298,7 @@ public class ApplicationObserverTest {
                                                                 + timedOutNonce))
                         .count());
         assertEquals(
-                1,
+                2,
                 kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
                         .list().getItems().stream()
                         .filter(e -> e.getReason().contains("SavepointError"))


### PR DESCRIPTION
… period


## What is the purpose of the change

As of now, SavepointObserver retries if savepoint fails within grace period until success or failure happens after the grace period. The grace period is for each retry.  If underlying problem for quick failure is not transient, such as a mis-configured path or a perisistent storage failure, retries keep going on without recording any error event. 
We should first add logic to record an error event per failed attempt. We can consider capping the retries if it become a pain for users.


## Brief change log


  - Recorded an error event when savepoint fails within grace period


## Verifying this change


This change added tests and can be verified as follows:


  - Updated test cases in ApplicationObserverTest for error event counts.
  - Also verified on Minikube by deploying the new operator and a job with savepoint dir set to wrong path.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: No
  - Core observer or reconciler logic that is regularly executed: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? No
