### PR TITLE
[FLINK-29851] Correctly depend on flink-kubernetes-standalone shaded classifier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.m2 mvn -ntp clean install -pl !flink-kubern
 RUN cd /app/tools/license; mkdir jars; cd jars; \
     cp /app/flink-kubernetes-operator/target/flink-kubernetes-operator-*-shaded.jar . && \
     cp /app/flink-kubernetes-webhook/target/flink-kubernetes-webhook-*-shaded.jar . && \
-    cp /app/flink-kubernetes-standalone/target/flink-kubernetes-shaded-*.jar . && \
+    cp /app/flink-kubernetes-standalone/target/flink-kubernetes-standalone-*-shaded.jar . && \
     cp -r /app/flink-kubernetes-operator/target/plugins ./plugins && \
     cd ../ && ./collect_license_files.sh ./jars ./licenses-output
 
@@ -38,7 +38,7 @@ ENV FLINK_HOME=/opt/flink
 ENV OPERATOR_VERSION=1.3-SNAPSHOT
 ENV OPERATOR_JAR=flink-kubernetes-operator-$OPERATOR_VERSION-shaded.jar
 ENV WEBHOOK_JAR=flink-kubernetes-webhook-$OPERATOR_VERSION-shaded.jar
-ENV FLINK_KUBERNETES_SHADED_JAR=flink-kubernetes-shaded-$OPERATOR_VERSION.jar
+ENV FLINK_KUBERNETES_SHADED_JAR=flink-kubernetes-standalone-$OPERATOR_VERSION-shaded.jar
 
 WORKDIR /flink-kubernetes-operator
 RUN groupadd --system --gid=9999 flink && \

--- a/docs/content/docs/development/guide.md
+++ b/docs/content/docs/development/guide.md
@@ -71,10 +71,19 @@ docker@minikube:~$ exit
 ```
 
 ### Installing the operator locally
+
 ```bash
 helm install flink-kubernetes-operator helm/flink-kubernetes-operator --set image.repository=<repo>/flink-kubernetes-operator --set image.tag=latest
 ```
-### Running the operator locally
+
+To uninstall you can simply call:
+
+```bash
+helm uninstall flink-kubernetes-operator
+```
+
+### Running the operator from the IDE
+
 You can run or debug the `FlinkOperator` from your preferred IDE. The operator itself is accessing the deployed Flink clusters through the REST interface. When running locally the `rest.port`, `rest.address` and `kubernetes.rest-service.exposed.type` Flink configuration parameters must be modified.
 
 When using `minikube tunnel` the rest service is exposed on `localhost:8081`
@@ -94,10 +103,25 @@ rest.address: localhost
 kubernetes.rest-service.exposed.type: LoadBalancer
 ```
 
-### Uninstalling the operator locally
-```bash
-helm uninstall flink-kubernetes-operator
+Due to fabric8 conflicts between core Flink and the operator, the `flink-kubernetes-operator` module depends on the shaded `flink-kubernetes-standalone` jar which contains the relocated version of the old fabric8 Kubernetes client. Unfortunately IntelliJ is not great at handling dependencies with classifiers so you might get the following error when trying to run `FlinkOperator#main`:
+
 ```
+java.lang.NoSuchMethodError: 'java.lang.Object io.fabric8.kubernetes.client.dsl.ServiceResource.fromServer()'
+```
+
+There are two solutions to this problem, both requires you to first build the project.
+
+First:
+
+```bash
+mvn clean install
+```
+
+Then either:
+
+ 1. Import the `flink-kubernetes-operator` submodule as a separate IntelliJ project. This will resolve the classifier dependency correctly from your local maven cache.
+ 2. If you want to keep a single multi-module project, you need to add the `flink-kubernetes-standalone-XX-shaded.jar` on the classpath manually when running the main method:
+ `Edit Run Configuration/Modify Options/Modify Classpath`
 
 ### Generating and Upgrading the CRD
 
@@ -119,6 +143,7 @@ helm install flink-operator helm/flink-operator --set operatorVolumeMounts.creat
 
 
 ## CI/CD
+
 We use [GitHub Actions](https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions) to help you automate your software development workflows in the same place you store code and collaborate on pull requests and issues.
 You can write individual tasks, called actions, and combine them to create a custom workflow.
 Workflows are custom automated processes that you can set up in your repository to build, test, package, release, or deploy any code project on GitHub.

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -94,13 +94,7 @@ under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-kubernetes-standalone</artifactId>
             <version>${project.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-kubernetes</artifactId>
-            <version>${flink.version}</version>
+            <classifier>shaded</classifier>
             <scope>provided</scope>
         </dependency>
 

--- a/flink-kubernetes-standalone/pom.xml
+++ b/flink-kubernetes-standalone/pom.xml
@@ -93,7 +93,8 @@ under the License.
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <finalName>flink-kubernetes-shaded-${project.version}</finalName>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
                             <artifactSet>
                                 <includes combine.children="append">
                                     <include>org.apache.flink:flink-kubernetes</include>


### PR DESCRIPTION
## What is the purpose of the change

Fix the `flink-kubernetes-standalone` dependency in the `flink-kubernetes-operator` submodule to actually use the shaded classifier which is required to avoid fabric8 conflicts when running from IntelliJ (and it's also the actual dependency we use at runtime also)

## Brief change log

This change is already covered by existing e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
