### PR TITLE
[FLINK-31219] Add support for canary resources

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -117,6 +117,12 @@
             <td>The timeout for the observer to wait the flink rest client to return.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.health.canary.resource.timeout</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>Allowed max time between spec update and reconciliation for canary resources.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.health.probe.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/system_advanced_section.html
+++ b/docs/layouts/shortcodes/generated/system_advanced_section.html
@@ -33,6 +33,12 @@
             <td>Whether to enable on-the-fly config changes through the operator configmap.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.health.canary.resource.timeout</h5></td>
+            <td style="word-wrap: break-word;">1 min</td>
+            <td>Duration</td>
+            <td>Allowed max time between spec update and reconciliation for canary resources.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.health.probe.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/examples/canary.yaml
+++ b/examples/canary.yaml
@@ -1,0 +1,24 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: canary
+  labels:
+    "flink.apache.org/canary": "true"

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/FlinkDeployment.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/FlinkDeployment.java
@@ -45,4 +45,9 @@ public class FlinkDeployment
     public FlinkDeploymentStatus initStatus() {
         return new FlinkDeploymentStatus();
     }
+
+    @Override
+    public FlinkDeploymentSpec initSpec() {
+        return new FlinkDeploymentSpec();
+    }
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/FlinkSessionJob.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/FlinkSessionJob.java
@@ -43,4 +43,9 @@ public class FlinkSessionJob
     protected FlinkSessionJobStatus initStatus() {
         return new FlinkSessionJobStatus();
     }
+
+    @Override
+    public FlinkSessionJobSpec initSpec() {
+        return new FlinkSessionJobSpec();
+    }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -458,4 +458,12 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(Duration.ofDays(1))
                     .withDescription(
                             "Time after which jobmanager pods of terminal application deployments are shut down.");
