### PR TITLE
[FLINK-31326] Consolidate source scaling logic

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -87,12 +87,6 @@
             <td>Enable vertex scaling execution by the autoscaler. If disabled, the autoscaler will only collect metrics and evaluate the suggested parallelism for each vertex but will not upgrade the jobs.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.job.autoscaler.scaling.sources.enabled</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Whether to enable scaling source vertices. Source vertices set the baseline ingestion rate for the processing based on the backlog size. If disabled, only regular job vertices will be scaled and source vertices will be unchanged.</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.job.autoscaler.stabilization.interval</h5></td>
             <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>

--- a/examples/autoscaling/autoscaling.yaml
+++ b/examples/autoscaling/autoscaling.yaml
@@ -25,7 +25,6 @@ spec:
   flinkVersion: v1_17
   flinkConfiguration:
     kubernetes.operator.job.autoscaler.enabled: "true"
-    kubernetes.operator.job.autoscaler.scaling.sources.enabled: "false"
     kubernetes.operator.job.autoscaler.stabilization.interval: "1m"
     kubernetes.operator.job.autoscaler.metrics.window: "3m"
     pipeline.max-parallelism: "24"

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
@@ -42,7 +42,6 @@ import org.apache.flink.util.Preconditions;
 
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import lombok.SneakyThrows;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,8 +59,6 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-
-import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.SOURCE_SCALING_ENABLED;
 
 /** Metric collector using flink rest api. */
 public abstract class ScalingMetricCollector {
@@ -249,7 +246,7 @@ public abstract class ScalingMetricCollector {
                     }
                     ScalingMetrics.computeLoadMetrics(vertexFlinkMetrics, vertexScalingMetrics);
 
-                    Optional<Double> lagGrowthRate =
+                    double lagGrowthRate =
                             computeLagGrowthRate(
                                     resourceID,
                                     jobVertexID,
@@ -270,30 +267,29 @@ public abstract class ScalingMetricCollector {
         return out;
     }
 
-    @NotNull
-    private Optional<Double> computeLagGrowthRate(
+    private double computeLagGrowthRate(
             ResourceID resourceID, JobVertexID jobVertexID, Double currentLag) {
         var metricHistory = histories.get(resourceID);
 
         if (metricHistory == null || metricHistory.isEmpty()) {
-            return Optional.empty();
+            return Double.NaN;
         }
 
         var lastCollectionTime = metricHistory.lastKey();
         var lastCollectedMetrics = metricHistory.get(lastCollectionTime).get(jobVertexID);
 
         if (lastCollectedMetrics == null) {
-            return Optional.empty();
+            return Double.NaN;
         }
 
         var lastLag = lastCollectedMetrics.get(ScalingMetric.LAG);
 
         if (lastLag == null || currentLag == null) {
-            return Optional.empty();
+            return Double.NaN;
         }
 
         var timeDiff = Duration.between(lastCollectionTime, clock.instant()).toSeconds();
-        return Optional.of((currentLag - lastLag) / timeDiff);
+        return (currentLag - lastLag) / timeDiff;
     }
 
     /** Query the available metric names for each job vertex for the current spec generation. */
@@ -369,20 +365,25 @@ public abstract class ScalingMetricCollector {
 
         if (topology.isSource(jobVertexID)) {
             requiredMetrics.add(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC);
-            if (conf.getBoolean(SOURCE_SCALING_ENABLED)) {
-                requiredMetrics.add(FlinkMetric.PENDING_RECORDS);
-            } else {
-                FlinkMetric.PENDING_RECORDS
-                        .findAny(allMetricNames)
-                        .ifPresent(m -> filteredMetrics.put(m, FlinkMetric.PENDING_RECORDS));
-                FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC
-                        .findAny(allMetricNames)
-                        .ifPresent(
-                                m ->
-                                        filteredMetrics.put(
-                                                m,
-                                                FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC));
-            }
+            // Pending records metric won't be available for some sources.
+            // The Kafka source, for instance, lazily initializes this metric on receiving
+            // the first record. If this is a fresh topic or no new data has been read since
+            // the last checkpoint, the pendingRecords metrics won't be available. Also, legacy
+            // sources do not have this metric.
+            Optional<String> pendingRecordsMetric =
+                    FlinkMetric.PENDING_RECORDS.findAny(allMetricNames);
+            pendingRecordsMetric.ifPresentOrElse(
+                    m -> filteredMetrics.put(m, FlinkMetric.PENDING_RECORDS),
+                    () ->
+                            LOG.warn(
+                                    "pendingRecords metric for {} could not be found. Either a legacy source or an idle source. Assuming no pending records.",
+                                    jobVertexID));
+            FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC
+                    .findAny(allMetricNames)
+                    .ifPresent(
+                            m ->
+                                    filteredMetrics.put(
+                                            m, FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC));
         } else {
             // Not a source so we must have numRecordsInPerSecond
             requiredMetrics.add(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
@@ -398,14 +399,6 @@ public abstract class ScalingMetricCollector {
             if (flinkMetricName.isPresent()) {
                 // Add actual Flink metric name to list
                 filteredMetrics.put(flinkMetricName.get(), flinkMetric);
-            } else if (flinkMetric == FlinkMetric.PENDING_RECORDS) {
-                // Pending records metric won't be available for some sources.
-                // The Kafka source, for instance, lazily initializes this metric on receiving
-                // the first record. If this is a fresh topic or no new data has been read since
-                // the last checkpoint, the pendingRecords metrics won't be available.
-                LOG.warn(
-                        "pendingRecords metric for {} could not be found. This usually means the source hasn't read data. Assuming 0 pending records.",
-                        jobVertexID);
             } else {
                 throw new RuntimeException(
                         "Could not find required metric "

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricEvaluator.java
@@ -205,11 +205,7 @@ public class ScalingMetricEvaluator {
         if (topology.isSource(vertex)) {
             double catchUpTargetSec = conf.get(AutoScalerOptions.CATCH_UP_DURATION).toSeconds();
 
-            var sourceRateMetric =
-                    latestVertexMetrics.containsKey(TARGET_DATA_RATE)
-                            ? TARGET_DATA_RATE
-                            : SOURCE_DATA_RATE;
-            if (!latestVertexMetrics.containsKey(sourceRateMetric)) {
+            if (!latestVertexMetrics.containsKey(SOURCE_DATA_RATE)) {
                 throw new RuntimeException(
                         "Cannot evaluate metrics without source target rate information");
             }
@@ -217,8 +213,8 @@ public class ScalingMetricEvaluator {
             out.put(
                     TARGET_DATA_RATE,
                     new EvaluatedScalingMetric(
-                            latestVertexMetrics.get(sourceRateMetric),
-                            getAverage(sourceRateMetric, vertex, metricsHistory)));
+                            latestVertexMetrics.get(SOURCE_DATA_RATE),
+                            getAverage(SOURCE_DATA_RATE, vertex, metricsHistory)));
 
             double lag = latestVertexMetrics.getOrDefault(LAG, 0.);
             double catchUpInputRate = catchUpTargetSec == 0 ? 0 : lag / catchUpTargetSec;

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -157,7 +157,7 @@ public class AutoScalerOptions {
             autoScalerConfig("vertex.exclude.ids")
                     .stringType()
                     .asList()
-                    .defaultValues(new String[0])
+                    .defaultValues()
                     .withDescription(
                             "A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling. Caution: For non-sink vertices this will still scale their downstream operators until https://issues.apache.org/jira/browse/FLINK-31215 is implemented.");
 }

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -59,15 +59,6 @@ public class AutoScalerOptions {
                     .withDescription(
                             "Stabilization period in which no new scaling will be executed");
 
-    public static final ConfigOption<Boolean> SOURCE_SCALING_ENABLED =
-            autoScalerConfig("scaling.sources.enabled")
-                    .booleanType()
-                    .defaultValue(true)
-                    .withDescription(
-                            "Whether to enable scaling source vertices. "
-                                    + "Source vertices set the baseline ingestion rate for the processing based on the backlog size. "
-                                    + "If disabled, only regular job vertices will be scaled and source vertices will be unchanged.");
-
     public static final ConfigOption<Double> TARGET_UTILIZATION =
             autoScalerConfig("target.utilization")
                     .doubleType()

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/MetricAggregator.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/MetricAggregator.java
@@ -19,7 +19,6 @@ package org.apache.flink.kubernetes.operator.autoscaler.metrics;
 
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
 
-import java.util.Optional;
 import java.util.function.Function;
 
 /** Enum specifying which aggregator to use when getting a metric value. */
@@ -34,7 +33,11 @@ public enum MetricAggregator {
         this.getter = getter;
     }
 
-    public Optional<Double> get(AggregatedMetric metric) {
-        return Optional.ofNullable(metric).map(getter).filter(d -> !d.isNaN());
+    public double get(AggregatedMetric metric) {
+        if (metric != null) {
+            return getter.apply(metric);
+        } else {
+            return Double.NaN;
+        }
     }
 }

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
@@ -26,7 +26,10 @@ import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /** Utilities for computing scaling metrics based on Flink metrics. */
 public class ScalingMetrics {
@@ -128,6 +131,7 @@ public class ScalingMetrics {
             LOG.error(
                     "No busyTimeMsPerSecond metric available for {}. No scaling will be performed for this vertex.",
                     jobVertexId);
+            excludeVertexFromScaling(conf, jobVertexId);
             // Pretend that the load is balanced because we don't know any better
             return conf.get(AutoScalerOptions.TARGET_UTILIZATION) * 1000;
         }
@@ -182,5 +186,11 @@ public class ScalingMetrics {
             return EFFECTIVELY_ZERO;
         }
         return value;
+    }
+
+    private static void excludeVertexFromScaling(Configuration conf, JobVertexID jobVertexId) {
+        Set<String> excludedIds = new HashSet<>(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS));
+        excludedIds.add(jobVertexId.toHexString());
+        conf.set(AutoScalerOptions.VERTEX_EXCLUDE_IDS, new ArrayList<>(excludedIds));
     }
 }

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -409,7 +409,7 @@ public class MetricsCollectionAndEvaluationTest {
                                 new AggregatedMetric("", Double.NaN, 0.1, Double.NaN, Double.NaN),
                                 FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
                                 new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 0.),
-                                FlinkMetric.NUM_RECORDS_IN_PER_SEC,
+                                FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC,
                                 new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 0.))));
 
         var collectedMetrics = collectMetrics();

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,7 +60,7 @@ public class ScalingMetricsTest {
                         new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 2000.)),
                 scalingMetrics,
                 topology,
-                Optional.of(15.),
+                15.,
                 new Configuration());
 
         assertEquals(
@@ -91,7 +90,7 @@ public class ScalingMetricsTest {
                         new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 2000.)),
                 scalingMetrics,
                 topology,
-                Optional.of(-50.),
+                -50.,
                 new Configuration());
 
         assertEquals(
@@ -120,7 +119,7 @@ public class ScalingMetricsTest {
                         new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 2000.)),
                 scalingMetrics,
                 topology,
-                Optional.empty(),
+                0.,
                 new Configuration());
 
         assertEquals(
@@ -150,7 +149,7 @@ public class ScalingMetricsTest {
                         new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 2000.)),
                 scalingMetrics,
                 topology,
-                Optional.empty(),
+                0.,
                 conf);
 
         assertEquals(
@@ -167,35 +166,41 @@ public class ScalingMetricsTest {
     }
 
     @Test
-    public void testSourceScalingDisabled() {
+    public void testLegacySourceScaling() {
         var source = new JobVertexID();
+        var sink = new JobVertexID();
 
-        var topology = new JobTopology(new VertexInfo(source, Collections.emptySet(), 1, 1));
+        var topology =
+                new JobTopology(
+                        new VertexInfo(source, Collections.emptySet(), 5, 1),
+                        new VertexInfo(sink, Collections.singleton(source), 10, 100));
 
         Configuration conf = new Configuration();
-        // Disable scaling sources
-        conf.setBoolean(AutoScalerOptions.SOURCE_SCALING_ENABLED, false);
 
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
         ScalingMetrics.computeDataRateMetrics(
                 source,
                 Map.of(
+                        // Busy time is NaN for legacy sources
                         FlinkMetric.BUSY_TIME_PER_SEC,
-                        new AggregatedMetric("", Double.NaN, 500., Double.NaN, Double.NaN),
+                        new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, Double.NaN),
                         FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC,
                         new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 2000.),
                         FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
                         new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 4000.)),
                 scalingMetrics,
                 topology,
-                Optional.empty(),
+                0.,
                 conf);
 
-        // Sources are not scaled, the rates are solely computed on the basis of the true output
-        // rate
-        assertEquals(Double.NaN, scalingMetrics.get(ScalingMetric.TRUE_PROCESSING_RATE));
-        assertEquals(8000, scalingMetrics.get(ScalingMetric.TARGET_DATA_RATE));
-        assertEquals(8000, scalingMetrics.get(ScalingMetric.TRUE_OUTPUT_RATE));
+        // Legacy source rates are computed based on the current rate and a balanced utilization
+        assertEquals(
+                2000 / conf.get(AutoScalerOptions.TARGET_UTILIZATION),
+                scalingMetrics.get(ScalingMetric.TRUE_PROCESSING_RATE));
+        assertEquals(2000, scalingMetrics.get(ScalingMetric.SOURCE_DATA_RATE));
+        assertEquals(
+                scalingMetrics.get(ScalingMetric.TRUE_PROCESSING_RATE) * 2,
+                scalingMetrics.get(ScalingMetric.TRUE_OUTPUT_RATE));
         assertEquals(2, scalingMetrics.get(ScalingMetric.OUTPUT_RATIO));
     }
 
