### PR TITLE
[FLINK-30669] update recent job status in flinkdeployment object

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -158,6 +158,7 @@ public abstract class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
     private void updateJobStatus(FlinkResourceContext<R> ctx, JobStatusMessage clusterJobStatus) {
         var resource = ctx.getResource();
         var jobStatus = resource.getStatus().getJobStatus();
+        var previousJobId = jobStatus.getJobId();
         var previousJobStatus = jobStatus.getState();
 
         jobStatus.setState(clusterJobStatus.getJobState().name());
@@ -165,7 +166,8 @@ public abstract class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
         jobStatus.setJobId(clusterJobStatus.getJobId().toHexString());
         jobStatus.setStartTime(String.valueOf(clusterJobStatus.getStartTime()));
 
-        if (jobStatus.getState().equals(previousJobStatus)) {
+        if (jobStatus.getJobId().equals(previousJobId)
+                && jobStatus.getState().equals(previousJobStatus)) {
             LOG.info("Job status ({}) unchanged", previousJobStatus);
         } else {
             jobStatus.setUpdateTime(String.valueOf(System.currentTimeMillis()));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
@@ -31,6 +31,7 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
@@ -79,6 +80,8 @@ public class ApplicationObserver extends AbstractFlinkDeploymentObserver {
         protected Optional<JobStatusMessage> filterTargetJob(
                 JobStatus status, List<JobStatusMessage> clusterJobStatuses) {
             if (!clusterJobStatuses.isEmpty()) {
+                clusterJobStatuses.sort(
+                        Comparator.comparingLong(JobStatusMessage::getStartTime).reversed());
                 return Optional.of(clusterJobStatuses.get(0));
             }
             return Optional.empty();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -263,13 +263,10 @@ public class ApplicationObserverTest extends OperatorTestBase {
         assertFalse(SavepointUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
         assertEquals(
                 1,
-                kubernetesClient
-                        .v1()
-                        .events()
-                        .inNamespace(deployment.getMetadata().getNamespace())
-                        .list()
-                        .getItems()
-                        .size());
+                kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
+                        .list().getItems().stream()
+                        .filter(e -> e.getReason().contains("SavepointError"))
+                        .count());
 
         deployment.getStatus().getJobStatus().getSavepointInfo().setTriggerId("unknown");
         deployment


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/FLINK-30669

## What is the purpose of the change

This pull request fix an issue where incorrect job status is updated in FlinkDeployment resource.
