### PR TITLE
[FLINK-30281] Parsing for log4j error entry instead of plain error string in e2e tests

### DIFF
--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -142,7 +142,8 @@ function check_operator_log_for_errors {
       | grep -v "Error during event processing" `#https://issues.apache.org/jira/browse/FLINK-30149` \
       | grep -v "REST service in session cluster is bad now" `#https://issues.apache.org/jira/browse/FLINK-30150` \
       | grep -v "AuditUtils" `#https://issues.apache.org/jira/browse/FLINK-30151` \
-      | grep -i "error" || true)
+      | grep -v "Error while patching status" `#https://issues.apache.org/jira/browse/FLINK-30283` \
+      | grep -e "\[\s*ERROR\s*\]" || true)
   if [ -z "${errors}" ]; then
     echo "No errors in log files."
     return 0


### PR DESCRIPTION
## What is the purpose of the change

The operator log error parser identified the metric as error which is definitely false positive:
```
Found error in log files.

flink-kubernetes-operator-7456697448-mgw42.k8soperator.flink.flink-kubernetes-operator.namespace.default.FlinkDeployment.JmDeploymentStatus.ERROR.Count: 0
```
In this PR I'm parsing for log4j error entry instead of plain error string in e2e tests.

## Brief change log

* Parsing for log4j error entry instead of plain error string in e2e tests.
* Added whitelist entry: `Error while patching status`

## Verifying this change

Existing e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
