### PR TITLE
[FLINK-31218] Improve health probe to only detect newly unhealthy informers

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/InformerHealthSummary.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/InformerHealthSummary.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.health;
+
+import io.javaoperatorsdk.operator.RuntimeInfo;
+import io.javaoperatorsdk.operator.health.InformerHealthIndicator;
+import io.javaoperatorsdk.operator.health.Status;
+import lombok.Value;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/** Operator informer health summary. */
+@Value
+public class InformerHealthSummary {
+
+    boolean anyHealthy;
+    Set<InformerIdentifier> unhealthyInformers;
+
+    public static InformerHealthSummary fromRuntimeInfo(RuntimeInfo runtimeInfo) {
+        var newUnHealthy = new HashSet<InformerIdentifier>();
+        boolean anyHealthy = false;
+
+        for (var controllerEntry :
+                runtimeInfo.unhealthyInformerWrappingEventSourceHealthIndicator().entrySet()) {
+            for (var eventSourceEntry : controllerEntry.getValue().entrySet()) {
+                Map<String, InformerHealthIndicator> informers =
+                        eventSourceEntry.getValue().informerHealthIndicators();
+                for (var informerEntry : informers.entrySet()) {
+                    if (informerEntry.getValue().getStatus() == Status.HEALTHY) {
+                        anyHealthy = true;
+                    } else {
+                        newUnHealthy.add(
+                                new InformerIdentifier(
+                                        controllerEntry.getKey(),
+                                        eventSourceEntry.getKey(),
+                                        informerEntry.getKey()));
+                    }
+                }
+            }
+        }
+
+        return new InformerHealthSummary(anyHealthy || newUnHealthy.isEmpty(), newUnHealthy);
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/InformerIdentifier.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/InformerIdentifier.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.health;
+
+import lombok.Value;
+
+/** Operator informer identifier. */
+@Value
+public class InformerIdentifier {
+
+    String controllerName;
+    String eventSourceName;
+    String informerName;
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -640,12 +640,7 @@ public abstract class AbstractFlinkService implements FlinkService {
     @Override
     public PodList getJmPodList(FlinkDeployment deployment, Configuration conf) {
         final String namespace = conf.getString(KubernetesConfigOptions.NAMESPACE);
-        final String clusterId;
-        try (ClusterClient<String> clusterClient = getClusterClient(conf)) {
-            clusterId = clusterClient.getClusterId();
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
+        final String clusterId = conf.getString(KubernetesConfigOptions.CLUSTER_ID);
         return getJmPodList(namespace, clusterId);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The current healthprobe will report unhealthy if any informers cannot start. This is in contradiction with the setting that can allow the operator to start while some informers are unhealthy (and keep trying to start them)

## Brief change log

  - *Add fine grained informer health check to probe*

## Verifying this change

New unittests added to HealthProbeTest, tested on local and cloud envs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
