### PR TITLE
[FLINK-29936] Add option to ignore informer errors on startup

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -237,6 +237,12 @@
             <td>The interval before a savepoint trigger attempt is marked as unsuccessful.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.startup.stop-on-informer-error</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether informer errors should stop operator startup. If false, the startup will ignore recoverable errors, caused for example by RBAC issues and will retry periodically.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.user.artifacts.base.dir</h5></td>
             <td style="word-wrap: break-word;">"/opt/flink/artifacts"</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/system_advanced_section.html
+++ b/docs/layouts/shortcodes/generated/system_advanced_section.html
@@ -74,5 +74,11 @@
             <td>Integer</td>
             <td>Maximum number threshold of savepoint history entries to retain.</td>
         </tr>
+        <tr>
+            <td><h5>kubernetes.operator.startup.stop-on-informer-error</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether informer errors should stop operator startup. If false, the startup will ignore recoverable errors, caused for example by RBAC issues and will retry periodically.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.kubernetes.operator.api.listener.FlinkResourceListener;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentController;
 import org.apache.flink.kubernetes.operator.controller.FlinkSessionJobController;
 import org.apache.flink.kubernetes.operator.health.OperatorHealthService;
@@ -117,6 +118,11 @@ public class FlinkOperator {
         if (configManager.getOperatorConfiguration().isJosdkMetricsEnabled()) {
             overrider.withMetrics(new OperatorJosdkMetrics(metricGroup, configManager));
         }
+
+        overrider.withStopOnInformerErrorDuringStartup(
+                configManager
+                        .getDefaultConfig()
+                        .get(KubernetesOperatorConfigOptions.OPERATOR_STOP_ON_INFORMER_ERROR));
     }
 
     @VisibleForTesting

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -346,6 +346,14 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(8085)
                     .withDescription("The port the health probe will use to expose the status.");
 
+    @Documentation.Section(SECTION_ADVANCED)
+    public static final ConfigOption<Boolean> OPERATOR_STOP_ON_INFORMER_ERROR =
+            operatorConfig("startup.stop-on-informer-error")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether informer errors should stop operator startup. If false, the startup will ignore recoverable errors, caused for example by RBAC issues and will retry periodically.");
+
     @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> OPERATOR_CLUSTER_HEALTH_CHECK_ENABLED =
             operatorConfig("cluster.health-check.enabled")

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
@@ -45,6 +45,7 @@ public class FlinkOperatorTest {
         operatorConfig.setInteger(
                 KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_PARALLELISM, testParallelism);
         operatorConfig.set(KubernetesOperatorConfigOptions.OPERATOR_LABEL_SELECTOR, testSelector);
+        operatorConfig.set(KubernetesOperatorConfigOptions.OPERATOR_STOP_ON_INFORMER_ERROR, false);
 
         var testOperator = new FlinkOperator(operatorConfig);
         testOperator.registerDeploymentController();
@@ -64,6 +65,8 @@ public class FlinkOperatorTest {
                         .map(ControllerConfiguration::getLabelSelector);
 
         labelSelectors.forEach(selector -> Assertions.assertEquals(testSelector, selector));
+        Assertions.assertFalse(
+                ConfigurationServiceProvider.instance().stopOnInformerErrorDuringStartup());
 
         // TODO: Overriding operator configuration twice in JOSDK v3 yields IllegalStateException
         var secondParallelism = 420;


### PR DESCRIPTION
## What is the purpose of the change

This PR exposes the JOSDK feature described in https://javaoperatorsdk.io/docs/patterns-best-practices#stopping-or-not-operator-in-case-of-informer-errors-and-cache-sync-timeouts.

This allows ignoring recoverable informer errors on startup to increase the robustness of the opreator in prod environments.

## Brief change log

  - *Add new config option*
  - *Add test*

## Verifying this change

Extended `FlinkOperatorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
