### PR TITLE
[FLINK-31277] Fix deployment recovery logic HA meta check

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -428,7 +428,10 @@ public abstract class AbstractFlinkResourceReconciler<
 
             if (jmMissingForRunningDeployment(deployment)) {
                 LOG.debug("Jobmanager deployment is missing, trying to recover");
-                if (HighAvailabilityMode.isHighAvailabilityModeActivated(conf)) {
+                var jobSpec = deployment.getSpec().getJob();
+                boolean stateless =
+                        jobSpec != null && jobSpec.getUpgradeMode() == UpgradeMode.STATELESS;
+                if (stateless || HighAvailabilityMode.isHighAvailabilityModeActivated(conf)) {
                     LOG.debug("HA is enabled, recovering lost jobmanager deployment");
                     result = true;
                 } else {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -224,12 +224,11 @@ public class ApplicationReconciler
     @Override
     protected void cleanupAfterFailedJob(FlinkResourceContext<FlinkDeployment> ctx) {
         // The job has already stopped. Delete the deployment and we are ready.
-        ctx.getFlinkService()
-                .deleteClusterDeployment(
-                        ctx.getResource().getMetadata(),
-                        ctx.getResource().getStatus(),
-                        ctx.getDeployConfig(ctx.getResource().getSpec()),
-                        false);
+        var flinkService = ctx.getFlinkService();
+        var conf = ctx.getDeployConfig(ctx.getResource().getSpec());
+        flinkService.deleteClusterDeployment(
+                ctx.getResource().getMetadata(), ctx.getResource().getStatus(), conf, false);
+        flinkService.waitForClusterShutdown(conf);
     }
 
     // Workaround for https://issues.apache.org/jira/browse/FLINK-27569

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -280,10 +280,10 @@ public class ApplicationReconciler
                         MSG_RESTART_UNHEALTHY);
                 cleanupAfterFailedJob(ctx);
             }
-            boolean requireHaMetadata =
-                    ReconciliationUtils.getDeployedSpec(ctx.getResource()).getJob().getUpgradeMode()
-                            != UpgradeMode.STATELESS;
-            resubmitJob(ctx, requireHaMetadata);
+
+            resubmitJob(
+                    ctx,
+                    HighAvailabilityMode.isHighAvailabilityModeActivated(ctx.getObserveConfig()));
             return true;
         }
 


### PR DESCRIPTION
## What is the purpose of the change

The current JM Deployment logic that restarts missing deployments strictly requires HA metadata event for stateless deployments.

This is inconsistent with how the cluster health check related restarts work which can cause the operator to delete an unhealthy deployment and potentially leave it missing if the first deploy attempt fails.


## Brief change log

 - Allow JM deployment recovery for stateless jobs
 - Require HA meta based on the HA config
 - Add hotfix for missing wait for cluster shutdown 

## Verifying this change

Extended deployment recovery test to cover the stateless case.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
