### PR TITLE
[FLINK-30766][tests] Do not parameterize tests with all Flink versions

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -119,7 +119,7 @@ public abstract class AbstractFlinkResourceReconciler<
                     Optional.ofNullable(spec.getJob()).map(JobSpec::getInitialSavepointPath),
                     false);
 
-            ReconciliationUtils.updateStatusForDeployedSpec(cr, deployConfig);
+            ReconciliationUtils.updateStatusForDeployedSpec(cr, deployConfig, clock);
             return;
         }
 
@@ -203,7 +203,7 @@ public abstract class AbstractFlinkResourceReconciler<
 
             spec.getJob().setUpgradeMode(initialUpgradeMode);
         }
-        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(cr, deployConfig);
+        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(cr, deployConfig, clock);
         // Before we try to submit the job we record the current spec in the status so we can
         // handle subsequent deployment and status update errors
         statusRecorder.patchAndCacheStatus(cr);
@@ -298,7 +298,7 @@ public abstract class AbstractFlinkResourceReconciler<
         if (resource.getSpec().equals(deployedSpec)) {
             LOG.info(
                     "The new spec matches the currently deployed last stable spec. No upgrade needed.");
-            ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConf);
+            ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConf, clock);
             return true;
         }
         return false;
@@ -324,7 +324,7 @@ public abstract class AbstractFlinkResourceReconciler<
         boolean scaled = flinkService.scale(cr.getMetadata(), cr.getSpec().getJob(), deployConfig);
         if (scaled) {
             LOG.info("Scaling succeeded");
-            ReconciliationUtils.updateStatusForDeployedSpec(cr, deployConfig);
+            ReconciliationUtils.updateStatusForDeployedSpec(cr, deployConfig, clock);
             return true;
         }
         return false;
@@ -467,7 +467,7 @@ public abstract class AbstractFlinkResourceReconciler<
     }
 
     @VisibleForTesting
-    protected void setClock(Clock clock) {
+    public void setClock(Clock clock) {
         this.clock = clock;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -109,9 +109,10 @@ public abstract class AbstractJobReconciler<
             currentDeploySpec.getJob().setUpgradeMode(availableUpgradeMode.get());
             cancelJob(ctx, availableUpgradeMode.get());
             if (desiredJobState == JobState.RUNNING) {
-                ReconciliationUtils.updateStatusBeforeDeploymentAttempt(resource, deployConfig);
+                ReconciliationUtils.updateStatusBeforeDeploymentAttempt(
+                        resource, deployConfig, clock);
             } else {
-                ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig);
+                ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig, clock);
             }
         }
 
@@ -123,7 +124,7 @@ public abstract class AbstractJobReconciler<
                         .setUpgradeMode(lastReconciledSpec.getJob().getUpgradeMode());
             }
             // We record the target spec into an upgrading state before deploying
-            ReconciliationUtils.updateStatusBeforeDeploymentAttempt(resource, deployConfig);
+            ReconciliationUtils.updateStatusBeforeDeploymentAttempt(resource, deployConfig, clock);
             statusRecorder.patchAndCacheStatus(resource);
 
             restoreJob(
@@ -133,7 +134,7 @@ public abstract class AbstractJobReconciler<
                     // We decide to enforce HA based on how job was previously suspended
                     lastReconciledSpec.getJob().getUpgradeMode() == UpgradeMode.LAST_STATE);
 
-            ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig);
+            ReconciliationUtils.updateStatusForDeployedSpec(resource, deployConfig, clock);
         }
         return true;
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -74,11 +74,11 @@ public class SessionReconciler
         deleteSessionCluster(ctx);
 
         // We record the target spec into an upgrading state before deploying
-        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(deployment, deployConfig);
+        ReconciliationUtils.updateStatusBeforeDeploymentAttempt(deployment, deployConfig, clock);
         statusRecorder.patchAndCacheStatus(deployment);
 
         deploy(ctx, deployment.getSpec(), deployConfig, Optional.empty(), false);
-        ReconciliationUtils.updateStatusForDeployedSpec(deployment, deployConfig);
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, deployConfig, clock);
         return true;
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -19,6 +19,8 @@ package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
+import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
@@ -47,6 +49,7 @@ import io.javaoperatorsdk.operator.processing.event.EventSourceRetriever;
 import okhttp3.Headers;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.provider.Arguments;
 
 import javax.annotation.Nullable;
 
