### PR TITLE
[FLINK-30154] Allow to set flinkConfiguration in SessionJob

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -61,9 +61,6 @@ public class DefaultValidator implements FlinkResourceValidator {
                 KubernetesConfigOptions.NAMESPACE.key(), KubernetesConfigOptions.CLUSTER_ID.key()
             };
 
-    private static final Set<String> ALLOWED_FLINK_SESSION_JOB_CONF_KEYS =
-            Set.of(KubernetesOperatorConfigOptions.JAR_ARTIFACT_HTTP_HEADER.key());
-
     private static final Set<String> ALLOWED_LOG_CONF_KEYS =
             Set.of(Constants.CONFIG_FILE_LOG4J_NAME, Constants.CONFIG_FILE_LOGBACK_NAME);
 
@@ -468,14 +465,7 @@ public class DefaultValidator implements FlinkResourceValidator {
             return Optional.empty();
         }
 
-        for (String key : flinkSessionJobConfig.keySet()) {
-            if (!ALLOWED_FLINK_SESSION_JOB_CONF_KEYS.contains(key)) {
-                return Optional.of(
-                        String.format(
-                                "Invalid session job flinkConfiguration key: %s. Allowed keys are %s",
-                                key, ALLOWED_FLINK_SESSION_JOB_CONF_KEYS));
-            }
-        }
+        // Exclude specific keys if they cause issues
         return Optional.empty();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -514,12 +514,11 @@ public class DefaultValidatorTest {
                                 .setFlinkConfiguration(
                                         Map.of(
                                                 KubernetesOperatorConfigOptions
-                                                        .OPERATOR_RECONCILE_INTERVAL
+                                                        .PERIODIC_SAVEPOINT_INTERVAL
                                                         .key(),
-                                                "60")),
+                                                "1m")),
                 flinkDeployment -> {},
-                "Invalid session job flinkConfiguration key: kubernetes.operator.reconcile.interval."
-                        + " Allowed keys are [kubernetes.operator.user.artifacts.http.header]");
+                null);
 
         testSessionJobValidateWithModifier(
                 sessionJob -> {


### PR DESCRIPTION
## What is the purpose of the change

At the moment it's not possible to add any flinkConfiguration in SessionJob which is blocking to submit session jobs. I can imagine configs which can be harmful in case of session jobs but we must have a blacklist like all other cases.

## Brief change log

Allow to set flinkConfiguration in SessionJob.

## Verifying this change

Existing unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
