### PR TITLE
[FLINK-31502] Limit the number of scale operations to reduce cluster churn

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -87,6 +87,12 @@
             <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.rescaling.cluster-cooldown</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>Cooldown period after rescaling jobs where no further scaling will be performed to minimize cluster churn.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.savepoint.format.type</h5></td>
             <td style="word-wrap: break-word;">CANONICAL</td>
             <td><p>Enum</p></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -225,6 +225,12 @@
             <td>The maximum number of threads running the reconciliation loop. Use -1 for infinite.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.rescaling.cluster-cooldown</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>Cooldown period after rescaling jobs where no further scaling will be performed to minimize cluster churn.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.resource.cleanup.timeout</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
@@ -110,7 +110,15 @@ public class JobAutoScalerImpl implements JobAutoScaler {
             registerResourceScalingMetrics(resource, ctx.getResourceMetricGroup());
 
             var specAdjusted =
-                    scalingExecutor.scaleResource(resource, autoScalerInfo, conf, evaluatedMetrics);
+                    ctx.getClusterScalingContext()
+                            .maybeExecuteScalingLogic(
+                                    () ->
+                                            scalingExecutor.scaleResource(
+                                                    resource,
+                                                    autoScalerInfo,
+                                                    conf,
+                                                    evaluatedMetrics));
+
             autoScalerInfo.replaceInKubernetes(kubernetesClient);
             return specAdjusted;
         } catch (Exception e) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -25,6 +25,7 @@ import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.kubernetes.operator.api.listener.FlinkResourceListener;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.controller.ClusterScalingContext;
 import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentController;
 import org.apache.flink.kubernetes.operator.controller.FlinkSessionJobController;
 import org.apache.flink.kubernetes.operator.health.HealthProbe;
