### PR TITLE
[FLINK-29959] Use optimistic locking when updating the status

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -274,8 +274,8 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | timeStamp | long | Millisecond timestamp at the start of the savepoint operation. |
 | location | java.lang.String | External pointer of the savepoint can be used to recover jobs. |
 | triggerType | org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType | Savepoint trigger mechanism. |
-| formatType | org.apache.flink.kubernetes.operator.api.status.SavepointFormatType |  |
-| triggerNonce | java.lang.Long | Nonce value used when the savepoint was triggered manually {@link SavepointTriggerType#MANUAL}, defaults to 0. |
+| formatType | org.apache.flink.kubernetes.operator.api.status.SavepointFormatType | Savepoint format. |
+| triggerNonce | java.lang.Long | Nonce value used when the savepoint was triggered manually {@link SavepointTriggerType#MANUAL}, null for other types of savepoints. |
 
 ### SavepointFormatType
 **Class**: org.apache.flink.kubernetes.operator.api.status.SavepointFormatType
@@ -297,9 +297,9 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | lastSavepoint | org.apache.flink.kubernetes.operator.api.status.Savepoint | Last completed savepoint by the operator. |
 | triggerId | java.lang.String | Trigger id of a pending savepoint operation. |
-| triggerTimestamp | long | Trigger timestamp of a pending savepoint operation. |
+| triggerTimestamp | java.lang.Long | Trigger timestamp of a pending savepoint operation. |
 | triggerType | org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType | Savepoint trigger mechanism. |
-| formatType | org.apache.flink.kubernetes.operator.api.status.SavepointFormatType |  |
+| formatType | org.apache.flink.kubernetes.operator.api.status.SavepointFormatType | Savepoint format. |
 | savepointHistory | java.util.List<org.apache.flink.kubernetes.operator.api.status.Savepoint> | List of recent savepoints. |
 | lastPeriodicSavepointTimestamp | long | Trigger timestamp of last periodic savepoint operation. |
 

--- a/e2e-tests/test_application_operations.sh
+++ b/e2e-tests/test_application_operations.sh
@@ -45,8 +45,8 @@ job_id=$(kubectl logs $jm_pod_name -c flink-main-container | grep -E -o 'Job [a-
 # Testing trigger savepoint
 kubectl patch $APPLICATION_IDENTIFIER --type merge --patch '{"spec":{"job": {"savepointTriggerNonce": 123456 } } }'
 wait_for_logs $jm_pod_name "Triggering savepoint for job" ${TIMEOUT} || exit 1
-wait_for_status $APPLICATION_IDENTIFIER '.status.jobStatus.savepointInfo.triggerId' "" $TIMEOUT || exit 1
-wait_for_status $APPLICATION_IDENTIFIER '.status.jobStatus.savepointInfo.triggerTimestamp' 0 $TIMEOUT || exit 1
+wait_for_status $APPLICATION_IDENTIFIER '.status.jobStatus.savepointInfo.triggerId' null $TIMEOUT || exit 1
+wait_for_status $APPLICATION_IDENTIFIER '.status.jobStatus.savepointInfo.triggerTimestamp' null $TIMEOUT || exit 1
 location=$(kubectl get $APPLICATION_IDENTIFIER -o yaml | yq '.status.jobStatus.savepointInfo.lastSavepoint.location')
 if [ "$location" == "" ];then
   echo "lost savepoint location"
@@ -68,5 +68,3 @@ wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RU
 assert_available_slots 1 $CLUSTER_ID
 
 echo "Successfully run the last-state upgrade test"
-
-

--- a/e2e-tests/test_sessionjob_operations.sh
+++ b/e2e-tests/test_sessionjob_operations.sh
@@ -46,8 +46,8 @@ assert_available_slots 0 $CLUSTER_ID
 # Testing trigger savepoint
 kubectl patch sessionjob ${SESSION_JOB_NAME} --type merge --patch '{"spec":{"job": {"savepointTriggerNonce": 123456 } } }'
 wait_for_logs $jm_pod_name "Triggering savepoint for job" ${TIMEOUT} || exit 1
-wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.savepointInfo.triggerId' "" $TIMEOUT || exit 1
-wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.savepointInfo.triggerTimestamp' 0 $TIMEOUT || exit 1
+wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.savepointInfo.triggerId' null $TIMEOUT || exit 1
+wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.savepointInfo.triggerTimestamp' null $TIMEOUT || exit 1
 location=$(kubectl get $SESSION_JOB_IDENTIFIER -o yaml | yq '.status.jobStatus.savepointInfo.lastSavepoint.location')
 if [ "$location" == "" ];then
   echo "lost savepoint location"

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
@@ -41,7 +41,7 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
     private JobStatus jobStatus = new JobStatus();
 
     /** Error information about the FlinkDeployment/FlinkSessionJob. */
-    private String error = "";
+    private String error;
 
     /**
      * Current reconciliation status of this resource.

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/Savepoint.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/Savepoint.java
@@ -22,6 +22,8 @@ import org.apache.flink.annotation.Experimental;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import javax.annotation.Nullable;
+
 /** Represents information about a finished savepoint. */
 @Experimental
 @Data
@@ -36,42 +38,43 @@ public class Savepoint {
     /** Savepoint trigger mechanism. */
     private SavepointTriggerType triggerType = SavepointTriggerType.UNKNOWN;
 
+    /** Savepoint format. */
     private SavepointFormatType formatType = SavepointFormatType.UNKNOWN;
 
     /**
      * Nonce value used when the savepoint was triggered manually {@link
-     * SavepointTriggerType#MANUAL}, defaults to 0.
+     * SavepointTriggerType#MANUAL}, null for other types of savepoints.
      */
-    private Long triggerNonce = 0L;
+    private Long triggerNonce;
 
     public Savepoint(
             long timeStamp,
             String location,
-            SavepointTriggerType triggerType,
-            SavepointFormatType formatType,
-            Long triggerNonce) {
+            @Nullable SavepointTriggerType triggerType,
+            @Nullable SavepointFormatType formatType,
+            @Nullable Long triggerNonce) {
         this.timeStamp = timeStamp;
         this.location = location;
-        this.triggerType = triggerType;
-        this.formatType = formatType;
-        setTriggerNonce(triggerNonce);
+        if (triggerType != null) {
+            this.triggerType = triggerType;
+        }
+        if (formatType != null) {
+            this.formatType = formatType;
+        }
+        this.triggerNonce = triggerNonce;
     }
 
     public static Savepoint of(String location, SavepointTriggerType triggerType) {
         return new Savepoint(
-                System.currentTimeMillis(), location, triggerType, SavepointFormatType.UNKNOWN, 0L);
+                System.currentTimeMillis(),
+                location,
+                triggerType,
+                SavepointFormatType.UNKNOWN,
+                null);
     }
 
     public static Savepoint of(
             String location, SavepointTriggerType triggerType, SavepointFormatType formatType) {
-        return new Savepoint(System.currentTimeMillis(), location, triggerType, formatType, 0L);
-    }
-
-    public void setTriggerNonce(Long triggerNonce) {
-        if (triggerNonce == null) {
-            this.triggerNonce = 0L;
-        } else {
-            this.triggerNonce = triggerNonce;
-        }
+        return new Savepoint(System.currentTimeMillis(), location, triggerType, formatType, null);
     }
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/SavepointInfo.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/SavepointInfo.java
@@ -38,15 +38,16 @@ public class SavepointInfo {
     private Savepoint lastSavepoint;
 
     /** Trigger id of a pending savepoint operation. */
-    private String triggerId = "";
+    private String triggerId;
 
     /** Trigger timestamp of a pending savepoint operation. */
-    private long triggerTimestamp = 0L;
+    private Long triggerTimestamp;
 
     /** Savepoint trigger mechanism. */
-    private SavepointTriggerType triggerType = SavepointTriggerType.UNKNOWN;
+    private SavepointTriggerType triggerType;
 
-    private SavepointFormatType formatType = SavepointFormatType.UNKNOWN;
+    /** Savepoint format. */
+    private SavepointFormatType formatType;
 
     /** List of recent savepoints. */
     private List<Savepoint> savepointHistory = new ArrayList<>();
@@ -63,8 +64,10 @@ public class SavepointInfo {
     }
 
     public void resetTrigger() {
-        this.triggerId = "";
-        this.triggerTimestamp = 0L;
+        this.triggerId = null;
+        this.triggerTimestamp = null;
+        this.triggerType = null;
+        this.formatType = null;
     }
 
     /**

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
@@ -76,6 +76,7 @@ public class BaseTestUtils {
                         .withNamespace(namespace)
                         .withCreationTimestamp(Instant.now().toString())
                         .withUid(UUID.randomUUID().toString())
+                        .withResourceVersion("1")
                         .build());
         deployment.setSpec(getTestFlinkDeploymentSpec(version));
         return deployment;
@@ -119,6 +120,7 @@ public class BaseTestUtils {
                         .withCreationTimestamp(Instant.now().toString())
                         .withUid(UUID.randomUUID().toString())
                         .withGeneration(1L)
+                        .withResourceVersion("1")
                         .build());
 
         Map<String, String> conf = new HashMap<>();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/StatusConflictException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/StatusConflictException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.exception;
+
+/** Exception for status updates. */
+public class StatusConflictException extends RuntimeException {
+
+    private static final long serialVersionUID = 2260638990044248181L;
+
+    public StatusConflictException(String msg) {
+        super(msg);
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -207,7 +207,7 @@ public abstract class AbstractFlinkDeploymentObserver
         if (status.getJobManagerDeploymentStatus() != JobManagerDeploymentStatus.ERROR
                 && !JobStatus.FAILED.name().equals(dep.getStatus().getJobStatus().getState())
                 && reconciliationStatus.isLastReconciledSpecStable()) {
-            status.setError("");
+            status.setError(null);
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -103,7 +103,7 @@ public class ReconciliationUtils {
         var reconciliationStatus = status.getReconciliationStatus();
 
         // Clear errors
-        status.setError("");
+        status.setError(null);
         reconciliationStatus.setReconciliationTimestamp(System.currentTimeMillis());
         reconciliationStatus.setState(
                 upgrading ? ReconciliationState.UPGRADING : ReconciliationState.DEPLOYED);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -247,7 +247,7 @@ public abstract class AbstractJobReconciler<
                 && observeConfig.getBoolean(OPERATOR_JOB_RESTART_FAILED)) {
             LOG.info("Stopping failed Flink job...");
             cleanupAfterFailedJob(resource, context, observeConfig);
-            resource.getStatus().setError("");
+            resource.getStatus().setError(null);
             resubmitJob(resource, context, observeConfig, false);
             return true;
         } else {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 /** Testing statusRecorder. */
 public class TestingStatusRecorder<
@@ -37,7 +38,7 @@ public class TestingStatusRecorder<
     @Override
     public void patchAndCacheStatus(CR resource) {
         statusCache.put(
-                getKey(resource),
+                ResourceID.fromResource(resource),
                 objectMapper.convertValue(resource.getStatus(), ObjectNode.class));
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -131,7 +131,7 @@ public class FlinkDeploymentControllerTest {
         // Validate reconciliation status
         ReconciliationStatus<FlinkDeploymentSpec> reconciliationStatus =
                 appCluster.getStatus().getReconciliationStatus();
-        assertEquals("", appCluster.getStatus().getError());
+        assertNull(appCluster.getStatus().getError());
         assertEquals(appCluster.getSpec(), reconciliationStatus.deserializeLastReconciledSpec());
         assertNull(appCluster.getStatus().getReconciliationStatus().getLastStableSpec());
 
@@ -971,7 +971,7 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 JobManagerDeploymentStatus.READY,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
-        assertEquals("", appCluster.getStatus().getError());
+        assertNull(appCluster.getStatus().getError());
 
         assertEquals(
                 appCluster.getStatus().getReconciliationStatus().getLastReconciledSpec(),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -343,7 +343,7 @@ public class RollbackTest {
         assertEquals(
                 ReconciliationState.DEPLOYED,
                 deployment.getStatus().getReconciliationStatus().getState());
-        assertEquals("", deployment.getStatus().getError());
+        assertNull(deployment.getStatus().getError());
 
         deployment.getSpec().setRestartNonce(456L);
         triggerRollback.run();
@@ -375,7 +375,7 @@ public class RollbackTest {
             assertEquals(
                     ReconciliationState.DEPLOYED,
                     deployment.getStatus().getReconciliationStatus().getState());
-            assertEquals("", deployment.getStatus().getError());
+            assertNull(deployment.getStatus().getError());
 
             deployment.getSpec().getJob().setState(JobState.RUNNING);
             testController.reconcile(deployment, context);
@@ -388,7 +388,7 @@ public class RollbackTest {
             assertEquals(
                     ReconciliationState.DEPLOYED,
                     deployment.getStatus().getReconciliationStatus().getState());
-            assertEquals("", deployment.getStatus().getError());
+            assertNull(deployment.getStatus().getError());
 
             // Verify suspending a rolled back job
             triggerRollback.run();
@@ -406,7 +406,7 @@ public class RollbackTest {
             assertEquals(
                     ReconciliationState.DEPLOYED,
                     deployment.getStatus().getReconciliationStatus().getState());
-            assertEquals("", deployment.getStatus().getError());
+            assertNull(deployment.getStatus().getError());
         }
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesClientMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesClientMetricsTest.java
@@ -92,7 +92,7 @@ public class KubernetesClientMetricsTest {
                         mockServer.createClient().getConfiguration());
 
         var deployment = TestUtils.buildApplicationCluster();
-        kubernetesClient.resource(deployment).get();
+        kubernetesClient.resource(deployment).fromServer().get();
         assertFalse(listener.getCounter(listener.getMetricId(REQUEST_COUNTER_ID)).isPresent());
         assertFalse(listener.getMeter(listener.getMetricId(REQUEST_METER_ID)).isPresent());
         assertFalse(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/ResourceLifecycleMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/ResourceLifecycleMetricsTest.java
@@ -81,7 +81,7 @@ public class ResourceLifecycleMetricsTest {
         application.getStatus().getJobStatus().setState(JobStatus.FAILED.name());
         assertEquals(FAILED, application.getStatus().getLifecycleState());
 
-        application.getStatus().setError("");
+        application.getStatus().setError(null);
 
         application
                 .getStatus()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for {@link SavepointObserver}. */
@@ -172,6 +173,6 @@ public class SavepointObserverTest {
         assertEquals(savepointInfo.getLastSavepoint(), savepointInfo.getSavepointHistory().get(0));
         assertEquals(
                 SavepointTriggerType.PERIODIC, savepointInfo.getLastSavepoint().getTriggerType());
-        assertEquals(0L, savepointInfo.getLastSavepoint().getTriggerNonce());
+        assertNull(savepointInfo.getLastSavepoint().getTriggerNonce());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -283,23 +283,13 @@ public class ApplicationReconcilerTest {
                 SavepointTriggerType.MANUAL,
                 spDeployment.getStatus().getJobStatus().getSavepointInfo().getTriggerType());
 
-        spDeployment.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
         ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(
                 spDeployment.getStatus().getJobStatus().getSavepointInfo(), spDeployment);
+        spDeployment.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
 
         // don't trigger when nonce is the same
         reconciler.reconcile(spDeployment, context);
         assertFalse(SavepointUtils.savepointInProgress(spDeployment.getStatus().getJobStatus()));
-
-        spDeployment.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
-        ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(
-                spDeployment.getStatus().getJobStatus().getSavepointInfo(), spDeployment);
-        // If manual savepointing is done but the last savepont is not updated, it is considered
-        // abandoned.
-        assertEquals(
-                SavepointStatus.ABANDONED, SavepointUtils.getLastSavepointStatus(spDeployment));
-
-        updateLastSavepoint(spDeployment);
         assertEquals(
                 SavepointStatus.SUCCEEDED, SavepointUtils.getLastSavepointStatus(spDeployment));
 
@@ -325,7 +315,6 @@ public class ApplicationReconcilerTest {
         assertEquals(
                 SavepointTriggerType.MANUAL,
                 spDeployment.getStatus().getJobStatus().getSavepointInfo().getTriggerType());
-        spDeployment.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
         ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(
                 spDeployment.getStatus().getJobStatus().getSavepointInfo(), spDeployment);
         updateLastSavepoint(spDeployment);


### PR DESCRIPTION
## What is the purpose of the change

Currently the operator uses `patchStatus()` without any resource version locking to update the Flink resources. This means that the operator overwrites whatever status was there previously. This was convenient so far but with leader election it is much more likely to get into a situation where this can be problematic.

This change introduces optimistic locking for the status which detects if someone externally modified the status without the reconciliation logic being aware of it.

There are 2 main problems that we target here:
 1. Status updates by zombie operators who has last lost leadership but not realized/dead yet.
 2. Stale status received when a new leader starts
 
**Why would these happen?**

Zombie operator: 
It could in theory happen that an operator loses leadership in a middle of reconciliation due to a very long GC pause (or some network issue or whatever) and the current CR reconcile loop continues while the new leader already started to reconcile this resource. This is very unlikely but can happen with leader election and a standby operator. In these cases we don't want to allow the old operator who lost leadership to be able to make any status updates. The new logic guarantees that if the new leader made any status update the old would never be able to do so again.

Stale status:
When the new leader starts processing (if it was on standby) there is no guarantee that the status/spec reconciled at the first time is up to date. This can happen because due to some unlucky cache update timing or even a zombie operator submitting late status updates. The current operator logic very much relies on seeing the last status otherwise we can have some very weird cornercases that would definitely cause problems for the resources.

**How the new logic tackles this in a safe way**
 
What the new logic does is that it basically only allows status updates to go through when the operator has the latest status information. So it's sort of a locking on the current status. If anyone else changed the status in the meantime, we simply throw an error and retrigger the reconciliation. This is actually safe to do as the operator reconcile logic already runs with the assumption that the operator can fail at any time before status update, and we always use the status as a "write-ahead-log" of the actions we are taking. In these cases zombie operators who have already lost leadership would never reconcile again (the leader election guarantees that), and in other cases this would give us the latest version of the resource.

*Note:*
It's not easy to write unit tests that validate the logic as the fabric8 mockserver/utilities do not work well with optimistic locking. See https://github.com/fabric8io/kubernetes-client/issues/4573 for details.

## Brief change log

  - *Add optimistic locking for status updates*
  - *Remove empty strings from status*
  - *Added new integration test*

## Verifying this change

 - Extended the operator IT case
 - Manually verified on minikube
 - e2es

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
