### PR TITLE
[FLINK-31345] Reduce AutoScalerInfo size by rounding metrics and compression

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
@@ -99,6 +99,7 @@ public class JobAutoScalerImpl implements JobAutoScaler {
                             resource, autoScalerInfo, ctx.getFlinkService(), conf);
 
             if (collectedMetrics.getMetricHistory().isEmpty()) {
+                autoScalerInfo.replaceInKubernetes(kubernetesClient);
                 return false;
             }
 

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
@@ -263,6 +263,10 @@ public abstract class ScalingMetricCollector {
                             lagGrowthRate,
                             conf);
 
+                    vertexScalingMetrics
+                            .entrySet()
+                            .forEach(e -> e.setValue(ScalingMetrics.roundMetric(e.getValue())));
+
                     LOG.debug(
                             "Vertex scaling metrics for {}: {}", jobVertexID, vertexScalingMetrics);
                 });

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricEvaluator.java
@@ -70,7 +70,7 @@ public class ScalingMetricEvaluator {
         for (var vertex : topology.getVerticesInTopologicalOrder()) {
             scalingOutput.put(
                     vertex,
-                    computeVertexScalingSummary(
+                    evaluateMetrics(
                             conf,
                             scalingOutput,
                             metricsHistory,
@@ -110,7 +110,7 @@ public class ScalingMetricEvaluator {
     }
 
     @NotNull
-    private Map<ScalingMetric, EvaluatedScalingMetric> computeVertexScalingSummary(
+    private Map<ScalingMetric, EvaluatedScalingMetric> evaluateMetrics(
             Configuration conf,
             HashMap<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> scalingOutput,
             SortedMap<Instant, Map<JobVertexID, Map<ScalingMetric, Double>>> metricsHistory,

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/EvaluatedScalingMetric.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/EvaluatedScalingMetric.java
@@ -17,18 +17,21 @@
 
 package org.apache.flink.kubernetes.operator.autoscaler.metrics;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /** Evaluated scaling metric. */
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 public class EvaluatedScalingMetric {
     private double current;
 
     private double average;
+
+    public EvaluatedScalingMetric(double current, double average) {
+        this.current = ScalingMetrics.roundMetric(current);
+        this.average = ScalingMetrics.roundMetric(average);
+    }
 
     public static EvaluatedScalingMetric of(double value) {
         return new EvaluatedScalingMetric(value, Double.NaN);

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.operator.autoscaler.topology.JobTopology;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
 
+import org.apache.commons.math3.util.Precision;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -193,5 +194,11 @@ public class ScalingMetrics {
             return EFFECTIVELY_ZERO;
         }
         return number;
+    }
+
+    public static double roundMetric(double value) {
+        double rounded = Precision.round(value, 3);
+        // Never round down to 0, return original value instead
+        return rounded == 0 ? value : rounded;
     }
 }

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
@@ -324,6 +324,30 @@ public class BacklogBasedScalingTest extends OperatorTestBase {
         assertEquals(2, scaledParallelism.get(sink));
     }
 
+    @Test
+    public void testMetricsPersistedAfterRedeploy() {
+        var ctx = createAutoscalerTestContext();
+        var now = Instant.ofEpochMilli(0);
+        setClocksTo(now);
+        app.getStatus().getJobStatus().setUpdateTime(String.valueOf(now.toEpochMilli()));
+        metricsCollector.setCurrentMetrics(
+                Map.of(
+                        source1,
+                        Map.of(
+                                FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
+                                new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 500.),
+                                FlinkMetric.NUM_RECORDS_IN_PER_SEC,
+                                new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 500.)),
+                        sink,
+                        Map.of(
+                                FlinkMetric.NUM_RECORDS_IN_PER_SEC,
+                                new AggregatedMetric(
+                                        "", Double.NaN, Double.NaN, Double.NaN, 500.))));
+
+        autoscaler.scale(getResourceContext(app, ctx));
+        assertFalse(AutoScalerInfo.forResource(app, kubernetesClient).getMetricHistory().isEmpty());
+    }
+
     private void redeployJob(Instant now) {
         // Offset the update time by one metrics window to simulate collecting one entire window
         app.getStatus()

--- a/flink-kubernetes-operator-autoscaler/src/test/resources/log4j2-test.properties
+++ b/flink-kubernetes-operator-autoscaler/src/test/resources/log4j2-test.properties
@@ -1,0 +1,26 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+rootLogger.level = DEBUG
+rootLogger.appenderRef.console.ref = ConsoleAppender
+
+# Log all infos to the console
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %style{%d}{yellow} %style{%-30c{1.}}{cyan} %highlight{[%-5level]%notEmpty{[%X{resource.namespace}/}%notEmpty{%X{resource.name}]} %msg%n%throwable}


### PR DESCRIPTION
## What is the purpose of the change

Compresses (GZip) the autoscaler info (metrics and scaling history) before storing in the configmap to greately reduce the size and allow keeping longer histories without reaching the 1MB limit.

We also introduce a 3 decimal place rounding for metrics to further reduce size and make the reported metrics nicer.

## Verifying this change

Change is covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
