### PR TITLE
[FLINK-30411] Validate empty JmSpec and TmSpec

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -19,6 +19,8 @@ package org.apache.flink.kubernetes.operator.validation;
 
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
@@ -42,6 +44,8 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
 import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
+import org.apache.flink.runtime.jobmanager.JobManagerProcessUtils;
 import org.apache.flink.util.StringUtils;
 
 import javax.annotation.Nullable;
@@ -88,7 +92,7 @@ public class DefaultValidator implements FlinkResourceValidator {
                 validateLogConfig(spec.getLogConfiguration()),
                 validateJobSpec(spec.getJob(), spec.getTaskManager(), effectiveConfig),
                 validateJmSpec(spec.getJobManager(), effectiveConfig),
-                validateTmSpec(spec.getTaskManager()),
+                validateTmSpec(spec.getTaskManager(), effectiveConfig),
                 validateSpecChange(deployment, effectiveConfig),
                 validateServiceAccount(spec.getServiceAccount()));
     }
@@ -241,13 +245,33 @@ public class DefaultValidator implements FlinkResourceValidator {
     }
 
     private Optional<String> validateJmSpec(JobManagerSpec jmSpec, Map<String, String> confMap) {
+        Configuration conf = Configuration.fromMap(confMap);
+        var jmMemoryDefined =
+                jmSpec != null
+                        && jmSpec.getResource() != null
+                        && !StringUtils.isNullOrWhitespaceOnly(jmSpec.getResource().getMemory());
+        Optional<String> jmMemoryValidation =
+                jmMemoryDefined ? Optional.empty() : validateJmMemoryConfig(conf);
+
         if (jmSpec == null) {
-            return Optional.of("JobManager spec must be specified.");
+            return jmMemoryValidation;
         }
 
         return firstPresent(
+                jmMemoryValidation,
                 validateResources("JobManager", jmSpec.getResource()),
                 validateJmReplicas(jmSpec.getReplicas(), confMap));
+    }
+
+    private Optional<String> validateJmMemoryConfig(Configuration conf) {
+        try {
+            JobManagerProcessUtils.processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
+                    conf, JobManagerOptions.JVM_HEAP_MEMORY);
+        } catch (IllegalConfigurationException e) {
+            return Optional.of(e.getMessage());
+        }
+
+        return Optional.empty();
     }
 
     private Optional<String> validateJmReplicas(int replicas, Map<String, String> confMap) {
@@ -261,16 +285,40 @@ public class DefaultValidator implements FlinkResourceValidator {
         return Optional.empty();
     }
 
-    private Optional<String> validateTmSpec(TaskManagerSpec tmSpec) {
+    private Optional<String> validateTmSpec(TaskManagerSpec tmSpec, Map<String, String> confMap) {
+        Configuration conf = Configuration.fromMap(confMap);
+
+        var tmMemoryDefined =
+                tmSpec != null
+                        && tmSpec.getResource() != null
+                        && !StringUtils.isNullOrWhitespaceOnly(tmSpec.getResource().getMemory());
+        Optional<String> tmMemoryConfigValidation =
+                tmMemoryDefined ? Optional.empty() : validateTmMemoryConfig(conf);
+
         if (tmSpec == null) {
-            return Optional.of("TaskManager spec must be specified.");
+            return tmMemoryConfigValidation;
         }
 
+        return firstPresent(
+                tmMemoryConfigValidation,
+                validateResources("TaskManager", tmSpec.getResource()),
+                validateTmReplicas(tmSpec));
+    }
+
+    private Optional<String> validateTmMemoryConfig(Configuration conf) {
+        try {
+            TaskExecutorProcessUtils.processSpecFromConfig(conf);
+        } catch (IllegalConfigurationException e) {
+            return Optional.of(e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    private Optional<String> validateTmReplicas(TaskManagerSpec tmSpec) {
         if (tmSpec.getReplicas() != null && tmSpec.getReplicas() < 1) {
             return Optional.of("TaskManager replicas should not be configured less than one.");
         }
-
-        return validateResources("TaskManager", tmSpec.getResource());
+        return Optional.empty();
     }
 
     private Optional<String> validateResources(String component, Resource resource) {
@@ -280,7 +328,7 @@ public class DefaultValidator implements FlinkResourceValidator {
 
         String memory = resource.getMemory();
         if (memory == null) {
-            return Optional.of(component + " resource memory must be defined.");
+            return Optional.empty();
         }
 
         try {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -19,7 +19,6 @@ package org.apache.flink.kubernetes.operator.validation;
 
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
@@ -267,7 +266,7 @@ public class DefaultValidator implements FlinkResourceValidator {
         try {
             JobManagerProcessUtils.processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
                     conf, JobManagerOptions.JVM_HEAP_MEMORY);
-        } catch (IllegalConfigurationException e) {
+        } catch (Exception e) {
             return Optional.of(e.getMessage());
         }
 
@@ -308,7 +307,7 @@ public class DefaultValidator implements FlinkResourceValidator {
     private Optional<String> validateTmMemoryConfig(Configuration conf) {
         try {
             TaskExecutorProcessUtils.processSpecFromConfig(conf);
-        } catch (IllegalConfigurationException e) {
+        } catch (Exception e) {
             return Optional.of(e.getMessage());
         }
         return Optional.empty();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -242,7 +242,7 @@ public class DefaultValidator implements FlinkResourceValidator {
 
     private Optional<String> validateJmSpec(JobManagerSpec jmSpec, Map<String, String> confMap) {
         if (jmSpec == null) {
-            return Optional.empty();
+            return Optional.of("JobManager spec must be specified.");
         }
 
         return firstPresent(
@@ -263,7 +263,7 @@ public class DefaultValidator implements FlinkResourceValidator {
 
     private Optional<String> validateTmSpec(TaskManagerSpec tmSpec) {
         if (tmSpec == null) {
-            return Optional.empty();
+            return Optional.of("TaskManager spec must be specified.");
         }
 
         if (tmSpec.getReplicas() != null && tmSpec.getReplicas() < 1) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -267,7 +267,8 @@ public class DefaultValidator implements FlinkResourceValidator {
             JobManagerProcessUtils.processSpecFromConfigWithNewOptionToInterpretLegacyHeap(
                     conf, JobManagerOptions.JVM_HEAP_MEMORY);
         } catch (Exception e) {
-            return Optional.of(e.getMessage());
+            return Optional.of(
+                    "JobManager resource memory must be defined using `spec.jobManager.resource.memory`");
         }
 
         return Optional.empty();
@@ -308,7 +309,8 @@ public class DefaultValidator implements FlinkResourceValidator {
         try {
             TaskExecutorProcessUtils.processSpecFromConfig(conf);
         } catch (Exception e) {
-            return Optional.of(e.getMessage());
+            return Optional.of(
+                    "TaskManager resource memory must be defined using `spec.taskManager.resource.memory`");
         }
         return Optional.empty();
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -79,6 +79,9 @@ public class DefaultValidatorTest {
                 dep -> dep.getSpec().getJob().setState(JobState.SUSPENDED),
                 "Job must start in running state");
 
+        testError(dep -> dep.getSpec().setJobManager(null), "JobManager spec must be specified.");
+        testError(dep -> dep.getSpec().setTaskManager(null), "TaskManager spec must be specified.");
+
         testError(
                 dep -> dep.getSpec().getJob().setParallelism(0),
                 "Job parallelism must be larger than 0");

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -254,16 +254,16 @@ public class DefaultValidatorTest {
                 "JobManager resource memory parse error");
         testError(
                 dep -> dep.getSpec().getTaskManager().getResource().setMemory(null),
-                "TaskManager memory configuration failed");
+                "TaskManager resource memory must be defined using `spec.taskManager.resource.memory`");
         testError(
                 dep -> dep.getSpec().getJobManager().getResource().setMemory(null),
-                "JobManager memory configuration failed");
+                "JobManager resource memory must be defined using `spec.jobManager.resource.memory`");
         testError(
                 dep -> {
                     dep.getSpec().getTaskManager().getResource().setMemory(null);
                     dep.getSpec().setFlinkConfiguration(Map.of(TASK_HEAP_MEMORY.key(), "1024m"));
                 },
-                "TaskManager memory configuration failed");
+                "TaskManager resource memory must be defined using `spec.taskManager.resource.memory`");
 
         testSuccess(
                 dep -> {


### PR DESCRIPTION
## What is the purpose of the change

This PR validates `FlinkDeployment` without `jobManager` or `taskManager` spec. Currently, `FlinkDeployment` gets stuck in `UPGRADING` state if you don't specify `jobManager` or `taskManager` spec. 

By adding validation, `helm install` directly fails.

**Example: `basic.yaml`**

```yaml
apiVersion: flink.apache.org/v1beta1
kind: FlinkDeployment
metadata:
  name: basic-example
spec:
  image: flink:1.15
  flinkVersion: v1_15
  flinkConfiguration:
    taskmanager.numberOfTaskSlots: "2"
  serviceAccount: flink
  job:
    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
    parallelism: 2
    upgradeMode: stateless
```

## Brief change log

- Validate `FlinkDeployment` without `jobManager` or `taskManager` spec.

## Verifying this change

This change added tests and can be verified as follows:

- Extended existing unit test for the change as part of the PR
- Manually verified by removing `jobManager` and `taskManager` from [`examples/basic.yaml`](https://github.com/apache/flink-kubernetes-operator/blob/c8ed11dfde1e0fc57d8fa45b0121ecec362bd03d/examples/basic.yaml#L29-L36)
  - *Before change* - ensured `FlinkDeployment` gets stuck in `UPGRADING` state.
  - *After change* - `helm install example/basic.yaml` fails with error message. Reverting back the file deploys the job successfully.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
