### PR TITLE
[FLINK-30757] Upgrade busybox version to a pinned version for operator

### DIFF
--- a/docs/content/docs/custom-resource/pod-template.md
+++ b/docs/content/docs/custom-resource/pod-template.md
@@ -93,7 +93,7 @@ spec:
         initContainers:
           # Sample sidecar container
           - name: busybox
-            image: busybox:1.36.0
+            image: busybox:1.35.0
             command: [ 'sh','-c','echo hello from task manager' ]
   job:
     jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar

--- a/docs/content/docs/custom-resource/pod-template.md
+++ b/docs/content/docs/custom-resource/pod-template.md
@@ -93,7 +93,7 @@ spec:
         initContainers:
           # Sample sidecar container
           - name: busybox
-            image: busybox:1.33.1
+            image: busybox:1.36.0
             command: [ 'sh','-c','echo hello from task manager' ]
   job:
     jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar

--- a/e2e-tests/data/flinkdep-cr.yaml
+++ b/e2e-tests/data/flinkdep-cr.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       initContainers:
         - name: artifacts-fetcher
-          image: busybox:1.36.0
+          image: busybox:1.35.0
           imagePullPolicy: IfNotPresent
           # Use wget or other tools to get user jars from remote storage
           command: [ 'wget', 'https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.4/flink-examples-streaming_2.12-1.14.4.jar', '-O', '/flink-artifact/myjob.jar' ]

--- a/e2e-tests/data/flinkdep-cr.yaml
+++ b/e2e-tests/data/flinkdep-cr.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       initContainers:
         - name: artifacts-fetcher
-          image: busybox:1.33.1
+          image: busybox:1.36.0
           imagePullPolicy: IfNotPresent
           # Use wget or other tools to get user jars from remote storage
           command: [ 'wget', 'https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.4/flink-examples-streaming_2.12-1.14.4.jar', '-O', '/flink-artifact/myjob.jar' ]

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -175,7 +175,9 @@ function debug_and_show_logs {
 
     echo "Flink logs:"
     kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | while read pod;do
+        echo "Printing init container logs"
         print_pod_container_logs "$pod" "{.spec.initContainers[*].name}" "{.status.initContainerStatuses[*].restartCount}"
+        echo "Printing main container logs"
         print_pod_container_logs "$pod" "{.spec.containers[*].name}" "{.status.containerStatuses[*].restartCount}"
     done
 }