@@ -58,6 +61,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -66,8 +70,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /** Testing utilities. */
 public class TestUtils extends BaseTestUtils {
@@ -269,6 +275,20 @@ public class TestUtils extends BaseTestUtils {
                 .setDelimiter(".".charAt(0))
                 .setRegisterConsumer((metric, name, group) -> {})
                 .build();
+    }
+
+    public static Stream<Arguments> flinkVersionsAndUpgradeModes() {
+        List<Arguments> args = new ArrayList<>();
+        for (FlinkVersion version : Set.of(FlinkVersion.v1_14, FlinkVersion.v1_15)) {
+            for (UpgradeMode upgradeMode : UpgradeMode.values()) {
+                args.add(arguments(version, upgradeMode));
+            }
+        }
+        return args.stream();
+    }
+
+    public static Stream<Arguments> flinkVersions() {
+        return List.of(arguments(FlinkVersion.v1_14), arguments(FlinkVersion.v1_15)).stream();
     }
 
     /** Testing ResponseProvider. */

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -53,7 +53,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -168,7 +168,7 @@ public class FlinkConfigBuilderTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testApplyFlinkConfigurationShouldSetShutdownOnFinishBasedOnFlinkVersion(
             FlinkVersion flinkVersion) {
         flinkDeployment.getSpec().setFlinkVersion(flinkVersion);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -32,17 +32,10 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /** @link Missing deployment recovery tests */
 @EnableKubernetesMockClient(crud = true)
@@ -66,7 +59,7 @@ public class DeploymentRecoveryTest {
     }
 
     @ParameterizedTest
-    @MethodSource("applicationTestParams")
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersionsAndUpgradeModes")
     public void verifyApplicationJmRecovery(FlinkVersion flinkVersion, UpgradeMode upgradeMode)
             throws Exception {
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster(flinkVersion);
@@ -144,7 +137,7 @@ public class DeploymentRecoveryTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void verifySessionJmRecovery(FlinkVersion flinkVersion) throws Exception {
         FlinkDeployment appCluster = TestUtils.buildSessionCluster(flinkVersion);
         testController.reconcile(appCluster, context);
@@ -169,15 +162,5 @@ public class DeploymentRecoveryTest {
         assertEquals(
                 JobManagerDeploymentStatus.READY,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
-    }
-
-    private static Stream<Arguments> applicationTestParams() {
-        List<Arguments> args = new ArrayList<>();
-        for (FlinkVersion version : FlinkVersion.values()) {
-            for (UpgradeMode upgradeMode : UpgradeMode.values()) {
-                args.add(arguments(version, upgradeMode));
-            }
-        }
-        return args.stream();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
@@ -31,16 +31,10 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
 
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_JOB_RESTART_FAILED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /** @link Unhealthy deployment restart tests */
 @EnableKubernetesMockClient(crud = true)
@@ -66,7 +60,7 @@ public class FailedDeploymentRestartTest {
     }
 
     @ParameterizedTest
-    @MethodSource("applicationTestParams")
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersionsAndUpgradeModes")
     public void verifyFailedApplicationRecovery(FlinkVersion flinkVersion, UpgradeMode upgradeMode)
             throws Exception {
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster(flinkVersion);
@@ -102,15 +96,5 @@ public class FailedDeploymentRestartTest {
         assertEquals(
                 appCluster.getSpec(),
                 appCluster.getStatus().getReconciliationStatus().deserializeLastReconciledSpec());
-    }
-
-    private static Stream<Arguments> applicationTestParams() {
-        List<Arguments> args = new ArrayList<>();
-        for (FlinkVersion version : FlinkVersion.values()) {
-            for (UpgradeMode upgradeMode : UpgradeMode.values()) {
-                args.add(arguments(version, upgradeMode));
-            }
-        }
-        return args.stream();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -53,17 +53,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_JOB_UPGRADE_LAST_STATE_FALLBACK_ENABLED;
 import static org.apache.flink.kubernetes.operator.utils.EventRecorder.Reason.ValidationError;
@@ -74,7 +70,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /** {@link FlinkDeploymentController} tests. */
 @EnableKubernetesMockClient(crud = true)
@@ -99,7 +94,7 @@ public class FlinkDeploymentControllerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void verifyBasicReconcileLoop(FlinkVersion flinkVersion) throws Exception {
 
         UpdateControl<FlinkDeployment> updateControl;
@@ -380,7 +375,7 @@ public class FlinkDeploymentControllerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void verifyUpgradeFromSavepoint(FlinkVersion flinkVersion) throws Exception {
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster(flinkVersion);
         appCluster.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
@@ -473,7 +468,7 @@ public class FlinkDeploymentControllerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void verifyStatelessUpgrade(FlinkVersion flinkVersion) throws Exception {
         testController.events().clear();
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster(flinkVersion);
@@ -625,13 +620,13 @@ public class FlinkDeploymentControllerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgradeNotReadyClusterSession(FlinkVersion flinkVersion) throws Exception {
         testUpgradeNotReadyCluster(TestUtils.buildSessionCluster(flinkVersion));
     }
 
     @ParameterizedTest
-    @MethodSource("applicationTestParams")
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersionsAndUpgradeModes")
     public void testUpgradeNotReadyClusterApplication(
             FlinkVersion flinkVersion, UpgradeMode upgradeMode) throws Exception {
         var appCluster = TestUtils.buildApplicationCluster(flinkVersion);
@@ -1052,16 +1047,6 @@ public class FlinkDeploymentControllerTest {
                                 appWithIngress.getMetadata().getName(),
                                 appWithIngress.getMetadata().getNamespace())
                         .getHost());
-    }
-
-    private static Stream<Arguments> applicationTestParams() {
-        List<Arguments> args = new ArrayList<>();
-        for (FlinkVersion version : FlinkVersion.values()) {
-            for (UpgradeMode upgradeMode : UpgradeMode.values()) {
-                args.add(arguments(version, upgradeMode));
-            }
-        }
-        return args.stream();
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -77,7 +77,9 @@ public class RollbackTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @EnumSource(
+            value = FlinkVersion.class,
+            names = {"v1_14", "v1_15"})
     public void testRollbackWithSavepoint(FlinkVersion flinkVersion) throws Exception {
         var dep = TestUtils.buildApplicationCluster(flinkVersion);
         dep.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
@@ -121,7 +123,9 @@ public class RollbackTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @EnumSource(
+            value = FlinkVersion.class,
+            names = {"v1_14", "v1_15"})
     public void testRollbackWithLastState(FlinkVersion flinkVersion) throws Exception {
         var dep = TestUtils.buildApplicationCluster(flinkVersion);
         dep.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
@@ -154,7 +158,9 @@ public class RollbackTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @EnumSource(
+            value = FlinkVersion.class,
+            names = {"v1_14", "v1_15"})
     public void testRollbackFailureWithLastState(FlinkVersion flinkVersion) throws Exception {
         var dep = TestUtils.buildApplicationCluster(flinkVersion);
         dep.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
@@ -206,7 +212,9 @@ public class RollbackTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @EnumSource(
+            value = FlinkVersion.class,
+            names = {"v1_14", "v1_15"})
     public void testRollbackStateless(FlinkVersion flinkVersion) throws Exception {
         var dep = TestUtils.buildApplicationCluster(flinkVersion);
         dep.getSpec().getJob().setUpgradeMode(UpgradeMode.STATELESS);
@@ -259,7 +267,9 @@ public class RollbackTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @EnumSource(
+            value = FlinkVersion.class,
+            names = {"v1_14", "v1_15"})
     public void testRollbackSession(FlinkVersion flinkVersion) throws Exception {
         var dep = TestUtils.buildSessionCluster(flinkVersion);
         testRollback(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -58,6 +58,7 @@ public class TestingFlinkDeploymentController
                 EventSourceInitializer<FlinkDeployment>,
                 Cleaner<FlinkDeployment> {
 
+    private ReconcilerFactory reconcilerFactory;
     private FlinkDeploymentController flinkDeploymentController;
     private StatusUpdateCounter statusUpdateCounter = new StatusUpdateCounter();
     private EventCollector eventCollector = new EventCollector();
@@ -79,13 +80,15 @@ public class TestingFlinkDeploymentController
         eventRecorder = new EventRecorder(kubernetesClient, eventCollector);
         statusRecorder =
                 new StatusRecorder<>(kubernetesClient, new MetricManager<>(), statusUpdateCounter);
+        reconcilerFactory =
+                new ReconcilerFactory(
+                        kubernetesClient, configManager, eventRecorder, statusRecorder);
         flinkDeploymentController =
                 new FlinkDeploymentController(
                         configManager,
                         ValidatorUtils.discoverValidators(configManager),
                         ctxFactory,
-                        new ReconcilerFactory(
-                                kubernetesClient, configManager, eventRecorder, statusRecorder),
+                        reconcilerFactory,
                         new FlinkDeploymentObserverFactory(configManager, eventRecorder),
                         statusRecorder,
                         eventRecorder);
@@ -153,5 +156,9 @@ public class TestingFlinkDeploymentController
 
     public int getInternalStatusUpdateCount() {
         return statusUpdateCounter.getCount();
+    }
+
+    public ReconcilerFactory getReconcilerFactory() {
+        return reconcilerFactory;
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/UnhealthyDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/UnhealthyDeploymentRestartTest.java
@@ -31,16 +31,10 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
 
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CLUSTER_HEALTH_CHECK_ENABLED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /** @link Unhealthy deployment restart tests */
 @EnableKubernetesMockClient(crud = true)
@@ -69,7 +63,7 @@ public class UnhealthyDeploymentRestartTest {
     }
 
     @ParameterizedTest
-    @MethodSource("applicationTestParams")
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersionsAndUpgradeModes")
     public void verifyApplicationUnhealthyJmRecovery(
             FlinkVersion flinkVersion, UpgradeMode upgradeMode) throws Exception {
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster(flinkVersion);
@@ -100,15 +94,5 @@ public class UnhealthyDeploymentRestartTest {
                 JobManagerDeploymentStatus.READY,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
         assertEquals("RUNNING", appCluster.getStatus().getJobStatus().getState());
-    }
-
-    private static Stream<Arguments> applicationTestParams() {
-        List<Arguments> args = new ArrayList<>();
-        for (FlinkVersion version : FlinkVersion.values()) {
-            for (UpgradeMode upgradeMode : UpgradeMode.values()) {
-                args.add(arguments(version, upgradeMode));
-            }
-        }
-        return args.stream();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -58,7 +58,7 @@ import lombok.Getter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.platform.commons.util.StringUtils;
 
 import java.time.Clock;
@@ -99,7 +99,7 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgrade(FlinkVersion flinkVersion) throws Exception {
         FlinkDeployment deployment = TestUtils.buildApplicationCluster(flinkVersion);
 
@@ -587,7 +587,7 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void verifyJobIdNotResetDuringLastStateRecovery(FlinkVersion flinkVersion) {
         FlinkDeployment deployment = TestUtils.buildApplicationCluster(flinkVersion);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
@@ -76,19 +75,19 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgradeFromStatelessToStateless(FlinkVersion flinkVersion) throws Exception {
         testUpgradeToStateless(flinkVersion, UpgradeMode.STATELESS);
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgradeFromSavepointToStateless(FlinkVersion flinkVersion) throws Exception {
         testUpgradeToStateless(flinkVersion, UpgradeMode.SAVEPOINT);
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgradeFromLastStateToStateless(FlinkVersion flinkVersion) throws Exception {
         testUpgradeToStateless(flinkVersion, UpgradeMode.LAST_STATE);
     }
@@ -114,19 +113,19 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgradeFromStatelessToSavepoint(FlinkVersion flinkVersion) throws Exception {
         testUpgradeToSavepoint(flinkVersion, UpgradeMode.STATELESS);
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgradeFromSavepointToSavepoint(FlinkVersion flinkVersion) throws Exception {
         testUpgradeToSavepoint(flinkVersion, UpgradeMode.SAVEPOINT);
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgradeFromLastStateToSavepoint(FlinkVersion flinkVersion) throws Exception {
         testUpgradeToSavepoint(flinkVersion, UpgradeMode.LAST_STATE);
     }
@@ -164,19 +163,19 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgradeFromStatelessToLastState(FlinkVersion flinkVersion) throws Exception {
         testUpgradeToLastState(flinkVersion, UpgradeMode.STATELESS);
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgradeFromSavepointToLastState(FlinkVersion flinkVersion) throws Exception {
         testUpgradeToLastState(flinkVersion, UpgradeMode.SAVEPOINT);
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testUpgradeFromLastStateToLastState(FlinkVersion flinkVersion) throws Exception {
         testUpgradeToLastState(flinkVersion, UpgradeMode.LAST_STATE);
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -57,7 +57,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -117,7 +117,7 @@ public class NativeFlinkServiceTest {
     }
 
     @ParameterizedTest
-    @EnumSource(FlinkVersion.class)
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void testCancelJobWithSavepointUpgradeMode(FlinkVersion flinkVersion) throws Exception {
         final TestingClusterClient<String> testingClusterClient =
                 new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);


### PR DESCRIPTION
## What is the purpose of the change

 - Improve test speed by only parameterizing with FlinkVersions that have different operator behaviour.
 - Fix flaky rollback test and make it deterministic instead of relying on sleeps

## Verifying this change

Covered by existing unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable