### PR TITLE
[FLINK-30176] Fix assert_available_slots when curl is returning empty response

### DIFF
--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -61,9 +61,9 @@ function assert_available_slots() {
   expected=$1
   CLUSTER_ID=$2
   ip=$(minikube ip)
-  actual=$(curl http://$ip/default/${CLUSTER_ID}/overview 2>/dev/null | grep -E -o '"slots-available":[0-9]+' | awk -F':' '{print $2}')
-  if [[ expected -ne actual ]]; then
-    echo "Expected available slots: $expected, actual: $actual"
+  actual=$(curl "http://$ip/default/${CLUSTER_ID}/overview" 2>/dev/null | grep -E -o '"slots-available":[0-9]+' | awk -F':' '{print $2}')
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "Expected available slots: ${expected}, actual: ${actual}"
     exit 1
   fi
   echo "Successfully assert available slots"


### PR DESCRIPTION
## What is the purpose of the change

The condition is simply wrong, please see the following case:
```
$ expected=0
$ actual=""

$ if [[ expected -ne actual ]] then echo "Not same"; else echo "Same"; fi
Same

$ if [[ $expected != $actual ]] then echo "Not same"; else echo "Same"; fi
Not same
```
In this PR I've fixed this edge case.

## Brief change log

Fixed the bash logic.

## Verifying this change

Existing e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