@@ -90,7 +91,10 @@ public class FlinkOperator {
                 KubernetesClientUtils.getKubernetesClient(
                         configManager.getOperatorConfiguration(), this.metricGroup);
         this.operator = createOperator();
-        this.ctxFactory = new FlinkResourceContextFactory(client, configManager, metricGroup);
+        var toBeNamedContext = new ClusterScalingContext(configManager.getOperatorConfiguration());
+        this.ctxFactory =
+                new FlinkResourceContextFactory(
+                        client, configManager, metricGroup, toBeNamedContext);
         this.validators = ValidatorUtils.discoverValidators(configManager);
         this.listeners = ListenerUtils.discoverListeners(configManager);
         PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(defaultConfig);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -67,6 +67,7 @@ public class FlinkOperatorConfiguration {
     int exceptionThrowableCountThreshold;
     String labelSelector;
     LeaderElectionConfiguration leaderElectionConfiguration;
+    Duration rescalingClusterCoolDown;
 
     public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
         Duration reconcileInterval =
@@ -172,6 +173,10 @@ public class FlinkOperatorConfiguration {
         String labelSelector =
                 operatorConfig.getString(KubernetesOperatorConfigOptions.OPERATOR_LABEL_SELECTOR);
 
+        Duration rescalingClusterCoolDown =
+                operatorConfig.get(
+                        KubernetesOperatorConfigOptions.OPERATOR_RESCALING_CLUSTER_COOLDOWN);
+
         return new FlinkOperatorConfiguration(
                 reconcileInterval,
                 reconcilerMaxParallelism,
@@ -196,7 +201,8 @@ public class FlinkOperatorConfiguration {
                 exceptionFieldLengthThreshold,
                 exceptionThrowableCountThreshold,
                 labelSelector,
-                getLeaderElectionConfig(operatorConfig));
+                getLeaderElectionConfig(operatorConfig),
+                rescalingClusterCoolDown);
     }
 
     private static LeaderElectionConfiguration getLeaderElectionConfig(Configuration conf) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -458,4 +458,12 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(Duration.ofDays(1))
                     .withDescription(
                             "Time after which jobmanager pods of terminal application deployments are shut down.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Duration> OPERATOR_RESCALING_CLUSTER_COOLDOWN =
+            operatorConfig("rescaling.cluster-cooldown")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(1))
+                    .withDescription(
+                            "Cooldown period after rescaling jobs where no further scaling will be performed to minimize cluster churn.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/ClusterScalingContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/ClusterScalingContext.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.controller;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.Supplier;
+
+/** A context to hold state across deployments. */
+public class ClusterScalingContext {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClusterScalingContext.class);
+
+    private final Duration clusterCoolDown;
+
+    private Clock clock;
+    private Instant nextPossibleRescaling;
+
+    public ClusterScalingContext(FlinkOperatorConfiguration operatorConfig) {
+        this(operatorConfig.getRescalingClusterCoolDown(), Clock.systemDefaultZone());
+    }
+
+    @VisibleForTesting
+    public ClusterScalingContext(Duration clusterCoolDown, Clock clock) {
+        this.clusterCoolDown = clusterCoolDown;
+        updateClock(clock);
+        updateNextPossibleRescaling();
+    }
+
+    public boolean maybeExecuteScalingLogic(Supplier<Boolean> scalingLogic) {
+        if (clock.instant().isBefore(nextPossibleRescaling)) {
+            LOG.info(
+                    "Deferring scaling evaluation until {} to allow cluster to cool down.",
+                    nextPossibleRescaling);
+            return false;
+        }
+
+        LOG.info("Evaluating scaling decision");
+        boolean scaled = scalingLogic.get();
+        if (scaled) {
+            updateNextPossibleRescaling();
+        }
+        return scaled;
+    }
+
+    private void updateNextPossibleRescaling() {
+        nextPossibleRescaling = clock.instant().plus(clusterCoolDown);
+    }
+
+    @VisibleForTesting
+    public Duration getClusterCoolDownDuration() {
+        return clusterCoolDown;
+    }
+
+    @VisibleForTesting
+    public void updateClock(Clock clock) {
+        this.clock = clock;
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentContext.java
@@ -39,8 +39,9 @@ public class FlinkDeploymentContext extends FlinkResourceContext<FlinkDeployment
             Context<?> josdkContext,
             KubernetesResourceMetricGroup resourceMetricGroup,
             FlinkService flinkService,
-            FlinkConfigManager configManager) {
-        super(resource, josdkContext, resourceMetricGroup);
+            FlinkConfigManager configManager,
+            ClusterScalingContext clusterScalingContext) {
+        super(resource, josdkContext, resourceMetricGroup, clusterScalingContext);
         this.configManager = configManager;
         this.flinkService = flinkService;
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -70,6 +70,8 @@ public class FlinkDeploymentController
     private final StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder;
     private final EventRecorder eventRecorder;
 
+    private final ClusterScalingContext clusterScalingContext;
+
     public FlinkDeploymentController(
             FlinkConfigManager configManager,
             Set<FlinkResourceValidator> validators,
@@ -85,6 +87,8 @@ public class FlinkDeploymentController
         this.observerFactory = observerFactory;
         this.statusRecorder = statusRecorder;
         this.eventRecorder = eventRecorder;
+        this.clusterScalingContext =
+                new ClusterScalingContext(configManager.getOperatorConfiguration());
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
@@ -34,6 +34,7 @@ public abstract class FlinkResourceContext<CR extends AbstractFlinkResource<?, ?
     @Getter private final CR resource;
     @Getter private final Context<?> josdkContext;
     @Getter private final KubernetesResourceMetricGroup resourceMetricGroup;
+    @Getter private final ClusterScalingContext clusterScalingContext;
 
     private Configuration observeConfig;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobContext.java
@@ -43,8 +43,9 @@ public class FlinkSessionJobContext extends FlinkResourceContext<FlinkSessionJob
             Context<?> josdkContext,
             KubernetesResourceMetricGroup resourceMetricGroup,
             FlinkResourceContextFactory flinkResourceContextFactory,
-            FlinkConfigManager configManager) {
-        super(resource, josdkContext, resourceMetricGroup);
+            FlinkConfigManager configManager,
+            ClusterScalingContext clusterScalingContext) {
+        super(resource, josdkContext, resourceMetricGroup, clusterScalingContext);
         this.flinkResourceContextFactory = flinkResourceContextFactory;
         this.configManager = configManager;
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/OperatorTestBase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/OperatorTestBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.controller.ClusterScalingContext;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
 import org.apache.flink.kubernetes.operator.utils.EventCollector;
@@ -30,10 +31,19 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.junit.jupiter.api.BeforeEach;
 
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
 /** @link JobStatusObserver unit tests */
 public abstract class OperatorTestBase {
 
     protected FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
+    protected ClusterScalingContext clusterScalingContext =
+            new ClusterScalingContext(
+                    Duration.ZERO, Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault()));
+
     protected TestingFlinkService flinkService;
     protected EventCollector eventCollector = new EventCollector();
     protected EventRecorder eventRecorder;
@@ -66,7 +76,11 @@ public abstract class OperatorTestBase {
             CR cr, Context josdkContext) {
         var ctxFactory =
                 new TestingFlinkResourceContextFactory(
-                        getKubernetesClient(), configManager, operatorMetricGroup, flinkService);
+                        getKubernetesClient(),
+                        configManager,
+                        operatorMetricGroup,
+                        flinkService,
+                        clusterScalingContext);
         return ctxFactory.getResourceContext(cr, josdkContext);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkResourceContextFactory.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.controller.ClusterScalingContext;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
 import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
@@ -33,8 +34,9 @@ public class TestingFlinkResourceContextFactory extends FlinkResourceContextFact
             KubernetesClient kubernetesClient,
             FlinkConfigManager configManager,
             KubernetesOperatorMetricGroup operatorMetricGroup,
-            FlinkService flinkService) {
-        super(kubernetesClient, configManager, operatorMetricGroup);
+            FlinkService flinkService,
+            ClusterScalingContext clusterScalingContext) {
+        super(kubernetesClient, configManager, operatorMetricGroup, clusterScalingContext);
         this.flinkService = flinkService;
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/ClusterScalingContextTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/ClusterScalingContextTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.controller;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Tests for ClusterScalingContext. */
+public class ClusterScalingContextTest {
+
+    private final Clock clock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault());
+
+    @Test
+    void testAlwaysAllowScalingWithZeroTimeout() {
+        var toBeNamedContext = new ClusterScalingContext(Duration.ZERO, clock);
+        var flag = new AtomicBoolean();
+
+        Assertions.assertFalse(
+                toBeNamedContext.maybeExecuteScalingLogic(() -> flag.getAndSet(true)));
+        Assertions.assertTrue(flag.get());
+        Assertions.assertTrue(toBeNamedContext.maybeExecuteScalingLogic(flag::get));
+    }
+
+    @Test
+    void testDeferScaling() {
+        var toBeNamedContext = new ClusterScalingContext(Duration.ofSeconds(1), clock);
+        var flag = new AtomicBoolean();
+
+        Assertions.assertFalse(
+                toBeNamedContext.maybeExecuteScalingLogic(
+                        () -> {
+                            flag.set(true);
+                            return true;
+                        }));
+        Assertions.assertFalse(flag.get());
+    }
+
+    @Test
+    void testAllowScalingWhenCoolDownFinishes() {
+        var toBeNamedContext = new ClusterScalingContext(Duration.ofMillis(1), clock);
+        Assertions.assertFalse(toBeNamedContext.maybeExecuteScalingLogic(() -> true));
+
+        toBeNamedContext.updateClock(Clock.fixed(Instant.ofEpochMilli(1), ZoneId.systemDefault()));
+
+        var flag = new AtomicBoolean();
+        Assertions.assertTrue(
+                toBeNamedContext.maybeExecuteScalingLogic(
+                        () -> {
+                            flag.set(true);
+                            return true;
+                        }));
+        Assertions.assertTrue(flag.get());
+
+        Assertions.assertFalse(toBeNamedContext.maybeExecuteScalingLogic(() -> true));
+    }
+
+    @Test
+    void testUsesCorrectConfigEntry() {
+        Configuration config = new Configuration();
+        config.set(
+                KubernetesOperatorConfigOptions.OPERATOR_RESCALING_CLUSTER_COOLDOWN,
+                Duration.ofSeconds(42));
+        var operatorConfig = FlinkOperatorConfiguration.fromConfiguration(config);
+
+        var toBeNamedContext = new ClusterScalingContext(operatorConfig);
+
+        Assertions.assertEquals(
+                Duration.ofSeconds(42), toBeNamedContext.getClusterCoolDownDuration());
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -76,7 +76,8 @@ public class TestingFlinkDeploymentController
                         kubernetesClient,
                         configManager,
                         TestUtils.createTestMetricGroup(new Configuration()),
-                        flinkService);
+                        flinkService,
+                        new ClusterScalingContext(configManager.getOperatorConfiguration()));
 
         eventRecorder = new EventRecorder(kubernetesClient, eventCollector);
         statusRecorder =

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
@@ -72,7 +72,8 @@ public class TestingFlinkSessionJobController
                         kubernetesClient,
                         configManager,
                         TestUtils.createTestMetricGroup(new Configuration()),
-                        flinkService);
+                        flinkService,
+                        new ClusterScalingContext(configManager.getOperatorConfiguration()));
 
         eventRecorder = new EventRecorder(kubernetesClient, eventCollector);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SavepointObserverTest.java
@@ -159,7 +159,8 @@ public class SavepointObserverTest extends OperatorTestBase {
         assertEquals(SavepointStatus.PENDING, SavepointUtils.getLastSavepointStatus(deployment));
         assertTrue(triggerTs > 0);
 
-        new FlinkDeploymentContext(deployment, null, null, flinkService, configManager);
+        new FlinkDeploymentContext(
+                deployment, null, null, flinkService, configManager, clusterScalingContext);
         // Pending
         observer.observeSavepointStatus(getResourceContext(deployment));
         // Completed


### PR DESCRIPTION
Until we move to using the upcoming Rescale API which recycles pods, we need to be mindful with how many deployments we scale at the same time because each of them is going to give up all its pods and require the new number of required pods.

This can cause churn in the cluster and temporary lead to "unallocatable" pods which triggers the k8s cluster autoscaler to add more cluster nodes. That is often not desirable because the actual required resources after the scalings have been settled, are lower.
