### PR TITLE
FLINK-30199: Add a script to run Kubernetes Operator e2e tests manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,10 @@ jobs:
           stop_minikube
   e2e_ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ "v1_16","v1_15","v1_14","v1_13" ]
+        namespace: [ "default","flink" ]
     name: e2e_ci
     steps:
       - uses: actions/checkout@v2
@@ -110,7 +114,7 @@ jobs:
       - name: Run the tests
         run: |
           source e2e-tests/utils.sh
-          bash e2e-tests/run_tests.sh -f v1_16,v1_15,v1_14,v1_13 -m native,standalone -n flink,default -d test_multi_sessionjob.sh test_application_operations.sh test_application_kubernetes_ha.sh test_sessionjob_kubernetes_ha.sh test_sessionjob_operations.sh || exit 1
+          bash e2e-tests/run_tests.sh -f ${{ matrix.version }} -n ${{ matrix.namespace }} -m native,standalone -d test_multi_sessionjob.sh test_application_operations.sh test_application_kubernetes_ha.sh test_sessionjob_kubernetes_ha.sh test_sessionjob_operations.sh || exit 1
       - name: Stop minikube
         run: |
           source e2e-tests/utils.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,8 @@ jobs:
           start_minikube
       - name: Install cert-manager
         run: |
-          kubectl get pods -A
-          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
-          kubectl -n cert-manager wait --all=true --for=condition=Available --timeout=300s deploy
+          source e2e-tests/utils.sh
+          install_cert_manager
       - name: Build image
         run: |
           export SHELL=/bin/bash
@@ -93,31 +92,6 @@ jobs:
           stop_minikube
   e2e_ci:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        version: ["v1_16","v1_15","v1_14","v1_13"]
-        namespace: ["default","flink"]
-        mode: ["native", "standalone"]
-        test:
-          - test_application_kubernetes_ha.sh
-          - test_application_operations.sh
-          - test_sessionjob_kubernetes_ha.sh
-          - test_sessionjob_operations.sh
-          - test_multi_sessionjob.sh
-        include:
-          - namespace: flink
-            extraArgs: '--create-namespace --set "watchNamespaces={default,flink}"'
-          - version: v1_16
-            image: flink:1.16
-          - version: v1_15
-            image: flink:1.15
-          - version: v1_14
-            image: flink:1.14
-          - version: v1_13
-            image: flink:1.13
-        exclude:
-          - namespace: default
-            test: test_multi_sessionjob.sh
     name: e2e_ci
     steps:
       - uses: actions/checkout@v2
@@ -133,39 +107,10 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - name: Start minikube
+      - name: Run the tests
         run: |
           source e2e-tests/utils.sh
