### PR TITLE
Backport remaining fixes for 1.3.1

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/TaskManagerSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/TaskManagerSpec.java
@@ -18,6 +18,9 @@
 package org.apache.flink.kubernetes.operator.api.spec;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.kubernetes.operator.api.diff.DiffType;
+import org.apache.flink.kubernetes.operator.api.diff.Diffable;
+import org.apache.flink.kubernetes.operator.api.diff.SpecDiff;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.model.annotation.SpecReplicas;
@@ -32,12 +35,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class TaskManagerSpec {
+public class TaskManagerSpec implements Diffable<TaskManagerSpec> {
     /** Resource specification for the TaskManager pods. */
     private Resource resource;
 
     /** Number of TaskManager replicas. If defined, takes precedence over parallelism */
-    @SpecReplicas private Integer replicas;
+    @SpecDiff(DiffType.SCALE)
+    @SpecReplicas
+    private Integer replicas;
 
     /** TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. */
     private Pod podTemplate;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -93,20 +93,6 @@ public abstract class AbstractJobReconciler<
         SPEC lastReconciledSpec = reconciliationStatus.deserializeLastReconciledSpec();
         SPEC currentDeploySpec = resource.getSpec();
 
-        if (diffType == DiffType.SCALE) {
-            boolean scaled =
-                    getFlinkService(resource, ctx)
-                            .scale(
-                                    resource.getMetadata(),
-                                    resource.getSpec().getJob(),
-                                    deployConfig);
-            if (scaled) {
-                LOG.info("Reactive scaling succeeded");
-                ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig);
-                return;
-            }
-        }
-
         JobState currentJobState = lastReconciledSpec.getJob().getState();
         JobState desiredJobState = currentDeploySpec.getJob().getState();
         if (currentJobState == JobState.RUNNING) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -80,7 +80,7 @@ public abstract class AbstractJobReconciler<
     }
 
     @Override
-    protected void reconcileSpecChange(
+    protected boolean reconcileSpecChange(
             CR resource,
             Context<?> ctx,
             Configuration observeConfig,
@@ -102,7 +102,7 @@ public abstract class AbstractJobReconciler<
             Optional<UpgradeMode> availableUpgradeMode =
                     getAvailableUpgradeMode(resource, ctx, deployConfig, observeConfig);
             if (availableUpgradeMode.isEmpty()) {
-                return;
+                return false;
             }
 
             eventRecorder.triggerEvent(
@@ -143,6 +143,7 @@ public abstract class AbstractJobReconciler<
 
             ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig);
         }
+        return true;
     }
 
     protected Optional<UpgradeMode> getAvailableUpgradeMode(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -133,8 +133,9 @@ public class ApplicationReconciler
             return getAvailableUpgradeMode(deployment, ctx, deployConfig, observeConfig);
         }
 
-        if (jmDeployStatus == JobManagerDeploymentStatus.MISSING
-                || jmDeployStatus == JobManagerDeploymentStatus.ERROR) {
+        if ((jmDeployStatus == JobManagerDeploymentStatus.MISSING
+                        || jmDeployStatus == JobManagerDeploymentStatus.ERROR)
+                && !flinkService.isHaMetadataAvailable(deployConfig)) {
             throw new RecoveryFailureException(
                     "JobManager deployment is missing and HA data is not available to make stateful upgrades. "
                             + "It is possible that the job has finished or terminally failed, or the configmaps have been deleted. "
@@ -143,7 +144,7 @@ public class ApplicationReconciler
         }
 
         LOG.info(
-                "Job is not running yet and HA metadata is not available, waiting for upgradeable state");
+                "Job is not running and HA metadata is not available or usable for executing the upgrade, waiting for upgradeable state");
         return Optional.empty();
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -89,7 +89,7 @@ public class SessionReconciler
     }
 
     @Override
-    protected void reconcileSpecChange(
+    protected boolean reconcileSpecChange(
             FlinkDeployment deployment,
             Context<?> ctx,
             Configuration observeConfig,
@@ -111,6 +111,7 @@ public class SessionReconciler
                 Optional.empty(),
                 false);
         ReconciliationUtils.updateStatusForDeployedSpec(deployment, deployConfig);
+        return true;
     }
 
     private void deleteSessionCluster(FlinkDeployment deployment, Configuration effectiveConfig) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.SchedulerExecutionMode;
 import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
