### PR TITLE
[FLINK-31246] Beautify the SpecChange message

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -127,7 +127,7 @@ public abstract class AbstractFlinkResourceReconciler<
                 cr.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
         SPEC currentDeploySpec = cr.getSpec();
 
-        var specDiff = new ReflectiveDiffBuilder<>(currentDeploySpec, lastReconciledSpec).build();
+        var specDiff = new ReflectiveDiffBuilder<>(lastReconciledSpec, currentDeploySpec).build();
 
         boolean specChanged =
                 DiffType.IGNORE != specDiff.getType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffBuilder.java
@@ -40,17 +40,17 @@ public class DiffBuilder<T> implements Builder<DiffResult<?>> {
 
     private static final String DELIMITER = ".";
 
-    private final T left;
-    private final T right;
+    private final T before;
+    private final T after;
 
     private final List<Diff<?>> diffs;
     private boolean triviallyEqual;
 
-    public DiffBuilder(@NonNull final T left, @NonNull final T right) {
+    public DiffBuilder(@NonNull final T before, @NonNull final T after) {
         this.diffs = new ArrayList<>();
-        this.left = left;
-        this.right = right;
-        this.triviallyEqual = left == right || left.equals(right);
+        this.before = before;
+        this.after = after;
+        this.triviallyEqual = before == after || before.equals(after);
     }
 
     public DiffBuilder<T> testTriviallyEqual(boolean testTriviallyEqual) {
@@ -348,6 +348,6 @@ public class DiffBuilder<T> implements Builder<DiffResult<?>> {
 
     @Override
     public DiffResult<T> build() {
-        return new DiffResult<>(left, right, diffs);
+        return new DiffResult<>(before, after, diffs);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
@@ -21,10 +21,10 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.kubernetes.operator.api.diff.DiffType;
 import org.apache.flink.kubernetes.operator.api.diff.Diffable;
 
-import io.fabric8.zjsonpatch.JsonDiff;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.zjsonpatch.JsonDiff;
 import lombok.Getter;
 import lombok.NonNull;
 
@@ -98,9 +98,11 @@ public class DiffResult<T> {
                                                 .append(", ");
                                     }
                                 });
+                        builder.setLength(builder.length() - 2);
                     } catch (JsonProcessingException je) {
                         builder.append(diff.getLeft()).append(" -> ").append(diff.getRight());
                     }
+                    builder.append(", ");
                 });
         builder.setLength(builder.length() - 2);
         builder.append("]");

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
@@ -100,7 +100,11 @@ public class DiffResult<T> {
                                 });
                         builder.setLength(builder.length() - 2);
                     } catch (JsonProcessingException je) {
-                        builder.append(diff.getLeft()).append(" -> ").append(diff.getRight());
+                        builder.append(diff.getFieldName())
+                                .append(" : ")
+                                .append(diff.getLeft())
+                                .append(" -> ")
+                                .append(diff.getRight());
                     }
                     builder.append(", ");
                 });

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.kubernetes.operator.api.diff.DiffType;
 import org.apache.flink.kubernetes.operator.api.diff.Diffable;
 
+import io.fabric8.kubernetes.api.model.Pod;
 import lombok.Getter;
 import lombok.NonNull;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -66,8 +67,13 @@ public class DiffResult<T> {
 
         diffList.forEach(
                 diff -> {
-                    lhsBuilder.append(diff.getFieldName(), diff.getLeft());
-                    rhsBuilder.append(diff.getFieldName(), diff.getRight());
+                    if (diff.getLeft() instanceof Pod) {
+                        lhsBuilder.append(diff.getFieldName(), "before");
+                        rhsBuilder.append(diff.getFieldName(), "after");
+                    } else {
+                        lhsBuilder.append(diff.getFieldName(), diff.getLeft());
+                        rhsBuilder.append(diff.getFieldName(), diff.getRight());
+                    }
                 });
 
         return String.format("%s differs from %s", lhsBuilder.build(), rhsBuilder.build());

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/ReflectiveDiffBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/ReflectiveDiffBuilder.java
@@ -46,23 +46,23 @@ import static org.apache.flink.kubernetes.operator.api.diff.DiffType.UPGRADE;
 @Experimental
 public class ReflectiveDiffBuilder<T> implements Builder<DiffResult<T>> {
 
-    private final Object left;
-    private final Object right;
+    private final Object before;
+    private final Object after;
     private final DiffBuilder<T> diffBuilder;
 
-    public ReflectiveDiffBuilder(@NonNull final T lhs, @NonNull final T rhs) {
-        this.left = lhs;
-        this.right = rhs;
-        diffBuilder = new DiffBuilder<>(lhs, rhs);
+    public ReflectiveDiffBuilder(@NonNull final T before, @NonNull final T after) {
+        this.before = before;
+        this.after = after;
+        diffBuilder = new DiffBuilder<>(before, after);
     }
 
     @Override
     public DiffResult<T> build() {
-        if (left.equals(right)) {
+        if (before.equals(after)) {
             return diffBuilder.build();
         }
 
-        appendFields(left.getClass());
+        appendFields(before.getClass());
         return diffBuilder.build();
     }
 
@@ -70,8 +70,8 @@ public class ReflectiveDiffBuilder<T> implements Builder<DiffResult<T>> {
         for (final Field field : FieldUtils.getAllFields(clazz)) {
             if (accept(field)) {
                 try {
-                    var leftField = readField(field, left, true);
-                    var rightField = readField(field, right, true);
+                    var leftField = readField(field, before, true);
+                    var rightField = readField(field, after, true);
                     if (field.isAnnotationPresent(SpecDiff.Config.class)
                             && Map.class.isAssignableFrom(field.getType())) {
                         diffBuilder.append(
@@ -99,8 +99,8 @@ public class ReflectiveDiffBuilder<T> implements Builder<DiffResult<T>> {
                     } else {
                         diffBuilder.append(
                                 field.getName(),
-                                readField(field, left, true),
-                                readField(field, right, true),
+                                readField(field, before, true),
+                                readField(field, after, true),
                                 UPGRADE);
                     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/diff/SpecDiffTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/diff/SpecDiffTest.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL;
 import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricOptions.SCOPE_NAMING_KUBERNETES_OPERATOR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Spec diff test. */
 public class SpecDiffTest {
@@ -180,5 +181,17 @@ public class SpecDiffTest {
         diff = new ReflectiveDiffBuilder<>(left, right).build();
         assertEquals(DiffType.UPGRADE, diff.getType());
         assertEquals(11, diff.getNumDiffs());
+    }
+
+    @Test
+    public void testPodTemplateChanges() {
+        var left = BaseTestUtils.buildApplicationCluster().getSpec();
+        left.setPodTemplate(BaseTestUtils.getTestPod("localhost", "v1", List.of()));
+        var right = BaseTestUtils.buildApplicationCluster().getSpec();
+        right.setPodTemplate(BaseTestUtils.getTestPod("localhost", "v2", List.of()));
+
+        var diff = new ReflectiveDiffBuilder<>(left, right).build();
+        assertEquals(DiffType.UPGRADE, diff.getType());
+        assertTrue(diff.toString().contains("before") && diff.toString().contains("after"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently the Spec Change message contains the full PodTemplate twice.
This makes the message seriously big and also contains very little useful information.

We should abbreviate the message


## Brief change log

- When we found different pod templates, we just print `before` and `after` instead of printing out the pod template itself

## Verifying this change
This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test verifying the text*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
