### PR TITLE
[FLINK-30574] Detect ineffective scale up operations to avoid scaling further

### DIFF
--- a/docs/content/docs/custom-resource/pod-template.md
+++ b/docs/content/docs/custom-resource/pod-template.md
@@ -93,7 +93,7 @@ spec:
         initContainers:
           # Sample sidecar container
           - name: busybox
-            image: busybox:latest
+            image: busybox:1.33.1
             command: [ 'sh','-c','echo hello from task manager' ]
   job:
     jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -45,6 +45,18 @@
             <td>Period in which no scale down is allowed after a scale up</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.autoscaler.scaling.effectiveness.detection.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable detection of ineffective scaling operations and allowing the autoscaler to block further scale ups.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.job.autoscaler.scaling.effectiveness.threshold</h5></td>
+            <td style="word-wrap: break-word;">0.1</td>
+            <td>Double</td>
+            <td>Processing rate increase threshold for detecting ineffective scaling threshold. 0.1 means if we do not accomplish at least 10% of the desired capacity increase with scaling, the action is marked ineffective.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.autoscaler.scaling.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -21,6 +21,18 @@
             <td>Enable job autoscaler module.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.autoscaler.history.max.age</h5></td>
+            <td style="word-wrap: break-word;">86400000 ms</td>
+            <td>Duration</td>
+            <td>Maximum age for past scaling decisions to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.job.autoscaler.history.max.count</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>Integer</td>
+            <td>Maximum number of past scaling decisions to retain per vertex.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.autoscaler.metrics.window</h5></td>
             <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>

--- a/e2e-tests/data/flinkdep-cr.yaml
+++ b/e2e-tests/data/flinkdep-cr.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       initContainers:
         - name: artifacts-fetcher
-          image: busybox:latest
+          image: busybox:1.33.1
           imagePullPolicy: IfNotPresent
           # Use wget or other tools to get user jars from remote storage
           command: [ 'wget', 'https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.4/flink-examples-streaming_2.12-1.14.4.jar', '-O', '/flink-artifact/myjob.jar' ]

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -65,7 +65,7 @@ spec:
         initContainers:
           # Sample init container for fetching remote artifacts
           - name: busybox
-            image: busybox:latest
+            image: busybox:1.33.1
             volumeMounts:
               - mountPath: /opt/flink/downloads
                 name: downloads

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScaler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScaler.java
@@ -86,7 +86,7 @@ public class JobAutoScaler implements Cleanup {
         }
 
         if (!resource.getStatus().getJobStatus().getState().equals(JobStatus.RUNNING.name())) {
-            LOG.info("Job autoscaler is waiting for RUNNING job     state");
+            LOG.info("Job autoscaler is waiting for RUNNING job state");
             return false;
         }
 
