### PR TITLE
FLINK-30222: Operator should handle 'kubernetes' as a valid setting for the 'high-availability' config key

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -160,9 +160,10 @@ public class FlinkUtils {
     }
 
     public static boolean isKubernetesHAActivated(Configuration configuration) {
-        return configuration
-                .get(HighAvailabilityOptions.HA_MODE)
-                .equalsIgnoreCase(KubernetesHaServicesFactory.class.getCanonicalName());
+        String haMode = configuration.get(HighAvailabilityOptions.HA_MODE);
+        return haMode.equalsIgnoreCase(KubernetesHaServicesFactory.class.getCanonicalName())
+                // Hardcoded config value should be removed when upgrading Flink dependency to 1.16
+                || haMode.equalsIgnoreCase("kubernetes");
     }
 
     public static boolean clusterShutdownDisabled(FlinkDeploymentSpec spec) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -416,6 +416,18 @@ public class DefaultValidatorTest {
                 "spec.serviceAccount must be defined. If you use helm, its value should be the same with the name of jobServiceAccount.");
 
         testSuccess(dep -> dep.getSpec().setServiceAccount("flink"));
+
+        testSuccess(
+                dep -> {
+                    dep.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
+                    dep.getSpec()
+                            .getFlinkConfiguration()
+                            .put(
+                                    HighAvailabilityOptions.HA_MODE.key(),
+                                    // Hardcoded config value should be removed when upgrading Flink
+                                    // dependency to 1.16
+                                    "kubernetes");
+                });
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Since 1.16 it is possible to set `kubernetes` as a value for `high-availability`
Operator needs to accept this as a valid value

## Brief change log

- Changed the `FlinkUtils.isKubernetesHAActivated` to accept the new value
- Added a new test for it

## Verifying this change
This change added tests and can be verified as follows:

- Added a new unit tests for the config checking
- Also run manual testing using the e2e tests to create a cluster using v1_16 flink and using the new config

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