-          start_minikube
-      - name: Install cert-manager
-        run: |
-          kubectl get pods -A
-          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
-          kubectl -n cert-manager wait --all=true --for=condition=Available --timeout=300s deploy
-      - name: Build image
-        run: |
-          export SHELL=/bin/bash
-          export DOCKER_BUILDKIT=1
-          eval $(minikube -p minikube docker-env)
-          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain .
-          docker images
-      - name: Start the operator
-        run: |
-          helm --debug install flink-kubernetes-operator -n ${{ matrix.namespace }} helm/flink-kubernetes-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-latest ${{ matrix.extraArgs }}
-          kubectl wait --for=condition=Available --timeout=120s -n ${{ matrix.namespace }} deploy/flink-kubernetes-operator
-          kubectl get pods
-      - name: Run Flink e2e tests
-        run: |
-          sed -i "s/image: flink:.*/image: ${{ matrix.image }}/" e2e-tests/data/*.yaml
-          sed -i "s/flinkVersion: .*/flinkVersion: ${{ matrix.version }}/" e2e-tests/data/*.yaml
-          sed -i "s/mode: .*/mode: ${{ matrix.mode }}/" e2e-tests/data/*.yaml
-          git diff HEAD
-          echo "Running e2e-tests/$test"
-          bash e2e-tests/${{ matrix.test }} || exit 1
-          git reset --hard
-      - name: Stop the operator
-        run: |
-          helm uninstall -n ${{ matrix.namespace }} flink-kubernetes-operator
+          bash e2e-tests/run_tests.sh -f v1_16,v1_15,v1_14,v1_13 -m native,standalone -n flink,default -d test_multi_sessionjob.sh test_application_operations.sh test_application_kubernetes_ha.sh test_sessionjob_kubernetes_ha.sh test_sessionjob_operations.sh || exit 1
       - name: Stop minikube
         run: |
           source e2e-tests/utils.sh

--- a/docs/content/docs/development/guide.md
+++ b/docs/content/docs/development/guide.md
@@ -82,6 +82,28 @@ To uninstall you can simply call:
 helm uninstall flink-kubernetes-operator
 ```
 
+### Installing the operator locally using the e2e test scripts
+
+Alternatively you can skip [Building docker images](#building-docker-images) and
+[Installing the operator locally](#installing-the-operator-locally) altogether and with the
+use of the e2e test scripts you can install the Flink Kubernetes Operator from the local codebase.
+
+You still need to install [Docker Desktop](https://www.docker.com/products/docker-desktop),
+[minikube](https://minikube.sigs.k8s.io/docs/start/) and [helm](https://helm.sh/docs/intro/quickstart/) locally.
+
+The e2e test scripts automate the following steps:
+- Starting minikube (if needed)
+- Installing the Certification Manager (overwriting the existing one if already installed)
+- Compiling the Flink Kubernetes Operator binary from the local codebase
+- Building the Flink Kubernetes Operator Docker image using the previously compiled binary
+- Installing the freshly created Kubernetes Operator to the specified namespace
+- Run a single test to check if the operator is working as expected
+
+It could be done simplz by calling the following script:
+```bash
+./e2e-tests/run_tests.sh -k
+```
+
 ### Running the operator from the IDE
 
 You can run or debug the `FlinkOperator` from your preferred IDE. The operator itself is accessing the deployed Flink clusters through the REST interface. When running locally the `rest.port`, `rest.address` and `kubernetes.rest-service.exposed.type` Flink configuration parameters must be modified.
@@ -152,3 +174,14 @@ Considering the cost of running the builds, the stability, and the maintainabili
 All the unit tests, integration tests, and the end-to-end tests will be triggered for each PR.
 
 Note: Please make sure the CI passed before merging.
+
+## Running the e2e tests locally
+
+After installing [Docker Desktop](https://www.docker.com/products/docker-desktop),
+[minikube](https://minikube.sigs.k8s.io/docs/start/) and [helm](https://helm.sh/docs/intro/quickstart/) locally
+you will be able to run the end-to-end tests locally using the `e2e-tests/run_tests.sh` script.
+
+For usage examples, please execute it with the following command:
+```bash
+./e2e-tests/run_tests.sh -h
+```

--- a/e2e-tests/run_tests.sh
+++ b/e2e-tests/run_tests.sh
@@ -25,55 +25,68 @@ function help() {
   echo "Script to run the flink kubernetes operator e2e tests."
   echo
   echo "Syntax: run_tests.sh [-i|-f|-m|-n|-s|-c|-h] scripts"
-  echo ""
+  echo
   echo "Options:"
-  echo " -i     The Flink image to use (eg. flink:1.16 / flink:1.15 / flink:1.14)."
-  echo " -f     The Flink version(s) to use (eg. v1_16 / v1_15 / v1_14)."
-  echo " -m     The run mode(s) to use (eg. native / standalone)."
-  echo " -n     The namespace(s) to install the operator to."
-  echo " -s     If set then skips the operator build (Make sure that minikube already has a version of the operator)."
+  echo " -i     The Flink image to use (eg. flink:1.16 / flink:1.15 / flink:1.14). Only needed if the default docker image for the Flink version need to be changed."
+  echo " -f     The Flink version(s) to use (eg. v1_16 / v1_15 / v1_14). Could contain multiple values separated by ','"
+  echo " -m     The run mode(s) to use (eg. native / standalone). Could contain multiple values separated by ','"
+  echo " -n     The namespace(s) to install the operator to. Could contain multiple values separated by ','"
+  echo " -s     If set then skips the operator build (Make sure that minikube already has a version of the operator with the name of 'flink-kubernetes-operator:ci-latest')."
+  echo " -k     After the test run the operator is not uninstalled. Will exit after the first test run."
   echo " -d     If set then the script will print debug logs."
   echo " -h     Print this help."
-  echo ""
+  echo
   echo "On MAC do not forget to start the 'minikube tunnel' in a different terminal."
   echo "Visit this terminal from time to time, as it will ask you for root password."
   echo "This is needed to forward the rest endpoint requests to port 80."
-  echo ""
+  echo
   echo "Examples:"
   echo "  Start the test_application_operations.sh (default) test on a newly built and deployed operator."
   echo "  The test will use the default settings for every config value:"
-  echo "    ./manual_tests.sh"
-  echo ""
-  echo "  Start a single test using the currently deployed operator which is deployed in the 'flink' namespace:"
-  echo "    ./manual_tests.sh -s -namespace flink"
-  echo ""
+  echo "    ./run_tests.sh"
+  echo
+  echo "  Start a single test using the currently compiled docker image of the operator which should be available on the minikube."
+  echo "  The operator will be deployed in the 'flink' namespace:"
+  echo "    ./run_tests.sh -s -namespace flink"
+  echo
   echo "  Run multiple tests:"
-  echo "    ./manual_tests.sh test_application_operations.sh test_sessionjob_operations.sh"
-  echo ""
+  echo "    ./run_tests.sh test_application_operations.sh test_sessionjob_operations.sh"
+  echo
   echo "  Run a single test and show debug logs:"
-  echo "     ./manual_tests.sh -d"
-  echo ""
+  echo "    ./run_tests.sh -d"
+  echo
   echo "  Use every possible configuration:"
-  echo "     ./manual_tests.sh -i 'flink:1.15' -f 'v1_15' -m standalone -n flink -s -k test_sessionjob_operations.sh"
-  echo ""
+  echo "    ./run_tests.sh -i 'flink:1.15' -f 'v1_15' -m standalone -n flink -s -k test_sessionjob_operations.sh"
+  echo
+  echo "  Run every possible test configuration:"
+  echo "    ./run_tests.sh -f v1_16,v1_15,v1_14,v1_13 -m native,standalone -n flink,default -d test_multi_sessionjob.sh test_application_operations.sh test_application_kubernetes_ha.sh test_sessionjob_kubernetes_ha.sh test_sessionjob_operations.sh"
+  echo
+  echo
+  echo "  Use the script to compile and deploy the current version of the operator, and check the deployment:"
+  echo "    ./run_tests.sh -k"
+  echo
 }
 
+# Default values
 image=""
 flink_versions="v1_16"
 modes="native"
 namespaces="default"
 skip_operator="false"
+keep_operator="false"
 
+# Flink version to Flink docker image mapping. Add new version and image here if it is supported.
 versions=("v1_16" "v1_15" "v1_14" "v1_13")
 images=("flink:1.16" "flink:1.15" "flink:1.14" "flink:1.13")
 
-while getopts "i:f:m:n:hsd" option; do
+while getopts "i:f:m:n:hsdk" option; do
    case $option in
       i) image=$OPTARG;;
       f) flink_versions=$OPTARG;;
       m) modes=$OPTARG;;
       n) namespaces=$OPTARG;;
       s) skip_operator="true";;
+      k) keep_operator="true";;
       d) DEBUG="true";;
       h) # display Help
          help
@@ -89,6 +102,7 @@ if [[ -z "${scripts}" ]]; then
   scripts="test_application_operations.sh"
 fi
 
+echo
 echo "-----------------------------------"
 echo "Start testing with the following parameters:"
 echo " Image:                  ${image}"
@@ -100,19 +114,46 @@ echo " Script() to run:        ${scripts}"
 echo "-----------------------------------"
 
 pushd $ROOT_DIR
-start_minikube
-install_cert_manager
+echo
+echo "-----------------------------------"
+echo "Starting minikube"
+echo "-----------------------------------"
+echo
+time start_minikube
+
+echo
+echo "-----------------------------------"
+echo "Installing certificate manager"
+echo "-----------------------------------"
+echo
+time install_cert_manager
+
 if [[ "$skip_operator" = true ]]; then
-  echo ""
-  echo "SKIPPING operator build"
-  echo ""
+  echo
+  echo "-----------------------------------"
+  echo "Skipping operator build"
+  echo "-----------------------------------"
 else
-  build_image
+  echo
+  echo "-----------------------------------"
+  echo "Building operator"
+  echo "-----------------------------------"
+  echo
+  time build_image
 fi
 
-if [[ ! -z $(get_operator_pod_name) ]]; then
-  echo "Found existing operator. Please remove and restart the script. The following command could be used:"
-  echo " helm delete flink-kubernetes-operator"
+if [[ ! -z $(get_operator_pod_name 2>/dev/null) ]]; then
+  operator_pod_namespace=$(get_operator_pod_namespace)
+  echo
+  echo "-----------------------------------"
+  echo "Found existing operator. Please remove and restart the script. The following commands could be used:"
+  echo " helm delete flink-kubernetes-operator -n ${operator_pod_namespace}"
+  echo " kubectl delete namespace flink"
+  echo " kubectl delete serviceaccount flink"
+  echo " kubectl delete role flink"
+  echo " kubectl delete rolebinding flink-role-binding"
+  echo "-----------------------------------"
+  echo
   exit 1;
 fi
 
@@ -125,7 +166,11 @@ for flink_version in ${flink_version_list[@]}; do
   if [[ -z ${test_image} ]]; then
     position=$(get_position ${flink_version} ${versions[@]})
     if [[ -z ${position} ]]; then
+      echo
+      echo "-----------------------------------"
       echo "Unknown Flink version ${flink_version}, please provide an image or a known Flink version"
+      echo "-----------------------------------"
+      echo
       exit 1;
     fi
     test_image=${images[${position}]};
@@ -135,7 +180,6 @@ for flink_version in ${flink_version_list[@]}; do
     prepare_tests ${test_image} ${flink_version} ${mode}
     for namespace in ${namespace_list[@]}; do
       for script in ${scripts}; do
-        install_operator $namespace
         if [[ ${script} = "test_multi_sessionjob.sh" && ${namespace} = "default" ]]; then
           echo
           echo "-----------------------------------"
@@ -146,6 +190,12 @@ for flink_version in ${flink_version_list[@]}; do
         fi
         echo
         echo "-----------------------------------"
+        echo "Installing operator to '${namespace}' namespace"
+        echo "-----------------------------------"
+        echo
+        install_operator $namespace
+        echo
+        echo "-----------------------------------"
         echo "Running test:"
         echo " Namespace:      ${namespace}"
         echo " Flink version:  ${flink_version}"
@@ -154,7 +204,32 @@ for flink_version in ${flink_version_list[@]}; do
         echo " Script:         ${script}"
         echo "-----------------------------------"
         echo
-        time bash $ROOT_DIR/e2e-tests/${script} || exit 1
+        time bash $ROOT_DIR/e2e-tests/${script}
+        if [[ $? -ne 0 ]]; then
+          echo
+          echo "-----------------------------------"
+          echo "Test failed: $ROOT_DIR/e2e-tests/${script}"
+          echo "-----------------------------------"
+          echo
+          exit 1
+        fi
+        echo
+        echo "-----------------------------------"
+        echo "Test succeeded: $ROOT_DIR/e2e-tests/${script}"
+        echo "-----------------------------------"
+        if [[ "$keep_operator" = true ]]; then
+          echo
+          echo "-----------------------------------"
+          echo "Keeping operator and exiting"
+          echo "-----------------------------------"
+          echo
+          exit 0
+        fi
+        echo
+        echo "-----------------------------------"
+        echo "Removing operator from '${namespace}' namespace"
+        echo "-----------------------------------"
+        echo
         uninstall_operator $namespace
       done
     done

--- a/e2e-tests/run_tests.sh
+++ b/e2e-tests/run_tests.sh
@@ -17,6 +17,20 @@
 # limitations under the License.
 ################################################################################
 
+
+readlink -f "$0" 2>/dev/null
+if [[ $? -ne 0 ]]; then
+  echo
+  echo "-----------------------------------"
+  echo "Please make sure that 'readlink -f \"$0\"' works."
+  echo "Maybe:"
+  echo " brew install coreutils"
+  echo " alias readlink=greadlink"
+  echo "-----------------------------------"
+  echo
+  exit 1
+fi
+
 ROOT_DIR=$(dirname $(dirname "$(readlink -f "$0")"))
 source "${ROOT_DIR}/e2e-tests/utils.sh"
 
@@ -183,7 +197,7 @@ for flink_version in ${flink_version_list[@]}; do
         if [[ ${script} = "test_multi_sessionjob.sh" && ${namespace} = "default" ]]; then
           echo
           echo "-----------------------------------"
-          echo "Skipping ${script} on ${namespace} namespace"
+          echo "Skipping ${script} on 'default' namespace, since an equivalent test will/should run on the 'flink' namespace and we want to save CPU time"
           echo "-----------------------------------"
           echo
           continue

--- a/e2e-tests/run_tests.sh
+++ b/e2e-tests/run_tests.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+ROOT_DIR=$(dirname $(dirname "$(readlink -f "$0")"))
+source "${ROOT_DIR}/e2e-tests/utils.sh"
+
+function help() {
+  # Display Help
+  echo "Script to run the flink kubernetes operator e2e tests."
+  echo
+  echo "Syntax: run_tests.sh [-i|-f|-m|-n|-s|-c|-h] scripts"
+  echo ""
+  echo "Options:"
+  echo " -i     The Flink image to use (eg. flink:1.16 / flink:1.15 / flink:1.14)."
+  echo " -f     The Flink version(s) to use (eg. v1_16 / v1_15 / v1_14)."
+  echo " -m     The run mode(s) to use (eg. native / standalone)."
+  echo " -n     The namespace(s) to install the operator to."
+  echo " -s     If set then skips the operator build (Make sure that minikube already has a version of the operator)."
+  echo " -d     If set then the script will print debug logs."
+  echo " -h     Print this help."
+  echo ""
+  echo "On MAC do not forget to start the 'minikube tunnel' in a different terminal."
+  echo "Visit this terminal from time to time, as it will ask you for root password."
+  echo "This is needed to forward the rest endpoint requests to port 80."
+  echo ""
+  echo "Examples:"
+  echo "  Start the test_application_operations.sh (default) test on a newly built and deployed operator."
+  echo "  The test will use the default settings for every config value:"
+  echo "    ./manual_tests.sh"
+  echo ""
+  echo "  Start a single test using the currently deployed operator which is deployed in the 'flink' namespace:"
+  echo "    ./manual_tests.sh -s -namespace flink"
+  echo ""
+  echo "  Run multiple tests:"
+  echo "    ./manual_tests.sh test_application_operations.sh test_sessionjob_operations.sh"
+  echo ""
+  echo "  Run a single test and show debug logs:"
+  echo "     ./manual_tests.sh -d"
+  echo ""
+  echo "  Use every possible configuration:"
+  echo "     ./manual_tests.sh -i 'flink:1.15' -f 'v1_15' -m standalone -n flink -s -k test_sessionjob_operations.sh"
+  echo ""
+}
+
+image=""
+flink_versions="v1_16"
+modes="native"
+namespaces="default"
+skip_operator="false"
+
+versions=("v1_16" "v1_15" "v1_14" "v1_13")
+images=("flink:1.16" "flink:1.15" "flink:1.14" "flink:1.13")
+
+while getopts "i:f:m:n:hsd" option; do
+   case $option in
+      i) image=$OPTARG;;
+      f) flink_versions=$OPTARG;;
+      m) modes=$OPTARG;;
+      n) namespaces=$OPTARG;;
+      s) skip_operator="true";;
+      d) DEBUG="true";;
+      h) # display Help
+         help
+         exit;;
+     \?) # Invalid option
+         echo "Error: Invalid option"
+         exit;;
+   esac
+done
+
+scripts=${@:$OPTIND}
+if [[ -z "${scripts}" ]]; then
+  scripts="test_application_operations.sh"
+fi
+
+echo "-----------------------------------"
+echo "Start testing with the following parameters:"
+echo " Image:                  ${image}"
+echo " Flink version(s):       ${flink_versions}"
+echo " Mode(s):                ${modes}"
+echo " Operator namespace(s):  ${namespaces}"
+echo " Skip operator build:    ${skip_operator}"
+echo " Script() to run:        ${scripts}"
+echo "-----------------------------------"
+
+pushd $ROOT_DIR
+start_minikube
+install_cert_manager
+if [[ "$skip_operator" = true ]]; then
+  echo ""
+  echo "SKIPPING operator build"
+  echo ""
+else
+  build_image
+fi
+
+if [[ ! -z $(get_operator_pod_name) ]]; then
+  echo "Found existing operator. Please remove and restart the script. The following command could be used:"
+  echo " helm delete flink-kubernetes-operator"
+  exit 1;
+fi
+
+IFS=',' read -ra flink_version_list <<< "${flink_versions}"
+IFS=',' read -ra mode_list <<< "${modes}"
+IFS=',' read -ra namespace_list <<< "${namespaces}"
+
+for flink_version in ${flink_version_list[@]}; do
+  test_image=${image}
+  if [[ -z ${test_image} ]]; then
+    position=$(get_position ${flink_version} ${versions[@]})
+    if [[ -z ${position} ]]; then
+      echo "Unknown Flink version ${flink_version}, please provide an image or a known Flink version"
+      exit 1;
+    fi
+    test_image=${images[${position}]};
+  fi
+
+  for mode in ${mode_list[@]}; do
+    prepare_tests ${test_image} ${flink_version} ${mode}
+    for namespace in ${namespace_list[@]}; do
+      for script in ${scripts}; do
+        install_operator $namespace
+        if [[ ${script} = "test_multi_sessionjob.sh" && ${namespace} = "default" ]]; then
+          echo
+          echo "-----------------------------------"
+          echo "Skipping ${script} on ${namespace} namespace"
+          echo "-----------------------------------"
+          echo
+          continue
+        fi
+        echo
+        echo "-----------------------------------"
+        echo "Running test:"
+        echo " Namespace:      ${namespace}"
+        echo " Flink version:  ${flink_version}"
+        echo " Flink image:    ${test_image}"
+        echo " Mode:           ${mode}"
+        echo " Script:         ${script}"
+        echo "-----------------------------------"
+        echo
+        time bash $ROOT_DIR/e2e-tests/${script} || exit 1
+        uninstall_operator $namespace
+      done
+    done
+    revert_tests
+  done
+done
+popd

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -296,7 +296,6 @@ function install_operator() {
   if [[ -n ${DEBUG} ]]; then
     debug="--debug"
   fi
-  echo "helm ${debug} install flink-kubernetes-operator -n ${namespace} helm/flink-kubernetes-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-latest --create-namespace --set 'watchNamespaces={default,flink}'"
   helm ${debug} install flink-kubernetes-operator -n ${namespace} helm/flink-kubernetes-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-latest --create-namespace --set 'watchNamespaces={default,flink}'
   kubectl wait --for=condition=Available --timeout=120s -n ${namespace} deploy/flink-kubernetes-operator
   if [[ -n ${DEBUG} ]]; then


### PR DESCRIPTION
## What is the purpose of the change

Adding a possibility to run the e2e tests manually and using this same script to run the tests on the CI

## Brief change log

- Refactored the test steps to `functions` in the util.sh
- Changed the `ci.yml` to use these new fuctions
- Created a shell script to run the tests

## Verifying this change

- This change is already covered by existing e2e - will see the test results
- Also manually executed the test script

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? There is a help text in the script
