### PR TITLE
[FLINK-30046] Support for operator docker image digest

### DIFF
--- a/docs/content/docs/operations/helm.md
+++ b/docs/content/docs/operations/helm.md
@@ -63,6 +63,7 @@ The configurable parameters of the Helm chart and which default values as detail
 | image.repository | The image repository of flink-kubernetes-operator. | ghcr.io/apache/flink-kubernetes-operator |
 | image.pullPolicy | The image pull policy of flink-kubernetes-operator. | IfNotPresent |
 | image.tag | The image tag of flink-kubernetes-operator. | latest |
+| image.digest | The image tag of flink-kubernetes-operator. If set then it takes precedence and the image tag will be ignored. | |
 | replicas | Operator replica count. Must be 1 unless leader election is configured. | 1 |
 | strategy.type | Operator pod upgrade strategy. Must be Recreate unless leader election is configured. | Recreate |
 | rbac.create | Whether to enable RBAC to create for said namespaces. | true |

--- a/helm/flink-kubernetes-operator/templates/_helpers.tpl
+++ b/helm/flink-kubernetes-operator/templates/_helpers.tpl
@@ -68,6 +68,17 @@ app.kubernetes.io/name: {{ include "flink-operator.name" . }}
 {{- end }}
 
 {{/*
+Create the path of the operator image to use
+*/}}
+{{- define "flink-operator.imagePath" -}}
+{{- if .Values.image.digest }}
+{{- .Values.image.repository }}@{{ .Values.image.digest }}
+{{- else }}
+{{- .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create the name of the operator role to use
 */}}
 {{- define "flink-operator.roleName" -}}

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -63,7 +63,7 @@ spec:
       serviceAccountName: {{ include "flink-operator.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "flink-operator.imagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/docker-entrypoint.sh", "operator"]
           ports:
@@ -127,7 +127,7 @@ spec:
           {{- end }}
         {{- if eq (include "flink-operator.webhook-enabled" .) "true" }}
         - name: flink-webhook
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "flink-operator.imagePath" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/docker-entrypoint.sh", "webhook"]
           env:

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -26,6 +26,8 @@ image:
   repository: flink-kubernetes-operator
   pullPolicy: IfNotPresent
   tag: latest
+  # If image digest is set then it takes precedence and the image tag will be ignored
+  # digest: ""
 
 imagePullSecrets: []
 


### PR DESCRIPTION
Tested it via running the following and similar commands:

```
% helm install flink-kubernetes-operator helm/flink-kubernetes-operator --set image.repository=ghcr.io/apache/flink-kubernetes-operator --set image.tag=main --set image.digest=sha256:a90c87d28f4e8832b8ac6cfa7318b01289f85fa35e46cc206d4de49212460111  --debug | grep image -C 5 
install.go:178: [debug] Original chart version: ""
install.go:195: [debug] CHART PATH: /Users/mbalassi/git/apple/apache-flink-kubernetes-operator/helm/flink-kubernetes-operator

client.go:128: [debug] creating 1 resource(s)
client.go:128: [debug] creating 1 resource(s)
install.go:165: [debug] Clearing discovery cache
wait.go:48: [debug] beginning wait for 2 resources with timeout of 1m0s
client.go:128: [debug] creating 14 resource(s)
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
USER-SUPPLIED VALUES:
image:
  digest: sha256:a90c87d28f4e8832b8ac6cfa7318b01289f85fa35e46cc206d4de49212460111
  repository: ghcr.io/apache/flink-kubernetes-operator
  tag: main

COMPUTED VALUES:
--
    # Flink Operator Logging Overrides
    # rootLogger.level = DEBUG
    # logger.operator.name= org.apache.flink.kubernetes.operator
    # logger.operator.level = DEBUG
fullnameOverride: ""
image:
  digest: sha256:a90c87d28f4e8832b8ac6cfa7318b01289f85fa35e46cc206d4de49212460111
  pullPolicy: IfNotPresent
  repository: ghcr.io/apache/flink-kubernetes-operator
  tag: main
imagePullSecrets: []
jobServiceAccount:
  annotations:
    helm.sh/resource-policy: keep
  create: true
  name: flink
--
        runAsGroup: 9999
        runAsUser: 9999
      serviceAccountName: flink-operator
      containers:
        - name: flink-kubernetes-operator
          image: ghcr.io/apache/flink-kubernetes-operator@sha256:a90c87d28f4e8832b8ac6cfa7318b01289f85fa35e46cc206d4de49212460111
          imagePullPolicy: IfNotPresent
          command: ["/docker-entrypoint.sh", "operator"]
          ports:
            - containerPort: 8085
              name: health-port
              protocol: TCP
--
            periodSeconds: 10
            httpGet:
              path: /
              port: health-port
        - name: flink-webhook
          image: ghcr.io/apache/flink-kubernetes-operator@sha256:a90c87d28f4e8832b8ac6cfa7318b01289f85fa35e46cc206d4de49212460111
          imagePullPolicy: IfNotPresent
          command: ["/docker-entrypoint.sh", "webhook"]
          env:
            - name: WEBHOOK_KEYSTORE_PASSWORD
              valueFrom:
                secretKeyRef:
```