@@ -287,13 +292,13 @@ public class ScalingMetricsTest {
                 Map.of(
                         FlinkMetric.BUSY_TIME_PER_SEC,
                         new AggregatedMetric("", Double.NaN, busyness, Double.NaN, Double.NaN),
-                        FlinkMetric.NUM_RECORDS_IN_PER_SEC,
+                        FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC,
                         new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, rate),
                         FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
                         new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, rate)),
                 scalingMetrics,
                 topology,
-                Optional.of(0.),
+                0.,
                 new Configuration());
 
         return scalingMetrics;

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for scaling metrics computation logic. */
 public class ScalingMetricsTest {
@@ -193,6 +194,8 @@ public class ScalingMetricsTest {
                 0.,
                 conf);
 
+        // Make sure vertex won't be scaled
+        assertTrue(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS).contains(source.toHexString()));
         // Legacy source rates are computed based on the current rate and a balanced utilization
         assertEquals(
                 2000 / conf.get(AutoScalerOptions.TARGET_UTILIZATION),


### PR DESCRIPTION
Previous changes removed the requirement for sources to have the `pendingRecords` metric. This allows to refactor and consolidate the source scaling code. We remove the option to disable scaling sources because the primary motivation was to skip scaling legacy sources which we can achieve without an extra configuration option. 

The refactored source scaling logic works like this:

* Modern sources (busy time available)

Scale source based on the busy time up. Add extra capacity if the lag
information, provided by the pending records metric, is available. Otherwise
assume 0 lag. Cap by the maximum number of partitions, if available.

* Legacy sources (busy time unavailable)

Leave the source parallelism unchanged, use the current processing rate as the
target rate downstream.