### PR TITLE
[FLINK-30845] HttpArtifactFetcher: Fix filename

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/artifact/HttpArtifactFetcher.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/artifact/HttpArtifactFetcher.java
@@ -54,7 +54,7 @@ public class HttpArtifactFetcher implements ArtifactFetcher {
 
         conn.setRequestMethod("GET");
 
-        String fileName = FilenameUtils.getName(url.getFile());
+        String fileName = FilenameUtils.getName(url.getPath());
         File targetFile = new File(targetDir, fileName);
         try (var inputStream = conn.getInputStream()) {
             FileUtils.copyToFile(inputStream, targetFile);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/artifact/ArtifactManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/artifact/ArtifactManagerTest.java
@@ -94,12 +94,12 @@ public class ArtifactManagerTest {
         try {
             httpServer = startHttpServer();
             var sourceFile = mockTheJarFile();
-            httpServer.createContext("/download", new DownloadFileHttpHandler(sourceFile));
+            httpServer.createContext("/download/file.jar", new DownloadFileHttpHandler(sourceFile));
 
             var file =
                     artifactManager.fetch(
                             String.format(
-                                    "http://127.0.0.1:%d/download?file=1",
+                                    "http://127.0.0.1:%d/download/file.jar?some=params",
                                     httpServer.getAddress().getPort()),
                             new Configuration()
                                     .set(
@@ -109,7 +109,7 @@ public class ArtifactManagerTest {
                             tempDir.toString());
             Assertions.assertTrue(file.exists());
             Assertions.assertEquals(tempDir.toString(), file.getParent());
-            Assertions.assertEquals("download?file=1", file.getName());
+            Assertions.assertEquals("file.jar", file.getName());
         } finally {
             if (httpServer != null) {
                 httpServer.stop(0);


### PR DESCRIPTION
## What is the purpose of the change

The HttpArtifactFetcher now only keeps the actual file name without the URI params as the file name. Previously the params were part of the resulting file name. This lead to problems submitting job files as Flink checks that the name of job files submitted end with ".jar".

## Brief change log

  - Filename determined from Job URIs do not contain URI-params anymore

## Verifying this change

This change is already covered by existing tests, such as *ArtifactManagerTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no

