### PR TITLE
[FLINK-31592] Improve Flink dependent resource deletion

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -243,6 +243,12 @@
             <td>The timeout for the resource clean up to wait for flink to shutdown cluster.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.resource.deletion.propagation</h5></td>
+            <td style="word-wrap: break-word;">Foreground</td>
+            <td><p>Enum</p></td>
+            <td>JM/TM Deployment deletion propagation.<br /><br />Possible values:<ul><li>"Orphan"</li><li>"Background"</li><li>"Foreground"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.retry.initial.interval</h5></td>
             <td style="word-wrap: break-word;">5 s</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/system_advanced_section.html
+++ b/docs/layouts/shortcodes/generated/system_advanced_section.html
@@ -69,6 +69,12 @@
             <td>Final delay before deployment is marked ready after port becomes accessible.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.resource.deletion.propagation</h5></td>
+            <td style="word-wrap: break-word;">Foreground</td>
+            <td><p>Enum</p></td>
+            <td>JM/TM Deployment deletion propagation.<br /><br />Possible values:<ul><li>"Orphan"</li><li>"Background"</li><li>"Foreground"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.age.threshold</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>

--- a/e2e-tests/test_application_operations.sh
+++ b/e2e-tests/test_application_operations.sh
@@ -56,7 +56,7 @@ fi
 # Testing last-state mode upgrade
 # Update the FlinkDeployment and trigger the last state upgrade
 kubectl patch flinkdep ${CLUSTER_ID} --type merge --patch '{"spec":{"job": {"parallelism": 1 } } }'
-kubectl wait --for=delete pod --timeout=${TIMEOUT}s --selector="app=${CLUSTER_ID}"
+kubectl wait --for=delete deployment --timeout=${TIMEOUT}s --selector="app=${CLUSTER_ID}"
 wait_for_jobmanager_running $CLUSTER_ID $TIMEOUT
 jm_pod_name=$(get_jm_pod_name $CLUSTER_ID)
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricOptions;
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
 import io.javaoperatorsdk.operator.api.config.RetryConfiguration;
 import lombok.Value;
