### PR TITLE
[FLINK-30157] Trigger Events Before JM Recovery and Unhealthy Job Restart

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -126,6 +126,8 @@ public class EventRecorder {
         Cleanup,
         CleanupFailed,
         Missing,
-        ValidationError
+        ValidationError,
+        RecoverDeployment,
+        RestartUnhealthyJob
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

To emit specific events along the following cases:
- JM recovery
- Unhealthy Job Restarts

## Brief change log

`ApplicationReconciler` has been updated with the extra event logic

## Verifying this change
Unit tests where added to `ApplicationReconcilerTest` that covers the functionality.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