@@ -171,7 +172,8 @@ public class StandaloneFlinkService extends AbstractFlinkService {
 
     @Override
     public boolean scale(ObjectMeta meta, JobSpec jobSpec, Configuration conf) {
-        if (conf.get(JobManagerOptions.SCHEDULER_MODE) == null) {
+        if (conf.get(JobManagerOptions.SCHEDULER_MODE) != SchedulerExecutionMode.REACTIVE
+                && jobSpec != null) {
             LOG.info("Reactive scaling is not enabled");
             return false;
         }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.PipelineOptionsInternal;
+import org.apache.flink.configuration.SchedulerExecutionMode;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
@@ -501,7 +502,8 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     @Override
     public boolean scale(ObjectMeta meta, JobSpec jobSpec, Configuration conf) {
-        if (conf.get(JobManagerOptions.SCHEDULER_MODE) == null) {
+        if (conf.get(JobManagerOptions.SCHEDULER_MODE) != SchedulerExecutionMode.REACTIVE
+                && jobSpec != null) {
             return false;
         }
         desiredReplicas =

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -431,6 +431,7 @@ public class ApplicationReconcilerTest {
                                 .toBuilder()
                                 .jobId(runningJobs.get(0).f1.getJobId().toHexString())
                                 .jobName(runningJobs.get(0).f1.getJobName())
+                                .updateTime(Long.toString(System.currentTimeMillis()))
                                 .state("RUNNING")
                                 .build());
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
@@ -704,5 +705,51 @@ public class ApplicationReconcilerTest {
                 deployment.getStatus().getClusterInfo(), clusterHealthInfo);
         reconciler.reconcile(deployment, context);
         Assertions.assertEquals(MSG_RESTART_UNHEALTHY, eventCollector.events.remove().getMessage());
+    }
+
+    @Test
+    public void testReconcileIfUpgradeModeNotAvailable() throws Exception {
+        FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        deployment.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
+
+        // We disable last state fallback as we want to test that the deployment is properly
+        // recovered before upgrade
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(
+                        KubernetesOperatorConfigOptions
+                                .OPERATOR_JOB_UPGRADE_LAST_STATE_FALLBACK_ENABLED
+                                .key(),
+                        "false");
+
+        // Initial deployment
+        reconciler.reconcile(deployment, context);
+
+        // Trigger upgrade but set jobmanager status to missing -> savepoint upgrade not available
+        deployment.getSpec().setRestartNonce(123L);
+        deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
+        flinkService.clear();
+
+        reconciler.reconcile(deployment, context);
+        // We verify that deployment was recovered before upgrade
+        assertEquals(
+                JobManagerDeploymentStatus.DEPLOYING,
+                deployment.getStatus().getJobManagerDeploymentStatus());
+
+        var lastReconciledSpec =
+                deployment.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
+        assertNotEquals(
+                deployment.getSpec().getRestartNonce(), lastReconciledSpec.getRestartNonce());
+
+        // Set to running to let savepoint upgrade proceed
+        verifyAndSetRunningJobsToStatus(deployment, flinkService.listJobs());
+
+        reconciler.reconcile(deployment, context);
+        // Make sure upgrade is properly triggered now
+        lastReconciledSpec =
+                deployment.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
+        assertEquals(deployment.getSpec().getRestartNonce(), lastReconciledSpec.getRestartNonce());
+        assertEquals(JobState.SUSPENDED, lastReconciledSpec.getJob().getState());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/diff/SpecDiffTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/diff/SpecDiffTest.java
@@ -124,6 +124,19 @@ public class SpecDiffTest {
         diff = new ReflectiveDiffBuilder<>(left, right).build();
         assertEquals(DiffType.UPGRADE, diff.getType());
         assertEquals(22, diff.getNumDiffs());
+        left.setMode(KubernetesDeploymentMode.STANDALONE);
+        left.getTaskManager().setReplicas(2);
+        left.getTaskManager().getResource().setMemory("1024");
+        right = SpecUtils.clone(left);
+        right.getTaskManager().setReplicas(3);
+        diff = new ReflectiveDiffBuilder<>(left, right).build();
+        assertEquals(DiffType.SCALE, diff.getType());
+        assertEquals(1, diff.getNumDiffs());
+        right.getTaskManager().getResource().setMemory("2048");
+        right.getTaskManager().setReplicas(4);
+        diff = new ReflectiveDiffBuilder<>(left, right).build();
+        assertEquals(DiffType.UPGRADE, diff.getType());
+        assertEquals(2, diff.getNumDiffs());
     }
 
     @Test


### PR DESCRIPTION
Backport:
 - 6e597f76  [FLINK-30527] Validate flinkVersion change for suspended jobs
 - 0d2595ac [FLINK-30528] Reconcile other changes if upgrade is not available
 - abc8e6b7 [FLINK-30361] Do not redeploy task managers when scaling standalone session cluster