### PR TITLE
[FLINK-30599][build] Publish SBOM artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,6 +402,20 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>2.7.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Based on https://github.com/apache/flink/pull/21606

Artifacts are populated to maven deploy, e.g.:
https://repository.apache.org/content/repositories/snapshots/org/apache/flink/flink-core/1.17-SNAPSHOT/flink-core-1.17-20230110.001959-122-cyclonedx.json