### PR TITLE
[FLINK-29851] Remove deprecated fabric8 api usage

### DIFF
--- a/examples/kubernetes-client-examples/src/main/java/org/apache/flink/examples/Basic.java
+++ b/examples/kubernetes-client-examples/src/main/java/org/apache/flink/examples/Basic.java
@@ -27,9 +27,8 @@ import org.apache.flink.kubernetes.operator.api.spec.TaskManagerSpec;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 
 import java.util.Map;
 
@@ -68,12 +67,8 @@ public class Basic {
                                 .upgradeMode(UpgradeMode.STATELESS)
                                 .build());
 
-        try (KubernetesClient kubernetesClient = new DefaultKubernetesClient()) {
-            FlinkDeployment orReplace =
-                    kubernetesClient.resource(flinkDeployment).createOrReplace();
-        } catch (KubernetesClientException e) {
-            // some error while connecting to kube cluster
-            e.printStackTrace();
+        try (KubernetesClient kubernetesClient = new KubernetesClientBuilder().build()) {
+            kubernetesClient.resource(flinkDeployment).createOrReplace();
         }
     }
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/FlinkDeploymentList.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/FlinkDeploymentList.java
@@ -19,13 +19,13 @@ package org.apache.flink.kubernetes.operator.api;
 
 import org.apache.flink.annotation.Experimental;
 
-import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
 
 /**
  * Multiple Flink deployments. Please do not delete. This class is used by downstream projects
  * interacting with the FlinkDeployment CRD via the Fabric8 Java client.
  */
 @Experimental
