### PR TITLE
[FLINK-30920] [AutoScaler] adds exclude vertex ids for autoscaler to ignore for evaluation and scaling

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -108,7 +108,7 @@
             <td><h5>kubernetes.operator.job.autoscaler.vertex.exclude.ids</h5></td>
             <td style="word-wrap: break-word;"></td>
             <td>List&lt;String&gt;</td>
-            <td>A (semicolon-separated) list of vertex ids in hexstring to disable for autoscaler to ignore for scaling.</td>
+            <td>A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling. Caution: For non-sink vertices this will still scale their downstream operators until https://issues.apache.org/jira/browse/FLINK-31215 is implemented.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.autoscaler.vertex.max-parallelism</h5></td>

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -105,6 +105,12 @@
             <td>Target vertex utilization boundary. Scaling won't be performed if utilization is within (target - boundary, target + boundary)</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.autoscaler.vertex.exclude.ids</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>List&lt;String&gt;</td>
+            <td>A (semicolon-separated) list of vertex ids in hexstring to disable for autoscaler to ignore for scaling.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.autoscaler.vertex.max-parallelism</h5></td>
             <td style="word-wrap: break-word;">2147483647</td>
             <td>Integer</td>

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -161,5 +161,5 @@ public class AutoScalerOptions {
                     .asList()
                     .defaultValues(new String[0])
                     .withDescription(
-                            "A (semicolon-separated) list of vertex ids in hexstring to disable for autoscaler to ignore for scaling.");
+                            "A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling. Caution: For non-sink vertices this will still scale their downstream operators until https://issues.apache.org/jira/browse/FLINK-31215 is implemented.");
 }

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.kubernetes.operator.autoscaler.metrics.MetricAggregator;
 
 import java.time.Duration;
+import java.util.List;
 
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.operatorConfig;
 
@@ -153,4 +154,12 @@ public class AutoScalerOptions {
                     .defaultValue(MetricAggregator.MAX)
                     .withDescription(
                             "Metric aggregator to use for busyTime metrics. This affects how true processing/output rate will be computed. Using max allows us to handle jobs with data skew more robustly, while avg may provide better stability when we know that the load distribution is even.");
+
+    public static final ConfigOption<List<String>> VERTEX_EXCLUDE_IDS =
+            autoScalerConfig("vertex.exclude.ids")
+                    .stringType()
+                    .asList()
+                    .defaultValues(new String[0])
+                    .withDescription(
+                            "A (semicolon-separated) list of vertex ids in hexstring to disable for autoscaler to ignore for scaling.");
 }

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutorTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutorTest.java
@@ -194,14 +194,15 @@ public class ScalingExecutorTest {
         var sink = JobVertexID.fromHexString(sinkHexString);
 
         var scalingInfo = new AutoScalerInfo(new HashMap<>());
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         var metrics =
                 Map.of(
                         source,
-                        evaluated(1, 70, 100),
+                        evaluated(10, 80, 100),
                         filterOperator,
-                        evaluated(1, 100, 80),
+                        evaluated(10, 60, 100),
                         sink,
-                        evaluated(1, 70, 80));
+                        evaluated(10, 80, 100));
         // filter operator should not scale
         conf.set(AutoScalerOptions.VERTEX_EXCLUDE_IDS, List.of(filterOperatorHexString));
         assertFalse(scalingDecisionExecutor.scaleResource(flinkDep, scalingInfo, conf, metrics));


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

- This pull request adds a new config parameter to exclude vertex ids for autoscaler to ignore for scaling


## Brief change log

- Changes in ScalingExecutor `computeScalingSummary` method and adds config parameter in AutoScalerOptions



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *no*
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: *no*
  - Core observer or reconciler logic that is regularly executed: *yes*

## Documentation

  - Does this pull request introduce a new feature? *yes*
  - Update docs/layouts/shortcodes/generated/auto_scaler_configuration.html
