### PR TITLE
[FLINK-30594] Fix JDK-8221218 + change to eclipse-temurin due to openjdk deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 # Build
-FROM maven:3.8.4-openjdk-11 AS build
+FROM maven:3.8.4-eclipse-temurin-11 AS build
 ARG SKIP_TESTS=true
 
 WORKDIR /app
@@ -33,7 +33,7 @@ RUN cd /app/tools/license; mkdir jars; cd jars; \
     cd ../ && ./collect_license_files.sh ./jars ./licenses-output
 
 # stage
-FROM openjdk:11-jre
+FROM eclipse-temurin:11-jre-jammy
 ENV FLINK_HOME=/opt/flink
 ENV OPERATOR_VERSION=1.4-SNAPSHOT
 ENV OPERATOR_JAR=flink-kubernetes-operator-$OPERATOR_VERSION-shaded.jar


### PR DESCRIPTION
## Brief change log

The main intention is the following:
* Fix the following JDK bug which is solved in `11.0.18`: [JDK-8221218](https://bugs.openjdk.org/browse/JDK-8221218)
* Migrate from OpenJDK which is announced to be deprecated [here](https://hub.docker.com/_/openjdk)

## Verifying this change

Compile docker images.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
