### PR TITLE
[FLINK-30150] Ignore "REST service in session cluster is bad now" where we kill the JobManager manually

### DIFF
--- a/e2e-tests/test_application_kubernetes_ha.sh
+++ b/e2e-tests/test_application_kubernetes_ha.sh
@@ -47,7 +47,7 @@ wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || e
 wait_for_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
 wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
-check_operator_log_for_errors '|grep -v "REST service in session cluster is bad now" \'|| exit 1
+check_operator_log_for_errors '|grep -v "REST service in session cluster is bad now"' || exit 1
 
 echo "Successfully run the Flink Kubernetes application HA test"
 

--- a/e2e-tests/test_application_kubernetes_ha.sh
+++ b/e2e-tests/test_application_kubernetes_ha.sh
@@ -47,7 +47,7 @@ wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || e
 wait_for_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
 wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
-check_operator_log_for_errors || exit 1
+check_operator_log_for_errors '|grep -v "REST service in session cluster is bad now" \'|| exit 1
 
 echo "Successfully run the Flink Kubernetes application HA test"
 

--- a/e2e-tests/test_sessionjob_kubernetes_ha.sh
+++ b/e2e-tests/test_sessionjob_kubernetes_ha.sh
@@ -48,7 +48,7 @@ wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || e
 wait_for_status $SESSION_CLUSTER_IDENTIFIER '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
 wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
-check_operator_log_for_errors '|grep -v "REST service in session cluster is bad now" \'|| exit 1
+check_operator_log_for_errors '|grep -v "REST service in session cluster is bad now"' || exit 1
 
 echo "Successfully run the Flink Session Job HA test"
 

--- a/e2e-tests/test_sessionjob_kubernetes_ha.sh
+++ b/e2e-tests/test_sessionjob_kubernetes_ha.sh
@@ -48,7 +48,7 @@ wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || e
 wait_for_status $SESSION_CLUSTER_IDENTIFIER '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
 wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
-check_operator_log_for_errors || exit 1
+check_operator_log_for_errors '|grep -v "REST service in session cluster is bad now" \'|| exit 1
 
 echo "Successfully run the Flink Session Job HA test"
 

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -140,7 +140,8 @@ function check_operator_log_for_errors {
   operator_pod_namespace=$(get_operator_pod_namespace)
   operator_pod_name=$(get_operator_pod_name)
   echo "Operator namespace: ${operator_pod_namespace} pod: ${operator_pod_name}"
-  logs="kubectl logs -n ${operator_pod_namespace} ${operator_pod_name}
+
+  local cmd="kubectl logs -n ${operator_pod_namespace} ${operator_pod_name}
     | grep -e '\[\s*ERROR\s*\]'
     | grep -v 'Failed to submit a listener notification task' `#https://issues.apache.org/jira/browse/FLINK-30147`
     | grep -v 'Failed to submit job to session cluster' `#https://issues.apache.org/jira/browse/FLINK-30148`
@@ -148,10 +149,9 @@ function check_operator_log_for_errors {
     | grep -v 'Error while patching status' `#https://issues.apache.org/jira/browse/FLINK-30283`
     ${ignore}"
 
-  echo "Executing: ${logs}"
-  errors=$(eval ${logs} || true)
+  echo "Filter command: ${cmd}"
+  errors=$(eval ${cmd} || true)
 
->>>>>>> 1d8ec88a ([FLINK-30150] Ignore "REST service in session cluster is bad now" where we kill the JobManager manually)
   if [ -z "${errors}" ]; then
     echo "No errors in log files."
     return 0

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -131,6 +131,7 @@ function retry_times() {
 }
 
 function check_operator_log_for_errors {
+  local ignore=$1
   echo "Checking for operator log errors..."
   #https://issues.apache.org/jira/browse/FLINK-30310
   echo "Error checking is temporarily turned off."
@@ -139,13 +140,18 @@ function check_operator_log_for_errors {
   operator_pod_namespace=$(get_operator_pod_namespace)
   operator_pod_name=$(get_operator_pod_name)
   echo "Operator namespace: ${operator_pod_namespace} pod: ${operator_pod_name}"
-  errors=$(kubectl logs -n "${operator_pod_namespace}" "${operator_pod_name}" \
-      | grep -v "Failed to submit a listener notification task" `#https://issues.apache.org/jira/browse/FLINK-30147` \
-      | grep -v "Failed to submit job to session cluster" `#https://issues.apache.org/jira/browse/FLINK-30148` \
-      | grep -v "Error during event processing" `#https://issues.apache.org/jira/browse/FLINK-30149` \
-      | grep -v "REST service in session cluster is bad now" `#https://issues.apache.org/jira/browse/FLINK-30150` \
-      | grep -v "Error while patching status" `#https://issues.apache.org/jira/browse/FLINK-30283` \
-      | grep -e "\[\s*ERROR\s*\]" || true)
+  logs="kubectl logs -n ${operator_pod_namespace} ${operator_pod_name}
+    | grep -e '\[\s*ERROR\s*\]'
+    | grep -v 'Failed to submit a listener notification task' `#https://issues.apache.org/jira/browse/FLINK-30147`
+    | grep -v 'Failed to submit job to session cluster' `#https://issues.apache.org/jira/browse/FLINK-30148`
+    | grep -v 'Error during event processing' `#https://issues.apache.org/jira/browse/FLINK-30149`
+    | grep -v 'Error while patching status' `#https://issues.apache.org/jira/browse/FLINK-30283`
+    ${ignore}"
+
+  echo "Executing: ${logs}"
+  errors=$(eval ${logs} || true)
+
+>>>>>>> 1d8ec88a ([FLINK-30150] Ignore "REST service in session cluster is bad now" where we kill the JobManager manually)
   if [ -z "${errors}" ]; then
     echo "No errors in log files."
     return 0


### PR DESCRIPTION
## What is the purpose of the change

e2e test change to ignore `REST service in session cluster is bad now` errors when we intentionally kill the JobManager

## Brief change log

Adds the possibility to add more filters to the `check_operator_log_for_errors` function.

## Verifying this change
This change is already covered by existing tests, such as *e2e tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
