### PR TITLE
[FLINK-30287] Delete job manager deployment first when cleaning up standalone cluster

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
@@ -134,20 +134,20 @@ public class StandaloneFlinkService extends AbstractFlinkService {
         final String clusterId = meta.getName();
         final String namespace = meta.getNamespace();
 
-        LOG.info("Deleting Flink Standalone cluster TM resources");
-        kubernetesClient
-                .apps()
-                .deployments()
-                .inNamespace(namespace)
-                .withName(StandaloneKubernetesUtils.getTaskManagerDeploymentName(clusterId))
-                .delete();
-
         LOG.info("Deleting Flink Standalone cluster JM resources");
         kubernetesClient
                 .apps()
                 .deployments()
                 .inNamespace(namespace)
                 .withName(StandaloneKubernetesUtils.getJobManagerDeploymentName(clusterId))
+                .delete();
+
+        LOG.info("Deleting Flink Standalone cluster TM resources");
+        kubernetesClient
+                .apps()
+                .deployments()
+                .inNamespace(namespace)
+                .withName(StandaloneKubernetesUtils.getTaskManagerDeploymentName(clusterId))
                 .delete();
 
         if (deleteHaConfigmaps) {


### PR DESCRIPTION
## What is the purpose of the change

Delete the Job manager resources first when deleting a standalone Flink cluster as part of an upgrade in order to prevent HA configmaps from getting cleaned up. As described in the ticket, I was seeing job HA data getting deleted between cluster upgrades.

## Brief change log

Changed the resource clean up order from TM then JM to JM then TM for standalone clusters.

## Verifying this change

Manually verified when upgrading a standalone session cluster with a SessionJob running on it, configmaps didn't get cleaned up after switching operator to deleting JM resources first.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