-public class FlinkDeploymentList extends CustomResourceList<FlinkDeployment> {
+public class FlinkDeploymentList extends DefaultKubernetesResourceList<FlinkDeployment> {
     public FlinkDeploymentList() {}
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/FlinkSessionJobList.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/FlinkSessionJobList.java
@@ -19,13 +19,13 @@ package org.apache.flink.kubernetes.operator.api;
 
 import org.apache.flink.annotation.Experimental;
 
-import io.fabric8.kubernetes.client.CustomResourceList;
+import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
 
 /**
  * Multiple Flink session jobs. Please do not delete. This class is used by downstream projects
  * interacting with the FlinkSessionJobs CRD via the Fabric8 Java client.
  */
 @Experimental
-public class FlinkSessionJobList extends CustomResourceList<FlinkSessionJob> {
+public class FlinkSessionJobList extends DefaultKubernetesResourceList<FlinkSessionJob> {
     public FlinkSessionJobList() {}
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -145,7 +145,6 @@ public class NativeFlinkService extends AbstractFlinkService {
                 .deployments()
                 .inNamespace(namespace)
                 .withName(KubernetesUtils.getDeploymentName(clusterId))
-                .cascading(true)
                 .delete();
 
         if (deleteHaConfigmaps) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
@@ -146,7 +146,6 @@ public class StandaloneFlinkService extends AbstractFlinkService {
                 .deployments()
                 .inNamespace(namespace)
                 .withName(StandaloneKubernetesUtils.getTaskManagerDeploymentName(clusterId))
-                .cascading(true)
                 .delete();
 
         LOG.info("Deleting Flink Standalone cluster JM resources");
@@ -155,7 +154,6 @@ public class StandaloneFlinkService extends AbstractFlinkService {
                 .deployments()
                 .inNamespace(namespace)
                 .withName(StandaloneKubernetesUtils.getJobManagerDeploymentName(clusterId))
-                .cascading(true)
                 .delete();
 
         if (deleteHaConfigmaps) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -76,10 +76,7 @@ public class EventUtils {
             existing.setLastTimestamp(Instant.now().toString());
             existing.setCount(existing.getCount() + 1);
             existing.setMessage(message);
-            client.v1()
-                    .events()
-                    .inNamespace(target.getMetadata().getNamespace())
-                    .createOrReplace(existing);
+            client.resource(existing).createOrReplace();
             eventListener.accept(existing);
             return false;
         } else {
@@ -107,7 +104,7 @@ public class EventUtils {
                             .withNamespace(target.getMetadata().getNamespace())
                             .endMetadata()
                             .build();
-            client.v1().events().inNamespace(target.getMetadata().getNamespace()).create(event);
+            client.resource(event).createOrReplace();
             eventListener.accept(event);
             return true;
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
@@ -76,10 +76,6 @@ public class StatusRecorder<
      */
     @SneakyThrows
     public void patchAndCacheStatus(CR resource) {
-        Class<CR> resourceClass = (Class<CR>) resource.getClass();
-        String namespace = resource.getMetadata().getNamespace();
-        String name = resource.getMetadata().getName();
-
         // This is necessary so the client wouldn't fail of the underlying resource spec was updated
         // in the meantime
         resource.getMetadata().setResourceVersion(null);
@@ -104,10 +100,7 @@ public class StatusRecorder<
             // In any case we retry the status update 3 times to avoid some intermittent
             // connectivity errors if any
             try {
-                client.resources(resourceClass)
-                        .inNamespace(namespace)
-                        .withName(name)
-                        .patchStatus(resource);
+                client.resource(resource).patchStatus();
                 statusUpdateListener.accept(resource, prevStatus);
                 metricManager.onUpdate(resource);
                 return;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
@@ -31,8 +31,8 @@ import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -57,7 +57,7 @@ public class FlinkOperatorITCase {
 
     @BeforeEach
     public void setup() {
-        client = new DefaultKubernetesClient();
+        client = new KubernetesClientBuilder().build();
         LOG.info("Cleaning up namespace {}", TEST_NAMESPACE);
         client.namespaces().withName(TEST_NAMESPACE).delete();
         await().atMost(1, MINUTES)
@@ -68,7 +68,7 @@ public class FlinkOperatorITCase {
                 new NamespaceBuilder()
                         .withMetadata(new ObjectMetaBuilder().withName(TEST_NAMESPACE).build())
                         .build();
-        client.namespaces().create(testNs);
+        client.resource(testNs).create();
         rbacSetup();
     }
 
@@ -131,7 +131,8 @@ public class FlinkOperatorITCase {
                         .withNamespace(TEST_NAMESPACE)
                         .endMetadata()
                         .build();
-        client.serviceAccounts().inNamespace(TEST_NAMESPACE).createOrReplace(serviceAccount);
+
+        client.resource(serviceAccount).createOrReplace();
 
         ClusterRoleBinding current =
                 client.rbac().clusterRoleBindings().withName(CLUSTER_ROLE_BINDING).get();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -160,10 +160,8 @@ public class NativeFlinkServiceTest {
                 new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
         final FlinkService flinkService = createFlinkService(testingClusterClient);
 
-        client.apps()
-                .deployments()
-                .inNamespace(TestUtils.TEST_NAMESPACE)
-                .create(createTestingDeployment());
+        client.resource(createTestingDeployment()).create();
+
         assertNotNull(
                 client.apps()
                         .deployments()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -230,10 +230,9 @@ public class StandaloneFlinkServiceTest {
                 StandaloneKubernetesUtils.getJobManagerDeploymentName(cr.getMetadata().getName()));
         jmDeployment.setMetadata(jmMetadata);
         kubernetesClient
-                .apps()
-                .deployments()
+                .resource(jmDeployment)
                 .inNamespace(cr.getMetadata().getNamespace())
-                .createOrReplace(jmDeployment);
+                .createOrReplace();
 
         Deployment tmDeployment = new Deployment();
         ObjectMeta tmMetadata = new ObjectMeta();
@@ -242,9 +241,8 @@ public class StandaloneFlinkServiceTest {
         tmDeployment.setMetadata(tmMetadata);
         tmDeployment.setSpec(new DeploymentSpec());
         kubernetesClient
-                .apps()
-                .deployments()
+                .resource(tmDeployment)
                 .inNamespace(cr.getMetadata().getNamespace())
-                .createOrReplace(tmDeployment);
+                .createOrReplace();
     }
 }

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
@@ -37,7 +37,7 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpServerCode
 import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContext;
 import org.apache.flink.shaded.netty4.io.netty.handler.stream.ChunkedWriteHandler;
 
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class FlinkOperatorWebhook {
 
     public static void main(String[] args) throws Exception {
         EnvUtils.logEnvironmentInfo(LOG, "Flink Kubernetes Webhook", args);
-        var informerManager = new InformerManager(new DefaultKubernetesClient());
+        var informerManager = new InformerManager(new KubernetesClientBuilder().build());
         var configManager = new FlinkConfigManager(informerManager::setNamespaces);
         if (!configManager.getOperatorConfiguration().isDynamicNamespacesEnabled()) {
             informerManager.setNamespaces(


### PR DESCRIPTION
## What is the purpose of the change

Removes deprecated fabric8 api usage after the 6.2.0 upgrade

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
