### PR TITLE
[FLINK-30266] Roll back change to HA metadata check logic

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.function.Predicate;
 
 /** Flink Utility methods used by the operator. */
 public class FlinkUtils {
@@ -147,12 +148,7 @@ public class FlinkUtils {
                         .list()
                         .getItems();
 
-        return configMaps.stream()
-                .anyMatch(
-                        map ->
-                                !map.isMarkedForDeletion()
-                                        && map.getData() != null
-                                        && !map.getData().isEmpty());
+        return configMaps.stream().anyMatch(Predicate.not(ConfigMap::isMarkedForDeletion));
     }
 
     private static boolean isJobGraphKey(Map.Entry<String, String> entry) {


### PR DESCRIPTION
## What is the purpose of the change

Revert an "improvement" to the HA metadata checking logic that actually only causes problems. In this case it did not allow jobs to recover without checkpoints in last-state mode.

## Brief change log

revert change

## Verifying this change

manually verified 

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no