### PR TITLE
[FLINK-30463] Start stabilization period only after job goes into RUNNING

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
@@ -118,7 +118,9 @@ public class BacklogBasedScalingTest {
         var ctx = createAutoscalerTestContext();
         var now = Instant.now();
         setClocksTo(now);
-        app.getStatus().getJobStatus().setStartTime(String.valueOf(now.toEpochMilli()));
+        String startTime = String.valueOf(now.toEpochMilli());
+        app.getStatus().getJobStatus().setStartTime(startTime);
+        app.getStatus().getJobStatus().setUpdateTime(startTime);
         metricsCollector.setCurrentMetrics(
                 Map.of(
                         source1,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.autoscaler;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
@@ -103,6 +104,8 @@ public class MetricsCollectionAndEvaluationTest {
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 1.);
         ReconciliationUtils.updateStatusForDeployedSpec(app, conf);
         app.getStatus().getJobStatus().setStartTime(String.valueOf(System.currentTimeMillis()));
+        app.getStatus().getJobStatus().setUpdateTime(String.valueOf(System.currentTimeMillis()));
+        app.getStatus().getJobStatus().setState(JobStatus.RUNNING.name());
     }
 
     @Test


### PR DESCRIPTION
We were tracking the stabilization period from the job start time which can greatly vary from the time the job goes into RUNNING state. This can result in no stabilization period at all leading to poor scaling decisions.

Thus, we change the logic to use the update time in combination with a RUNNING job status.
