### PR TITLE
[FLINK-30405] Add ResourceLifecycleStatus to CommonStatus and printer column

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -198,7 +198,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | jobStatus | org.apache.flink.kubernetes.operator.api.status.JobStatus | Last observed status of the Flink job on Application/Session cluster. |
 | error | java.lang.String | Error information about the FlinkDeployment/FlinkSessionJob. |
-| lifecycleState | org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState |  |
+| lifecycleState | org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState | Lifecycle state of the Flink resource (including being rolled back, failed etc.). |
 | clusterInfo | java.util.Map<java.lang.String,java.lang.String> | Information from running clusters. |
 | jobManagerDeploymentStatus | org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus | Last observed status of the JobManager deployment. |
 | reconciliationStatus | org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentReconciliationStatus | Status of the last reconcile operation. |
@@ -225,7 +225,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | jobStatus | org.apache.flink.kubernetes.operator.api.status.JobStatus | Last observed status of the Flink job on Application/Session cluster. |
 | error | java.lang.String | Error information about the FlinkDeployment/FlinkSessionJob. |
-| lifecycleState | org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState |  |
+| lifecycleState | org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState | Lifecycle state of the Flink resource (including being rolled back, failed etc.). |
 | reconciliationStatus | org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobReconciliationStatus | Status of the last reconcile operation. |
 
 ### JobManagerDeploymentStatus

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -198,6 +198,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | jobStatus | org.apache.flink.kubernetes.operator.api.status.JobStatus | Last observed status of the Flink job on Application/Session cluster. |
 | error | java.lang.String | Error information about the FlinkDeployment/FlinkSessionJob. |
+| lifecycleState | org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState |  |
 | clusterInfo | java.util.Map<java.lang.String,java.lang.String> | Information from running clusters. |
 | jobManagerDeploymentStatus | org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus | Last observed status of the JobManager deployment. |
 | reconciliationStatus | org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentReconciliationStatus | Status of the last reconcile operation. |
@@ -224,6 +225,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | jobStatus | org.apache.flink.kubernetes.operator.api.status.JobStatus | Last observed status of the Flink job on Application/Session cluster. |
 | error | java.lang.String | Error information about the FlinkDeployment/FlinkSessionJob. |
+| lifecycleState | org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState |  |
 | reconciliationStatus | org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobReconciliationStatus | Status of the last reconcile operation. |
 
 ### JobManagerDeploymentStatus

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/lifecycle/ResourceLifecycleState.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/lifecycle/ResourceLifecycleState.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.api.lifecycle;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 
 import java.util.Collections;
