### PR TITLE
[FLINK-30151] Remove AuditUtils from error log check whitelist

### DIFF
--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -141,7 +141,6 @@ function check_operator_log_for_errors {
       | grep -v "Failed to submit job to session cluster" `#https://issues.apache.org/jira/browse/FLINK-30148` \
       | grep -v "Error during event processing" `#https://issues.apache.org/jira/browse/FLINK-30149` \
       | grep -v "REST service in session cluster is bad now" `#https://issues.apache.org/jira/browse/FLINK-30150` \
-      | grep -v "AuditUtils" `#https://issues.apache.org/jira/browse/FLINK-30151` \
       | grep -v "Error while patching status" `#https://issues.apache.org/jira/browse/FLINK-30283` \
       | grep -e "\[\s*ERROR\s*\]" || true)
   if [ -z "${errors}" ]; then


### PR DESCRIPTION
## What is the purpose of the change

In [#467](https://github.com/apache/flink-kubernetes-operator/pull/467) we've switched to `[ERROR]` parsing instead of case-insesitive `error`. `AuditUtils` is emitting only info level logs so we can safely remove from the whitelist.

## Brief change log

Remove AuditUtils from error log check whitelist

## Verifying this change

Existing e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
