### PR TITLE
[FLINK-30575] Set processing capacity to infinite if task is idle

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.kubernetes.operator.autoscaler.metrics.CollectedMetrics;
 import org.apache.flink.kubernetes.operator.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.kubernetes.operator.autoscaler.metrics.FlinkMetric;
 import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric;
-import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetrics;
 import org.apache.flink.kubernetes.operator.autoscaler.topology.JobTopology;
 import org.apache.flink.kubernetes.operator.autoscaler.topology.VertexInfo;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
@@ -57,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetrics.EFFECTIVELY_INFINITE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -416,11 +416,10 @@ public class MetricsCollectionAndEvaluationTest {
 
         Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluation =
                 evaluator.evaluate(conf, collectedMetrics);
+        assertEquals(0, evaluation.get(source1).get(ScalingMetric.TARGET_DATA_RATE).getCurrent());
         assertEquals(
-                ScalingMetrics.EFFECTIVELY_ZERO,
-                evaluation.get(source1).get(ScalingMetric.TARGET_DATA_RATE).getCurrent());
-        assertEquals(
-                1E-6, evaluation.get(source1).get(ScalingMetric.TRUE_PROCESSING_RATE).getCurrent());
+                EFFECTIVELY_INFINITE,
+                evaluation.get(source1).get(ScalingMetric.TRUE_PROCESSING_RATE).getCurrent());
         assertEquals(
                 0.,
                 evaluation.get(source1).get(ScalingMetric.SCALE_DOWN_RATE_THRESHOLD).getCurrent());

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetrics.EFFECTIVELY_INFINITE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -228,9 +229,10 @@ public class ScalingMetricsTest {
         assertEquals(
                 Map.of(
                         ScalingMetric.TRUE_PROCESSING_RATE,
-                        1.0E14,
+                        // When not busy at all, we have infinite processing power
+                        EFFECTIVELY_INFINITE * dataRate,
                         ScalingMetric.TRUE_OUTPUT_RATE,
-                        1.0E14,
+                        EFFECTIVELY_INFINITE * dataRate,
                         ScalingMetric.OUTPUT_RATIO,
                         1.,
                         ScalingMetric.SOURCE_DATA_RATE,
@@ -248,15 +250,17 @@ public class ScalingMetricsTest {
         assertEquals(
                 Map.of(
                         ScalingMetric.TRUE_PROCESSING_RATE,
-                        1.0E-9,
+                        // When no records are coming in, we assume infinite processing power
+                        EFFECTIVELY_INFINITE,
                         ScalingMetric.TRUE_OUTPUT_RATE,
-                        1.0E-9,
+                        0.,
                         ScalingMetric.OUTPUT_RATIO,
-                        1.,
+                        // We are not producing any records
+                        0.,
                         ScalingMetric.SOURCE_DATA_RATE,
-                        ScalingMetrics.EFFECTIVELY_ZERO,
+                        0.,
                         ScalingMetric.CURRENT_PROCESSING_RATE,
-                        ScalingMetrics.EFFECTIVELY_ZERO),
+                        0.),
                 scalingMetrics);
     }
 
@@ -265,17 +269,18 @@ public class ScalingMetricsTest {
         Map<ScalingMetric, Double> scalingMetrics = testZeroValuesForRatesOrBusyness(0, 1, 100);
         assertEquals(
                 Map.of(
-                        // Output ratio should be kept to 1
+                        // If there is zero input the out ratio must be zero
                         ScalingMetric.OUTPUT_RATIO,
-                        1.,
+                        0.,
                         ScalingMetric.TRUE_PROCESSING_RATE,
-                        ScalingMetrics.EFFECTIVELY_ZERO * 10,
+                        // When no records are coming in, we assume infinite processing power
+                        EFFECTIVELY_INFINITE,
                         ScalingMetric.TRUE_OUTPUT_RATE,
-                        ScalingMetrics.EFFECTIVELY_ZERO * 10,
+                        0.,
                         ScalingMetric.SOURCE_DATA_RATE,
-                        ScalingMetrics.EFFECTIVELY_ZERO,
+                        0.,
                         ScalingMetric.CURRENT_PROCESSING_RATE,
-                        ScalingMetrics.EFFECTIVELY_ZERO),
+                        0.),
                 scalingMetrics);
     }
 
@@ -285,15 +290,16 @@ public class ScalingMetricsTest {
         assertEquals(
                 Map.of(
                         ScalingMetric.TRUE_PROCESSING_RATE,
-                        1000.0,
+                        // Nothing is coming in, we must assume infinite processing power
+                        EFFECTIVELY_INFINITE,
                         ScalingMetric.TRUE_OUTPUT_RATE,
-                        1000.0,
+                        0.,
                         ScalingMetric.OUTPUT_RATIO,
-                        1.,
+                        0.,
                         ScalingMetric.SOURCE_DATA_RATE,
-                        ScalingMetrics.EFFECTIVELY_ZERO,
+                        0.,
                         ScalingMetric.CURRENT_PROCESSING_RATE,
-                        ScalingMetrics.EFFECTIVELY_ZERO),
+                        0.),
                 scalingMetrics);
     }
 


### PR DESCRIPTION
In a prior change we set the processing rates and capacity (true processing rate) to near zero values to allow scaling down in case of idle tasks. This has worked well but caused issues for tasks which are fed via upstream selective outputs (side outputs). Those tests usually received none or only a few records of the upstream outputted records. Setting low values for the incoming records rate will yield a relatively low true processing rate which quickly triggers upscaling even if no records are being processed at all.

We don't currently have per-output/per-input metrics, so the best we can do, is to assume infinite processing capacity if we don't receive any records or are completely idle. Once we received records, we can measure our true processing rate. In the case of selective outputs, we will still assume we receive all the data which is suboptimal but far better than scaling up all the way to the max parallelism as we have seen for the near zero true processing rates during idleness.