+
+    @Documentation.Section(SECTION_ADVANCED)
+    public static final ConfigOption<Duration> CANARY_RESOURCE_TIMEOUT =
+            operatorConfig("health.canary.resource.timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(1))
+                    .withDescription(
+                            "Allowed max time between spec update and reconciliation for canary resources.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/CanaryResourceManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/CanaryResourceManager.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.health;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/** Logic encapsulating canary tests. */
+@RequiredArgsConstructor
+public class CanaryResourceManager<CR extends AbstractFlinkResource<?, ?>> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CanaryResourceManager.class);
+
+    public static final String CANARY_LABEL = "flink.apache.org/canary";
+
+    private final ConcurrentHashMap<ResourceID, CanaryResourceState> canaryResources =
+            new ConcurrentHashMap<>();
+
+    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(3);
+
+    private final FlinkConfigManager configManager;
+    private final KubernetesClient kubernetesClient;
+
+    public boolean allCanariesHealthy() {
+        return canaryResources.values().stream().allMatch(cr -> cr.isHealthy);
+    }
+
+    public boolean handleCanaryResourceReconciliation(CR resource) {
+        if (!isCanaryResource(resource)) {
+            return false;
+        }
+
+        var resourceId = ResourceID.fromResource(resource);
+
+        LOG.info("Reconciling canary resource");
+
+        canaryResources.compute(
+                resourceId,
+                (id, previousState) -> {
+                    boolean firstReconcile = false;
+                    if (previousState == null) {
+                        firstReconcile = true;
+                        previousState = new CanaryResourceState();
+                    }
+                    previousState.onReconcile(resource);
+                    if (firstReconcile) {
+                        updateSpecAndScheduleHealthCheck(resourceId, previousState);
+                    }
+                    return previousState;
+                });
+
+        return true;
+    }
+
+    public boolean handleCanaryResourceDeletion(CR resource) {
+        if (!isCanaryResource(resource)) {
+            return false;
+        }
+
+        var resourceId = ResourceID.fromResource(resource);
+        LOG.info("Deleting canary resource");
+        canaryResources.remove(resourceId);
+        return true;
+    }
+
+    private void updateSpecAndScheduleHealthCheck(ResourceID resourceID, CanaryResourceState crs) {
+        var canaryTimeout =
+                configManager
+                        .getDefaultConfig()
+                        .get(KubernetesOperatorConfigOptions.CANARY_RESOURCE_TIMEOUT);
+
+        Long restartNonce = crs.resource.getSpec().getRestartNonce();
+        crs.resource.getSpec().setRestartNonce(restartNonce == null ? 1L : restartNonce + 1);
+        crs.previousGeneration = crs.resource.getMetadata().getGeneration();
+
+        LOG.info("Scheduling canary check for {} in {}s", resourceID, canaryTimeout.toSeconds());
+
+        try {
+            kubernetesClient.resource(ReconciliationUtils.clone(crs.resource)).replace();
+        } catch (Throwable t) {
+            LOG.warn("Could not bump canary deployment, it may have been deleted", t);
+        }
+
+        executorService.schedule(
+                () -> checkHealth(resourceID), canaryTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @VisibleForTesting
+    protected void checkHealth(ResourceID resourceID) {
+        CanaryResourceState crs = canaryResources.get(resourceID);
+        if (crs == null) {
+            LOG.info("Canary resource {} not found. Stopping health checks", resourceID);
+            return;
+        }
+
+        // We did not reconcile since the last spec update within deadline
+        if (crs.canaryReconciledSinceUpdate()) {
+            LOG.info("Canary deployment healthy");
+            crs.isHealthy = true;
+        } else {
+            LOG.error(
+                    "Canary deployment {} latest spec not reconciled. Expected generation larger than {}, received {}",
+                    resourceID,
+                    crs.previousGeneration,
+                    crs.resource.getMetadata().getGeneration());
+            crs.isHealthy = false;
+        }
+
+        // Update spec and reschedule health check
+        updateSpecAndScheduleHealthCheck(resourceID, crs);
+    }
+
+    @VisibleForTesting
+    public int getNumberOfActiveCanaries() {
+        return canaryResources.size();
+    }
+
+    public static boolean isCanaryResource(HasMetadata resource) {
+        var labels = resource.getMetadata().getLabels();
+        if (labels == null) {
+            return false;
+        }
+        return "true".equalsIgnoreCase(labels.getOrDefault(CANARY_LABEL, "false"));
+    }
+
+    private class CanaryResourceState {
+        CR resource;
+
+        long previousGeneration;
+
+        boolean isHealthy = true;
+
+        void onReconcile(CR cr) {
+            resource = cr;
+        }
+
+        boolean canaryReconciledSinceUpdate() {
+            return resource.getMetadata().getGeneration() > previousGeneration;
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -19,10 +19,13 @@ package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils;
+import org.apache.flink.kubernetes.operator.health.CanaryResourceManager;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
@@ -289,6 +292,30 @@ public class TestUtils extends BaseTestUtils {
 
     public static Stream<Arguments> flinkVersions() {
         return Stream.of(arguments(FlinkVersion.v1_14), arguments(FlinkVersion.v1_15));
+    }
+
+    public static FlinkDeployment createCanaryDeployment() {
+        var cr = new FlinkDeployment();
+        cr.setSpec(cr.initSpec());
+        var meta = new ObjectMeta();
+        meta.setGeneration(0L);
+        meta.setLabels(Map.of(CanaryResourceManager.CANARY_LABEL, "true"));
+        meta.setName("canary");
+        meta.setNamespace("default");
+        cr.setMetadata(meta);
+        return cr;
+    }
+
+    public static FlinkSessionJob createCanaryJob() {
+        var cr = new FlinkSessionJob();
+        cr.setSpec(cr.initSpec());
+        var meta = new ObjectMeta();
+        meta.setGeneration(0L);
+        meta.setLabels(Map.of(CanaryResourceManager.CANARY_LABEL, "true"));
+        meta.setName("canary");
+        meta.setNamespace("default");
+        cr.setMetadata(meta);
+        return cr;
     }
 
     /** Testing ResponseProvider. */

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -1105,6 +1105,18 @@ public class FlinkDeploymentControllerTest {
                 appCluster.getStatus().getJobStatus().getState());
     }
 
+    @Test
+    public void verifyCanaryHandling() throws Exception {
+        var canary = TestUtils.createCanaryDeployment();
+        kubernetesClient.resource(canary).create();
+        assertTrue(testController.reconcile(canary, context).isNoUpdate());
+        assertEquals(0, testController.getInternalStatusUpdateCount());
+        assertEquals(1, testController.getCanaryResourceManager().getNumberOfActiveCanaries());
+        testController.cleanup(canary, context);
+        assertEquals(0, testController.getInternalStatusUpdateCount());
+        assertEquals(0, testController.getCanaryResourceManager().getNumberOfActiveCanaries());
+    }
+
     private HasMetadata getIngress(FlinkDeployment deployment) {
         if (IngressUtils.ingressInNetworkingV1(kubernetesClient)) {
             return kubernetesClient

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
@@ -499,4 +499,16 @@ class FlinkSessionJobControllerTest {
         testController.reconcile(sessionJob, context);
         assertEquals("msp", flinkService.listJobs().get(0).f0);
     }
+
+    @Test
+    public void verifyCanaryHandling() throws Exception {
+        var canary = TestUtils.createCanaryJob();
+        kubernetesClient.resource(canary).create();
+        assertTrue(testController.reconcile(canary, context).isNoUpdate());
+        assertEquals(0, testController.getInternalStatusUpdateCount());
+        assertEquals(1, testController.getCanaryResourceManager().getNumberOfActiveCanaries());
+        testController.cleanup(canary, context);
+        assertEquals(0, testController.getInternalStatusUpdateCount());
+        assertEquals(0, testController.getCanaryResourceManager().getNumberOfActiveCanaries());
+    }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/HealthProbeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/HealthProbeTest.java
@@ -30,6 +30,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.RuntimeInfo;
+import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import org.junit.jupiter.api.Test;
 
@@ -57,6 +58,7 @@ public class HealthProbeTest {
                     new FlinkOperator(conf) {
                         @Override
                         protected Operator createOperator() {
+                            ConfigurationServiceProvider.reset();
                             return new Operator(client);
                         }
                     };

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/HealthProbeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/HealthProbeTest.java
@@ -15,17 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.kubernetes.operator;
+package org.apache.flink.kubernetes.operator.health;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.FlinkOperator;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
-import org.apache.flink.kubernetes.operator.health.HealthProbe;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.util.NetUtils;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.RuntimeInfo;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import org.junit.jupiter.api.Test;
 
 import java.net.HttpURLConnection;
@@ -50,7 +55,8 @@ public class HealthProbeTest {
 
             FlinkOperator operator =
                     new FlinkOperator(conf) {
-                        Operator createOperator() {
+                        @Override
+                        protected Operator createOperator() {
                             return new Operator(client);
                         }
                     };
@@ -90,6 +96,36 @@ public class HealthProbeTest {
         assertTrue(HealthProbe.INSTANCE.isHealthy());
         isRunning.set(false);
         assertFalse(HealthProbe.INSTANCE.isHealthy());
+        isRunning.set(true);
+
+        var canaryManager =
+                new CanaryResourceManager<FlinkDeployment>(
+                        new FlinkConfigManager(new Configuration()), client);
+        HealthProbe.INSTANCE.registerCanaryResourceManager(canaryManager);
+
+        // No canary resources
+        assertTrue(HealthProbe.INSTANCE.isHealthy());
+
+        var canary = TestUtils.createCanaryDeployment();
+        canaryManager.handleCanaryResourceReconciliation(ReconciliationUtils.clone(canary));
+
+        // Canary resource healthy before health check
+        assertTrue(HealthProbe.INSTANCE.isHealthy());
+
+        // No reconciliation before health check
+        canaryManager.checkHealth(ResourceID.fromResource(canary));
+        assertFalse(HealthProbe.INSTANCE.isHealthy());
+
+        // Healthy again
+        canary.getMetadata().setGeneration(2L);
+        canaryManager.handleCanaryResourceReconciliation(ReconciliationUtils.clone(canary));
+        canaryManager.checkHealth(ResourceID.fromResource(canary));
+        assertTrue(HealthProbe.INSTANCE.isHealthy());
+
+        canary.getMetadata().setGeneration(3L);
+        canaryManager.handleCanaryResourceReconciliation(ReconciliationUtils.clone(canary));
+        canaryManager.checkHealth(ResourceID.fromResource(canary));
+        assertTrue(HealthProbe.INSTANCE.isHealthy());
     }
 
     private boolean callHealthEndpoint(Configuration conf) throws Exception {

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkValidator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkValidator.java
@@ -21,6 +21,7 @@ import org.apache.flink.kubernetes.operator.admission.informer.InformerManager;
 import org.apache.flink.kubernetes.operator.api.CrdConstants;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.health.CanaryResourceManager;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -52,6 +53,10 @@ public class FlinkValidator implements Validator<HasMetadata> {
     @Override
     public void validate(HasMetadata resource, Operation operation) throws NotAllowedException {
         LOG.debug("Validating resource {}", resource);
+
+        if (CanaryResourceManager.isCanaryResource(resource)) {
+            return;
+        }
 
         if (CrdConstants.KIND_FLINK_DEPLOYMENT.equals(resource.getKind())) {
             validateDeployment(resource);


### PR DESCRIPTION
## What is the purpose of the change

While the current health probe mechanism is able to detect different types of errors like startup / informer issues it can be generally beneficial to allow a simply canary mechanism that can verify that the operator recieives updates and reconciles resources in a timely manner.

This PR introduces a simple canary mechanism that allows platform admins/users to deploy simple canary resources identified by a special label. The canary resource reconciliation logic then feeds into the Health probe through a configurable timeout which will be able to detect if the operator did not reconcile the resource.

The canary resource won't deploy any Flink resources. 

## Brief change log

  - *Add canary resource logic and canary resource manager to handle timeouts*
  - *Wire canary logic into HealthProbe*
  - *Add unit tests*

## Verifying this change

HealthProbe test has been extended with canary specific logic.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  [TODO]
