### PR TITLE
FLINK-30577 unable to access flink artifacts dir

### DIFF
--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -101,6 +101,8 @@ spec:
           volumeMounts:
             - name: flink-operator-config-volume
               mountPath: /opt/flink/conf
+            - name: flink-artifacts-volume
+              mountPath: /opt/flink/artifacts
             {{- if .Values.operatorVolumeMounts.create }}
                 {{- toYaml .Values.operatorVolumeMounts.data | nindent 12 }}
             {{- end }}
@@ -193,6 +195,8 @@ spec:
             - key: keystore.p12
               path: keystore.p12
         {{- end }}
+        - name: flink-artifacts-volume
+          emptyDir: {}
 ---
 {{- if .Values.defaultConfiguration.create }}
 apiVersion: v1


### PR DESCRIPTION
## What is the purpose of the change

In openshift when the operator is installed into a restricted namespace the operator is unable to create the /opt/flink/artifacts dir in order to download remote jars for jobs

## Brief change log

 - Modified the flink-operator.yaml to add an emptyDir volume mount for /opt/flink/artifacts

## Verifying this change

This change can be verified as follows:

  - On an opensshift cluster create a new namespace
  - Install the helm chart
  - Apply the examples/basic-session-deployment-and-job.yaml
  - Verify the jobs are running correctly
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
