### PR TITLE
[FLINK-30456] Fixing Version and provider in OLM Description

### DIFF
--- a/tools/olm/csv-template/bases/flink-kubernetes-operator.clusterserviceversion.yaml
+++ b/tools/olm/csv-template/bases/flink-kubernetes-operator.clusterserviceversion.yaml
@@ -130,7 +130,7 @@ spec:
         metadata:
           labels:
             app.kubernetes.io/name: flink-kubernetes-operator
-            app.kubernetes.io/version: 1.2.0
+            app.kubernetes.io/version: RELEASE_VERSION
           name: flink
         ---
         apiVersion: rbac.authorization.k8s.io/v1
@@ -138,7 +138,7 @@ spec:
         metadata:
           labels:
             app.kubernetes.io/name: flink-kubernetes-operator
-            app.kubernetes.io/version: 1.2.0
+            app.kubernetes.io/version: RELEASE_VERSION
           name: flink
         rules:
         - apiGroups:
@@ -161,7 +161,7 @@ spec:
         metadata:
           labels:
             app.kubernetes.io/name: flink-kubernetes-operator
-            app.kubernetes.io/version: 1.2.0
+            app.kubernetes.io/version: RELEASE_VERSION
           name: flink-role-binding
         roleRef:
           apiGroup: rbac.authorization.k8s.io
@@ -176,7 +176,7 @@ spec:
     3. Proceed deploying Flink applications using the the Custom Resource Definition below.
 
         ```sh
-        kubectl create -f https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.1/examples/basic.yaml
+        kubectl create -f https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-RELEASE_VERSION/examples/basic.yaml
         ```
 
     See [Flink custom resources](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/overview/#overview) for more detail.
@@ -207,6 +207,17 @@ spec:
   - email: jbusche@us.ibm.com
     name: James Busche
   maturity: beta
+  links:
+    - name: Website
+      url: https://flink.apache.org/
+    - name: Documentation
+      url: https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/
+    - name: Mailing list
+      url: https://lists.apache.org/list.html?dev@flink.apache.org
+    - name: Slack
+      url: https://apache-flink.slack.com/join/shared_invite/zt-1llkzbgyt-K2nNGGg88rfsDGLkT09Qzg#/shared-invite/email
+    - name: GitHub
+      url: https://github.com/apache/flink-kubernetes-operator
   provider:
     name: Community
     url: https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/try-flink-kubernetes-operator/quick-start/

--- a/tools/olm/csv-template/bases/flink-kubernetes-operator.clusterserviceversion.yaml
+++ b/tools/olm/csv-template/bases/flink-kubernetes-operator.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     name: James Busche
   maturity: beta
   provider:
-    name: " "
+    name: Community
     url: https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/try-flink-kubernetes-operator/quick-start/
   replaces:
   version: 1.1.0

--- a/tools/olm/docker-entry.sh
+++ b/tools/olm/docker-entry.sh
@@ -78,12 +78,6 @@ generate_olm_bundle() {
   yq ea -i '.spec.install.spec.deployments[0].spec.template.spec.containers[0].resources = {"requests": {"cpu": "10m", "memory": "100Mi"}}' "${CSV_FILE}"
   yq ea -i '.spec.install.spec.deployments[0].spec.template.spec.containers[1].resources = {"requests": {"cpu": "10m", "memory": "100Mi"}}' "${CSV_FILE}"
 
-  # Only needed until this PR gets merged: https://github.com/apache/flink-kubernetes-operator/pull/420
-  # yq ea -i '.spec.webhookdefinitions[0].rules[0].apiGroups=["flink.apache.org"]' "${CSV_FILE}"
-  # yq ea -i '.spec.webhookdefinitions[1].rules[0].apiGroups=["flink.apache.org"]' "${CSV_FILE}"
-  # yq ea -i '.spec.webhookdefinitions[0].generateName="validationwebhook.flink.apache.org"' "${CSV_FILE}"
-  # yq ea -i '.spec.webhookdefinitions[1].generateName="mutationwebhook.flink.apache.org"' "${CSV_FILE}"
-
   # The OLM lets operator to watch specified namespace with i.e.: spec.targetNamespaces:[bar, foo] in the OperatorGroup crd.
   # The OLM then automatically injects template.metadata.annotations.olm.targetNamespaces:[bar, foo] into deployment.apps/flink-kubernetes-operator
   # See PR https://github.com/apache/flink-kubernetes-operator/pull/420 see how the watchedNamespaces is assigned to targetNamespaces.
@@ -102,6 +96,10 @@ generate_olm_bundle() {
   yq ea -i ".spec.replaces = \"${PACKAGE_NAME}.v${PREVIOUS_BUNDLE_VERSION}\" | .spec.replaces style=\"\"" "${CSV_FILE}"
 
   yq ea -i "del(.subjects[0].namespace)" "${ROLE_BINDING}"
+
+  # Needed to replace description with new bundle values
+  sed -i "s/release-1.1/release-${BUNDLE_VERSION}/" "${CSV_FILE}"
+  sed -i "s/version: 1.2.0/version: ${BUNDLE_VERSION}/" "${CSV_FILE}"
 }
 
 validate_olm_bundle() {

--- a/tools/olm/docker-entry.sh
+++ b/tools/olm/docker-entry.sh
@@ -98,8 +98,7 @@ generate_olm_bundle() {
   yq ea -i "del(.subjects[0].namespace)" "${ROLE_BINDING}"
 
   # Needed to replace description with new bundle values
-  sed -i "s/release-1.1/release-${BUNDLE_VERSION}/" "${CSV_FILE}"
-  sed -i "s/version: 1.2.0/version: ${BUNDLE_VERSION}/" "${CSV_FILE}"
+  sed -i "s/RELEASE_VERSION/${BUNDLE_VERSION}/" "${CSV_FILE}"
 }
 
 validate_olm_bundle() {

--- a/tools/olm/generate-olm-bundle.sh
+++ b/tools/olm/generate-olm-bundle.sh
@@ -139,7 +139,7 @@ echo
 echo "After the operator is ready, deploy a flink job using:
 kubectl create -f ../../examples/basic.yaml
 or
-kubectl create -f https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.2/examples/basic.yaml
+kubectl create -f https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-$BUNDLE_VERSION/examples/basic.yaml
 "
 
 


### PR DESCRIPTION
Signed-off-by: James Busche <jbusche@us.ibm.com>

<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fixes OLM Documentation issues that I noticed 
- basic.yaml was described using an old version
- The labels were hardcoded to 1.2.0
- The empty Provider needs to change to something to avoid future operator-sdk CI issues.  Changing to "Community" for now but possibly can make "The Apache Software Foundation" if people agree.


## Brief change log

Fix basic.yaml version in:
- generate-olm-bundle.sh
- docker-entry.sh
Fix label version issues in:
- docker-entry.sh
Fix Provider in the csv-template
- csv-template/bases/flink-kubernetes-operator.clusterserviceversion.yaml

## Verifying this change
git clone https://github.com/jbusche/flink-kubernetes-operator.git

git checkout FLINK-30456

cd /tools/olm

vi env.sh and replace:
```
OPERATOR_IMG=ghcr.io/apache/flink-kubernetes-operator:main
with
OPERATOR_IMG=docker.io/apache/flink-kubernetes-operator:1.3.0
```
./generate-olm-bundle.sh

Follow the output provided from the ./generate-olm-bundle.sh command to create a catsrc and subscription.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
