### PR TITLE
[FLINK-30920] [AutoScaler] adds exclude vertex ids for autoscaler to ignore for evaluation and scaling

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -116,5 +116,11 @@
             <td>Integer</td>
             <td>The minimum parallelism the autoscaler can use.</td>
         </tr>
+        <tr>
+            <td><h5>kubernetes.operator.job.autoscaler.exclude.vertex.ids</h5></td>
+            <td style="word-wrap: break-word;">1</td>
+            <td>String</td>
+            <td>comma separated list of vertex ids in hexstring to disable for autoscaler to ignore for evaluating and scaling.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricEvaluator.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
@@ -66,12 +67,15 @@ public class ScalingMetricEvaluator {
         var scalingOutput = new HashMap<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>();
         var metricsHistory = collectedMetrics.getMetricHistory();
         var topology = collectedMetrics.getJobTopology();
+        var excludeVertexIdList = Arrays.asList(conf.get(AutoScalerOptions.EXCLUDE_VERTEX_IDS).split(","));
 
         for (var vertex : topology.getVerticesInTopologicalOrder()) {
-            scalingOutput.put(
-                    vertex,
-                    computeVertexScalingSummary(
-                            conf, scalingOutput, metricsHistory, topology, vertex));
+            if (!excludeVertexIdList.contains(vertex.toHexString())) {
+                scalingOutput.put(
+                        vertex,
+                        computeVertexScalingSummary(
+                                conf, scalingOutput, metricsHistory, topology, vertex));
+            }
         }
 
         return scalingOutput;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -153,4 +153,11 @@ public class AutoScalerOptions {
                     .defaultValue(MetricAggregator.MAX)
                     .withDescription(
                             "Metric aggregator to use for busyTime metrics. This affects how true processing/output rate will be computed. Using max allows us to handle jobs with data skew more robustly, while avg may provide better stability when we know that the load distribution is even.");
+
+    public static final ConfigOption<String> EXCLUDE_VERTEX_IDS =
+            autoScalerConfig("exclude.vertex.ids")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("comma separated list of vertex ids in hexstring to disable for autoscaler to ignore for evaluating and scaling.");
+
 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

- This pull request adds a new config parameter to exclude vertex ids for autoscaler to ignore for evaluation and scaling


## Brief change log

- Changes in ScalingMetricEvaluator `evaluate` method and adds config parameter in AutoScalerOptions



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *no*
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: *no*
  - Core observer or reconciler logic that is regularly executed: *yes*

## Documentation

  - Does this pull request introduce a new feature? *yes*
  - Update docs/layouts/shortcodes/generated/auto_scaler_configuration.html
