### PR TITLE
[FLINK-30653] Trigger resource Events on autoscaler actions

### DIFF
--- a/examples/autoscaling/autoscaling.yaml
+++ b/examples/autoscaling/autoscaling.yaml
@@ -28,9 +28,8 @@ spec:
     kubernetes.operator.job.autoscaler.scaling.sources.enabled: "false"
     kubernetes.operator.job.autoscaler.stabilization.interval: "1m"
     kubernetes.operator.job.autoscaler.metrics.window: "3m"
-    pipeline.max-parallelism: "8"
-
-    taskmanager.numberOfTaskSlots: "2"
+    pipeline.max-parallelism: "24"
+    taskmanager.numberOfTaskSlots: "4"
     state.savepoints.dir: file:///flink-data/savepoints
     state.checkpoints.dir: file:///flink-data/checkpoints
     high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
@@ -61,3 +60,4 @@ spec:
     jarURI: local:///opt/flink/usrlib/autoscaling.jar
     parallelism: 1
     upgradeMode: last-state
+    args: ["10"]

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScaler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScaler.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.operator.autoscaler.metrics.EvaluatedScalingM
 import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -172,11 +173,12 @@ public class JobAutoScaler implements Cleanup {
                         });
     }
 
-    public static JobAutoScaler create(KubernetesClient kubernetesClient) {
+    public static JobAutoScaler create(
+            KubernetesClient kubernetesClient, EventRecorder eventRecorder) {
         return new JobAutoScaler(
                 kubernetesClient,
                 new RestApiMetricsCollector(),
                 new ScalingMetricEvaluator(),
-                new ScalingExecutor(kubernetesClient));
+                new ScalingExecutor(kubernetesClient, eventRecorder));
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/AuditUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/AuditUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.listener;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.listener.FlinkResourceListener;
 import org.apache.flink.kubernetes.operator.api.status.CommonStatus;
@@ -52,7 +53,8 @@ public class AuditUtils {
                         : status.getError());
     }
 
-    private static String format(@NonNull Event event) {
+    @VisibleForTesting
+    public static String format(@NonNull Event event) {
         return String.format(
                 ">>> Event  | %-7s | %-15s | %s",
                 event.getType().equals("Normal") ? "Info" : event.getType(),

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -90,7 +90,7 @@ public abstract class AbstractFlinkResourceReconciler<
         this.kubernetesClient = kubernetesClient;
         this.eventRecorder = eventRecorder;
         this.statusRecorder = statusRecorder;
-        this.resourceScaler = JobAutoScaler.create(kubernetesClient);
+        this.resourceScaler = JobAutoScaler.create(kubernetesClient, eventRecorder);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -128,6 +128,8 @@ public class EventRecorder {
         Missing,
         ValidationError,
         RecoverDeployment,
-        RestartUnhealthyJob
+        RestartUnhealthyJob,
+        ScalingReport,
+        IneffectiveScaling
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
@@ -29,6 +29,8 @@ import org.apache.flink.kubernetes.operator.autoscaler.topology.JobTopology;
 import org.apache.flink.kubernetes.operator.autoscaler.topology.VertexInfo;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+import org.apache.flink.kubernetes.operator.utils.EventCollector;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
 
@@ -69,7 +71,10 @@ public class BacklogBasedScalingTest extends OperatorTestBase {
     @BeforeEach
     public void setup() {
         evaluator = new ScalingMetricEvaluator();
-        scalingExecutor = new ScalingExecutor(kubernetesClient);
+        scalingExecutor =
+                new ScalingExecutor(
+                        kubernetesClient,
+                        new EventRecorder(kubernetesClient, new EventCollector()));
 
         app = TestUtils.buildApplicationCluster();
         app.getMetadata().setGeneration(1L);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -29,6 +29,8 @@ import org.apache.flink.kubernetes.operator.autoscaler.topology.JobTopology;
 import org.apache.flink.kubernetes.operator.autoscaler.topology.VertexInfo;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+import org.apache.flink.kubernetes.operator.utils.EventCollector;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
@@ -81,7 +83,10 @@ public class MetricsCollectionAndEvaluationTest {
     @BeforeEach
     public void setup() {
         evaluator = new ScalingMetricEvaluator();
-        scalingExecutor = new ScalingExecutor(kubernetesClient);
+        scalingExecutor =
+                new ScalingExecutor(
+                        kubernetesClient,
+                        new EventRecorder(kubernetesClient, new EventCollector()));
         service = new TestingFlinkService();
 
         app = TestUtils.buildApplicationCluster();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventCollector.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventCollector.java
@@ -19,8 +19,11 @@
 package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.listener.AuditUtils;
 
 import io.fabric8.kubernetes.api.model.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
 import java.util.Queue;
@@ -28,11 +31,12 @@ import java.util.function.BiConsumer;
 
 /** Simple consumer that collects triggered events for tests. */
 public class EventCollector implements BiConsumer<AbstractFlinkResource<?, ?>, Event> {
-
+    private static final Logger LOG = LoggerFactory.getLogger(EventCollector.class);
     public final Queue<Event> events = new LinkedList<>();
 
     @Override
     public void accept(AbstractFlinkResource<?, ?> abstractFlinkResource, Event event) {
+        LOG.info(AuditUtils.format(event));
         events.add(event);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The autoscaler currently doesn't trigger any events. We should use Kube events to notify users about scaling actions on a per-vertex level or in cases where the autoscaler blocked some scaling action due to past history.

## Brief change log
  - Added event triggering to `ScalingExecutor` in case of any parallelism change
  - Added event triggering to `JobVertexScaler` in case of ineffective scaling 
  - Added hotfix for autoscaling example
  
## Verifying this change

Added new unit tests:

- `ScalingExecutorTest.testScalingEvents()`
- `JobVertexScalerTest.testIneffectiveScalingDetection()`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
