### PR TITLE
[FLINK-30800] Add doc entry how to re-generate java doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,11 @@ that you always have docs corresponding to your checked-out version.
 
 # Requirements
 
+### Generate the java doc (only if anything changed)
+```sh
+mvn clean install -DskipTests -Pgenerate-docs
+```
+
 ### Build the site locally
 
 #### Using Hugo Docker image:


### PR DESCRIPTION
## What is the purpose of the change

At the moment CI notifies contributors that the doc needs to be re-generated which is fine. It would be good to add the command how to re-generate to the readme not to dig CI yaml all the time.

## Brief change log

Added doc entry how to re-generate java doc.

## Verifying this change

Just a look at the doc readme.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
