### PR TITLE
[chore] increase the default ReadinessTimeout to 5 minutes

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -40,7 +40,7 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.deployment.readiness.timeout</h5></td>
-            <td style="word-wrap: break-word;">1 min</td>
+            <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>
             <td>The timeout for deployments to become ready/stable before being rolled back if rollback is enabled.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -52,7 +52,7 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.deployment.readiness.timeout</h5></td>
-            <td style="word-wrap: break-word;">1 min</td>
+            <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>
             <td>The timeout for deployments to become ready/stable before being rolled back if rollback is enabled.</td>
         </tr>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -130,7 +130,7 @@ public class KubernetesOperatorConfigOptions {
     public static final ConfigOption<Duration> DEPLOYMENT_READINESS_TIMEOUT =
             operatorConfig("deployment.readiness.timeout")
                     .durationType()
-                    .defaultValue(Duration.ofMinutes(1))
+                    .defaultValue(Duration.ofMinutes(5))
                     .withDescription(
                             "The timeout for deployments to become ready/stable "
                                     + "before being rolled back if rollback is enabled.");

--- a/helm/flink-kubernetes-operator/conf/flink-conf.yaml
+++ b/helm/flink-kubernetes-operator/conf/flink-conf.yaml
@@ -30,7 +30,7 @@ parallelism.default: 1
 # kubernetes.operator.observer.savepoint.trigger.grace-period: 10 s
 # kubernetes.operator.flink.client.timeout: 10 s
 # kubernetes.operator.deployment.rollback.enabled: false
-# kubernetes.operator.deployment.readiness.timeout: 1min
+# kubernetes.operator.deployment.readiness.timeout: 5min
 # kubernetes.operator.user.artifacts.base.dir: /opt/flink/artifacts
 # kubernetes.operator.job.upgrade.ignore-pending-savepoint: false
 # kubernetes.operator.watched.namespaces: ns1,ns2


### PR DESCRIPTION
## What is the purpose of the change

This pull request increases the default value of `kubernetes.operator.deployment.readiness.timeout` to 5 minutes from 1 minute.

Discussed with @gyfora that the current default value of 1 minute might be too short in many prod deployment scenarios.

## Brief change log

- simply updated the current `kubernetes.operator.deployment.readiness.timeout` to 5 minutes.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage. -> quick config default value update.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