@@ -67,6 +68,7 @@ public class FlinkOperatorConfiguration {
     int exceptionThrowableCountThreshold;
     String labelSelector;
     LeaderElectionConfiguration leaderElectionConfiguration;
+    DeletionPropagation deletionPropagation;
 
     public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
         Duration reconcileInterval =
@@ -172,6 +174,9 @@ public class FlinkOperatorConfiguration {
         String labelSelector =
                 operatorConfig.getString(KubernetesOperatorConfigOptions.OPERATOR_LABEL_SELECTOR);
 
+        DeletionPropagation deletionPropagation =
+                operatorConfig.get(KubernetesOperatorConfigOptions.RESOURCE_DELETION_PROPAGATION);
+
         return new FlinkOperatorConfiguration(
                 reconcileInterval,
                 reconcilerMaxParallelism,
@@ -196,7 +201,8 @@ public class FlinkOperatorConfiguration {
                 exceptionFieldLengthThreshold,
                 exceptionThrowableCountThreshold,
                 labelSelector,
-                getLeaderElectionConfig(operatorConfig));
+                getLeaderElectionConfig(operatorConfig),
+                deletionPropagation);
     }
 
     private static LeaderElectionConfiguration getLeaderElectionConfig(Configuration conf) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
@@ -474,4 +475,11 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(false)
                     .withDescription(
                             "Configure the array merge behaviour during pod merging. Arrays can be either merged by position or name matching.");
+
+    @Documentation.Section(SECTION_ADVANCED)
+    public static final ConfigOption<DeletionPropagation> RESOURCE_DELETION_PROPAGATION =
+            operatorConfig("resource.deletion.propagation")
+                    .enumType(DeletionPropagation.class)
+                    .defaultValue(DeletionPropagation.FOREGROUND)
+                    .withDescription("JM/TM Deployment deletion propagation.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -465,7 +465,7 @@ public abstract class AbstractFlinkResourceReconciler<
                         "kind", owner.getKind(),
                         "name", owner.getMetadata().getName(),
                         "uid", owner.getMetadata().getUid(),
-                        "blockOwnerDeletion", "false",
+                        "blockOwnerDeletion", "true",
                         "controller", "false");
         deployConfig.set(
                 KubernetesConfigOptions.JOB_MANAGER_OWNER_REFERENCE, List.of(ownerReference));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -32,6 +32,7 @@ import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -108,7 +109,10 @@ public class NativeFlinkService extends AbstractFlinkService {
 
     @Override
     protected void deleteClusterInternal(
-            ObjectMeta meta, Configuration conf, boolean deleteHaData) {
+            ObjectMeta meta,
+            Configuration conf,
+            boolean deleteHaData,
+            DeletionPropagation deletionPropagation) {
 
         String namespace = meta.getNamespace();
         String clusterId = meta.getName();
@@ -121,6 +125,7 @@ public class NativeFlinkService extends AbstractFlinkService {
                 .deployments()
                 .inNamespace(namespace)
                 .withName(KubernetesUtils.getDeploymentName(clusterId))
+                .withPropagationPolicy(deletionPropagation)
                 .delete();
 
         if (deleteHaData) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
@@ -38,6 +38,7 @@ import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfi
 import org.apache.flink.kubernetes.operator.utils.StandaloneKubernetesUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -129,7 +130,10 @@ public class StandaloneFlinkService extends AbstractFlinkService {
 
     @Override
     protected void deleteClusterInternal(
-            ObjectMeta meta, Configuration conf, boolean deleteHaData) {
+            ObjectMeta meta,
+            Configuration conf,
+            boolean deleteHaData,
+            DeletionPropagation deletionPropagation) {
         final String clusterId = meta.getName();
         final String namespace = meta.getNamespace();
 
@@ -139,6 +143,7 @@ public class StandaloneFlinkService extends AbstractFlinkService {
                 .deployments()
                 .inNamespace(namespace)
                 .withName(StandaloneKubernetesUtils.getJobManagerDeploymentName(clusterId))
+                .withPropagationPolicy(deletionPropagation)
                 .delete();
 
         LOG.info("Deleting Flink Standalone cluster TM resources");
@@ -147,6 +152,7 @@ public class StandaloneFlinkService extends AbstractFlinkService {
                 .deployments()
                 .inNamespace(namespace)
                 .withName(StandaloneKubernetesUtils.getTaskManagerDeploymentName(clusterId))
+                .withPropagationPolicy(deletionPropagation)
                 .delete();
         if (deleteHaData) {
             deleteHAData(namespace, clusterId, conf);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -134,7 +134,7 @@ public class TestUtils extends BaseTestUtils {
                 "kind", owner.getKind(),
                 "name", owner.getMetadata().getName(),
                 "uid", owner.getMetadata().getUid(),
-                "blockOwnerDeletion", "false",
+                "blockOwnerDeletion", "true",
                 "controller", "false");
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -60,6 +60,7 @@ import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
 import org.apache.flink.util.SerializedThrowable;
 
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -429,7 +430,10 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     @Override
     protected void deleteClusterInternal(
-            ObjectMeta meta, Configuration conf, boolean deleteHaMeta) {
+            ObjectMeta meta,
+            Configuration conf,
+            boolean deleteHaMeta,
+            DeletionPropagation deletionPropagation) {
         jobs.clear();
         sessions.remove(meta.getName());
     }


### PR DESCRIPTION
## What is the purpose of the change

Currently we use the default (background) deletion propagation when we delete Kubernetes resources such as the JobManager deployment.

In most cases this is acceptable however this can lead to lingering resources when the garbage collection is slow on the k8s cluster. We therefore propose to make this configurable and also change the default to Foreground which is more predictable and works better for our purposes in the operator.

## Brief change log

  - *Change default resource deletion to foreground propagation*
  - *Make it configurable*
  - *Add tests*

## Verifying this change

Added unit test to NativeFlinkServiceTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
