### PR TITLE
[FLINK-30786] Support merge by name for podTemplate array fields

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -87,6 +87,12 @@
             <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.pod-template.merge-arrays-by-name</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Configure the array merge behaviour during pod merging. Arrays can be either merged by position or name matching.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.savepoint.format.type</h5></td>
             <td style="word-wrap: break-word;">CANONICAL</td>
             <td><p>Enum</p></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -219,6 +219,12 @@
             <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.pod-template.merge-arrays-by-name</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Configure the array merge behaviour during pod merging. Arrays can be either merged by position or name matching.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.reconcile.interval</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -407,7 +407,14 @@ public class FlinkConfigBuilder {
                             ? KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE
                             : KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE;
             effectiveConfig.setString(
-                    podConfigOption, createTempFile(mergePodTemplates(basicPod, appendPod)));
+                    podConfigOption,
+                    createTempFile(
+                            mergePodTemplates(
+                                    basicPod,
+                                    appendPod,
+                                    effectiveConfig.get(
+                                            KubernetesOperatorConfigOptions
+                                                    .POD_TEMPLATE_MERGE_BY_NAME))));
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -466,4 +466,12 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(Duration.ofMinutes(1))
                     .withDescription(
                             "Allowed max time between spec update and reconciliation for canary resources.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> POD_TEMPLATE_MERGE_BY_NAME =
+            operatorConfig("pod-template.merge-arrays-by-name")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Configure the array merge behaviour during pod merging. Arrays can be either merged by position or name matching.");
 }


### PR DESCRIPTION
## What is the purpose of the change

Allow users to select the pod template merging strategy for object arrays.
Currently we use a strictly position based merge strategy which can be difficult to use when defining multiple levels of pod templates.

With the new name based optional merge strategy, object arrays containing the name fields would be merged by the name instead of position.

## Verifying this change

Unit tests extended, manual and cluster tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
