### PR TITLE
[hotfix][FLINK-30265] Turn on debug logs for k8s operator e2e tests in CI when tests failing

### DIFF
--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -217,7 +217,7 @@ function stop_minikube {
 }
 
 function cleanup_and_exit() {
-    if [[ $TRAPPED_EXIT_CODE != 0 && -n $DEBUG ]]; then
+    if [[ $TRAPPED_EXIT_CODE != 0 ]]; then
       debug_and_show_logs
     fi
 


### PR DESCRIPTION
## What is the purpose of the change

Now e2e tests are not providing any operator or job logs when failing which makes it impossible to debug them. In this PR I've enabled debug logs when tests are failing.

## Brief change log

Enabled debug logs when tests are failing.

## Verifying this change

Trivial change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
