### PR TITLE
[FLINK-31318] Improve stability during backlog processing

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -9,6 +9,12 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.operator.job.autoscaler.backlog-processing.lag-threshold</h5></td>
+            <td style="word-wrap: break-word;">5 min</td>
+            <td>Duration</td>
+            <td>Lag threshold which will prevent unnecessary scalings while removing the pending messages responsible for the lag.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.autoscaler.catch-up.duration</h5></td>
             <td style="word-wrap: break-word;">10 min</td>
             <td>Duration</td>

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -121,6 +121,13 @@ public class AutoScalerOptions {
                     .withDescription(
                             "Expected restart time to be used until the operator can determine it reliably from history.");
 
+    public static final ConfigOption<Duration> BACKLOG_PROCESSING_LAG_THRESHOLD =
+            autoScalerConfig("backlog-processing.lag-threshold")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(5))
+                    .withDescription(
+                            "Lag threshold which will prevent unnecessary scalings while removing the pending messages responsible for the lag.");
+
     public static final ConfigOption<Boolean> SCALING_EFFECTIVENESS_DETECTION_ENABLED =
             autoScalerConfig("scaling.effectiveness.detection.enabled")
                     .booleanType()

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
@@ -35,6 +35,9 @@ public enum ScalingMetric {
     /** Output rate at full capacity (records/sec). */
     TRUE_OUTPUT_RATE(true),
 
+    /** Current processing rate. */
+    CURRENT_PROCESSING_RATE(true),
+
     /**
      * Incoming data rate to the source, e.g. rate of records written to the Kafka topic
      * (records/sec).

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
@@ -96,6 +96,7 @@ public class ScalingMetrics {
                 targetDataRate =
                         flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC).getSum();
             }
+            scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, targetDataRate);
             scalingMetrics.put(ScalingMetric.TRUE_PROCESSING_RATE, Double.NaN);
             scalingMetrics.put(ScalingMetric.OUTPUT_RATIO, outputPerSecond / targetDataRate);
             var trueOutputRate = busyTimeMultiplier * outputPerSecond;
@@ -128,6 +129,7 @@ public class ScalingMetrics {
                     trueProcessingRate = Double.NaN;
                 }
                 scalingMetrics.put(ScalingMetric.TRUE_PROCESSING_RATE, trueProcessingRate);
+                scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, numRecordsInPerSecond);
             } else {
                 LOG.error("Cannot compute true processing rate without numRecordsInPerSecond");
             }

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
@@ -337,7 +337,6 @@ public class BacklogBasedScalingTest extends OperatorTestBase {
     private void setClocksTo(Instant time) {
         var clock = Clock.fixed(time, ZoneId.systemDefault());
         metricsCollector.setClock(clock);
-        evaluator.setClock(clock);
         scalingExecutor.setClock(clock);
     }
 

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScalerTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScalerTest.java
@@ -345,7 +345,7 @@ public class JobVertexScalerTest {
         metrics.put(
                 ScalingMetric.TRUE_PROCESSING_RATE,
                 new EvaluatedScalingMetric(trueProcessingRate, trueProcessingRate));
-        ScalingMetricEvaluator.computeProcessingRateThresholds(metrics, conf);
+        ScalingMetricEvaluator.computeProcessingRateThresholds(metrics, conf, false);
         return metrics;
     }
 }

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -173,7 +173,6 @@ public class MetricsCollectionAndEvaluationTest {
         collectedMetrics = metricsCollector.updateMetrics(app, scalingInfo, service, conf);
         assertEquals(3, collectedMetrics.getMetricHistory().size());
 
-        evaluator.setClock(clock);
         var evaluation = evaluator.evaluate(conf, collectedMetrics);
         scalingExecutor.scaleResource(app, scalingInfo, conf, evaluation);
 
@@ -258,7 +257,6 @@ public class MetricsCollectionAndEvaluationTest {
 
         var clock = Clock.fixed(Instant.now().plus(Duration.ofSeconds(3)), ZoneId.systemDefault());
         metricsCollector.setClock(clock);
-        evaluator.setClock(clock);
 
         var collectedMetrics = metricsCollector.updateMetrics(app, scalingInfo, service, conf);
 
@@ -267,7 +265,6 @@ public class MetricsCollectionAndEvaluationTest {
 
         clock = Clock.fixed(Instant.now().plus(Duration.ofSeconds(3)), ZoneId.systemDefault());
         metricsCollector.setClock(clock);
-        evaluator.setClock(clock);
 
         metricsCollector.setMetricNames(
                 Map.of(

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutorTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutorTest.java
@@ -252,7 +252,7 @@ public class ScalingExecutorTest {
         metrics.put(ScalingMetric.CATCH_UP_DATA_RATE, EvaluatedScalingMetric.of(catchupRate));
         metrics.put(
                 ScalingMetric.TRUE_PROCESSING_RATE, new EvaluatedScalingMetric(procRate, procRate));
-        ScalingMetricEvaluator.computeProcessingRateThresholds(metrics, conf);
+        ScalingMetricEvaluator.computeProcessingRateThresholds(metrics, conf, false);
         return metrics;
     }
 

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
@@ -73,7 +73,9 @@ public class ScalingMetricsTest {
                         ScalingMetric.OUTPUT_RATIO,
                         2.,
                         ScalingMetric.SOURCE_DATA_RATE,
-                        1015.),
+                        1015.,
+                        ScalingMetric.CURRENT_PROCESSING_RATE,
+                        1000.),
                 scalingMetrics);
 
         // test negative lag growth (catch up)
@@ -101,7 +103,9 @@ public class ScalingMetricsTest {
                         ScalingMetric.OUTPUT_RATIO,
                         2.,
                         ScalingMetric.SOURCE_DATA_RATE,
-                        950.),
+                        950.,
+                        ScalingMetric.CURRENT_PROCESSING_RATE,
+                        1000.),
                 scalingMetrics);
 
         scalingMetrics.clear();
@@ -126,7 +130,9 @@ public class ScalingMetricsTest {
                         ScalingMetric.TRUE_OUTPUT_RATE,
                         20000.,
                         ScalingMetric.OUTPUT_RATIO,
-                        2.),
+                        2.,
+                        ScalingMetric.CURRENT_PROCESSING_RATE,
+                        1000.),
                 scalingMetrics);
 
         // Test using avg busyTime aggregator
@@ -154,7 +160,9 @@ public class ScalingMetricsTest {
                         ScalingMetric.TRUE_OUTPUT_RATE,
                         20000.,
                         ScalingMetric.OUTPUT_RATIO,
-                        2.),
+                        2.,
+                        ScalingMetric.CURRENT_PROCESSING_RATE,
+                        1000.),
                 scalingMetrics);
     }
 
@@ -217,7 +225,9 @@ public class ScalingMetricsTest {
                         ScalingMetric.OUTPUT_RATIO,
                         1.,
                         ScalingMetric.SOURCE_DATA_RATE,
-                        dataRate),
+                        dataRate,
+                        ScalingMetric.CURRENT_PROCESSING_RATE,
+                        10.),
                 scalingMetrics);
     }
 
@@ -235,6 +245,8 @@ public class ScalingMetricsTest {
                         ScalingMetric.OUTPUT_RATIO,
                         1.,
                         ScalingMetric.SOURCE_DATA_RATE,
+                        ScalingMetrics.EFFECTIVELY_ZERO,
+                        ScalingMetric.CURRENT_PROCESSING_RATE,
                         ScalingMetrics.EFFECTIVELY_ZERO),
                 scalingMetrics);
     }
@@ -251,6 +263,8 @@ public class ScalingMetricsTest {
                         ScalingMetric.OUTPUT_RATIO,
                         1.,
                         ScalingMetric.SOURCE_DATA_RATE,
+                        ScalingMetrics.EFFECTIVELY_ZERO,
+                        ScalingMetric.CURRENT_PROCESSING_RATE,
                         ScalingMetrics.EFFECTIVELY_ZERO),
                 scalingMetrics);
     }


### PR DESCRIPTION
## What is the purpose of the change

When catching up (processing backlog) the best thing for the autoscaler is to remain stable as long as the job can keep up with the required / target data rate.

Currently however it can be possible that the operator would trigger the scale down some underutilized vertices triggering a restart and even more backlog, putting the job in a vicious cycle.

Also it would not make sense to scale vertices even further for minimal utilization gains if the current parallelism is enough to process the backlog in a timely manner.

## Brief change log

  - *Compute CURRENT_PROCESS_RATE metric for sources and use it together with LAG to detect the backlog processing state*
  - *Set the scale down utilization threshold to 0% and scale up to 100% to avoid triggering unnecessary scaling actions*

## Verifying this change

New unit tests added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
