### PR TITLE
[FLINK-30705] Fix CR ref gen to use JsonProperty annotation values

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -130,8 +130,8 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 | Value | Docs |
 | ----- | ---- |
-| RUNNING | Job is expected to be processing data. |
-| SUSPENDED | Processing is suspended with the intention of continuing later. |
+| running | Job is expected to be processing data. |
+| suspended | Processing is suspended with the intention of continuing later. |
 
 ### KubernetesDeploymentMode
 **Class**: org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode
@@ -140,8 +140,8 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 | Value | Docs |
 | ----- | ---- |
-| NATIVE | Deploys Flink using Flinks native Kubernetes support. Only supported for newer versions of Flink |
-| STANDALONE | Deploys Flink on-top of kubernetes in standalone mode. |
+| native | Deploys Flink using Flinks native Kubernetes support. Only supported for newer versions of Flink |
+| standalone | Deploys Flink on-top of kubernetes in standalone mode. |
 
 ### Resource
 **Class**: org.apache.flink.kubernetes.operator.api.spec.Resource
@@ -171,9 +171,9 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 
 | Value | Docs |
 | ----- | ---- |
-| SAVEPOINT | Job is upgraded by first taking a savepoint of the running job, shutting it down and restoring from the savepoint. |
-| LAST_STATE | Job is upgraded using any latest checkpoint or savepoint available. |
-| STATELESS | Job is upgraded with empty state. |
+| savepoint | Job is upgraded by first taking a savepoint of the running job, shutting it down and restoring from the savepoint. |
+| last-state | Job is upgraded using any latest checkpoint or savepoint available. |
+| stateless | Job is upgraded with empty state. |
 
 ## Status
 

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/docs/CrdReferenceDoclet.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/docs/CrdReferenceDoclet.java
@@ -55,7 +55,7 @@ public class CrdReferenceDoclet implements Doclet {
     private String outputFile;
     private Map<Element, Element> child2ParentElements;
 
-    private String getJsonPropValueOfEnum(Element e) {
+    private String getNameOrJsonPropValue(Element e) {
         return e.getAnnotationMirrors().stream()
                 .filter(
                         am ->
@@ -213,7 +213,7 @@ public class CrdReferenceDoclet implements Doclet {
                 case FIELD:
                     out.println(
                             "| "
-                                    + e
+                                    + getNameOrJsonPropValue(e)
                                     + " | "
                                     + e.asType().toString()
                                     + " | "
@@ -233,7 +233,7 @@ public class CrdReferenceDoclet implements Doclet {
                 case ENUM_CONSTANT:
                     out.println(
                             "| "
-                                    + getJsonPropValueOfEnum(e)
+                                    + getNameOrJsonPropValue(e)
                                     + " | "
                                     + (dcTree != null ? cleanDoc(dcTree.toString()) : "")
                                     + " |");

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/docs/CrdReferenceDoclet.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/docs/CrdReferenceDoclet.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.api.docs;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.util.DocTrees;
 import jdk.javadoc.doclet.Doclet;
@@ -25,6 +26,7 @@ import jdk.javadoc.doclet.Reporter;
 import org.apache.commons.io.FileUtils;
 
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
@@ -52,6 +54,27 @@ public class CrdReferenceDoclet implements Doclet {
     private String templateFile;
     private String outputFile;
     private Map<Element, Element> child2ParentElements;
+
+    private String getJsonPropValueOfEnum(Element e) {
+        return e.getAnnotationMirrors().stream()
+                .filter(
+                        am ->
+                                am.getAnnotationType()
+                                        .toString()
+                                        .equals(JsonProperty.class.getName()))
+                .flatMap(am -> am.getElementValues().entrySet().stream())
+                .filter(entry -> entry.getKey().getSimpleName().toString().equals("value"))
+                .map(
+                        entry -> {
+                            AnnotationValue value = entry.getValue();
+                            if (value.getValue() instanceof String) {
+                                return (String) value.getValue();
+                            }
+                            return e.getSimpleName().toString();
+                        })
+                .findFirst()
+                .orElse(e.getSimpleName().toString());
+    }
 
     @Override
     public void init(Locale locale, Reporter reporter) {}
@@ -210,7 +233,7 @@ public class CrdReferenceDoclet implements Doclet {
                 case ENUM_CONSTANT:
                     out.println(
                             "| "
-                                    + e
+                                    + getJsonPropValueOfEnum(e)
                                     + " | "
                                     + (dcTree != null ? cleanDoc(dcTree.toString()) : "")
                                     + " |");


### PR DESCRIPTION
## What is the purpose of the change

*This PR will resolve the CRD reference generation process. Currently the CRD reference generator does not respect JsonProperty annotation in case of enums (eg.: `public enum JobState`) which means the procedure generates the name of the ENUM instead of the value of the particular json property (eg.: `SUSPENDED` instead of suspended from `@JsonProperty("suspended")`). With these modifications generator will return with the values of the json properties in case of enums.*


## Brief change log

#### In `CrdReferenceDoclet` class:
  - A new method added: `getNameOrJsonPropValue(Element e)`
  - Call the `getNameOrJsonPropValue(Element e)` inside the `public Void scan(Element e, Integer depth)` method

## Verifying this change

  - First I suggest to check the current version here: [/custom-resource/reference/](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/custom-resource/reference/)
  - Then checkout this PR and
  - Run the `mvn clean install -Pgenerate-docs -DskipTests` command within the `/flink-kubernetes-operator` (so from the top level within the project)
  - After it returned with **success**, then you can go to the `/flink-kubernetes-operator/docs` folder and
  - Run the `hugo -b "" serve` command (for more information about this and about the pre-reqs, please check this [READ ME](https://github.com/apache/flink-kubernetes-operator/tree/main/docs#build-the-site-locally))
  - After you built the site locally, you can check the changes at `http://localhost:1313/`

*Example:*

#### 1. Before changes:

<img width="777" alt="Screenshot 2023-01-18 at 15 17 13" src="https://user-images.githubusercontent.com/73717102/213194689-01b8ffa6-5c8a-4657-b562-5e1eccf636db.png">

#### 2. After changes:

<img width="750" alt="Screenshot 2023-01-18 at 15 17 24" src="https://user-images.githubusercontent.com/73717102/213194723-d72d50b1-a90c-48ed-87b7-4518ffea1fca.png">

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes (new method within `CrdReferenceDoclet` class)
  - If yes, how is the feature documented? not documented
