### PR TITLE
[FLINK-30832] helm/flink-kubernetes-operator - allow specifying resources for operator pod on flink-webhook container

### DIFF
--- a/docs/content/docs/operations/helm.md
+++ b/docs/content/docs/operations/helm.md
@@ -74,7 +74,8 @@ The configurable parameters of the Helm chart and which default values as detail
 | operatorPod.dnsPolicy | DNS policy to be used by the operator pod. | |
 | operatorPod.dnsConfig | DNS configuration to be used by the operator pod. | |
 | operatorPod.nodeSelector | Custom nodeSelector to be added to the operator pod. | |
-| operatorPod.resources | Custom resources block to be added to the operator pod. | |
+| operatorPod.resources | Custom resources block to be added to the operator pod on main container. | |
+| operatorPod.webhook.resources | Custom resources block to be added to the operator pod on flink-webhook container. | |
 | operatorPod.tolerations | Custom tolerations to be added to the operator pod. | |
 | operatorServiceAccount.create | Whether to enable operator service account to create for flink-kubernetes-operator. | true |
 | operatorServiceAccount.annotations | The annotations of operator service account. | |

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -157,6 +157,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          resources:
+            {{- toYaml .Values.operatorPod.webhook.resources | nindent 12 }}
           securityContext:
             {{- toYaml .Values.webhookSecurityContext | nindent 12 }}
           volumeMounts:

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -80,6 +80,8 @@ operatorPod:
   #   requests:
   #     cpu: "250m"
   #     memory: "512Mi"
+  webhook:
+    resources: {}
 
 operatorServiceAccount:
   create: true


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds the possibility for helm chart users to specify resources block for operator pod on flink-webhook container.

Forgot to add this in previous PR... https://github.com/apache/flink-kubernetes-operator/pull/516

## Brief change log

  - Allow configuring resources block for operator pod flink-webhook container

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs