### PR TITLE
[FLINK-30406] Detect when jobmanager never started

### DIFF
--- a/e2e-tests/test_application_kubernetes_ha.sh
+++ b/e2e-tests/test_application_kubernetes_ha.sh
@@ -47,7 +47,7 @@ wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || e
 wait_for_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
 wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
-check_operator_log_for_errors '|grep -v "REST service in session cluster is bad now"' || exit 1
+check_operator_log_for_errors '|grep -v "REST service in session cluster timed out"' || exit 1
 
 echo "Successfully run the Flink Kubernetes application HA test"
 

--- a/e2e-tests/test_sessionjob_kubernetes_ha.sh
+++ b/e2e-tests/test_sessionjob_kubernetes_ha.sh
@@ -48,7 +48,7 @@ wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || e
 wait_for_status $SESSION_CLUSTER_IDENTIFIER '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
 wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 
-check_operator_log_for_errors '|grep -v "REST service in session cluster is bad now"' || exit 1
+check_operator_log_for_errors '|grep -v "REST service in session cluster timed out"' || exit 1
 
 echo "Successfully run the Flink Session Job HA test"
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
@@ -51,7 +51,7 @@ public class SessionObserver extends AbstractFlinkDeploymentObserver {
                 rs.markReconciledSpecAsStable();
             }
         } catch (Exception e) {
-            logger.error("REST service in session cluster is bad now", e);
+            logger.error("REST service in session cluster timed out", e);
             if (e instanceof TimeoutException) {
                 // check for problems with the underlying deployment
                 observeJmDeployment(deployment, context, observerContext.getDeployedConfig());

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -27,9 +27,12 @@ import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
+import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.api.status.CommonStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
+import org.apache.flink.kubernetes.operator.api.status.Savepoint;
+import org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.autoscaler.JobAutoScaler;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
@@ -99,7 +102,7 @@ public abstract class AbstractFlinkResourceReconciler<
     }
 
     @Override
-    public final void reconcile(CR cr, Context<?> ctx) throws Exception {
+    public void reconcile(CR cr, Context<?> ctx) throws Exception {
         var spec = cr.getSpec();
         var deployConfig = getDeployConfig(cr.getMetadata(), spec, ctx);
         var status = cr.getStatus();
@@ -115,12 +118,7 @@ public abstract class AbstractFlinkResourceReconciler<
         // No further logic is required at this point.
         if (reconciliationStatus.isBeforeFirstDeployment()) {
             LOG.info("Deploying for the first time");
-
-            // Before we try to submit the job we record the current spec in the status so we can
-            // handle subsequent deployment and status update errors
-            ReconciliationUtils.updateStatusBeforeDeploymentAttempt(cr, deployConfig);
-            statusRecorder.patchAndCacheStatus(cr);
-
+            updateStatusBeforeFirstDeployment(cr, spec, deployConfig, status);
             deploy(
                     cr,
                     spec,
@@ -186,6 +184,36 @@ public abstract class AbstractFlinkResourceReconciler<
                 LOG.info("Resource fully reconciled, nothing to do...");
             }
         }
+    }
+
+    /**
+     * Update the status before the first deployment. We have to record the upgrade mode based on
+     * the initial savepoint path provided, and record the to-be-deployed spec in the status.
+     *
+     * @param cr Related flink resource
+     * @param spec Spec to be deployed
+     * @param deployConfig Deploy configuration
+     * @param status Resource status
+     */
+    private void updateStatusBeforeFirstDeployment(
+            CR cr, SPEC spec, Configuration deployConfig, STATUS status) {
+        if (spec.getJob() != null) {
+            var initialUpgradeMode = UpgradeMode.STATELESS;
+            var initialSp = spec.getJob().getInitialSavepointPath();
+
+            if (initialSp != null) {
+                status.getJobStatus()
+                        .getSavepointInfo()
+                        .setLastSavepoint(Savepoint.of(initialSp, SavepointTriggerType.UNKNOWN));
+                initialUpgradeMode = UpgradeMode.SAVEPOINT;
+            }
+
+            spec.getJob().setUpgradeMode(initialUpgradeMode);
+        }
+        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(cr, deployConfig);
+        // Before we try to submit the job we record the current spec in the status so we can
+        // handle subsequent deployment and status update errors
+        statusRecorder.patchAndCacheStatus(cr);
     }
 
     /**
@@ -260,7 +288,7 @@ public abstract class AbstractFlinkResourceReconciler<
             CR cr, Context<?> context, Configuration observeConfig) throws Exception;
 
     @Override
-    public final DeleteControl cleanup(CR resource, Context<?> context) {
+    public DeleteControl cleanup(CR resource, Context<?> context) {
         resourceScaler.cleanup(resource);
         return cleanupInternal(resource, context);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -102,7 +102,7 @@ public abstract class AbstractJobReconciler<
                 LOG.info("Upgrading/Restarting running job, suspending first...");
             }
             Optional<UpgradeMode> availableUpgradeMode =
-                    getAvailableUpgradeMode(resource, deployConfig, observeConfig);
+                    getAvailableUpgradeMode(resource, ctx, deployConfig, observeConfig);
             if (availableUpgradeMode.isEmpty()) {
                 return;
             }
@@ -122,7 +122,14 @@ public abstract class AbstractJobReconciler<
                 ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig);
             }
         }
+
         if (currentJobState == JobState.SUSPENDED && desiredJobState == JobState.RUNNING) {
+            // We inherit the upgrade mode unless stateless upgrade requested
+            if (currentDeploySpec.getJob().getUpgradeMode() != UpgradeMode.STATELESS) {
+                currentDeploySpec
+                        .getJob()
+                        .setUpgradeMode(lastReconciledSpec.getJob().getUpgradeMode());
+            }
             // We record the target spec into an upgrading state before deploying
             ReconciliationUtils.updateStatusBeforeDeploymentAttempt(resource, deployConfig);
             statusRecorder.patchAndCacheStatus(resource);
@@ -141,7 +148,7 @@ public abstract class AbstractJobReconciler<
     }
 
     protected Optional<UpgradeMode> getAvailableUpgradeMode(
-            CR resource, Configuration deployConfig, Configuration observeConfig) {
+            CR resource, Context<?> ctx, Configuration deployConfig, Configuration observeConfig) {
         var status = resource.getStatus();
         var upgradeMode = resource.getSpec().getJob().getUpgradeMode();
 
@@ -150,7 +157,9 @@ public abstract class AbstractJobReconciler<
             return Optional.of(UpgradeMode.STATELESS);
         }
 
-        if (ReconciliationUtils.isJobInTerminalState(status)) {
+        var flinkService = getFlinkService(resource, ctx);
+        if (ReconciliationUtils.isJobInTerminalState(status)
+                && !flinkService.isHaMetadataAvailable(observeConfig)) {
             LOG.info(
                     "Job is in terminal state, ready for upgrade from observed latest checkpoint/savepoint");
             return Optional.of(UpgradeMode.SAVEPOINT);
@@ -203,6 +212,7 @@ public abstract class AbstractJobReconciler<
             throws Exception {
         var reconciliationStatus = resource.getStatus().getReconciliationStatus();
         var rollbackSpec = reconciliationStatus.deserializeLastStableSpec();
+        rollbackSpec.getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
 
         UpgradeMode upgradeMode = resource.getSpec().getJob().getUpgradeMode();
 
@@ -249,6 +259,7 @@ public abstract class AbstractJobReconciler<
             throws Exception {
         LOG.info("Resubmitting Flink job...");
         SPEC specToRecover = ReconciliationUtils.getDeployedSpec(deployment);
+        specToRecover.getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
         restoreJob(
                 deployment,
                 specToRecover,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -57,6 +57,7 @@ import java.net.HttpURLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -94,15 +95,27 @@ public class TestUtils extends BaseTestUtils {
     }
 
     public static Deployment createDeployment(boolean ready) {
-        DeploymentStatus status = new DeploymentStatus();
+        String nowTs = Instant.now().toString();
+        var status = new DeploymentStatus();
         status.setAvailableReplicas(ready ? 1 : 0);
         status.setReplicas(1);
+        var availableCondition = new DeploymentCondition();
+        availableCondition.setType("Available");
+        availableCondition.setStatus(ready ? "True" : "False");
+        availableCondition.setLastTransitionTime(nowTs);
+        status.setConditions(List.of(availableCondition));
+
         DeploymentSpec spec = new DeploymentSpec();
         spec.setReplicas(1);
+
+        var meta = new ObjectMeta();
+        meta.setCreationTimestamp(nowTs);
+
         Deployment deployment = new Deployment();
-        deployment.setMetadata(new ObjectMeta());
+        deployment.setMetadata(meta);
         deployment.setSpec(spec);
         deployment.setStatus(status);
+
         return deployment;
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingApplicationReconciler.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator;
+
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+import org.apache.flink.kubernetes.operator.reconciler.deployment.ApplicationReconciler;
+import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
+
+/** Testing wrapper for {@link ApplicationReconciler}. */
+public class TestingApplicationReconciler extends ApplicationReconciler {
+    public TestingApplicationReconciler(
+            KubernetesClient kubernetesClient,
+            FlinkService flinkService,
+            FlinkConfigManager configManager,
+            EventRecorder eventRecorder,
+            StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder,
+            KubernetesOperatorMetricGroup operatorMetricGroup) {
+        super(
+                kubernetesClient,
+                flinkService,
+                configManager,
+                eventRecorder,
+                statusRecorder,
+                operatorMetricGroup);
+    }
+
+    @Override
+    public void reconcile(FlinkDeployment flinkDeployment, Context<?> context) throws Exception {
+        var cr = ReconciliationUtils.clone(flinkDeployment);
+        cr.setStatus(flinkDeployment.getStatus());
+        super.reconcile(cr, context);
+    }
+
+    @Override
+    public DeleteControl cleanup(FlinkDeployment flinkDeployment, Context<?> context) {
+        var cr = ReconciliationUtils.clone(flinkDeployment);
+        cr.setStatus(flinkDeployment.getStatus());
+        return super.cleanup(cr, context);
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -96,6 +96,7 @@ public class TestingFlinkService extends AbstractFlinkService {
     private final Set<String> sessions = new HashSet<>();
     private boolean isPortReady = true;
     private boolean haDataAvailable = true;
+    private boolean jobManagerReady = true;
     private boolean deployFailure = false;
     private Runnable sessionJobSubmittedCallback;
     private PodList podList = new PodList();
@@ -123,7 +124,7 @@ public class TestingFlinkService extends AbstractFlinkService {
                 if (jobs.isEmpty() && sessions.isEmpty()) {
                     return Optional.empty();
                 }
-                return (Optional<T>) Optional.of(TestUtils.createDeployment(true));
+                return (Optional<T>) Optional.of(TestUtils.createDeployment(jobManagerReady));
             }
         };
     }
@@ -192,6 +193,10 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     public void setHaDataAvailable(boolean haDataAvailable) {
         this.haDataAvailable = haDataAvailable;
+    }
+
+    public void setJobManagerReady(boolean jmReady) {
+        this.jobManagerReady = jmReady;
     }
 
     public void setDeployFailure(boolean deployFailure) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
@@ -96,6 +96,9 @@ public class FailedDeploymentRestartTest {
                 JobManagerDeploymentStatus.READY,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
         assertEquals("RUNNING", appCluster.getStatus().getJobStatus().getState());
+
+        // We started without savepoint
+        appCluster.getSpec().getJob().setUpgradeMode(UpgradeMode.STATELESS);
         assertEquals(
                 appCluster.getSpec(),
                 appCluster.getStatus().getReconciliationStatus().deserializeLastReconciledSpec());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/UnhealthyDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/UnhealthyDeploymentRestartTest.java
@@ -100,9 +100,6 @@ public class UnhealthyDeploymentRestartTest {
                 JobManagerDeploymentStatus.READY,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
         assertEquals("RUNNING", appCluster.getStatus().getJobStatus().getState());
-        assertEquals(
-                appCluster.getSpec(),
-                appCluster.getStatus().getReconciliationStatus().deserializeLastReconciledSpec());
     }
 
     private static Stream<Arguments> applicationTestParams() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.PipelineOptionsInternal;
 import org.apache.flink.configuration.SchedulerExecutionMode;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.TestingApplicationReconciler;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.TestingStatusRecorder;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
@@ -94,6 +95,7 @@ public class ApplicationReconcilerTest {
     private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
     private TestingFlinkService flinkService;
     private ApplicationReconciler reconciler;
+
     private Context<FlinkDeployment> context;
     private StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder;
 
@@ -107,7 +109,7 @@ public class ApplicationReconcilerTest {
         flinkService = new TestingFlinkService(kubernetesClient);
         context = flinkService.getContext();
         reconciler =
-                new ApplicationReconciler(
+                new TestingApplicationReconciler(
                         kubernetesClient,
                         flinkService,
                         configManager,


### PR DESCRIPTION
## What is the purpose of the change

The purpose of this PR is to fix the long standing annoying case where the job was stuck after a non-upgradable state after starting/upgrading from a savepoint but the JobManager never starts.

In these cases previously we only supported last-state (HA based) upgrade which was impossible to do if the JM never started and never created the HA metadata configmaps.

The PR introduces a check whether the JobManager pods ever started by checking the Availability conditions on the JM deployment and comparing condition times with the deployment creation timestamp.

If availability is False and the Deployment never transitioned out of this state after creation, we can then assume that the JM never started and we can perform the upgrade using the last recorded savepoint.

This also removes the slightly adhoc logic we had in place for upgrades on initial deployments before stable state (that basically intended to work around this limitaiton).

## Verifying this change

Unit tests + manual testing on minikube

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
