### PR TITLE
[FLINK-27491] Support env replacement in flink-kubernetes-operator

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.operator.argument.variables.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to resolve job args containing environment variables, e.g. '--args ${ENV}'</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.cluster.health-check.checkpoint-progress.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.operator.argument.variables.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to resolve job args containing environment variables, e.g. '--args ${ENV}'</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.cluster.health-check.checkpoint-progress.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -442,6 +442,14 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription("Leader election retry period.");
 
     @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> ARGUMENT_VARIABLES_ENABLED =
+            operatorConfig("argument.variables.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to resolve job args containing environment variables, e.g. '--args ${ENV}'");
+
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Duration> OPERATOR_JM_SHUTDOWN_TTL =
             operatorConfig("jm-deployment.shutdown-ttl")
                     .durationType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -57,7 +57,6 @@ import static org.apache.flink.kubernetes.operator.utils.FlinkResourceExceptionU
 
 /** Reconciliation utilities. */
 public class ReconciliationUtils {
-
     private static final Logger LOG = LoggerFactory.getLogger(ReconciliationUtils.class);
 
     private static final ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
## What is the purpose of the change
Flink deployment resources support env interpolation natively using $() syntax. Users expected this to "just work" like other resources when using the operator, but it does not. It would be a great addition, simplifying job startup decision-making while following existing conventions.

```
job:  
  args:
    - "--sleep"
    - "${SLEEP}"
    - "--error-rate"
    - "${ERROR_RATE}"
```

Note: The feature is considered experymental and controlled by a flag `argument.variables.enabled=false`

## Brief change log

The logic uses the idea to append the `-D$internal.application.program-args=--sleep;${SLEEP};--error-rate;${ERROR_RATE}` as a dynamic property to `kubernetes.jobmanager.entrypoint.args` which results in the following container command:
```
 - args:
    - bash
    - -c
    - kubernetes-jobmanager.sh kubernetes-application -D\$internal.application.program-args=--sleep\;${SLEEP}\;--error-rate\;${ERROR_RATE}
```
## Verifying this change

- Unit tests where added to cover the functionality
- Also verified manually by running:
```
apiVersion: flink.apache.org/v1beta1
kind: FlinkDeployment
metadata:
  name: basic-example
spec:
  image: flink:1.16
  flinkVersion: v1_16
  flinkConfiguration:
    taskmanager.numberOfTaskSlots: "2"
  serviceAccount: flink
  podTemplate:
    apiVersion: v1
    kind: Pod
    metadata:
      name: pod-template
    spec:
      containers:        
        - name: flink-main-container
          env:
            - name: SLEEP
              value: "10"
            - name: ERROR_RATE
              value: "0.1"
  jobManager:
    resource:
      memory: "2048m"
      cpu: 1
  taskManager:
    resource:
      memory: "2048m"
      cpu: 1
  job:
    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
    args: ["--sleep","${SLEEP}","--error-rate", "${ERROR_RATE}"]
    parallelism: 2
    upgradeMode: stateless
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:  no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (autoganarated)
