### PR TITLE
[FLINK-30119] Breaking change: Flink Kubernetes Operator should store…

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -267,7 +267,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 ### Savepoint
 **Class**: org.apache.flink.kubernetes.operator.api.status.Savepoint
 
-**Description**: Represents information about a finished savepoint.
+**Description**: Represents information about an attempted or finished savepoint.
 
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
@@ -295,11 +295,11 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
-| lastSavepoint | org.apache.flink.kubernetes.operator.api.status.Savepoint | Last completed savepoint by the operator. |
+| lastSavepoint | org.apache.flink.kubernetes.operator.api.status.Savepoint | Last savepoint attempted or completed by the operator. For the last completed savepoint, call retrieveLastCompletedSavepoint(). |
 | triggerId | java.lang.String | Trigger id of a pending savepoint operation. |
-| triggerTimestamp | java.lang.Long | Trigger timestamp of a pending savepoint operation. |
-| triggerType | org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType | Savepoint trigger mechanism. |
-| formatType | org.apache.flink.kubernetes.operator.api.status.SavepointFormatType | Savepoint format. |
+| triggerTimestamp | java.lang.Long | Trigger timestamp of a pending savepoint operation.@deprecated This field is deprecated and will always be null. Use information from     lastSavepoint instead |
+| triggerType | org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType | Savepoint trigger mechanism of a pending savepoint operation.@deprecated This field is deprecated and will always be null. Use information from     lastSavepoint instead |
+| formatType | org.apache.flink.kubernetes.operator.api.status.SavepointFormatType | Savepoint format type of a pending savepoint operation.@deprecated This field is deprecated and will always be null. Use information from     lastSavepoint instead |
 | savepointHistory | java.util.List<org.apache.flink.kubernetes.operator.api.status.Savepoint> | List of recent savepoints. |
 | lastPeriodicSavepointTimestamp | long | Trigger timestamp of last periodic savepoint operation. |
 

