### PR TITLE
[FLINK-30315] Add more information about image pull failures to the operator log

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedException.java
@@ -25,6 +25,7 @@ public class DeploymentFailedException extends RuntimeException {
 
     public static final String REASON_CRASH_LOOP_BACKOFF = "CrashLoopBackOff";
     public static final String REASON_IMAGE_PULL_BACKOFF = "ImagePullBackOff";
+    public static final String REASON_ERR_IMAGE_PULL = "ErrImagePull";
 
     private static final long serialVersionUID = -1070179896083579221L;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -189,7 +189,8 @@ public abstract class AbstractFlinkDeploymentObserver
                 if (csw != null
                         && Set.of(
                                         DeploymentFailedException.REASON_CRASH_LOOP_BACKOFF,
-                                        DeploymentFailedException.REASON_IMAGE_PULL_BACKOFF)
+                                        DeploymentFailedException.REASON_IMAGE_PULL_BACKOFF,
+                                        DeploymentFailedException.REASON_ERR_IMAGE_PULL)
                                 .contains(csw.getReason())) {
                     throw new DeploymentFailedException(csw);
                 }


### PR DESCRIPTION
## What is the purpose of the change

Throw DeploymentFailedException on ErrImagePull.
This would add more info for the user to understand why the issue happened.

## Brief change log

- Introduce a new value to check in the `ContainerStateWaiting.reason`
- Updated the relevant tests
- Removed a method which was accidentally added during a previous change

## Verifying this change

This change is already covered by the existing `FlinkDeploymentControllerTest.verifyInProgressDeploymentWithBackoff` test, just added a new reason to check 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
