### PR TITLE
[FLINK-31187] Fix standalone HA JobManager --host argument order

### DIFF
--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
@@ -99,14 +99,14 @@ public class CmdStandaloneJobManagerDecorator extends AbstractKubernetesStepDeco
             args.add(savepointPath);
         }
 
-        List<String> jobSpecArgs = kubernetesJobManagerParameters.getJobSpecArgs();
-        if (jobSpecArgs != null) {
-            args.addAll(kubernetesJobManagerParameters.getJobSpecArgs());
-        }
-
         if (kubernetesJobManagerParameters.isHAEnabled()) {
             args.add("--host");
             args.add(POD_IP_ARG);
+        }
+
+        List<String> jobSpecArgs = kubernetesJobManagerParameters.getJobSpecArgs();
+        if (jobSpecArgs != null) {
+            args.addAll(kubernetesJobManagerParameters.getJobSpecArgs());
         }
 
         return args;

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
@@ -30,7 +30,10 @@ import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
 /** @link CmdStandaloneJobManagerDecorator unit tests */
@@ -135,14 +138,17 @@ public class CmdStandaloneJobManagerDecoratorTest {
                 StandaloneKubernetesConfigOptionsInternal.ClusterMode.APPLICATION);
 
         configuration.set(HighAvailabilityOptions.HA_MODE, "KUBERNETES");
+        configuration.set(ApplicationConfiguration.APPLICATION_ARGS, List.of("--test", "123"));
 
         FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
 
         assertThat(
                 decoratedPod.getMainContainer().getArgs(),
-                containsInAnyOrder(
+                contains(
                         CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG,
                         "--host",
-                        CmdStandaloneJobManagerDecorator.POD_IP_ARG));
+                        CmdStandaloneJobManagerDecorator.POD_IP_ARG,
+                        "--test",
+                        "123"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Standalone mode with HA enabled will call the JobManager entrypoint with a `--host` argument, but in case there are any dynamic properties in `JobSpec.args`, this will only be added after those, and thus will be ignored by the JobManager.

## Brief change log

- Move `--host` to be added before `JobSpec.args` in `CmdStandaloneJobManagerDecorator.java`

## Verifying this change

- Corresponding unit test changed
- Manually tested in local environment

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no) no
  - Core observer or reconciler logic that is regularly executed: (yes / no) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