--- a/e2e-tests/test_application_operations.sh
+++ b/e2e-tests/test_application_operations.sh
@@ -46,7 +46,6 @@ job_id=$(kubectl logs $jm_pod_name -c flink-main-container | grep -E -o 'Job [a-
 kubectl patch $APPLICATION_IDENTIFIER --type merge --patch '{"spec":{"job": {"savepointTriggerNonce": 123456 } } }'
 wait_for_logs $jm_pod_name "Triggering savepoint for job" ${TIMEOUT} || exit 1
 wait_for_status $APPLICATION_IDENTIFIER '.status.jobStatus.savepointInfo.triggerId' null $TIMEOUT || exit 1
-wait_for_status $APPLICATION_IDENTIFIER '.status.jobStatus.savepointInfo.triggerTimestamp' null $TIMEOUT || exit 1
 location=$(kubectl get $APPLICATION_IDENTIFIER -o yaml | yq '.status.jobStatus.savepointInfo.lastSavepoint.location')
 if [ "$location" == "" ];then
   echo "lost savepoint location"

--- a/e2e-tests/test_sessionjob_operations.sh
+++ b/e2e-tests/test_sessionjob_operations.sh
@@ -47,7 +47,6 @@ assert_available_slots 0 $CLUSTER_ID
 kubectl patch sessionjob ${SESSION_JOB_NAME} --type merge --patch '{"spec":{"job": {"savepointTriggerNonce": 123456 } } }'
 wait_for_logs $jm_pod_name "Triggering savepoint for job" ${TIMEOUT} || exit 1
 wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.savepointInfo.triggerId' null $TIMEOUT || exit 1
-wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.savepointInfo.triggerTimestamp' null $TIMEOUT || exit 1
 location=$(kubectl get $SESSION_JOB_IDENTIFIER -o yaml | yq '.status.jobStatus.savepointInfo.lastSavepoint.location')
 if [ "$location" == "" ];then
   echo "lost savepoint location"

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/Savepoint.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/Savepoint.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 
 import javax.annotation.Nullable;
 
-/** Represents information about a finished savepoint. */
+/** Represents information about an attempted or finished savepoint. */
 @Experimental
 @Data
 @NoArgsConstructor
@@ -76,5 +76,9 @@ public class Savepoint {
     public static Savepoint of(
             String location, SavepointTriggerType triggerType, SavepointFormatType formatType) {
         return new Savepoint(System.currentTimeMillis(), location, triggerType, formatType, null);
+    }
+
+    public Savepoint copy() {
+        return new Savepoint(timeStamp, location, triggerType, formatType, triggerNonce);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
@@ -52,6 +52,13 @@ public abstract class AbstractFlinkResourceObserver<
             return;
         }
 
+        // If the CR has lingering savepoint trigger data at deprecated fields, migrate them.
+        if (SavepointUtils.savepointInProgress(resource.getStatus().getJobStatus())) {
+            SavepointUtils.checkAndMigrateDeprecatedTriggerFields(
+                    resource.getStatus().getJobStatus().getSavepointInfo(),
+                    resource.getSpec().getJob().getSavepointTriggerNonce());
+        }
+
         // Trigger resource specific observe logic
         observeInternal(resource, context, observerContext);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -24,7 +24,6 @@ import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.status.CommonStatus;
 import org.apache.flink.kubernetes.operator.api.status.Savepoint;
 import org.apache.flink.kubernetes.operator.api.status.SavepointInfo;
-import org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
@@ -123,18 +122,10 @@ public class SavepointObserver<
             return;
         }
 
-        var savepoint =
-                new Savepoint(
-                        savepointInfo.getTriggerTimestamp(),
-                        savepointFetchResult.getLocation(),
-                        savepointInfo.getTriggerType(),
-                        savepointInfo.getFormatType(),
-                        SavepointTriggerType.MANUAL == savepointInfo.getTriggerType()
-                                ? resource.getSpec().getJob().getSavepointTriggerNonce()
-                                : null);
-
+        var lastSavepoint = savepointInfo.getLastSavepoint().copy();
+        lastSavepoint.setLocation(savepointFetchResult.getLocation());
         ReconciliationUtils.updateLastReconciledSavepointTriggerNonce(savepointInfo, resource);
-        savepointInfo.updateLastSavepoint(savepoint);
+        savepointInfo.updateLastSavepoint(lastSavepoint);
     }
 
     /** Clean up and dispose savepoints according to the configured max size/age. */

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -139,9 +139,10 @@ public class ReconciliationUtils {
 
     public static <SPEC extends AbstractFlinkSpec> void updateLastReconciledSavepointTriggerNonce(
             SavepointInfo savepointInfo, AbstractFlinkResource<SPEC, ?> target) {
-
         // We only need to update for MANUAL triggers
-        if (savepointInfo.getTriggerType() != SavepointTriggerType.MANUAL) {
+        if (savepointInfo.getLastSavepoint() == null
+                || savepointInfo.getLastSavepoint().getTriggerType()
+                        != SavepointTriggerType.MANUAL) {
             return;
         }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -203,7 +203,9 @@ public abstract class AbstractJobReconciler<
 
         if (spec.getJob().getUpgradeMode() != UpgradeMode.STATELESS) {
             savepointOpt =
-                    Optional.ofNullable(status.getJobStatus().getSavepointInfo().getLastSavepoint())
+                    status.getJobStatus()
+                            .getSavepointInfo()
+                            .retrieveLastCompletedSavepoint()
                             .flatMap(s -> Optional.ofNullable(s.getLocation()));
         }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -438,6 +438,7 @@ public abstract class AbstractFlinkService implements FlinkService {
             String jobId,
             SavepointTriggerType triggerType,
             org.apache.flink.kubernetes.operator.api.status.SavepointInfo savepointInfo,
+            Long triggerNonce,
             Configuration conf)
             throws Exception {
         LOG.info("Triggering new savepoint");
@@ -474,7 +475,8 @@ public abstract class AbstractFlinkService implements FlinkService {
             savepointInfo.setTrigger(
                     response.getTriggerId().toHexString(),
                     triggerType,
-                    SavepointFormatType.valueOf(savepointFormatType.name()));
+                    SavepointFormatType.valueOf(savepointFormatType.name()),
+                    triggerNonce);
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -81,6 +81,7 @@ public interface FlinkService {
             String jobId,
             SavepointTriggerType triggerType,
             SavepointInfo savepointInfo,
+            Long triggerNonce,
             Configuration conf)
             throws Exception;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointStatus.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointStatus.java
@@ -24,5 +24,5 @@ public enum SavepointStatus {
     /** Savepoint is completed successfully. */
     SUCCEEDED,
     /** Manual savepoint is abandoned after defined retries. */
-    ABANDONED
+    FAILED
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/SavepointTestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/SavepointTestUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator;
+
+import org.apache.flink.kubernetes.operator.api.status.JobStatus;
+import org.apache.flink.kubernetes.operator.api.status.SavepointInfo;
+import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/** Testing utilities. */
+public class SavepointTestUtils {
+    /**
+     * Set up trigger info from a CR of version 1.2 with pending savepoint and no completed
+     * savepoint.
+     *
+     * @param savepointInfo
+     * @param withOldCR
+     */
+    public static void setupCRV1_2TrigerInfo(SavepointInfo savepointInfo, boolean withOldCR) {
+        if (!withOldCR) {
+            return;
+        }
+        assertNotNull(savepointInfo);
+        var lastSavepoint = savepointInfo.getLastSavepoint();
+        if (lastSavepoint != null) {
+            savepointInfo.setFormatType(lastSavepoint.getFormatType());
+            savepointInfo.setTriggerTimestamp(lastSavepoint.getTimeStamp());
+            savepointInfo.setTriggerType(lastSavepoint.getTriggerType());
+            savepointInfo.setLastSavepoint(
+                    savepointInfo.retrieveLastCompletedSavepoint().orElse(null));
+        }
+    }
+
+    /**
+     * Migrate the old CR to new CR version.
+     *
+     * @param jobStatus
+     * @param triggerNonce
+     * @param withOldCR
+     */
+    public static void checkAndMigrate(JobStatus jobStatus, Long triggerNonce, boolean withOldCR) {
+        if (!withOldCR || !SavepointUtils.savepointInProgress(jobStatus)) {
+            return;
+        }
+        var savepointInfo = jobStatus.getSavepointInfo();
+        assertNotNull(savepointInfo);
+        SavepointUtils.checkAndMigrateDeprecatedTriggerFields(savepointInfo, triggerNonce);
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -255,12 +255,16 @@ public class TestingFlinkService extends AbstractFlinkService {
             String jobId,
             SavepointTriggerType triggerType,
             SavepointInfo savepointInfo,
+            Long triggerNonce,
             Configuration conf) {
         var triggerId = "trigger_" + triggerCounter++;
 
         var savepointFormatType = SavepointUtils.getSavepointFormatType(conf);
         savepointInfo.setTrigger(
-                triggerId, triggerType, SavepointFormatType.valueOf(savepointFormatType.name()));
+                triggerId,
+                triggerType,
+                SavepointFormatType.valueOf(savepointFormatType.name()),
+                triggerNonce);
         savepointTriggers.put(triggerId, false);
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
@@ -234,7 +234,7 @@ public class ApplicationReconcilerUpgradeModeTest {
                 .getStatus()
                 .getJobStatus()
                 .getSavepointInfo()
-                .setLastSavepoint(Savepoint.of("finished_sp", SavepointTriggerType.UPGRADE));
+                .updateLastSavepoint(Savepoint.of("finished_sp", SavepointTriggerType.UPGRADE));
         deployment.getStatus().getJobStatus().setState("FINISHED");
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
         deployment

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -232,6 +232,7 @@ public class NativeFlinkServiceTest {
                 flinkDeployment.getStatus().getJobStatus().getJobId(),
                 SavepointTriggerType.MANUAL,
                 flinkDeployment.getStatus().getJobStatus().getSavepointInfo(),
+                0L,
                 configuration);
         assertTrue(triggerSavepointFuture.isDone());
         assertEquals(jobID, triggerSavepointFuture.get().f0);
@@ -438,6 +439,7 @@ public class NativeFlinkServiceTest {
                 deployment.getStatus().getJobStatus().getJobId(),
                 SavepointTriggerType.MANUAL,
                 deployment.getStatus().getJobStatus().getSavepointInfo(),
+                0L,
                 new Configuration(configuration)
                         .set(OPERATOR_SAVEPOINT_FORMAT_TYPE, SavepointFormatType.NATIVE));
         assertTrue(triggerSavepointFuture.isDone());


### PR DESCRIPTION
… last savepoint in the SavepointInfo.lastSavepoint field whether it is completed or pending


## What is the purpose of the change

End user experience proposal:

User can see the properties of last savepoint pending or completed and can get status in one of three states for the status: PENDING, SUCCEEDED and ABANDONED. If there is never savepoint taken or attempted, it is empty. Completed savepoints (manual, periodic and upgrade) are included Savepoint history, merged with savepoints form Flink job.

User can manually trigger a savepoint. If there is another savepoint pending, triggering is disabled. User can see this savepoint with PENDING status. Once completed, user can see last savepoint status changed to SUCCEEDED and included in savepoint history or ABANDONED and not in savepoint history. If there is other savepoint triggered after completion before user checks, user cannot see the status of the one they triggered but they can check if the savepoint is in the history.

Currently lastSavepoint only stores the last completed one, duplicate with savepoint history.

To expose the properties of the currently pending savepoint or last savepoint that failed, we need to expose those info in separate fields in SavepointInfo. The internal logic of Operator uses those fields for triggering and retries and creates compatibility issues with client.

Code change proposal:

Use lastSavepoint to store the last completed/attempted one and remove SavepointInfo.triggerTimstamp, SavepointInfo.triggerType and SavepointInfo.formatType.

Add SavepointInfo::retrieveLastSavepoint method to return the last succeeded one.

Update getLastSavepointStatus to simplify the logic and change SavepointStatus.ABANDONED state to FAILED.

This is a breaking change:
 - Existing application using lastSavepoint or trigger related fields in Savepoint info except triggerId may be broken. 
 - For triggerId dependence, better use SavepointUtils.savepointInProgress which is guaranteed to work.
 - savepointHistory is not changed and still keeps the completed savepoints only. Unit tests for savepoint history also cover a few scenarios.

## Brief change log

  - Use Savepoint.lastSavepoint to store last savepoint, completed or attempted .
  - Added SavepointInfo::retrieveLastCompletedSavepoint() method to find the last completed one.
  - Updated related logic.
  - Added migration logic to handle lingering trigger information on old CR

## Verifying this change
This change added tests and can be verified as follows:

*(example:)*
  - Updated existing tests to check for regression.
  - Added tests for migration and backward compatibility with old CR
  - Updated e2e testes to remove tests that are no longer needed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  JavaDocs and will roll into public doc
