### PR TITLE
[FLINK-30280] Default operator logging configuration is broken

### DIFF
--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -87,7 +87,10 @@ spec:
             - name: FLINK_PLUGINS_DIR
               value: /opt/flink/plugins
             - name: LOG_CONFIG
-              value: -Dlog4j.configurationFile=/opt/flink/conf/log4j-operator.properties
+              # An empty value will use the default logging config bundled with the operator
+              # Overrides can also be defined in the attached log4j-operator config map or via
+              # including a logging file in the Docker image and uncommenting the property below.
+              value: "" #-Dlog4j.configurationFile=/opt/flink/conf/log4j-operator.properties
             - name: JVM_ARGS
               value: {{ .Values.jvmArgs.operator }}
             {{- range $k, $v := .Values.operatorPod.env }}


### PR DESCRIPTION
The default logging configuration is set here: https://github.com/apache/flink-kubernetes-operator/blob/ea01e294cf1b68d597244d0a11b3c81822a163e7/helm/flink-kubernetes-operator/templates/flink-operator.yaml#L89

However, this file is not available in the official Docker image. It's best to not set this value and rely on the included logging configuration in the operator JAR. Users can define overrides on the deployment in https://github.com/apache/flink-kubernetes-operator/blob/ea01e294cf1b68d597244d0a11b3c81822a163e7/helm/flink-kubernetes-operator/values.yaml#L135 or re-add the environment variable pointing to a valid file.