### PR TITLE
[FLINK-30047] getLastSavepointStatus should return null when there is…

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -87,8 +87,8 @@ public class SavepointUtils {
                 return SavepointStatus.SUCCEEDED;
             }
         } else {
-            // Currently, we return SUCCEEDED if no savepoints were ever taken
-            return SavepointStatus.SUCCEEDED;
+            // Return null if no savepoint was ever taken
+            return null;
         }
 
         return SavepointStatus.ABANDONED;


### PR DESCRIPTION
… never savepoint completed or pending

## What is the purpose of the change

This is for FLINK-30047 getLastSavepointStatus should return null when there is never savepoint completed or not currently pending.  This to indicate an initial state.


## Brief change log

  -  getLastSavepointStatus return null instead of SUCCEEDED when there is never savepoint completed or not currently pending. 

## Verifying this change

This change added tests and can be verified as follows:

  - Test cases updated to reflect the change
 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: No
  - Core observer or reconciler logic that is regularly executed: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? not applicable
