### PR TITLE
[FLINK-30437][FLINK-30408] Harden HA meta check to avoid state loss

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -46,7 +46,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.function.Predicate;
 
 /** Flink Utility methods used by the operator. */
 public class FlinkUtils {
@@ -148,7 +147,20 @@ public class FlinkUtils {
                         .list()
                         .getItems();
 
-        return configMaps.stream().anyMatch(Predicate.not(ConfigMap::isMarkedForDeletion));
+        return configMaps.stream().anyMatch(FlinkUtils::isValidHaConfigMap);
+    }
+
+    private static boolean isValidHaConfigMap(ConfigMap cm) {
+        if (cm.isMarkedForDeletion()) {
+            return false;
+        }
+
+        var name = cm.getMetadata().getName();
+        if (name.endsWith("-config-map")) {
+            return !name.endsWith("-cluster-config-map");
+        }
+
+        return name.endsWith("-jobmanager-leader");
     }
 
     private static boolean isJobGraphKey(Map.Entry<String, String> entry) {


### PR DESCRIPTION
## What is the purpose of the change

The previous HA metadata check recognizes unrelated configmaps as HA metadata which can under certain circumstances lead to state loss.

## Brief change log
 - harden HA meta check
 - add test

## Verifying this change

Added unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