@@ -98,8 +98,7 @@ public class JobAutoScaler implements Cleanup {
                     metricsCollector.updateMetrics(
                             resource, autoScalerInfo, ctx.getFlinkService(), conf);
 
-            if (collectedMetrics == null || collectedMetrics.getMetricHistory().isEmpty()) {
-                LOG.info("No metrics were collected. Skipping scaling step");
+            if (collectedMetrics.getMetricHistory().isEmpty()) {
                 return false;
             }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScaler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScaler.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.autoscaler;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.autoscaler.metrics.EvaluatedScalingMetric;
+import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.kubernetes.operator.autoscaler.utils.AutoScalerUtils;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.util.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.SortedMap;
+
+import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.MAX_SCALE_DOWN_FACTOR;
+import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.SCALE_UP_GRACE_PERIOD;
+import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION;
+import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.VERTEX_MAX_PARALLELISM;
+import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.VERTEX_MIN_PARALLELISM;
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.MAX_PARALLELISM;
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.PARALLELISM;
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_RATE;
+
+/** Component responsible for computing vertex parallelism based on the scaling metrics. */
+public class JobVertexScaler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JobVertexScaler.class);
+
+    private Clock clock = Clock.system(ZoneId.systemDefault());
+
+    public int computeScaleTargetParallelism(
+            Configuration conf,
+            JobVertexID vertex,
+            Map<ScalingMetric, EvaluatedScalingMetric> evaluatedMetrics,
+            SortedMap<Instant, ScalingSummary> history) {
+
+        var currentParallelism = (int) evaluatedMetrics.get(PARALLELISM).getCurrent();
+        double averageTrueProcessingRate = evaluatedMetrics.get(TRUE_PROCESSING_RATE).getAverage();
+
+        if (Double.isNaN(averageTrueProcessingRate)) {
+            LOG.info(
+                    "True processing rate is not available for {}, cannot compute new parallelism",
+                    vertex);
+            return currentParallelism;
+        }
+
+        double targetCapacity =
+                AutoScalerUtils.getTargetProcessingCapacity(
+                        evaluatedMetrics, conf, conf.get(TARGET_UTILIZATION), true);
+        if (Double.isNaN(targetCapacity)) {
+            LOG.info(
+                    "Target data rate is not available for {}, cannot compute new parallelism",
+                    vertex);
+            return currentParallelism;
+        }
+
+        LOG.info("Target processing capacity for {} is {}", vertex, targetCapacity);
+        double scaleFactor = targetCapacity / averageTrueProcessingRate;
+        double minScaleFactor = 1 - conf.get(MAX_SCALE_DOWN_FACTOR);
+        if (scaleFactor < minScaleFactor) {
+            LOG.info(
+                    "Computed scale factor of {} for {} is capped by maximum scale down factor to {}",
+                    scaleFactor,
+                    vertex,
+                    minScaleFactor);
+            scaleFactor = minScaleFactor;
+        }
+
+        int newParallelism =
+                scale(
+                        currentParallelism,
+                        (int) evaluatedMetrics.get(MAX_PARALLELISM).getCurrent(),
+                        scaleFactor,
+                        conf.getInteger(VERTEX_MIN_PARALLELISM),
+                        conf.getInteger(VERTEX_MAX_PARALLELISM));
+
+        if (!history.isEmpty()) {
+            if (detectImmediateScaleDownAfterScaleUp(
+                    conf, history, currentParallelism, newParallelism)) {
+                LOG.info(
+                        "Skipping immediate scale down after scale up for {} resetting target parallelism to {}",
+                        vertex,
+                        currentParallelism);
+                newParallelism = currentParallelism;
+            }
+
+            // currentParallelism = 2 , newParallelism = 1, minimumProcRate = 1000 r/s
+            // history
+            // currentParallelism 1 => 3 -> empiricalProcRate = 800
+            // empiricalProcRate + upperBoundary < minimumProcRate => don't scale
+        }
+
+        return newParallelism;
+    }
+
+    private boolean detectImmediateScaleDownAfterScaleUp(
+            Configuration conf,
+            SortedMap<Instant, ScalingSummary> history,
+            int currentParallelism,
+            int newParallelism) {
+        var lastScalingTs = history.lastKey();
+        var lastSummary = history.get(lastScalingTs);
+
+        boolean isScaleDown = newParallelism < currentParallelism;
+        boolean lastScaleUp = lastSummary.getNewParallelism() > lastSummary.getCurrentParallelism();
+
+        var gracePeriod = conf.get(SCALE_UP_GRACE_PERIOD);
+
+        boolean withinConfiguredTime =
+                Duration.between(lastScalingTs, clock.instant()).minus(gracePeriod).isNegative();
+
+        return isScaleDown && lastScaleUp && withinConfiguredTime;
+    }
+
+    @VisibleForTesting
+    protected static int scale(
+            int parallelism,
+            int numKeyGroups,
+            double scaleFactor,
+            int minParallelism,
+            int maxParallelism) {
+        Preconditions.checkArgument(
+                minParallelism <= maxParallelism,
+                "The minimum parallelism must not be greater than the maximum parallelism.");
+        if (minParallelism > numKeyGroups) {
+            LOG.warn(
+                    "Specified autoscaler minimum parallelism {} is greater than the operator max parallelism {}. The min parallelism will be set to the operator max parallelism.",
+                    minParallelism,
+                    numKeyGroups);
+        }
+        if (numKeyGroups < maxParallelism && maxParallelism != Integer.MAX_VALUE) {
+            LOG.warn(
+                    "Specified autoscaler maximum parallelism {} is greater than the operator max parallelism {}. This means the operator max parallelism can never be reached.",
+                    maxParallelism,
+                    numKeyGroups);
+        }
+
+        int newParallelism =
+                // Prevent integer overflow when converting from double to integer.
+                // We do not have to detect underflow because doubles cannot
+                // underflow.
+                (int) Math.min(Math.ceil(scaleFactor * parallelism), Integer.MAX_VALUE);
+
+        // Cap parallelism at either number of key groups or parallelism limit
+        final int upperBound = Math.min(numKeyGroups, maxParallelism);
+
+        // Apply min/max parallelism
+        newParallelism = Math.min(Math.max(minParallelism, newParallelism), upperBound);
+
+        // Try to adjust the parallelism such that it divides the number of key groups without a
+        // remainder => state is evenly spread across subtasks
+        for (int p = newParallelism; p <= numKeyGroups / 2 && p <= upperBound; p++) {
+            if (numKeyGroups % p == 0) {
+                return p;
+            }
+        }
+
+        // If key group adjustment fails, use originally computed parallelism
+        return newParallelism;
+    }
+
+    @VisibleForTesting
+    protected void setClock(Clock clock) {
+        this.clock = Preconditions.checkNotNull(clock);
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
@@ -25,7 +25,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric;
-import org.apache.flink.kubernetes.operator.autoscaler.utils.AutoScalerUtils;
 import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.Preconditions;
@@ -35,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Collections;
@@ -43,15 +41,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
 
-import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.MAX_SCALE_DOWN_FACTOR;
-import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.SCALE_UP_GRACE_PERIOD;
 import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.SCALING_ENABLED;
 import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.STABILIZATION_INTERVAL;
-import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION;
-import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.VERTEX_MAX_PARALLELISM;
-import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.VERTEX_MIN_PARALLELISM;
-import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.MAX_PARALLELISM;
-import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.PARALLELISM;
 import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.SCALE_DOWN_RATE_THRESHOLD;
 import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.SCALE_UP_RATE_THRESHOLD;
 import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_RATE;
@@ -70,11 +61,17 @@ public class ScalingExecutor implements Cleanup {
     private static final Logger LOG = LoggerFactory.getLogger(ScalingExecutor.class);
 
     private final KubernetesClient kubernetesClient;
+    private final JobVertexScaler jobVertexScaler;
 
     private Clock clock = Clock.system(ZoneId.systemDefault());
 
     public ScalingExecutor(KubernetesClient kubernetesClient) {
+        this(kubernetesClient, new JobVertexScaler());
+    }
+
+    public ScalingExecutor(KubernetesClient kubernetesClient, JobVertexScaler jobVertexScaler) {
         this.kubernetesClient = kubernetesClient;
+        this.jobVertexScaler = jobVertexScaler;
     }
 
     public boolean scaleResource(
@@ -192,7 +189,7 @@ public class ScalingExecutor implements Cleanup {
                     var currentParallelism =
                             (int) metrics.get(ScalingMetric.PARALLELISM).getCurrent();
                     var newParallelism =
-                            computeScaleTargetParallelism(
+                            jobVertexScaler.computeScaleTargetParallelism(
                                     conf,
                                     v,
                                     metrics,
@@ -203,136 +200,6 @@ public class ScalingExecutor implements Cleanup {
                 });
 
         return out;
-    }
-
-    protected int computeScaleTargetParallelism(
-            Configuration conf,
-            JobVertexID vertex,
-            Map<ScalingMetric, EvaluatedScalingMetric> evaluatedMetrics,
-            SortedMap<Instant, ScalingSummary> history) {
-
-        var currentParallelism = (int) evaluatedMetrics.get(PARALLELISM).getCurrent();
-        double averageTrueProcessingRate = evaluatedMetrics.get(TRUE_PROCESSING_RATE).getAverage();
-
-        if (Double.isNaN(averageTrueProcessingRate)) {
-            LOG.info(
-                    "True processing rate is not available for {}, cannot compute new parallelism",
-                    vertex);
-            return currentParallelism;
-        }
-
-        double targetCapacity =
-                AutoScalerUtils.getTargetProcessingCapacity(
-                        evaluatedMetrics, conf, conf.get(TARGET_UTILIZATION), true);
-        if (Double.isNaN(targetCapacity)) {
-            LOG.info(
-                    "Target data rate is not available for {}, cannot compute new parallelism",
-                    vertex);
-            return currentParallelism;
-        }
-
-        LOG.info("Target processing capacity for {} is {}", vertex, targetCapacity);
-        double scaleFactor = targetCapacity / averageTrueProcessingRate;
-        double minScaleFactor = 1 - conf.get(MAX_SCALE_DOWN_FACTOR);
-        if (scaleFactor < minScaleFactor) {
-            LOG.info(
-                    "Computed scale factor of {} for {} is capped by maximum scale down factor to {}",
-                    scaleFactor,
-                    vertex,
-                    minScaleFactor);
-            scaleFactor = minScaleFactor;
-        }
-
-        int newParallelism =
-                scale(
-                        currentParallelism,
-                        (int) evaluatedMetrics.get(MAX_PARALLELISM).getCurrent(),
-                        scaleFactor,
-                        conf.getInteger(VERTEX_MIN_PARALLELISM),
-                        conf.getInteger(VERTEX_MAX_PARALLELISM));
-
-        if (!history.isEmpty()) {
-            if (detectImmediateScaleDownAfterScaleUp(
-                    conf, history, currentParallelism, newParallelism)) {
-                LOG.info(
-                        "Skipping immediate scale down after scale up for {} resetting target parallelism to {}",
-                        vertex,
-                        currentParallelism);
-                newParallelism = currentParallelism;
-            }
-
-            // currentParallelism = 2 , newParallelism = 1, minimumProcRate = 1000 r/s
-            // history
-            // currentParallelism 1 => 3 -> empiricalProcRate = 800
-            // empiricalProcRate + upperBoundary < minimumProcRate => don't scale
-        }
-
-        return newParallelism;
-    }
-
-    private boolean detectImmediateScaleDownAfterScaleUp(
-            Configuration conf,
-            SortedMap<Instant, ScalingSummary> history,
-            int currentParallelism,
-            int newParallelism) {
-        var lastScalingTs = history.lastKey();
-        var lastSummary = history.get(lastScalingTs);
-
-        boolean isScaleDown = newParallelism < currentParallelism;
-        boolean lastScaleUp = lastSummary.getNewParallelism() > lastSummary.getCurrentParallelism();
-
-        var gracePeriod = conf.get(SCALE_UP_GRACE_PERIOD);
-
-        boolean withinConfiguredTime =
-                Duration.between(lastScalingTs, clock.instant()).minus(gracePeriod).isNegative();
-
-        return isScaleDown && lastScaleUp && withinConfiguredTime;
-    }
-
-    public static int scale(
-            int parallelism,
-            int numKeyGroups,
-            double scaleFactor,
-            int minParallelism,
-            int maxParallelism) {
-        Preconditions.checkArgument(
-                minParallelism <= maxParallelism,
-                "The minimum parallelism must not be greater than the maximum parallelism.");
-        if (minParallelism > numKeyGroups) {
-            LOG.warn(
-                    "Specified autoscaler minimum parallelism {} is greater than the operator max parallelism {}. The min parallelism will be set to the operator max parallelism.",
-                    minParallelism,
-                    numKeyGroups);
-        }
-        if (numKeyGroups < maxParallelism && maxParallelism != Integer.MAX_VALUE) {
-            LOG.warn(
-                    "Specified autoscaler maximum parallelism {} is greater than the operator max parallelism {}. This means the operator max parallelism can never be reached.",
-                    maxParallelism,
-                    numKeyGroups);
-        }
-
-        int newParallelism =
-                // Prevent integer overflow when converting from double to integer.
-                // We do not have to detect underflow because doubles cannot
-                // underflow.
-                (int) Math.min(Math.ceil(scaleFactor * parallelism), Integer.MAX_VALUE);
-
-        // Cap parallelism at either number of key groups or parallelism limit
-        final int upperBound = Math.min(numKeyGroups, maxParallelism);
-
-        // Apply min/max parallelism
-        newParallelism = Math.min(Math.max(minParallelism, newParallelism), upperBound);
-
-        // Try to adjust the parallelism such that it divides the number of key groups without a
-        // remainder => state is evenly spread across subtasks
-        for (int p = newParallelism; p <= numKeyGroups / 2 && p <= upperBound; p++) {
-            if (numKeyGroups % p == 0) {
-                return p;
-            }
-        }
-
-        // If key group adjustment fails, use originally computed parallelism
-        return newParallelism;
     }
 
     private void setVertexParallelismOverrides(
@@ -362,6 +229,7 @@ public class ScalingExecutor implements Cleanup {
     @VisibleForTesting
     protected void setClock(Clock clock) {
         this.clock = Preconditions.checkNotNull(clock);
+        jobVertexScaler.setClock(clock);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
@@ -111,7 +111,7 @@ public class ScalingExecutor implements Cleanup {
         setVertexParallelismOverrides(resource, evaluatedMetrics, scalingSummaries);
 
         KubernetesClientUtils.replaceSpecAfterScaling(kubernetesClient, resource);
-        scalingInformation.addToScalingHistory(clock.instant(), scalingSummaries);
+        scalingInformation.addToScalingHistory(clock.instant(), scalingSummaries, conf);
 
         return true;
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
@@ -49,12 +49,10 @@ import org.slf4j.LoggerFactory;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -97,7 +95,7 @@ public abstract class ScalingMetricCollector implements Cleanup {
             cleanup(cr);
         }
 
-        var topology = getJobTopology(flinkService, cr, conf);
+        var topology = getJobTopology(flinkService, cr, conf, scalingInformation);
 
         var stabilizationDuration = conf.get(AutoScalerOptions.STABILIZATION_INTERVAL);
         var stableTime = currentJobUpdateTs.plus(stabilizationDuration);
@@ -151,14 +149,22 @@ public abstract class ScalingMetricCollector implements Cleanup {
     }
 
     protected JobTopology getJobTopology(
-            FlinkService flinkService, AbstractFlinkResource<?, ?> cr, Configuration conf)
+            FlinkService flinkService,
+            AbstractFlinkResource<?, ?> cr,
+            Configuration conf,
+            AutoScalerInfo scalerInfo)
             throws Exception {
 
         try (var restClient = (RestClusterClient<String>) flinkService.getClusterClient(conf)) {
             var jobId = JobID.fromHexString(cr.getStatus().getJobStatus().getJobId());
             var topology =
                     topologies.computeIfAbsent(
-                            ResourceID.fromResource(cr), r -> queryJobTopology(restClient, jobId));
+                            ResourceID.fromResource(cr),
+                            r -> {
+                                var t = queryJobTopology(restClient, jobId);
+                                scalerInfo.updateVertexList(t.getVerticesInTopologicalOrder());
+                                return t;
+                            });
             updateKafkaSourceMaxParallelisms(restClient, jobId, topology);
             return topology;
         }
@@ -210,13 +216,6 @@ public abstract class ScalingMetricCollector implements Cleanup {
                                 });
             }
         }
-    }
-
-    private List<JobVertexID> getVertexList(
-            FlinkService flinkService, AbstractFlinkResource<?, ?> cr, Configuration conf)
-            throws Exception {
-        JobTopology topology = getJobTopology(flinkService, cr, conf);
-        return new ArrayList<>(topology.getParallelisms().keySet());
     }
 
     /**
@@ -301,7 +300,7 @@ public abstract class ScalingMetricCollector implements Cleanup {
             JobTopology topology) {
 
         var jobId = JobID.fromHexString(cr.getStatus().getJobStatus().getJobId());
-        var vertices = getVertexList(flinkService, cr, conf);
+        var vertices = topology.getVerticesInTopologicalOrder();
 
         long deployedGeneration = getDeployedGeneration(cr);
 
@@ -390,19 +389,18 @@ public abstract class ScalingMetricCollector implements Cleanup {
         }
 
         requiredMetrics.forEach(
-                flinkMetric -> {
-                    filteredMetrics.put(
-                            flinkMetric
-                                    .findAny(allMetricNames)
-                                    .orElseThrow(
-                                            () ->
-                                                    new RuntimeException(
-                                                            "Could not find required metric "
-                                                                    + flinkMetric.name()
-                                                                    + " for "
-                                                                    + jobVertexID)),
-                            flinkMetric);
-                });
+                flinkMetric ->
+                        filteredMetrics.put(
+                                flinkMetric
+                                        .findAny(allMetricNames)
+                                        .orElseThrow(
+                                                () ->
+                                                        new RuntimeException(
+                                                                "Could not find required metric "
+                                                                        + flinkMetric.name()
+                                                                        + " for "
+                                                                        + jobVertexID)),
+                                flinkMetric));
 
         return filteredMetrics;
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingSummary.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingSummary.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.autoscaler;
 import org.apache.flink.kubernetes.operator.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -47,5 +48,10 @@ public class ScalingSummary {
         this.currentParallelism = currentParallelism;
         this.newParallelism = newParallelism;
         this.metrics = metrics;
+    }
+
+    @JsonIgnore
+    public boolean isScaledUp() {
+        return newParallelism > currentParallelism;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -118,4 +118,18 @@ public class AutoScalerOptions {
                     .defaultValue(Duration.ofMinutes(5))
                     .withDescription(
                             "Expected restart time to be used until the operator can determine it reliably from history.");
+
+    public static final ConfigOption<Boolean> SCALING_EFFECTIVENESS_DETECTION_ENABLED =
+            autoScalerConfig("scaling.effectiveness.detection.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to enable detection of ineffective scaling operations and allowing the autoscaler to block further scale ups.");
+
+    public static final ConfigOption<Double> SCALING_EFFECTIVENESS_THRESHOLD =
+            autoScalerConfig("scaling.effectiveness.threshold")
+                    .doubleType()
+                    .defaultValue(0.1)
+                    .withDescription(
+                            "Processing rate increase threshold for detecting ineffective scaling threshold. 0.1 means if we do not accomplish at least 10% of the desired capacity increase with scaling, the action is marked ineffective.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -132,4 +132,17 @@ public class AutoScalerOptions {
                     .defaultValue(0.1)
                     .withDescription(
                             "Processing rate increase threshold for detecting ineffective scaling threshold. 0.1 means if we do not accomplish at least 10% of the desired capacity increase with scaling, the action is marked ineffective.");
+
+    public static final ConfigOption<Integer> VERTEX_SCALING_HISTORY_COUNT =
+            autoScalerConfig("history.max.count")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription(
+                            "Maximum number of past scaling decisions to retain per vertex.");
+
+    public static final ConfigOption<Duration> VERTEX_SCALING_HISTORY_AGE =
+            autoScalerConfig("history.max.age")
+                    .durationType()
+                    .defaultValue(Duration.ofHours(24))
+                    .withDescription("Maximum age for past scaling decisions to retain.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
@@ -60,7 +60,10 @@ public enum ScalingMetric {
     SCALE_UP_RATE_THRESHOLD(false),
 
     /** Lower boundary of the target data rate range. */
-    SCALE_DOWN_RATE_THRESHOLD(false);
+    SCALE_DOWN_RATE_THRESHOLD(false),
+
+    /** Expected true processing rate after scale up. */
+    EXPECTED_PROCESSING_RATE(false);
 
     private final boolean calculateAverage;
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfoTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfoTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.autoscaler;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test for AutoScalerInfo. */
+public class AutoScalerInfoTest {
+
+    @Test
+    public void testTopologyUpdate() {
+        var data = new HashMap<String, String>();
+        var info = new AutoScalerInfo(data);
+
+        var v1 = new JobVertexID();
+        var v2 = new JobVertexID();
+        var v3 = new JobVertexID();
+
+        var history = new HashMap<JobVertexID, ScalingSummary>();
+        history.put(v1, new ScalingSummary(1, 2, null));
+        history.put(v2, new ScalingSummary(1, 2, null));
+
+        info.addToScalingHistory(Instant.now(), history, new Configuration());
+
+        assertEquals(history.keySet(), info.getScalingHistory().keySet());
+        assertEquals(history.keySet(), new AutoScalerInfo(data).getScalingHistory().keySet());
+
+        info.updateVertexList(List.of(v2, v3));
+
+        // Expect v1 to be removed
+        assertEquals(Set.of(v2), info.getScalingHistory().keySet());
+        assertEquals(Set.of(v2), new AutoScalerInfo(data).getScalingHistory().keySet());
+    }
+
+    @Test
+    public void testHistorySizeConfigs() {
+        var data = new HashMap<String, String>();
+        var info = new AutoScalerInfo(data);
+
+        var v1 = new JobVertexID();
+
+        var history = new HashMap<JobVertexID, ScalingSummary>();
+        history.put(v1, new ScalingSummary(1, 2, null));
+
+        var conf = new Configuration();
+        conf.set(AutoScalerOptions.VERTEX_SCALING_HISTORY_COUNT, 2);
+        conf.set(AutoScalerOptions.VERTEX_SCALING_HISTORY_AGE, Duration.ofSeconds(10));
+
+        var now = Instant.now();
+
+        // Verify count based expiration
+        info.addToScalingHistory(now, history, conf);
+        assertEquals(1, info.getScalingHistory().get(v1).size());
+
+        info.addToScalingHistory(now.plus(Duration.ofSeconds(1)), history, conf);
+        info.addToScalingHistory(now.plus(Duration.ofSeconds(2)), history, conf);
+
+        assertEquals(2, info.getScalingHistory().get(v1).size());
+        assertEquals(
+                Set.of(now.plus(Duration.ofSeconds(1)), now.plus(Duration.ofSeconds(2))),
+                info.getScalingHistory().get(v1).keySet());
+
+        // Verify time based expiration
+        info.addToScalingHistory(now.plus(Duration.ofSeconds(15)), history, conf);
+        assertEquals(1, info.getScalingHistory().get(v1).size());
+        assertEquals(
+                Set.of(now.plus(Duration.ofSeconds(15))),
+                info.getScalingHistory().get(v1).keySet());
+        assertEquals(
+                Set.of(now.plus(Duration.ofSeconds(15))),
+                new AutoScalerInfo(data).getScalingHistory().get(v1).keySet());
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScalerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScalerTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.autoscaler;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.kubernetes.operator.autoscaler.metrics.EvaluatedScalingMetric;
+import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test for vertex parallelism scaler logic. */
+public class JobVertexScalerTest {
+
+    private JobVertexScaler vertexScaler;
+    private Configuration conf;
+
+    @BeforeEach
+    public void setup() {
+        vertexScaler = new JobVertexScaler();
+        conf = new Configuration();
+        conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 1.);
+        conf.set(AutoScalerOptions.CATCH_UP_DURATION, Duration.ZERO);
+    }
+
+    @Test
+    public void testParallelismScaling() {
+        var op = new JobVertexID();
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        assertEquals(
+                5,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf, op, evaluated(10, 50, 100), Collections.emptySortedMap()));
+
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
+        assertEquals(
+                8,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf, op, evaluated(10, 50, 100), Collections.emptySortedMap()));
+
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
+        assertEquals(
+                10,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf, op, evaluated(10, 80, 100), Collections.emptySortedMap()));
+
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
+        assertEquals(
+                8,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf, op, evaluated(10, 60, 100), Collections.emptySortedMap()));
+
+        assertEquals(
+                8,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf, op, evaluated(10, 59, 100), Collections.emptySortedMap()));
+
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.5);
+        assertEquals(
+                10,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf, op, evaluated(2, 100, 40), Collections.emptySortedMap()));
+
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
+        assertEquals(
+                4,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf, op, evaluated(2, 100, 100), Collections.emptySortedMap()));
+
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.5);
+        assertEquals(
+                5,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf, op, evaluated(10, 10, 100), Collections.emptySortedMap()));
+
+        conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.6);
+        assertEquals(
+                4,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf, op, evaluated(10, 10, 100), Collections.emptySortedMap()));
+    }
+
+    @Test
+    public void testParallelismComputation() {
+        final int minParallelism = 1;
+        final int maxParallelism = Integer.MAX_VALUE;
+        assertEquals(1, JobVertexScaler.scale(1, 720, 0.0001, minParallelism, maxParallelism));
+        assertEquals(1, JobVertexScaler.scale(2, 720, 0.1, minParallelism, maxParallelism));
+        assertEquals(5, JobVertexScaler.scale(6, 720, 0.8, minParallelism, maxParallelism));
+        assertEquals(32, JobVertexScaler.scale(16, 128, 1.5, minParallelism, maxParallelism));
+        assertEquals(400, JobVertexScaler.scale(200, 720, 2, minParallelism, maxParallelism));
+        assertEquals(
+                720,
+                JobVertexScaler.scale(200, 720, Integer.MAX_VALUE, minParallelism, maxParallelism));
+    }
+
+    @Test
+    public void testParallelismComputationWithLimit() {
+        assertEquals(5, JobVertexScaler.scale(6, 720, 0.8, 1, 700));
+        assertEquals(8, JobVertexScaler.scale(8, 720, 0.8, 8, 700));
+
+        assertEquals(32, JobVertexScaler.scale(16, 128, 1.5, 1, Integer.MAX_VALUE));
+        assertEquals(64, JobVertexScaler.scale(16, 128, 1.5, 60, Integer.MAX_VALUE));
+
+        assertEquals(300, JobVertexScaler.scale(200, 720, 2, 1, 300));
+        assertEquals(600, JobVertexScaler.scale(200, 720, Integer.MAX_VALUE, 1, 600));
+    }
+
+    @Test
+    public void ensureMinParallelismDoesNotExceedMax() {
+        Assert.assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        assertEquals(
+                                600, JobVertexScaler.scale(200, 720, Integer.MAX_VALUE, 500, 499)));
+    }
+
+    @Test
+    public void testMinParallelismLimitIsUsed() {
+        conf.setInteger(AutoScalerOptions.VERTEX_MIN_PARALLELISM, 5);
+        assertEquals(
+                5,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf,
+                        new JobVertexID(),
+                        evaluated(10, 100, 500),
+                        Collections.emptySortedMap()));
+    }
+
+    @Test
+    public void testMaxParallelismLimitIsUsed() {
+        conf.setInteger(AutoScalerOptions.VERTEX_MAX_PARALLELISM, 10);
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        assertEquals(
+                10,
+                vertexScaler.computeScaleTargetParallelism(
+                        conf,
+                        new JobVertexID(),
+                        evaluated(10, 500, 100),
+                        Collections.emptySortedMap()));
+    }
+
+    private Map<ScalingMetric, EvaluatedScalingMetric> evaluated(
+            int parallelism, double target, double procRate, double catchupRate) {
+        var metrics = new HashMap<ScalingMetric, EvaluatedScalingMetric>();
+        metrics.put(ScalingMetric.PARALLELISM, EvaluatedScalingMetric.of(parallelism));
+        metrics.put(ScalingMetric.MAX_PARALLELISM, EvaluatedScalingMetric.of(720));
+        metrics.put(ScalingMetric.TARGET_DATA_RATE, new EvaluatedScalingMetric(target, target));
+        metrics.put(ScalingMetric.CATCH_UP_DATA_RATE, EvaluatedScalingMetric.of(catchupRate));
+        metrics.put(
+                ScalingMetric.TRUE_PROCESSING_RATE, new EvaluatedScalingMetric(procRate, procRate));
+        ScalingMetricEvaluator.computeProcessingRateThresholds(metrics, conf);
+        return metrics;
+    }
+
+    private Map<ScalingMetric, EvaluatedScalingMetric> evaluated(
+            int parallelism, double target, double procRate) {
+        return evaluated(parallelism, target, procRate, 0.);
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -336,4 +336,17 @@ public class MetricsCollectionAndEvaluationTest {
         app.getStatus().getJobStatus().setUpdateTime("0");
         assertEquals(1, metricsHistory.getMetricHistory().size());
     }
+
+    @Test
+    public void testClearHistoryOnTopoChange() throws Exception {
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.);
+
+        setDefaultMetrics(metricsCollector);
+
+        // We haven't left the stabilization period
+        // => no metrics reporting and collection should take place
+        var collectedMetrics = metricsCollector.updateMetrics(app, scalingInfo, service, conf);
+        assertTrue(collectedMetrics.getMetricHistory().isEmpty());
+    }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutorTest.java
@@ -29,7 +29,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +36,6 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -47,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** Test for scaling metrics collection logic. */
+/** Test for scaling execution logic. */
 @EnableKubernetesMockClient(crud = true)
 public class ScalingExecutorTest {
 
@@ -170,124 +168,6 @@ public class ScalingExecutorTest {
         evaluated = Map.of(op1, evaluated(1, 70, 100, 15));
         scalingSummary = Map.of(op1, new ScalingSummary(1, 2, evaluated.get(op1)));
         assertFalse(ScalingExecutor.allVerticesWithinUtilizationTarget(evaluated, scalingSummary));
-    }
-
-    @Test
-    public void testParallelismScaling() {
-        var op = new JobVertexID();
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
-        assertEquals(
-                5,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf, op, evaluated(10, 50, 100), Collections.emptySortedMap()));
-
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
-        assertEquals(
-                8,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf, op, evaluated(10, 50, 100), Collections.emptySortedMap()));
-
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
-        assertEquals(
-                10,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf, op, evaluated(10, 80, 100), Collections.emptySortedMap()));
-
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
-        assertEquals(
-                8,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf, op, evaluated(10, 60, 100), Collections.emptySortedMap()));
-
-        assertEquals(
-                8,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf, op, evaluated(10, 59, 100), Collections.emptySortedMap()));
-
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.5);
-        assertEquals(
-                10,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf, op, evaluated(2, 100, 40), Collections.emptySortedMap()));
-
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
-        assertEquals(
-                4,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf, op, evaluated(2, 100, 100), Collections.emptySortedMap()));
-
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
-        conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.5);
-        assertEquals(
-                5,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf, op, evaluated(10, 10, 100), Collections.emptySortedMap()));
-
-        conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.6);
-        assertEquals(
-                4,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf, op, evaluated(10, 10, 100), Collections.emptySortedMap()));
-    }
-
-    @Test
-    public void testParallelismComputation() {
-        final int minParallelism = 1;
-        final int maxParallelism = Integer.MAX_VALUE;
-        assertEquals(1, ScalingExecutor.scale(1, 720, 0.0001, minParallelism, maxParallelism));
-        assertEquals(1, ScalingExecutor.scale(2, 720, 0.1, minParallelism, maxParallelism));
-        assertEquals(5, ScalingExecutor.scale(6, 720, 0.8, minParallelism, maxParallelism));
-        assertEquals(32, ScalingExecutor.scale(16, 128, 1.5, minParallelism, maxParallelism));
-        assertEquals(400, ScalingExecutor.scale(200, 720, 2, minParallelism, maxParallelism));
-        assertEquals(
-                720,
-                ScalingExecutor.scale(200, 720, Integer.MAX_VALUE, minParallelism, maxParallelism));
-    }
-
-    @Test
-    public void testParallelismComputationWithLimit() {
-        assertEquals(5, ScalingExecutor.scale(6, 720, 0.8, 1, 700));
-        assertEquals(8, ScalingExecutor.scale(8, 720, 0.8, 8, 700));
-
-        assertEquals(32, ScalingExecutor.scale(16, 128, 1.5, 1, Integer.MAX_VALUE));
-        assertEquals(64, ScalingExecutor.scale(16, 128, 1.5, 60, Integer.MAX_VALUE));
-
-        assertEquals(300, ScalingExecutor.scale(200, 720, 2, 1, 300));
-        assertEquals(600, ScalingExecutor.scale(200, 720, Integer.MAX_VALUE, 1, 600));
-    }
-
-    @Test
-    public void ensureMinParallelismDoesNotExceedMax() {
-        Assert.assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        assertEquals(
-                                600, ScalingExecutor.scale(200, 720, Integer.MAX_VALUE, 500, 499)));
-    }
-
-    @Test
-    public void testMinParallelismLimitIsUsed() {
-        conf.setInteger(AutoScalerOptions.VERTEX_MIN_PARALLELISM, 5);
-        assertEquals(
-                5,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf,
-                        new JobVertexID(),
-                        evaluated(10, 100, 500),
-                        Collections.emptySortedMap()));
-    }
-
-    @Test
-    public void testMaxParallelismLimitIsUsed() {
-        conf.setInteger(AutoScalerOptions.VERTEX_MAX_PARALLELISM, 10);
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
-        assertEquals(
-                10,
-                scalingDecisionExecutor.computeScaleTargetParallelism(
-                        conf,
-                        new JobVertexID(),
-                        evaluated(10, 500, 100),
-                        Collections.emptySortedMap()));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Refactor:
 - Move parallelism computation logic from JobScalingExecutor to JobVertexScaler
 
Improvement:
 - Improve scaling history management (added configs + cleanup) + tests
 
New Feature:
 - Add configurable option to detect ineffective scaling decision by checking the capacity increase

## Verifying this change

Added new unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
