### PR TITLE
[FLINK-30825] Change Ingress to work with Kubernetes version < 1.19

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/IngressUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/IngressUtils.java
@@ -24,12 +24,12 @@ import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.util.Preconditions;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.OwnerReferenceBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.networking.v1.HTTPIngressRuleValueBuilder;
-import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressRuleBuilder;
@@ -65,18 +65,35 @@ public class IngressUtils {
             KubernetesClient client) {
 
         if (spec.getIngress() != null) {
-            Ingress ingress =
-                    new IngressBuilder()
-                            .withNewMetadata()
-                            .withAnnotations(spec.getIngress().getAnnotations())
-                            .withName(objectMeta.getName())
-                            .withNamespace(objectMeta.getNamespace())
-                            .endMetadata()
-                            .withNewSpec()
-                            .withIngressClassName(spec.getIngress().getClassName())
-                            .withRules(getIngressRule(objectMeta, spec, effectiveConfig))
-                            .endSpec()
-                            .build();
+            HasMetadata ingress;
+            if (ingressInNetworkingV1(client)) {
+                ingress =
+                        new IngressBuilder()
+                                .withNewMetadata()
+                                .withAnnotations(spec.getIngress().getAnnotations())
+                                .withName(objectMeta.getName())
+                                .withNamespace(objectMeta.getNamespace())
+                                .endMetadata()
+                                .withNewSpec()
+                                .withIngressClassName(spec.getIngress().getClassName())
+                                .withRules(getIngressRule(objectMeta, spec, effectiveConfig))
+                                .endSpec()
+                                .build();
+            } else {
+                ingress =
+                        new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder()
+                                .withNewMetadata()
+                                .withAnnotations(spec.getIngress().getAnnotations())
+                                .withName(objectMeta.getName())
+                                .withNamespace(objectMeta.getNamespace())
+                                .endMetadata()
+                                .withNewSpec()
+                                .withIngressClassName(spec.getIngress().getClassName())
+                                .withRules(
+                                        getIngressRuleForV1beta1(objectMeta, spec, effectiveConfig))
+                                .endSpec()
+                                .build();
+            }
 
             Deployment deployment =
                     client.apps()
@@ -137,6 +154,47 @@ public class IngressUtils {
         return ingressRuleBuilder.build();
     }
 
+    private static io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule
+            getIngressRuleForV1beta1(
+                    ObjectMeta objectMeta,
+                    FlinkDeploymentSpec spec,
+                    Configuration effectiveConfig) {
+        final String clusterId = objectMeta.getName();
+        final int restPort = effectiveConfig.getInteger(RestOptions.PORT);
+
+        URL ingressUrl =
+                getIngressUrl(
+                        spec.getIngress().getTemplate(),
+                        objectMeta.getName(),
+                        objectMeta.getNamespace());
+
+        io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRuleBuilder ingressRuleBuilder =
+                new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRuleBuilder();
+        ingressRuleBuilder.withHttp(
+                new io.fabric8.kubernetes.api.model.networking.v1beta1.HTTPIngressRuleValueBuilder()
+                        .addNewPath()
+                        .withNewBackend()
+                        .withServiceName(clusterId + REST_SVC_NAME_SUFFIX)
+                        .withServicePort(new IntOrString(restPort))
+                        .endBackend()
+                        .endPath()
+                        .build());
+
+        if (!StringUtils.isBlank(ingressUrl.getHost())) {
+            ingressRuleBuilder.withHost(ingressUrl.getHost());
+        }
+
+        if (!StringUtils.isBlank(ingressUrl.getPath())) {
+            ingressRuleBuilder
+                    .editHttp()
+                    .editFirstPath()
+                    .withPath(ingressUrl.getPath())
+                    .endPath()
+                    .endHttp();
+        }
+        return ingressRuleBuilder.build();
+    }
+
     private static void setOwnerReference(HasMetadata owner, List<HasMetadata> resources) {
         final OwnerReference ownerReference =
                 new OwnerReferenceBuilder()
@@ -174,5 +232,17 @@ public class IngressUtils {
             url = "http://" + url;
         }
         return url;
+    }
+
+    private static boolean ingressInNetworkingV1(KubernetesClient client) {
+        // networking.k8s.io/v1/Ingress is available in K8s 1.19
+        // See:
+        // https://kubernetes.io/docs/reference/using-api/deprecation-guide/
+        // https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/
+        return (client.getKubernetesVersion().getMajor()
+                                + "."
+                                + client.getKubernetesVersion().getMinor())
+                        .compareTo("1.19")
+                >= 0;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/IngressUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/IngressUtils.java
@@ -234,7 +234,7 @@ public class IngressUtils {
         return url;
     }
 
-    private static boolean ingressInNetworkingV1(KubernetesClient client) {
+    public static boolean ingressInNetworkingV1(KubernetesClient client) {
         // networking.k8s.io/v1/Ingress is available in K8s 1.19
         // See:
         // https://kubernetes.io/docs/reference/using-api/deprecation-guide/

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -42,6 +42,7 @@ import org.apache.flink.kubernetes.operator.utils.IngressUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
 import io.fabric8.kubernetes.api.model.EventBuilder;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -1006,41 +1007,11 @@ public class FlinkDeploymentControllerTest {
         testController.reconcile(appWithIngress, context);
         testController.reconcile(appWithIngress, context);
 
-        Ingress ingress = null;
-        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingressV1beta1 = null;
-        if (IngressUtils.ingressInNetworkingV1(kubernetesClient)) {
-            ingress =
-                    kubernetesClient
-                            .network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appWithIngress.getMetadata().getNamespace())
-                            .withName(appWithIngress.getMetadata().getName())
-                            .get();
-            Assertions.assertNotNull(ingress);
-        } else {
-            ingressV1beta1 =
-                    kubernetesClient
-                            .network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appWithIngress.getMetadata().getNamespace())
-                            .withName(appWithIngress.getMetadata().getName())
-                            .get();
-            Assertions.assertNotNull(ingressV1beta1);
-        }
+        HasMetadata ingress = getIngress(appWithIngress);
+        Assertions.assertNotNull(ingress);
 
-        IngressRule ingressRule = null;
-        io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule ingressRuleV1beta1 = null;
-        if (IngressUtils.ingressInNetworkingV1(kubernetesClient)) {
-            ingressRule = ingress.getSpec().getRules().stream().findFirst().get();
-        } else {
-            ingressRuleV1beta1 = ingressV1beta1.getSpec().getRules().stream().findFirst().get();
-        }
         Assertions.assertEquals(
-                IngressUtils.ingressInNetworkingV1(kubernetesClient)
-                        ? ingressRule.getHost()
-                        : ingressRuleV1beta1.getHost(),
+                getIngressHost(ingress),
                 IngressUtils.getIngressUrl(
                                 "{{name}}.{{namespace}}.example.com",
                                 appWithIngress.getMetadata().getName(),
@@ -1053,35 +1024,10 @@ public class FlinkDeploymentControllerTest {
         appWithIngress.getSpec().setIngress(ingressSpec);
         testController.reconcile(appWithIngress, context);
         testController.reconcile(appWithIngress, context);
-        if (IngressUtils.ingressInNetworkingV1(kubernetesClient)) {
-            ingress =
-                    kubernetesClient
-                            .network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appWithIngress.getMetadata().getNamespace())
-                            .withName(appWithIngress.getMetadata().getName())
-                            .get();
-            Assertions.assertNotNull(ingress);
-            ingressRule = ingress.getSpec().getRules().stream().findFirst().get();
-            Assertions.assertNotNull(ingressRule);
-        } else {
-            ingressV1beta1 =
-                    kubernetesClient
-                            .network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appWithIngress.getMetadata().getNamespace())
-                            .withName(appWithIngress.getMetadata().getName())
-                            .get();
-            Assertions.assertNotNull(ingressV1beta1);
-            ingressRuleV1beta1 = ingressV1beta1.getSpec().getRules().stream().findFirst().get();
-            Assertions.assertNotNull(ingressRuleV1beta1);
-        }
+
+        ingress = getIngress(appWithIngress);
         Assertions.assertEquals(
-                IngressUtils.ingressInNetworkingV1(kubernetesClient)
-                        ? ingressRule.getHost()
-                        : ingressRuleV1beta1.getHost(),
+                getIngressHost(ingress),
                 IngressUtils.getIngressUrl(
                                 "{{name}}.{{namespace}}.foo.bar",
                                 appWithIngress.getMetadata().getName(),
@@ -1157,5 +1103,42 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 org.apache.flink.api.common.JobStatus.RUNNING.name(),
                 appCluster.getStatus().getJobStatus().getState());
+    }
+
+    private HasMetadata getIngress(FlinkDeployment deployment) {
+        if (IngressUtils.ingressInNetworkingV1(kubernetesClient)) {
+            return kubernetesClient
+                    .network()
+                    .v1()
+                    .ingresses()
+                    .inNamespace(deployment.getMetadata().getNamespace())
+                    .withName(deployment.getMetadata().getName())
+                    .get();
+        } else {
+            return kubernetesClient
+                    .network()
+                    .v1beta1()
+                    .ingresses()
+                    .inNamespace(deployment.getMetadata().getNamespace())
+                    .withName(deployment.getMetadata().getName())
+                    .get();
+        }
+    }
+
+    private String getIngressHost(HasMetadata ingress) {
+        IngressRule ingressRule = null;
+        io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule ingressRuleV1beta1 = null;
+
+        if (IngressUtils.ingressInNetworkingV1(kubernetesClient)) {
+            ingressRule = ((Ingress) ingress).getSpec().getRules().stream().findFirst().get();
+            Assertions.assertNotNull(ingressRule);
+            return ingressRule.getHost();
+        } else {
+            ingressRuleV1beta1 =
+                    ((io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress) ingress)
+                            .getSpec().getRules().stream().findFirst().get();
+            Assertions.assertNotNull(ingressRuleV1beta1);
+            return ingressRuleV1beta1.getHost();
+        }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

`networking.k8s.io/v1/Ingress` is not available in Kubernetes with version < 1.19 ( https://kubernetes.io/docs/reference/using-api/deprecation-guide/).
Instead, we can check the Kubernetes version and use `networking.k8s.io/v1/Ingress` or  `networking.k8s.io/v1beta1/Ingress`.

## Brief change log

Reworked ingress creation depending on Kubernetes version.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change is already covered by existing tests, such as *IngressUtilsTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
