### PR TITLE
[FLINK-29871] Add 1.16 to CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["v1_15","v1_14","v1_13"]
+        version: ["v1_16","v1_15","v1_14","v1_13"]
         namespace: ["default","flink"]
         mode: ["native", "standalone"]
         test:
@@ -107,6 +107,8 @@ jobs:
         include:
           - namespace: flink
             extraArgs: '--create-namespace --set "watchNamespaces={default,flink}"'
+          - version: v1_16
+            image: flink:1.16
           - version: v1_15
             image: flink:1.15
           - version: v1_14

--- a/e2e-tests/data/flinkdep-cr.yaml
+++ b/e2e-tests/data/flinkdep-cr.yaml
@@ -22,8 +22,8 @@ metadata:
   namespace: default
   name: flink-example-statemachine
 spec:
-  image: flink:1.15
-  flinkVersion: v1_15
+  image: flink:1.16
+  flinkVersion: v1_16
   ingress:
     template: "/{{namespace}}/{{name}}(/|$)(.*)"
     className: "nginx"

--- a/e2e-tests/data/multi-sessionjob.yaml
+++ b/e2e-tests/data/multi-sessionjob.yaml
@@ -22,8 +22,8 @@ metadata:
   namespace: default
   name: session-cluster-1
 spec:
-  image: flink:1.15
-  flinkVersion: v1_15
+  image: flink:1.16
+  flinkVersion: v1_16
   ingress:
     template: "/{{namespace}}/{{name}}(/|$)(.*)"
     className: "nginx"
@@ -74,8 +74,8 @@ metadata:
   namespace: flink
   name: session-cluster-1
 spec:
-  image: flink:1.15
-  flinkVersion: v1_15
+  image: flink:1.16
+  flinkVersion: v1_16
   ingress:
     template: "/{{namespace}}/{{name}}(/|$)(.*)"
     className: "nginx"

--- a/e2e-tests/data/sessionjob-cr.yaml
+++ b/e2e-tests/data/sessionjob-cr.yaml
@@ -22,8 +22,8 @@ metadata:
   namespace: default
   name: session-cluster-1
 spec:
-  image: flink:1.15
-  flinkVersion: v1_15
+  image: flink:1.16
+  flinkVersion: v1_16
   ingress:
     template: "/{{namespace}}/{{name}}(/|$)(.*)"
     className: "nginx"
@@ -105,4 +105,3 @@ metadata:
   name: nginx
 spec:
   controller: k8s.io/ingress-nginx
-


### PR DESCRIPTION
## What is the purpose of the change

Enable 1.16 CI tests as a first step to support Flink 1.16. As agreed on JIRA we will move to using the 1.16 flink dependency once 1.16.1 is out.

## Brief change log

Added new e2e test case for 1.16