### PR TITLE
[FLINK-30781] Add completed checkpoint check to cluster health check

### DIFF
--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -238,8 +238,11 @@ When Kubernetes HA is enabled, the operator can restart the Flink cluster deploy
 unhealthy. Unhealthy deployment restart can be turned on in the configuration by setting `kubernetes.operator.cluster.health-check.enabled` to `true` (default: `false`).  
 In order this feature to work one must enable [recovery of missing job deployments](#recovery-of-missing-job-deployments).
 
-At the moment deployment is considered unhealthy when Flink's restarts count reaches `kubernetes.operator.cluster.health-check.restarts.threshold` (default: `64`)
+At the moment deployment is considered unhealthy when:
+* Flink's restarts count reaches `kubernetes.operator.cluster.health-check.restarts.threshold` (default: `64`)
 within time window of `kubernetes.operator.cluster.health-check.restarts.window` (default: 2 minutes).
+* `cluster.health-check.checkpoint-progress.enabled` is turned on and Flink's successful checkpoints count is not
+changing within time window of within time window of `kubernetes.operator.cluster.health-check.checkpoint-progress.window` (default: 5 minutes).
 
 ## Restart failed job deployments
 

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -9,6 +9,18 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.operator.cluster.health-check.checkpoint-progress.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable checkpoint progress health check for clusters.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.cluster.health-check.checkpoint-progress.window</h5></td>
+            <td style="word-wrap: break-word;">5 min</td>
+            <td>Duration</td>
+            <td>If no checkpoints are completed within the defined time window, the job is considered unhealthy. This must be bigger than checkpointing interval.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.cluster.health-check.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -9,6 +9,18 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.operator.cluster.health-check.checkpoint-progress.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to enable checkpoint progress health check for clusters.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.cluster.health-check.checkpoint-progress.window</h5></td>
+            <td style="word-wrap: break-word;">5 min</td>
+            <td>Duration</td>
+            <td>If no checkpoints are completed within the defined time window, the job is considered unhealthy. This must be bigger than checkpointing interval.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.cluster.health-check.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -380,6 +380,24 @@ public class KubernetesOperatorConfigOptions {
                                     + "If the restart count is reaching the threshold then full cluster restart is initiated.");
 
     @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean>
+            OPERATOR_CLUSTER_HEALTH_CHECK_CHECKPOINT_PROGRESS_ENABLED =
+                    operatorConfig("cluster.health-check.checkpoint-progress.enabled")
+                            .booleanType()
+                            .defaultValue(false)
+                            .withDescription(
+                                    "Whether to enable checkpoint progress health check for clusters.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Duration>
+            OPERATOR_CLUSTER_HEALTH_CHECK_CHECKPOINT_PROGRESS_WINDOW =
+                    operatorConfig("cluster.health-check.checkpoint-progress.window")
+                            .durationType()
+                            .defaultValue(Duration.ofMinutes(5))
+                            .withDescription(
+                                    "If no checkpoints are completed within the defined time window, the job is considered unhealthy. This must be bigger than checkpointing interval.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> OPERATOR_JOB_RESTART_FAILED =
             operatorConfig("job.restart.failed")
                     .booleanType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/ClusterHealthInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/ClusterHealthInfo.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 import java.time.Clock;
 
@@ -31,7 +30,6 @@ import java.time.Clock;
 @Experimental
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
 public class ClusterHealthInfo {
     /** Millisecond timestamp of the last observed health information. */
     private long timeStamp;
@@ -39,15 +37,25 @@ public class ClusterHealthInfo {
     /** Number of restarts. */
     private int numRestarts;
 
+    /** Millisecond timestamp lastly evaluated the number of restarts. */
+    private long numRestartsEvaluationTimeStamp;
+
+    /** Number of successfully completed checkpoints. */
+    private int numCompletedCheckpoints;
+
+    /** Millisecond timestamp lastly increased the number of completed checkpoints. */
+    private long numCompletedCheckpointsIncreasedTimeStamp;
+
     /** Calculated field whether the cluster is healthy or not. */
     private boolean healthy;
 
-    public static ClusterHealthInfo of(int numRestarts) {
-        return of(Clock.systemDefaultZone(), numRestarts);
+    public ClusterHealthInfo() {
+        this(Clock.systemDefaultZone());
     }
 
-    public static ClusterHealthInfo of(Clock clock, int numRestarts) {
-        return new ClusterHealthInfo(clock.millis(), numRestarts, true);
+    public ClusterHealthInfo(Clock clock) {
+        timeStamp = clock.millis();
+        healthy = true;
     }
 
     public static boolean isValid(ClusterHealthInfo clusterHealthInfo) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -249,7 +249,9 @@ public abstract class AbstractJobReconciler<
             throws Exception {
         LOG.info("Resubmitting Flink job...");
         SPEC specToRecover = ReconciliationUtils.getDeployedSpec(ctx.getResource());
-        specToRecover.getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
+        if (requireHaMetadata) {
+            specToRecover.getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
+        }
         restoreJob(ctx, specToRecover, ctx.getObserveConfig(), requireHaMetadata);
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -145,6 +145,10 @@ public class ApplicationReconciler
         var relatedResource = ctx.getResource();
         var status = relatedResource.getStatus();
         var flinkService = ctx.getFlinkService();
+
+        ClusterHealthEvaluator.removeLastValidClusterHealthInfo(
+                relatedResource.getStatus().getClusterInfo());
+
         if (savepoint.isPresent()) {
             deployConfig.set(SavepointConfigOptions.SAVEPOINT_PATH, savepoint.get());
         } else {
@@ -271,7 +275,10 @@ public class ApplicationReconciler
                         MSG_RESTART_UNHEALTHY);
                 cleanupAfterFailedJob(ctx);
             }
-            resubmitJob(ctx, true);
+            boolean requireHaMetadata =
+                    ReconciliationUtils.getDeployedSpec(ctx.getResource()).getJob().getUpgradeMode()
+                            != UpgradeMode.STATELESS;
+            resubmitJob(ctx, requireHaMetadata);
             return true;
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/ClusterHealthInfoTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/ClusterHealthInfoTest.java
@@ -32,19 +32,33 @@ class ClusterHealthInfoTest {
     @Test
     public void isValidShouldReturnFalseWhenTimestampIsZero() {
         var clock = Clock.fixed(ofEpochSecond(0), ZoneId.systemDefault());
-        assertFalse(ClusterHealthInfo.isValid(ClusterHealthInfo.of(clock, 0)));
+        assertFalse(ClusterHealthInfo.isValid(new ClusterHealthInfo(clock)));
     }
 
     @Test
     public void isValidShouldReturnTrueWhenTimestampIsNonzero() {
         var clock = Clock.fixed(ofEpochSecond(1), ZoneId.systemDefault());
-        assertTrue(ClusterHealthInfo.isValid(ClusterHealthInfo.of(clock, 0)));
+        assertTrue(ClusterHealthInfo.isValid(new ClusterHealthInfo(clock)));
+    }
+
+    @Test
+    public void deserializeWithOldVersionShouldDeserializeCorrectly() {
+        var clusterHealthInfoJson = "{\"timeStamp\":1,\"numRestarts\":2,\"healthy\":true}";
+        var clusterHealthInfoFromJson = ClusterHealthInfo.deserialize(clusterHealthInfoJson);
+        assertEquals(1, clusterHealthInfoFromJson.getTimeStamp());
+        assertEquals(2, clusterHealthInfoFromJson.getNumRestarts());
+        assertTrue(clusterHealthInfoFromJson.isHealthy());
     }
 
     @Test
     public void serializationRoundTrip() {
-        var clock = Clock.fixed(ofEpochSecond(123), ZoneId.systemDefault());
-        var clusterHealthInfo = ClusterHealthInfo.of(clock, 456);
+        var clock = Clock.fixed(ofEpochSecond(1), ZoneId.systemDefault());
+        var clusterHealthInfo = new ClusterHealthInfo(clock);
+        clusterHealthInfo.setNumRestarts(2);
+        clusterHealthInfo.setNumRestartsEvaluationTimeStamp(3);
+        clusterHealthInfo.setNumCompletedCheckpoints(4);
+        clusterHealthInfo.setNumCompletedCheckpointsIncreasedTimeStamp(5);
+        clusterHealthInfo.setHealthy(false);
         var clusterHealthInfoJson = ClusterHealthInfo.serialize(clusterHealthInfo);
 
         var clusterHealthInfoFromJson = ClusterHealthInfo.deserialize(clusterHealthInfoJson);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -691,7 +691,10 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
         Assertions.assertEquals(MSG_SUBMIT, eventCollector.events.remove().getMessage());
         verifyAndSetRunningJobsToStatus(deployment, flinkService.listJobs());
 
-        var clusterHealthInfo = new ClusterHealthInfo(System.currentTimeMillis(), 2, false);
+        var clusterHealthInfo = new ClusterHealthInfo();
+        clusterHealthInfo.setTimeStamp(System.currentTimeMillis());
+        clusterHealthInfo.setNumRestarts(2);
+        clusterHealthInfo.setHealthy(false);
         ClusterHealthEvaluator.setLastValidClusterHealthInfo(
                 deployment.getStatus().getClusterInfo(), clusterHealthInfo);
         reconciler.reconcile(deployment, context);


### PR DESCRIPTION
## What is the purpose of the change

There are workloads which stuck in such a way that they're in RUNNING state most of the time but not able to proceed and make checkpoints. Such cases must be detected by the operator. In this PR I've added the possibility to ask the operator to watch the number of successful checkpoints. If the feature is enabled by `cluster.health-check.completed-checkpoints.enabled` and there are no successful checkpoint within the defined window in `cluster.health-check.completed-checkpoints.window` then the operator considers it as unhealthy deployment and re-creates it.

## Brief change log

* Added config `cluster.health-check.completed-checkpoints.enabled`
* Added config `cluster.health-check.completed-checkpoints.window`
* Added number of successful checkpoints watching

## Verifying this change

Changed/added automated tests + manually on Minikube (stateless job w/o checkpoint restarted all the time).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
