### PR TITLE
[FLINK-30518] Pass JM Pod IP to Flink when starting up with K8s HA 

### DIFF
--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParameters.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.kubeclient.parameters;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
@@ -37,6 +38,10 @@ import java.util.Map;
  * for constructing the JobManager deployment used for standalone cluster deployments.
  */
 public class StandaloneKubernetesJobManagerParameters extends KubernetesJobManagerParameters {
+
+    private static final String KUBERNETES_HA_FQN_FACTORY_CLASS =
+            "org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory";
+    private static final String KUBERNETES_HA_MODE = "KUBERNETES";
 
     public StandaloneKubernetesJobManagerParameters(
             Configuration flinkConfig, ClusterSpecification clusterSpecification) {
@@ -106,5 +111,11 @@ public class StandaloneKubernetesJobManagerParameters extends KubernetesJobManag
             return flinkConfig.get(ApplicationConfiguration.APPLICATION_ARGS);
         }
         return null;
+    }
+
+    public boolean isKubernetesHA() {
+        String haMode = flinkConfig.getValue(HighAvailabilityOptions.HA_MODE);
+        return haMode.equals(KUBERNETES_HA_FQN_FACTORY_CLASS)
+                || haMode.equalsIgnoreCase(KUBERNETES_HA_MODE);
     }
 }

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.kubeclient.decorators;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.operator.kubeclient.parameters.StandaloneKubernetesJobManagerParameters;
@@ -104,5 +105,44 @@ public class CmdStandaloneJobManagerDecoratorTest {
         assertThat(
                 decoratedPod.getMainContainer().getArgs(),
                 containsInAnyOrder(CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG));
+    }
+
+    @Test
+    public void testSessionKubernetesHAArgsAdded() {
+        configuration.set(
+                StandaloneKubernetesConfigOptionsInternal.CLUSTER_MODE,
+                StandaloneKubernetesConfigOptionsInternal.ClusterMode.SESSION);
+
+        configuration.set(
+                HighAvailabilityOptions.HA_MODE,
+                "org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory");
+
+        FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
+
+        assertThat(
+                decoratedPod.getMainContainer().getCommand(), containsInAnyOrder(MOCK_ENTRYPATH));
+        assertThat(
+                decoratedPod.getMainContainer().getArgs(),
+                containsInAnyOrder(
+                        CmdStandaloneJobManagerDecorator.JOBMANAGER_ENTRYPOINT_ARG,
+                        CmdStandaloneJobManagerDecorator.POD_IP_ARG));
+    }
+
+    @Test
+    public void testApplicationKubernetesHAArgsAdded() {
+        configuration.set(
+                StandaloneKubernetesConfigOptionsInternal.CLUSTER_MODE,
+                StandaloneKubernetesConfigOptionsInternal.ClusterMode.APPLICATION);
+
+        configuration.set(HighAvailabilityOptions.HA_MODE, "KUBERNETES");
+
+        FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
+
+        assertThat(
+                decoratedPod.getMainContainer().getArgs(),
+                containsInAnyOrder(
+                        CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG,
+                        "--host",
+                        CmdStandaloneJobManagerDecorator.POD_IP_ARG));
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

* This Pull Request modified the Standalone JobManager CMD decorator to start the pods with their IP address instead of the k8s service. (https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/deployment/resource-providers/standalone/kubernetes/)
* This fixes the issue where Kubernetes HA doesn't work with standalone mode

## Brief change log

- JobManager pods start with their IP Address when in standalone mode and K8s HA is enabled

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
*(Please pick either of the following options)*

## Verifying this change
Added unit tests and verified on EKS cluster

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
