### PR TITLE
[FLINK-27273] Zookeeper HA support

### DIFF
--- a/docs/content/docs/concepts/overview.md
+++ b/docs/content/docs/concepts/overview.md
@@ -88,7 +88,7 @@ The examples are maintained as part of the operator repo and can be found [here]
 ## Known Issues & Limitations
 
 ### JobManager High-availability
-The Operator leverages [Kubernetes HA Services](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/kubernetes_ha/) for providing High-availability for Flink jobs. The HA solution can benefit form using additional [Standby replicas](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/overview/), it will result in a faster recovery time, but Flink jobs will still restart when the Leader JobManager goes down.
+The Operator supports both [Kubernetes HA Services](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/kubernetes_ha/) and [Zookeeper HA Services](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/zookeeper_ha/) for providing High-availability for Flink jobs. The HA solution can benefit form using additional [Standby replicas](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/overview/), it will result in a faster recovery time, but Flink jobs will still restart when the Leader JobManager goes down.
 
 ### JobResultStore Resource Leak
 To mitigate the impact of [FLINK-27569](https://issues.apache.org/jira/browse/FLINK-27569) the operator introduced a workaround [FLINK-27573](https://issues.apache.org/jira/browse/FLINK-27573) by setting `job-result-store.delete-on-commit=false` and a unique value for `job-result-store.storage-path` for every cluster launch. The storage path for older runs must be cleaned up manually, keeping the latest directory always:

--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -86,14 +86,14 @@ The `upgradeMode` setting controls both the stop and restore mechanisms as detai
 
 |                        | Stateless               | Last State                                 | Savepoint                              |
 |------------------------|-------------------------|--------------------------------------------|----------------------------------------|
-| Config Requirement     | None                    | Checkpointing & Kubernetes HA Enabled      | Checkpoint/Savepoint directory defined |
+| Config Requirement     | None                    | Checkpointing & HA Enabled                 | Checkpoint/Savepoint directory defined |
 | Job Status Requirement | None                    | HA metadata available                      | Job Running*                           |
 | Suspend Mechanism      | Cancel / Delete         | Delete Flink deployment (keep HA metadata) | Cancel with savepoint                  |
 | Restore Mechanism      | Deploy from empty state | Recover last state using HA metadata       | Restore From savepoint                 |
 | Production Use         | Not recommended         | Recommended                                | Recommended                            |
 
 
-*\* When Kubernetes HA is enabled the `savepoint` upgrade mode may fall back to the `last-state` behaviour in cases where the job is in an unhealthy state.*
+*\* When HA is enabled the `savepoint` upgrade mode may fall back to the `last-state` behaviour in cases where the job is in an unhealthy state.*
 
 The three upgrade modes are intended to support different scenarios:
 
@@ -216,7 +216,7 @@ It is therefore very likely that savepoints live beyond the max age configuratio
 
 ## Recovery of missing job deployments
 
-When Kubernetes HA is enabled, the operator can recover the Flink cluster deployments in cases when it was accidentally deleted
+When HA is enabled, the operator can recover the Flink cluster deployments in cases when it was accidentally deleted
 by the user or some external process. Deployment recovery can be turned off in the configuration by setting `kubernetes.operator.jm-deployment-recovery.enabled` to `false`, however it is recommended to keep this setting on the default `true` value.
 
 This is not something that would usually happen during normal operation and can also indicate a deeper problem,
@@ -234,7 +234,7 @@ Please check the [manual Recovery section](#manual-recovery) to understand how t
 
 ## Restart of unhealthy job deployments
 
-When Kubernetes HA is enabled, the operator can restart the Flink cluster deployments in cases when it was considered
+When HA is enabled, the operator can restart the Flink cluster deployments in cases when it was considered
 unhealthy. Unhealthy deployment restart can be turned on in the configuration by setting `kubernetes.operator.cluster.health-check.enabled` to `true` (default: `false`).  
 In order this feature to work one must enable [recovery of missing job deployments](#recovery-of-missing-job-deployments).
 
@@ -266,7 +266,7 @@ To enable rollbacks you need to set:
 kubernetes.operator.deployment.rollback.enabled: true
 ```
 
-Kubernetes HA is currently required for the rollback functionality.
+HA is currently required for the rollback functionality.
 
 Applications are never rolled back to a previous running state if they were suspended before the upgrade.
 In these cases no rollback will be performed.

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -167,6 +167,20 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.apache.curator</groupId>
+            <artifactId>curator-test</artifactId>
+            <version>${curator-test.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <!-- Exclude an older version of junit-jupiter-api -->
+                <exclusion>
+                    <groupId>org.junit.jupiter</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-kubernetes-operator-api</artifactId>
             <version>${project.version}</version>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.DeploymentOptionsInternal;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.PipelineOptions;
@@ -340,6 +341,9 @@ public class FlinkConfigBuilder {
         // Set cluster config
         effectiveConfig.setString(KubernetesConfigOptions.NAMESPACE, namespace);
         effectiveConfig.setString(KubernetesConfigOptions.CLUSTER_ID, clusterId);
+        if (HighAvailabilityMode.isHighAvailabilityModeActivated(effectiveConfig)) {
+            effectiveConfig.setString(HighAvailabilityOptions.HA_CLUSTER_ID, clusterId);
+        }
         return effectiveConfig;
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -37,6 +37,7 @@ import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.exception.ValidationException;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -276,7 +277,7 @@ public class ReconciliationUtils {
 
         return previousUpgradeMode != UpgradeMode.LAST_STATE
                 && currentUpgradeMode == UpgradeMode.LAST_STATE
-                && !FlinkUtils.isKubernetesHAActivated(observeConfig);
+                && !HighAvailabilityMode.isHighAvailabilityModeActivated(observeConfig);
     }
 
     public static <SPEC extends AbstractFlinkSpec> SPEC getDeployedSpec(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -41,8 +41,8 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.diff.ReflectiveDiffBuilder;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
@@ -426,7 +426,7 @@ public abstract class AbstractFlinkResourceReconciler<
 
             if (jmMissingForRunningDeployment(deployment)) {
                 LOG.debug("Jobmanager deployment is missing, trying to recover");
-                if (FlinkUtils.isKubernetesHAActivated(conf)) {
+                if (HighAvailabilityMode.isHighAvailabilityModeActivated(conf)) {
                     LOG.debug("HA is enabled, recovering lost jobmanager deployment");
                     result = true;
                 } else {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -84,8 +84,10 @@ public class SessionReconciler
 
     private void deleteSessionCluster(FlinkResourceContext<FlinkDeployment> ctx) {
         var deployment = ctx.getResource();
+        var conf = ctx.getDeployConfig(ctx.getResource().getSpec());
         ctx.getFlinkService()
-                .deleteClusterDeployment(deployment.getMetadata(), deployment.getStatus(), false);
+                .deleteClusterDeployment(
+                        deployment.getMetadata(), deployment.getStatus(), conf, false);
         ctx.getFlinkService().waitForClusterShutdown(ctx.getObserveConfig());
     }
 
@@ -163,9 +165,10 @@ public class SessionReconciler
                                     .toMillis());
         } else {
             LOG.info("Stopping session cluster");
+            var conf = ctx.getDeployConfig(ctx.getResource().getSpec());
             ctx.getFlinkService()
                     .deleteClusterDeployment(
-                            deployment.getMetadata(), deployment.getStatus(), true);
+                            deployment.getMetadata(), deployment.getStatus(), conf, true);
             return DeleteControl.defaultDelete();
         }
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -73,7 +73,10 @@ public interface FlinkService {
             throws Exception;
 
     void deleteClusterDeployment(
-            ObjectMeta meta, FlinkDeploymentStatus status, boolean deleteHaData);
+            ObjectMeta meta,
+            FlinkDeploymentStatus status,
+            Configuration conf,
+            boolean deleteHaData);
 
     void cancelSessionJob(FlinkSessionJob sessionJob, UpgradeMode upgradeMode, Configuration conf)
             throws Exception;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -48,6 +48,7 @@ import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.messages.webmonitor.JobDetails;
@@ -188,7 +189,7 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     @Override
     public boolean isHaMetadataAvailable(Configuration conf) {
-        return FlinkUtils.isKubernetesHAActivated(conf) && haDataAvailable;
+        return HighAvailabilityMode.isHighAvailabilityModeActivated(conf) && haDataAvailable;
     }
 
     public void setHaDataAvailable(boolean haDataAvailable) {
@@ -404,7 +405,8 @@ public class TestingFlinkService extends AbstractFlinkService {
     }
 
     @Override
-    protected void deleteClusterInternal(ObjectMeta meta, boolean deleteHaMeta) {
+    protected void deleteClusterInternal(
+            ObjectMeta meta, Configuration conf, boolean deleteHaMeta) {
         jobs.clear();
         sessions.remove(meta.getName());
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
@@ -443,8 +443,9 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
         verifyAndSetRunningJobsToStatus(deployment, flinkService.listJobs());
 
         // Delete cluster and keep HA metadata
+        var conf = Configuration.fromMap(deployment.getSpec().getFlinkConfiguration());
         flinkService.deleteClusterDeployment(
-                deployment.getMetadata(), deployment.getStatus(), false);
+                deployment.getMetadata(), deployment.getStatus(), conf, false);
         flinkService.setHaDataAvailable(true);
 
         // Submit upgrade

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -79,7 +79,7 @@ public class StandaloneFlinkServiceTest {
 
         var requestsBeforeDelete = mockServer.getRequestCount();
         flinkStandaloneService.deleteClusterDeployment(
-                flinkDeployment.getMetadata(), flinkDeployment.getStatus(), false);
+                flinkDeployment.getMetadata(), flinkDeployment.getStatus(), configuration, false);
 
         assertEquals(2, mockServer.getRequestCount() - requestsBeforeDelete);
         assertTrue(mockServer.getLastRequest().getPath().contains("taskmanager"));
@@ -100,7 +100,7 @@ public class StandaloneFlinkServiceTest {
         assertEquals(2, deployments.size());
 
         flinkStandaloneService.deleteClusterDeployment(
-                flinkDeployment.getMetadata(), flinkDeployment.getStatus(), true);
+                flinkDeployment.getMetadata(), flinkDeployment.getStatus(), configuration, true);
 
         deployments = kubernetesClient.apps().deployments().list().getItems();
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
@@ -98,11 +98,11 @@ public class FlinkUtilsTest {
     }
 
     @Test
-    public void haMetaDataCheckTest() {
+    public void kubernetesHaMetaDataCheckTest() {
         var cr = TestUtils.buildApplicationCluster();
         var confManager = new FlinkConfigManager(new Configuration());
         assertFalse(
-                FlinkUtils.isHaMetadataAvailable(
+                FlinkUtils.isKubernetesHaMetadataAvailable(
                         confManager.getDeployConfig(cr.getMetadata(), cr.getSpec()),
                         kubernetesClient));
 
@@ -113,7 +113,7 @@ public class FlinkUtilsTest {
                 cr.getMetadata().getName(),
                 null);
         assertFalse(
-                FlinkUtils.isHaMetadataAvailable(
+                FlinkUtils.isKubernetesHaMetadataAvailable(
                         confManager.getDeployConfig(cr.getMetadata(), cr.getSpec()),
                         kubernetesClient));
 
@@ -123,14 +123,14 @@ public class FlinkUtilsTest {
                 cr.getMetadata().getName(),
                 null);
         assertTrue(
-                FlinkUtils.isHaMetadataAvailable(
+                FlinkUtils.isKubernetesHaMetadataAvailable(
                         confManager.getDeployConfig(cr.getMetadata(), cr.getSpec()),
                         kubernetesClient));
 
         // Flink 1.13-1.14
         kubernetesClient.configMaps().inAnyNamespace().delete();
         assertFalse(
-                FlinkUtils.isHaMetadataAvailable(
+                FlinkUtils.isKubernetesHaMetadataAvailable(
                         confManager.getDeployConfig(cr.getMetadata(), cr.getSpec()),
                         kubernetesClient));
 
@@ -140,7 +140,7 @@ public class FlinkUtilsTest {
                 cr.getMetadata().getName(),
                 null);
         assertFalse(
-                FlinkUtils.isHaMetadataAvailable(
+                FlinkUtils.isKubernetesHaMetadataAvailable(
                         confManager.getDeployConfig(cr.getMetadata(), cr.getSpec()),
                         kubernetesClient));
 
@@ -150,7 +150,7 @@ public class FlinkUtilsTest {
                 cr.getMetadata().getName(),
                 null);
         assertTrue(
-                FlinkUtils.isHaMetadataAvailable(
+                FlinkUtils.isKubernetesHaMetadataAvailable(
                         confManager.getDeployConfig(cr.getMetadata(), cr.getSpec()),
                         kubernetesClient));
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsZookeeperHATest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsZookeeperHATest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.runtime.dispatcher.NoOpJobGraphListener;
+import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
+import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
+import org.apache.flink.runtime.util.TestingFatalErrorHandler;
+import org.apache.flink.runtime.util.ZooKeeperUtils;
+
+import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
+
+import org.apache.curator.test.TestingServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for Zookeeper functions in FlinkUtils. */
+public class FlinkUtilsZookeeperHATest {
+
+    Configuration configuration;
+    TestingServer testingServer;
+    TemporaryFolder temporaryFolder;
+    CuratorFramework curator;
+    JobID jobID = JobID.generate();
+
+    public CuratorFrameworkWithUnhandledErrorListener getTestCurator(Configuration configuration) {
+        return ZooKeeperUtils.startCuratorFramework(configuration, new TestingFatalErrorHandler());
+    }
+
+    @BeforeEach
+    public void setupZookeeper() throws Exception {
+        // Start a ZK server
+        testingServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
+
+        // Generate configuration for the Curator
+        configuration = new Configuration();
+        configuration.setString(
+                HighAvailabilityOptions.HA_MODE, HighAvailabilityMode.ZOOKEEPER.toString());
+        configuration.setString(
+                HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
+        temporaryFolder = new TemporaryFolder();
+        temporaryFolder.create();
+        configuration.setString(
+                HighAvailabilityOptions.HA_STORAGE_PATH,
+                temporaryFolder.newFolder().getAbsolutePath());
+
+        // Create the Curator
+        curator = getTestCurator(configuration).asCuratorFramework();
+
+        // Populate the HA metadata with a test JobGraph
+        var jobGraphStore = ZooKeeperUtils.createJobGraphs(curator, configuration);
+        jobGraphStore.start(NoOpJobGraphListener.INSTANCE);
+        var jobGraph = JobGraphTestUtils.emptyJobGraph();
+        jobGraph.setJobID(jobID);
+        jobGraphStore.putJobGraph(jobGraph);
+        jobGraphStore.stop();
+    }
+
+    @AfterEach
+    public void cleanupZookeeper() throws Exception {
+        curator.close();
+        testingServer.close();
+        temporaryFolder.delete();
+    }
+
+    @Test
+    public void testDeleteZookeeperHAMetadata() throws Exception {
+        // First verify that the HA metadata path exists and is not empty
+        assertNotNull(curator.checkExists().forPath("/"));
+        assertTrue(curator.getChildren().forPath("/").size() != 0);
+
+        // Now delete all data
+        FlinkUtils.deleteZookeeperHAMetadata(configuration);
+
+        // Verify that the root path doesn't exist anymore
+        assertNull(curator.checkExists().forPath("/"));
+    }
+
+    @Test
+    public void testDeleteJobGraphInZookeeperHA() throws Exception {
+        // First verify that the JobGraph exists in ZK for the test JobID
+        var jobGraphPath = configuration.get(HighAvailabilityOptions.HA_ZOOKEEPER_JOBGRAPHS_PATH);
+        assertEquals(List.of(jobID.toString()), curator.getChildren().forPath(jobGraphPath));
+
+        // Now delete the JobGraph
+        FlinkUtils.deleteJobGraphInZookeeperHA(configuration);
+
+        // Verify the JobGraph path doesn't exist anymore
+        assertNull(curator.checkExists().forPath(jobGraphPath));
+    }
+
+    @Test
+    public void zookeeperHaMetaDataCheckTest() throws Exception {
+        // Verify that the HA metadata exists since it was created in setupZookeeper()
+        assertTrue(FlinkUtils.isZookeeperHaMetadataAvailable(configuration));
+
+        // Now delete all data
+        curator.delete().deletingChildrenIfNeeded().forPath("/");
+
+        // Verify that the HA metadata no longer exists
+        assertFalse(FlinkUtils.isZookeeperHaMetadataAvailable(configuration));
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -109,7 +109,7 @@ public class DefaultValidatorTest {
                     dep.getSpec().setFlinkConfiguration(new HashMap<>());
                     dep.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
                 },
-                "Job could not be upgraded with last-state while Kubernetes HA disabled");
+                "Job could not be upgraded with last-state while HA disabled");
 
         testError(
                 dep -> {
@@ -190,6 +190,15 @@ public class DefaultValidatorTest {
                 dep ->
                         dep.getSpec()
                                 .setFlinkConfiguration(
+                                        Collections.singletonMap(
+                                                HighAvailabilityOptions.HA_CLUSTER_ID.key(),
+                                                "my-cluster-id")),
+                "Forbidden Flink config key");
+
+        testError(
+                dep ->
+                        dep.getSpec()
+                                .setFlinkConfiguration(
                                         Map.of(
                                                 KubernetesOperatorConfigOptions
                                                                 .OPERATOR_CLUSTER_HEALTH_CHECK_ENABLED
@@ -240,7 +249,19 @@ public class DefaultValidatorTest {
                     dep.getSpec().setFlinkConfiguration(new HashMap<>());
                     dep.getSpec().getJobManager().setReplicas(2);
                 },
-                "Kubernetes High availability should be enabled when starting standby JobManagers.");
+                "High availability should be enabled when starting standby JobManagers.");
+
+        testError(
+                dep ->
+                        dep.getSpec()
+                                .setFlinkConfiguration(
+                                        Map.of(
+                                                KubernetesOperatorConfigOptions
+                                                        .DEPLOYMENT_ROLLBACK_ENABLED
+                                                        .key(),
+                                                "true")),
+                "HA must be enabled for rollback support.");
+
         testError(
                 dep -> dep.getSpec().getJobManager().setReplicas(0),
                 "JobManager replicas should not be configured less than one.");

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
@@ -64,7 +64,7 @@ public class CmdStandaloneJobManagerDecorator extends AbstractKubernetesStepDeco
                         .withCommand(kubernetesJobManagerParameters.getContainerEntrypoint())
                         .addToArgs(JOBMANAGER_ENTRYPOINT_ARG);
 
-        if (kubernetesJobManagerParameters.isKubernetesHA()) {
+        if (kubernetesJobManagerParameters.isHAEnabled()) {
             containerBuilder.addToArgs(POD_IP_ARG);
         }
 
@@ -104,7 +104,7 @@ public class CmdStandaloneJobManagerDecorator extends AbstractKubernetesStepDeco
             args.addAll(kubernetesJobManagerParameters.getJobSpecArgs());
         }
 
-        if (kubernetesJobManagerParameters.isKubernetesHA()) {
+        if (kubernetesJobManagerParameters.isHAEnabled()) {
             args.add("--host");
             args.add(POD_IP_ARG);
         }

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
@@ -20,13 +20,13 @@ package org.apache.flink.kubernetes.operator.kubeclient.parameters;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
 import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfigOptionsInternal;
 import org.apache.flink.kubernetes.operator.utils.StandaloneKubernetesUtils;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
+import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,10 +38,6 @@ import java.util.Map;
  * for constructing the JobManager deployment used for standalone cluster deployments.
  */
 public class StandaloneKubernetesJobManagerParameters extends KubernetesJobManagerParameters {
-
-    private static final String KUBERNETES_HA_FQN_FACTORY_CLASS =
-            "org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory";
-    private static final String KUBERNETES_HA_MODE = "KUBERNETES";
 
     public StandaloneKubernetesJobManagerParameters(
             Configuration flinkConfig, ClusterSpecification clusterSpecification) {
@@ -113,9 +109,7 @@ public class StandaloneKubernetesJobManagerParameters extends KubernetesJobManag
         return null;
     }
 
-    public boolean isKubernetesHA() {
-        String haMode = flinkConfig.getValue(HighAvailabilityOptions.HA_MODE);
-        return haMode.equals(KUBERNETES_HA_FQN_FACTORY_CLASS)
-                || haMode.equalsIgnoreCase(KUBERNETES_HA_MODE);
+    public boolean isHAEnabled() {
+        return HighAvailabilityMode.isHighAvailabilityModeActivated(flinkConfig);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@ under the License.
 
         <okhttp.version>4.10.0</okhttp.version>
         <snakeyaml.version>1.33</snakeyaml.version>
+        <curator-test.version>5.2.0</curator-test.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## What is the purpose of the change
https://issues.apache.org/jira/browse/FLINK-27273
This PR makes sure that Flink applications which use Zookeeper-based HA can be deployed via the Kubernetes Operator.
It wasn't previously possible mainly due to the lack of proper clean-up of Zookeeper data which could cause unexpected behaviour in Flink applications, as mentioned in the ticket.

## Brief change log
- JobGraph-related data is now properly cleaned in Zookeeper (same behaviour as when using Kubernetes HA)
- All HA metadata is now properly cleaned when application is deleted or suspended in some cases (same behaviour as when using Kubernetes HA)
- Code has been updated to support both Kubernetes and Zookeper-based HA settings. All features which worked with Kubernetes HA (such as JM deployment recovery, unhealthy job restarts or rollbacks) should also work with Zookeeper HA as well.
- Made sure https://github.com/apache/flink-kubernetes-operator/pull/518 is compatible with ZK as well

## Verifying this change
- Wrote unit tests
- Verified all existing unit tests succeed
- Tried some scenarios in our Kubernetes environment:
  - `upgradeMode: savepoint`:
    - [x] Successfully deployed a Flink application with `upgradeMode: savepoint` and Zookeeper HA enabled
    - [x] Updated the `FlinkDeployment` object, verified that the JobGraph data was successfully deleted in Zookeeper and that the new version of the application was successfully rolled out
    - [x] Manually deleted the JobManager Kubernetes Deployment, verified that the Operator was able to recover it (with `kubernetes.operator.jm-deployment-recovery.enabled` and `kubernetes.operator.job.upgrade.last-state-fallback.enabled` set to `true`) and that the application restarted successfully (this process relies on HA metadata too)
    - [x] Suspended a Standalone Flink application, verified that after the Savepoint was taken, the Zookeeper HA metadata was cleaned-up 
    - [x] Deleted the Flink Deployment, verified that the HA metadata was cleaned-up 
  - `upgradeMode: last-state`:
    - [x] Successfully deployed a Flink application with `upgradeMode: last-state` and Zookeeper HA enabled
    - [x] Updated the `FlinkDeployment` object, verified that the JobGraph data was successfully deleted in Zookeeper and that the new version of the application was successfully rolled out
    - [x] Manually deleted the JobManager Kubernetes Deployment, verified that the Operator was able to recover it with `kubernetes.operator.jm-deployment-recovery.enabled` set to `true` and that the application restarted successfully (this process relies on HA metadata too) 
  - [x] Set `kubernetes.operator.cluster.health-check.enabled` to `true` and deployed a Flink application which was continuously failing and restarting. Once the restart threshold (`kubernetes.operator.cluster.health-check.restarts.threshold`) was hit, the Operator was able to successfully validate that the Zookeeper HA metadata exists and restarted the job  
  - [x] Set `kubernetes.operator.deployment.rollback.enabled` to `true` and deployed a Flink application which was in `CrashLoopBackOff`. Once the `kubernetes.operator.deployment.readiness.timeout` passed, the Operator was able to successfully validate that the Zookeeper HA metadata exists and rolled back the job to the previous version. 
  - `upgradeMode: stateless`:
    - [x] Suspended a Flink application, verified that the Zookeeper HA metadata was cleaned-up (it's always deleted regardless of Native vs Standalone mode)

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes 

## Documentation
  - Does this pull request introduce a new feature?: yes
  - If yes, how is the feature documented?: Updated the documentation where applicable