### PR TITLE
[FLINK-29974] Not allowing the cancelling the which are already in the completed state.

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -369,29 +369,24 @@ public abstract class AbstractFlinkService implements FlinkService {
         var jobId = JobID.fromHexString(jobIdString);
         Optional<String> savepointOpt = Optional.empty();
 
-        if (ReconciliationUtils.isJobInTerminalState(sessionJobStatus)) {
-            LOG.info("Job is already in terminal state. JobID {}", jobId.toHexString());
-            return;
-        } else if (!ReconciliationUtils.isJobRunning(sessionJobStatus)) {
-            throw new RuntimeException(
-                    "Unexpected non-terminal status: "
-                            + sessionJobStatus.getJobStatus().getState());
-        }
+        LOG.debug("Current Job State, {}", jobStatus.getState());
 
         try (ClusterClient<String> clusterClient = getClusterClient(conf)) {
             final String clusterId = clusterClient.getClusterId();
             switch (upgradeMode) {
                 case STATELESS:
-                    LOG.info("Cancelling job.");
-                    clusterClient
-                            .cancel(jobId)
-                            .get(
-                                    configManager
-                                            .getOperatorConfiguration()
-                                            .getFlinkCancelJobTimeout()
-                                            .toSeconds(),
-                                    TimeUnit.SECONDS);
-                    LOG.info("Job successfully cancelled.");
+                    if (ReconciliationUtils.isJobRunning(sessionJobStatus)) {
+                        LOG.info("Cancelling job.");
+                        clusterClient
+                                .cancel(jobId)
+                                .get(
+                                        configManager
+                                                .getOperatorConfiguration()
+                                                .getFlinkCancelJobTimeout()
+                                                .toSeconds(),
+                                        TimeUnit.SECONDS);
+                        LOG.info("Job successfully cancelled.");
+                    }
                     break;
                 case SAVEPOINT:
                     LOG.info("Suspending job with savepoint.");
@@ -402,22 +397,31 @@ public abstract class AbstractFlinkService implements FlinkService {
                             conf.get(ExecutionCheckpointingOptions.CHECKPOINTING_TIMEOUT)
                                     .getSeconds();
                     try {
-                        String savepoint =
-                                clusterClient
-                                        .stopWithSavepoint(
-                                                jobId,
-                                                false,
-                                                savepointDirectory,
-                                                conf.get(FLINK_VERSION)
-                                                                .isNewerVersionThan(
-                                                                        FlinkVersion.v1_14)
-                                                        ? conf.get(
-                                                                KubernetesOperatorConfigOptions
-                                                                        .OPERATOR_SAVEPOINT_FORMAT_TYPE)
-                                                        : null)
-                                        .get(timeout, TimeUnit.SECONDS);
-                        savepointOpt = Optional.of(savepoint);
-                        LOG.info("Job successfully suspended with savepoint {}.", savepoint);
+                        if (ReconciliationUtils.isJobRunning(sessionJobStatus)) {
+                            String savepoint =
+                                    clusterClient
+                                            .stopWithSavepoint(
+                                                    jobId,
+                                                    false,
+                                                    savepointDirectory,
+                                                    conf.get(FLINK_VERSION)
+                                                                    .isNewerVersionThan(
+                                                                            FlinkVersion.v1_14)
+                                                            ? conf.get(
+                                                                    KubernetesOperatorConfigOptions
+                                                                            .OPERATOR_SAVEPOINT_FORMAT_TYPE)
+                                                            : null)
+                                            .get(timeout, TimeUnit.SECONDS);
+                            savepointOpt = Optional.of(savepoint);
+                            LOG.info("Job successfully suspended with savepoint {}.", savepoint);
+                        } else if (ReconciliationUtils.isJobInTerminalState(sessionJobStatus)) {
+                            LOG.info(
+                                    "Job is already in terminal state skipping cancel-with-savepoint operation: "
+                                            + jobStatus.getState());
+                        } else {
+                            throw new RuntimeException(
+                                    "Unexpected non-terminal status: " + jobStatus.getState());
+                        }
                     } catch (TimeoutException exception) {
                         throw new FlinkException(
                                 String.format(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -416,8 +416,8 @@ public abstract class AbstractFlinkService implements FlinkService {
                             LOG.info("Job successfully suspended with savepoint {}.", savepoint);
                         } else if (ReconciliationUtils.isJobInTerminalState(sessionJobStatus)) {
                             LOG.info(
-                                    "Job is already in terminal state skipping cancel-with-savepoint operation: "
-                                            + jobStatus.getState());
+                                    "Job is already in terminal state skipping cancel-with-savepoint operation: {}",
+                                    jobStatus.getState());
                         } else {
                             throw new RuntimeException(
                                     "Unexpected non-terminal status: " + jobStatus.getState());

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -370,7 +370,7 @@ public abstract class AbstractFlinkService implements FlinkService {
         Optional<String> savepointOpt = Optional.empty();
 
         if (ReconciliationUtils.isJobInTerminalState(sessionJobStatus)) {
-            LOG.info("Job is already in terminal state.");
+            LOG.info("Job is already in terminal state. JobID {}", jobId.toHexString());
             return;
         } else if (!ReconciliationUtils.isJobRunning(sessionJobStatus)) {
             throw new RuntimeException(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -371,6 +371,7 @@ public abstract class AbstractFlinkService implements FlinkService {
 
         if (ReconciliationUtils.isJobInTerminalState(sessionJobStatus)) {
             LOG.info("Job is already in terminal state.");
+            return;
         } else if (!ReconciliationUtils.isJobRunning(sessionJobStatus)) {
             throw new RuntimeException(
                     "Unexpected non-terminal status: "

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_JOB_RESTART_FAILED;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -233,7 +234,7 @@ public class SessionJobReconcilerTest {
     }
 
     @Test
-    public void testAlreadyCancelledJob() throws Exception {
+    public void testAlreadyCompletedJob() throws Exception {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
         var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
@@ -259,15 +260,10 @@ public class SessionJobReconcilerTest {
                 flinkService.listJobs().get(0).f1.getJobState());
 
         verifyJobState(statelessSessionJob, JobState.SUSPENDED, "FINISHED");
-
-        var exception =
-                Assertions.assertThrows(
-                        RuntimeException.class,
-                        () ->
-                                flinkService.cancelSessionJob(
-                                        statelessSessionJob, UpgradeMode.STATELESS, jobConfig));
-
-        Assertions.assertTrue(exception.getMessage().equals("Job is Already in FINISHED state"));
+        assertDoesNotThrow(
+                () ->
+                        flinkService.cancelSessionJob(
+                                statelessSessionJob, UpgradeMode.STATELESS, jobConfig));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

*Allowing the only required job can be cancelled.*

## Brief change log

  - *Changed the `AbstractFlinkService` class `CancelSessionJob` method to allow only the necessary jobs can be cancelled*

## Verifying this change

This change added tests and can be verified as follows:

  - *Extended the `SessionJobReconcilerTest` for testing this scenario.*
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduces a new feature? no
  - If yes, how is the feature documented? docs / JavaDocs 
