### PR TITLE
[FLINK-29609] Shut down JM for terminated applications after configured duration

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -45,6 +45,12 @@
             <td>Whether to enable recovery of missing/deleted jobmanager deployments.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.jm-deployment.shutdown-ttl</h5></td>
+            <td style="word-wrap: break-word;">86400000 ms</td>
+            <td>Duration</td>
+            <td>Time after which jobmanager pods of terminal application deployments are shut down.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.restart.failed</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -123,6 +123,12 @@
             <td>Whether to enable recovery of missing/deleted jobmanager deployments.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.jm-deployment.shutdown-ttl</h5></td>
+            <td style="word-wrap: break-word;">86400000 ms</td>
+            <td>Duration</td>
+            <td>Time after which jobmanager pods of terminal application deployments are shut down.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.restart.failed</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -422,4 +422,12 @@ public class KubernetesOperatorConfigOptions {
                     .durationType()
                     .defaultValue(LeaderElectionConfiguration.RETRY_PERIOD_DEFAULT_VALUE)
                     .withDescription("Leader election retry period.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Duration> OPERATOR_JM_SHUTDOWN_TTL =
+            operatorConfig("jm-deployment.shutdown-ttl")
+                    .durationType()
+                    .defaultValue(Duration.ofDays(1))
+                    .withDescription(
+                            "Time after which jobmanager pods of terminal application deployments are shut down.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
@@ -28,7 +28,6 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
-import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.kubeclient.Fabric8FlinkStandaloneKubeClient;
@@ -84,12 +83,6 @@ public class StandaloneFlinkService extends AbstractFlinkService {
     }
 
     @Override
-    public void deleteClusterDeployment(
-            ObjectMeta meta, FlinkDeploymentStatus status, boolean deleteHaData) {
-        deleteClusterInternal(meta, deleteHaData);
-    }
-
-    @Override
     protected PodList getJmPodList(String namespace, String clusterId) {
         return kubernetesClient
                 .pods()
@@ -136,7 +129,8 @@ public class StandaloneFlinkService extends AbstractFlinkService {
         return new KubernetesClusterClientFactory().getClusterSpecification(conf);
     }
 
-    private void deleteClusterInternal(ObjectMeta meta, boolean deleteHaConfigmaps) {
+    @Override
+    protected void deleteClusterInternal(ObjectMeta meta, boolean deleteHaConfigmaps) {
         final String clusterId = meta.getName();
         final String namespace = meta.getNamespace();
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -32,8 +32,6 @@ import org.apache.flink.kubernetes.operator.api.spec.FlinkSessionJobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
-import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
-import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.Savepoint;
 import org.apache.flink.kubernetes.operator.api.status.SavepointFormatType;
 import org.apache.flink.kubernetes.operator.api.status.SavepointInfo;
@@ -393,12 +391,9 @@ public class TestingFlinkService extends AbstractFlinkService {
     }
 
     @Override
-    public void deleteClusterDeployment(
-            ObjectMeta meta, FlinkDeploymentStatus status, boolean deleteHaMeta) {
+    protected void deleteClusterInternal(ObjectMeta meta, boolean deleteHaMeta) {
         jobs.clear();
         sessions.remove(meta.getName());
-        status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
-        status.getJobStatus().setState(JobStatus.FINISHED.name());
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Currently Flink 1.15+ application JMs are never shut down after termination.
This is not necessary as we only rely on them for one succesful observe step from the operator logic perspective.

This PR introduces a configured time after which the operator shuts down terminated application JMs. This allows users to still inspect the cluster for some time but not have lingering pods forever.

## Brief change log

  - *Add shutdown ttl config for application JMs*
  - *Some FlinkService cleanup*

## Verifying this change

Extended the `ApplicationReconcilerTest` to cover for custom shutdown ttl.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs / JavaDocs