@@ -36,8 +37,8 @@ public enum ResourceLifecycleState {
     ROLLED_BACK(true, "The resource is deployed with the last stable spec"),
     FAILED(true, "The job terminally failed");
 
-    private final boolean terminal;
-    @Getter private final String description;
+    @JsonIgnore private final boolean terminal;
+    @JsonIgnore @Getter private final String description;
 
     ResourceLifecycleState(boolean terminal, String description) {
         this.terminal = terminal;

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
@@ -43,7 +43,10 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
     /** Error information about the FlinkDeployment/FlinkSessionJob. */
     private String error;
 
-    @PrinterColumn(name = "Resource Lifecycle State")
+    /** Lifecycle state of the Flink resource (including being rolled back, failed etc.). */
+    @PrinterColumn(name = "Lifecycle State")
+    // Calculated from the status, requires no setter. The purpose of this is to expose as a printer
+    // column.
     private ResourceLifecycleState lifecycleState;
 
     /**

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
@@ -22,7 +22,7 @@ import org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.fabric8.kubernetes.model.annotation.PrinterColumn;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -43,6 +43,9 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
     /** Error information about the FlinkDeployment/FlinkSessionJob. */
     private String error;
 
+    @PrinterColumn(name = "Resource Lifecycle State")
+    private ResourceLifecycleState lifecycleState;
+
     /**
      * Current reconciliation status of this resource.
      *
@@ -50,7 +53,6 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
      */
     public abstract ReconciliationStatus<SPEC> getReconciliationStatus();
 
-    @JsonIgnore
     public ResourceLifecycleState getLifecycleState() {
         var reconciliationStatus = getReconciliationStatus();
 

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/ReconciliationStatus.java
@@ -24,7 +24,6 @@ import org.apache.flink.kubernetes.operator.api.utils.SpecUtils;
 import org.apache.flink.kubernetes.operator.api.utils.SpecWithMeta;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.fabric8.kubernetes.model.annotation.PrinterColumn;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -50,7 +49,6 @@ public abstract class ReconciliationStatus<SPEC extends AbstractFlinkSpec> {
     private String lastStableSpec;
 
     /** Deployment state of the last reconciled spec. */
-    @PrinterColumn(name = "Reconciliation Status")
     private ReconciliationState state = ReconciliationState.UPGRADING;
 
     @JsonIgnore

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -18,8 +18,10 @@ spec:
       jsonPath: .status.jobStatus.state
       name: Job Status
       type: string
-    - jsonPath: .status.lifecycleState
-      name: Resource Lifecycle State
+    - description: "Lifecycle state of the Flink resource (including being rolled\
+        \ back, failed etc.)."
+      jsonPath: .status.lifecycleState
+      name: Lifecycle State
       type: string
     name: v1beta1
     schema:
@@ -9252,8 +9254,6 @@ spec:
                 - ROLLING_BACK
                 - ROLLED_BACK
                 - FAILED
-                - terminal
-                - description
                 type: string
             type: object
         type: object

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -18,9 +18,8 @@ spec:
       jsonPath: .status.jobStatus.state
       name: Job Status
       type: string
-    - description: Deployment state of the last reconciled spec.
-      jsonPath: .status.reconciliationStatus.state
-      name: Reconciliation Status
+    - jsonPath: .status.lifecycleState
+      name: Resource Lifecycle State
       type: string
     name: v1beta1
     schema:
@@ -9242,6 +9241,19 @@ spec:
                     type: object
                 type: object
               error:
+                type: string
+              lifecycleState:
+                enum:
+                - CREATED
+                - SUSPENDED
+                - UPGRADING
+                - DEPLOYED
+                - STABLE
+                - ROLLING_BACK
+                - ROLLED_BACK
+                - FAILED
+                - terminal
+                - description
                 type: string
             type: object
         type: object

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -18,8 +18,10 @@ spec:
       jsonPath: .status.jobStatus.state
       name: Job Status
       type: string
-    - jsonPath: .status.lifecycleState
-      name: Resource Lifecycle State
+    - description: "Lifecycle state of the Flink resource (including being rolled\
+        \ back, failed etc.)."
+      jsonPath: .status.lifecycleState
+      name: Lifecycle State
       type: string
     name: v1beta1
     schema:
@@ -177,8 +179,6 @@ spec:
                 - ROLLING_BACK
                 - ROLLED_BACK
                 - FAILED
-                - terminal
-                - description
                 type: string
             type: object
         type: object

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -18,9 +18,8 @@ spec:
       jsonPath: .status.jobStatus.state
       name: Job Status
       type: string
-    - description: Deployment state of the last reconciled spec.
-      jsonPath: .status.reconciliationStatus.state
-      name: Reconciliation Status
+    - jsonPath: .status.lifecycleState
+      name: Resource Lifecycle State
       type: string
     name: v1beta1
     schema:
@@ -167,6 +166,19 @@ spec:
                     type: object
                 type: object
               error:
+                type: string
+              lifecycleState:
+                enum:
+                - CREATED
+                - SUSPENDED
+                - UPGRADING
+                - DEPLOYED
+                - STABLE
+                - ROLLING_BACK
+                - ROLLED_BACK
+                - FAILED
+                - terminal
+                - description
                 type: string
             type: object
         type: object


### PR DESCRIPTION
## What is the purpose of the change

*I had to remove the JsonIgnore annotation above the ResourceLifecycleState getter in CommonStatus and also I had to expose this as a printer column instead of the reconciliation status that is used currently.*


## Brief change log

  - *Remove the `@JsonIgnore` annotation above the `ResourceLifecycleState` getter*
  - *Added a new private field to `CommonStatus` with `@PrinterColumn` annotation*
  - *Remove the `@PrinterColumn` annotation above the `state` field within the `ReconciliationStatus` class*

## Verifying this change

1. Checkout this PR
2. And go through the quick-start guide
3. Finally use the `kubectl get flinkdeployments` command to check the results

*(OR)*

1. (After you checked out this PR) Build the flink-kubernetes-operator with `mvn clean install -Pgenerate-docs -DskipTests` command
2. Upgrade the `flinkdeployments` and `flinksessionjobs` CRDs
4. Build a new docker image
5. Load that image into minikube
6. Install the operator locally
7. Submit the basic-example Flink job
8. Finally use the `kubectl get flinkdeployments` command to check the results

You should see something like this as result:
<img width="319" alt="image" src="https://user-images.githubusercontent.com/73717102/216645617-9c92b058-54c2-4c0b-8148-440d9ca8f5fe.png">

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
