### PR TITLE
[FLINK-30146] Log job listing exception as warning

### DIFF
--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -140,7 +140,6 @@ function check_operator_log_for_errors {
   operator_pod_name=$(get_operator_pod_name)
   echo "Operator namespace: ${operator_pod_namespace} pod: ${operator_pod_name}"
   errors=$(kubectl logs -n "${operator_pod_namespace}" "${operator_pod_name}" \
-      | grep -v "Exception while listing jobs" `#https://issues.apache.org/jira/browse/FLINK-30146` \
       | grep -v "Failed to submit a listener notification task" `#https://issues.apache.org/jira/browse/FLINK-30147` \
       | grep -v "Failed to submit job to session cluster" `#https://issues.apache.org/jira/browse/FLINK-30148` \
       | grep -v "Error during event processing" `#https://issues.apache.org/jira/browse/FLINK-30149` \

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -77,7 +77,7 @@ public abstract class JobStatusObserver<
             clusterJobStatuses = new ArrayList<>(flinkService.listJobs(ctx.getDeployedConfig()));
         } catch (Exception e) {
             // Error while accessing the rest api, will try again later...
-            LOG.error("Exception while listing jobs", e);
+            LOG.warn("Exception while listing jobs", e);
             ifRunningMoveToReconciling(jobStatus, previousJobStatus);
             if (e instanceof TimeoutException) {
                 onTimeout(resource, resourceContext, ctx);


### PR DESCRIPTION
## What is the purpose of the change

There are circumstances when job listing is not possible. Most of the errors what seen are temporary issues and the code is doing retry. In this PR I've changed the error message to a warning.

## Brief change log

Log job listing exception as warning.

## Verifying this change

Existing e2e tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
