### PR TITLE
[FLINK-30858] Always record reconciled spec generation

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.reconciler.ReconciliationMetadata;
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
@@ -481,5 +482,20 @@ public class ReconciliationUtils {
         reconciliationStatus.setLastReconciledSpec(
                 SpecUtils.writeSpecWithMeta(
                         lastSpecWithMeta.getSpec(), lastSpecWithMeta.getMeta()));
+    }
+
+    public static <SPEC extends AbstractFlinkSpec> void updateReconciliationMetadata(
+            AbstractFlinkResource<SPEC, ?> resource) {
+        var reconciliationStatus = resource.getStatus().getReconciliationStatus();
+        var lastSpecWithMeta = reconciliationStatus.deserializeLastReconciledSpecWithMeta();
+        var newMeta = ReconciliationMetadata.from(resource);
+
+        if (newMeta.equals(lastSpecWithMeta.getMeta())) {
+            // Nothing to update
+            return;
+        }
+
+        reconciliationStatus.setLastReconciledSpec(
+                SpecUtils.writeSpecWithMeta(lastSpecWithMeta.getSpec(), newMeta));
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -157,6 +157,8 @@ public abstract class AbstractFlinkResourceReconciler<
                 // reconcile other changes
                 return;
             }
+        } else {
+            ReconciliationUtils.updateReconciliationMetadata(cr);
         }
 
         if (shouldRollBack(cr, observeConfig, ctx.getFlinkService())) {


### PR DESCRIPTION
## What is the purpose of the change

Record reconciled generation even if no Flink deployment took place in order to allow users to determine whether a given spec version has been reconciled or not.

## Verifying this change

Unit test added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
