### PR TITLE
[FLINK-30004] Cleanup deployment after savepoint for Flink versions < 1.15

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -326,6 +326,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                                 exception);
                     }
                     if (deleteClusterAfterSavepoint) {
+                        LOG.info("Cleaning up deployment after stop-with-savepoint");
                         deleteClusterDeployment(deployment.getMetadata(), deploymentStatus, true);
                     }
                     break;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -27,6 +27,7 @@ import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.client.deployment.application.cli.ApplicationClusterDeployer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
@@ -80,7 +81,11 @@ public class NativeFlinkService extends AbstractFlinkService {
     public void cancelJob(
             FlinkDeployment deployment, UpgradeMode upgradeMode, Configuration configuration)
             throws Exception {
-        cancelJob(deployment, upgradeMode, configuration, false);
+        // prior to Flink 1.15, ensure removal of orphaned config maps
+        // https://issues.apache.org/jira/browse/FLINK-30004
+        boolean deleteClusterAfterSavepoint =
+                !deployment.getSpec().getFlinkVersion().isNewerVersionThan(FlinkVersion.v1_14);
+        cancelJob(deployment, upgradeMode, configuration, deleteClusterAfterSavepoint);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

* Cleanup underlying deployment resources after cancel with savepoint. Flink version < 1.15 is supposed to do that automatically but we see instances where stray HA config maps cause resume/restore to fail.

## Brief change log

* if the Flink version is < 1.15, cleanup deployment after cancel

## Verifying this change

* unit test modified to cover the version specific behavior
* manual verification with existing deployment

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / **no**)
  - Core observer or reconciler logic that is regularly executed: (yes / **no**)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)

