### PR TITLE
[FLINK-29974] Allow session job cancel to be called for each job state

### DIFF
--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -159,12 +159,14 @@ function debug_and_show_logs {
     kubectl describe all
 
     echo "Operator logs:"
+    operator_pod_namespace=$(get_operator_pod_namespace)
     operator_pod_name=$(get_operator_pod_name)
-    kubectl logs "${operator_pod_name}"
+    echo "Operator namespace: ${operator_pod_namespace} pod: ${operator_pod_name}"
+    kubectl logs -n "${operator_pod_namespace}" "${operator_pod_name}"
 
     echo "Flink logs:"
     kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | while read pod;do
-        containers=(`kubectl get pods  $pod -o jsonpath='{.spec.containers[*].name}'`)
+        containers=(`kubectl get pods $pod -o jsonpath='{.spec.containers[*].name}'`)
         i=0
         for container in "${containers[@]}"; do
           echo "Current logs for $pod:$container: "

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -102,6 +102,7 @@ public class TestingFlinkService extends AbstractFlinkService {
     private final List<String> disposedSavepoints = new ArrayList<>();
     private final Map<String, Boolean> savepointTriggers = new HashMap<>();
     private int desiredReplicas = 0;
+    private int cancelJobCallCount = 0;
 
     private Map<String, String> metricsValues = new HashMap<>();
 
@@ -366,6 +367,8 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     private String cancelJob(FlinkVersion flinkVersion, JobID jobID, boolean savepoint)
             throws Exception {
+        cancelJobCallCount++;
+
         var jobOpt = jobs.stream().filter(js -> js.f1.getJobId().equals(jobID)).findAny();
 
         if (jobOpt.isEmpty()) {
@@ -509,5 +512,9 @@ public class TestingFlinkService extends AbstractFlinkService {
     public Map<String, String> getMetrics(
             Configuration conf, String jobId, List<String> metricNames) {
         return metricsValues;
+    }
+
+    public int getCancelJobCallCount() {
+        return cancelJobCallCount;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

When session jobs are in a specific states and cancel called they throw exceptions. In this PR I've added test for each state and changed the code to handle states correctly.

## Brief change log

* Allow session job cancel to be called for each job state
* Minor refactor in the app cancel area

## Verifying this change
Existing + additional unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
