### PR TITLE
[FLINK-30575] Limit output ratio in case of near zero values

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
@@ -195,8 +195,8 @@ public class ScalingMetrics {
         return value;
     }
 
-    private static boolean isEffectivelyZero(double numRecordsInPerSecond) {
-        return numRecordsInPerSecond <= EFFECTIVELY_ZERO;
+    private static boolean isEffectivelyZero(double value) {
+        return value <= EFFECTIVELY_ZERO;
     }
 
     private static void excludeVertexFromScaling(Configuration conf, JobVertexID jobVertexId) {


### PR DESCRIPTION
When the rates drop to zero, we set near zero values to continue to use the same scaling logic. There is a gap in this logic when only the input rate drops to zero but the output rate is still measured to be greater than zero. This is because we do not pass on the output rates directly but the output / input ratio which becomes very large in this special scenario.

In this change we cap the output rate in case we use near zero input rates. This has been tested to effectively prevent scale up spikes in pipelines which only occasionally receive data.