@@ -193,11 +195,13 @@ function print_pod_container_logs {
   fi
 
   for idx in "${!containers[@]}"; do
-    echo "Current logs for $pod:${containers[idx]}: "
+    echo "--------BEGIN CURRENT LOG for $pod:${containers[idx]}--------"
     kubectl logs $pod ${containers[idx]};
+    echo "--------END CURRENT LOG--------"
     if [[ ${restart_counts[idx]} -gt 0 ]];then
-      echo "Previous logs for $pod:${containers[idx]}: "
+      echo "--------BEGIN PREVIOUS LOGS for $pod:${containers[idx]}--------"
       kubectl logs $pod ${containers[idx]} --previous
+      echo "--------END PREVIOUS LOGS--------"
     fi
   done
 }

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -175,18 +175,31 @@ function debug_and_show_logs {
 
     echo "Flink logs:"
     kubectl get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | while read pod;do
-        containers=(`kubectl get pods $pod -o jsonpath='{.spec.containers[*].name}'`)
-        i=0
-        for container in "${containers[@]}"; do
-          echo "Current logs for $pod:$container: "
-          kubectl logs $pod $container;
-          restart_count=$(kubectl get pod $pod -o jsonpath='{.status.containerStatuses['$i'].restartCount}')
-          if [[ ${restart_count} -gt 0 ]];then
-            echo "Previous logs for $pod: "
-            kubectl logs $pod $container --previous
-          fi
-        done
+        print_pod_container_logs "$pod" "{.spec.initContainers[*].name}" "{.status.initContainerStatuses[*].restartCount}"
+        print_pod_container_logs "$pod" "{.spec.containers[*].name}" "{.status.containerStatuses[*].restartCount}"
     done
+}
+
+function print_pod_container_logs {
+  pod=$1
+  container_path=$2
+  restart_count_path=$3
+
+  containers=(`kubectl get pods $pod -o jsonpath=$container_path`)
+  restart_counts=(`kubectl get pod $pod -o jsonpath=$restart_count_path`)
+
+  if [[ -z "$containers" ]];then
+    return 0
+  fi
+
+  for idx in "${!containers[@]}"; do
+    echo "Current logs for $pod:${containers[idx]}: "
+    kubectl logs $pod ${containers[idx]};
+    if [[ ${restart_counts[idx]} -gt 0 ]];then
+      echo "Previous logs for $pod:${containers[idx]}: "
+      kubectl logs $pod ${containers[idx]} --previous
+    fi
+  done
 }
 
 function start_minikube {

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -65,7 +65,7 @@ spec:
         initContainers:
           # Sample init container for fetching remote artifacts
           - name: busybox
-            image: busybox:1.33.1
+            image: busybox:1.36.0
             volumeMounts:
               - mountPath: /opt/flink/downloads
                 name: downloads

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -65,7 +65,7 @@ spec:
         initContainers:
           # Sample init container for fetching remote artifacts
           - name: busybox
-            image: busybox:1.36.0
+            image: busybox:1.35.0
             volumeMounts:
               - mountPath: /opt/flink/downloads
                 name: downloads


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Since [e2e test](https://github.com/apache/flink-kubernetes-operator/actions/runs/3895555690/jobs/6662337363) is flaky with latest busybox image in init container, we [pinned](https://github.com/apache/flink-kubernetes-operator/commit/8e41ed5ec1adda9ae06bc0b6203abf42939fbf2b) the image version to a relatively old version. This pull request would like to enable e2e test print init container log and try to upgrade busybox version to the latest pinned version.

## Brief change log
  - Add log printing for init container if e2e test is failed.
  - Upgrade the busybox version to the latest in a pinned way.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change is already covered by existing tests, such as `e2e-tests/test_application_kubernetes_ha.sh`.

To reproduce the failed tests locally and test modified init container log printing code:
  - Change the init container command in `e2e-tests/data/flinkdep-cr.yaml` to `command: ['/bin/sh', '-c', 'wget https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.4/flink-examples-streaming_2.12-1.14.4.jar -O /flink-artifact/myjob.jar; echo "test error msg"; exit 1;']`.
  - Run `./e2e-tests/test_application_kubernetes_ha.sh`.
  - Part of the print log will be 
  ```
...
Flink logs:
Printing init container logs
--------BEGIN CURRENT LOG for flink-example-statemachine-599c95bbf-42wtl:artifacts-fetcher--------
Connecting to repo1.maven.org (198.18.3.208:443)
wget: note: TLS certificate validation not implemented
saving to '/flink-artifact/myjob.jar'
myjob.jar            100% |********************************|  267k  0:00:00 ETA
'/flink-artifact/myjob.jar' saved
test error msg
--------END CURRENT LOG--------
--------BEGIN PREVIOUS LOGS for flink-example-statemachine-599c95bbf-42wtl:artifacts-fetcher--------
Connecting to repo1.maven.org (198.18.3.208:443)
wget: note: TLS certificate validation not implemented
saving to '/flink-artifact/myjob.jar'
myjob.jar            100% |********************************|  267k  0:00:00 ETA
'/flink-artifact/myjob.jar' saved
test error msg
--------END PREVIOUS LOGS--------
Printing main container logs
--------BEGIN CURRENT LOG for flink-example-statemachine-599c95bbf-42wtl:flink-main-container--------
--------END CURRENT LOG--------
Printing init container logs
Printing main container logs
--------BEGIN CURRENT LOG for flink-kubernetes-operator-9744c66bd-27q2r:flink-kubernetes-operator--------
Starting Operator
...
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
