### PR TITLE
[FLINK-30528] Reconcile other changes if upgrade is not available

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -145,9 +145,7 @@ public abstract class AbstractFlinkResourceReconciler<
                         || reconciliationStatus.getState() == ReconciliationState.UPGRADING;
 
         var observeConfig = getObserveConfig(cr, ctx);
-
         if (specChanged) {
-
             if (checkNewSpecAlreadyDeployed(cr, deployConfig)) {
                 return;
             }
@@ -162,11 +160,18 @@ public abstract class AbstractFlinkResourceReconciler<
                         EventRecorder.Component.JobManagerDeployment,
                         specChangeMessage);
             }
-            boolean scale = scaleCluster(cr, ctx, observeConfig, deployConfig, specDiff.getType());
-            if (!scale) {
-                reconcileSpecChange(cr, ctx, observeConfig, deployConfig, specDiff.getType());
+            boolean reconciled =
+                    scaleCluster(cr, ctx, observeConfig, deployConfig, specDiff.getType())
+                            || reconcileSpecChange(
+                                    cr, ctx, observeConfig, deployConfig, specDiff.getType());
+            if (reconciled) {
+                // If we executed a scale or spec upgrade action we return, otherwise we continue to
+                // reconcile other changes
+                return;
             }
-        } else if (shouldRollBack(cr, observeConfig, flinkService)) {
+        }
+
+        if (shouldRollBack(cr, observeConfig, flinkService)) {
             // Rollbacks are executed in two steps, we initiate it first then return
             if (initiateRollBack(status)) {
                 return;
@@ -255,8 +260,9 @@ public abstract class AbstractFlinkResourceReconciler<
      * @param observeConfig Observe configuration.
      * @param deployConfig Deployment configuration.
      * @throws Exception Error during spec upgrade.
+     * @return True if spec change reconciliation was executed
      */
-    protected abstract void reconcileSpecChange(
+    protected abstract boolean reconcileSpecChange(
             CR cr,
             Context<?> ctx,
             Configuration observeConfig,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -82,7 +82,7 @@ public abstract class AbstractJobReconciler<
     }
 
     @Override
-    protected void reconcileSpecChange(
+    protected boolean reconcileSpecChange(
             CR resource,
             Context<?> ctx,
             Configuration observeConfig,
@@ -104,7 +104,7 @@ public abstract class AbstractJobReconciler<
             Optional<UpgradeMode> availableUpgradeMode =
                     getAvailableUpgradeMode(resource, ctx, deployConfig, observeConfig);
             if (availableUpgradeMode.isEmpty()) {
-                return;
+                return false;
             }
 
             eventRecorder.triggerEvent(
@@ -145,6 +145,7 @@ public abstract class AbstractJobReconciler<
 
             ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig);
         }
+        return true;
     }
 
     protected Optional<UpgradeMode> getAvailableUpgradeMode(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -135,8 +135,9 @@ public class ApplicationReconciler
             return getAvailableUpgradeMode(deployment, ctx, deployConfig, observeConfig);
         }
 
-        if (jmDeployStatus == JobManagerDeploymentStatus.MISSING
-                || jmDeployStatus == JobManagerDeploymentStatus.ERROR) {
+        if ((jmDeployStatus == JobManagerDeploymentStatus.MISSING
+                        || jmDeployStatus == JobManagerDeploymentStatus.ERROR)
+                && !flinkService.isHaMetadataAvailable(deployConfig)) {
             throw new RecoveryFailureException(
                     "JobManager deployment is missing and HA data is not available to make stateful upgrades. "
                             + "It is possible that the job has finished or terminally failed, or the configmaps have been deleted. "
@@ -145,7 +146,7 @@ public class ApplicationReconciler
         }
 
         LOG.info(
-                "Job is not running yet and HA metadata is not available, waiting for upgradeable state");
+                "Job is not running and HA metadata is not available or usable for executing the upgrade, waiting for upgradeable state");
         return Optional.empty();
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -91,7 +91,7 @@ public class SessionReconciler
     }
 
     @Override
-    protected void reconcileSpecChange(
+    protected boolean reconcileSpecChange(
             FlinkDeployment deployment,
             Context<?> ctx,
             Configuration observeConfig,
@@ -113,6 +113,7 @@ public class SessionReconciler
                 Optional.empty(),
                 false);
         ReconciliationUtils.updateStatusForDeployedSpec(deployment, deployConfig);
+        return true;
     }
 
     private void deleteSessionCluster(FlinkDeployment deployment, Configuration effectiveConfig) {


### PR DESCRIPTION
## What is the purpose of the change

Trigger other reconciliation actions even if upgrademode is currently not available to not cause a stuck upgrade loop.

## Brief change log

 - Improved spec reconciliation logic
 - Unit tests

## Verifying this change

Added new reconciler unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
