### PR TITLE
[FLINK-31630] Limit max checkpoint age for last-state upgrade

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -81,6 +81,12 @@
             <td>Enables last-state fallback for savepoint upgrade mode. When the job is not running thus savepoint cannot be triggered but HA metadata is available for last state restore the operator can initiate the upgrade process when the flag is enabled.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.upgrade.last-state.max.allowed.checkpoint.age</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Max allowed checkpoint age for initiating last-state upgrades on running jobs. If a checkpoint is not available within the desired age (and nothing in progress) a savepoint will be triggered.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.periodic.savepoint.interval</h5></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -165,6 +165,12 @@
             <td>Enables last-state fallback for savepoint upgrade mode. When the job is not running thus savepoint cannot be triggered but HA metadata is available for last state restore the operator can initiate the upgrade process when the flag is enabled.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.upgrade.last-state.max.allowed.checkpoint.age</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Max allowed checkpoint age for initiating last-state upgrades on running jobs. If a checkpoint is not available within the desired age (and nothing in progress) a savepoint will be triggered.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.label.selector</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/Savepoint.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/Savepoint.java
@@ -64,6 +64,10 @@ public class Savepoint {
         this.triggerNonce = triggerNonce;
     }
 
+    public static Savepoint of(String location, long timeStamp, SavepointTriggerType triggerType) {
+        return new Savepoint(timeStamp, location, triggerType, SavepointFormatType.UNKNOWN, null);
+    }
+
     public static Savepoint of(String location, SavepointTriggerType triggerType) {
         return new Savepoint(
                 System.currentTimeMillis(),

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -326,6 +326,14 @@ public class KubernetesOperatorConfigOptions {
                             "Enables last-state fallback for savepoint upgrade mode. When the job is not running thus savepoint cannot be triggered but HA metadata is available for last state restore the operator can initiate the upgrade process when the flag is enabled.");
 
     @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Duration> OPERATOR_JOB_UPGRADE_LAST_STATE_CHECKPOINT_MAX_AGE =
+            operatorConfig("job.upgrade.last-state.max.allowed.checkpoint.age")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Max allowed checkpoint age for initiating last-state upgrades on running jobs. If a checkpoint is not available within the desired age (and nothing in progress) a savepoint will be triggered.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<SavepointFormatType> OPERATOR_SAVEPOINT_FORMAT_TYPE =
             operatorConfig("savepoint.format.type")
                     .enumType(SavepointFormatType.class)

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -512,6 +512,30 @@ public abstract class AbstractFlinkService implements FlinkService {
 
     @Override
     public Optional<Savepoint> getLastCheckpoint(JobID jobId, Configuration conf) throws Exception {
+        var latestCheckpointOpt = getCheckpointInfo(jobId, conf).f0;
+
+        if (latestCheckpointOpt.isPresent()
+                && latestCheckpointOpt
+                        .get()
+                        .getExternalPointer()
+                        .equals(NonPersistentMetadataCheckpointStorageLocation.EXTERNAL_POINTER)) {
+            throw new RecoveryFailureException(
+                    "Latest checkpoint not externally addressable, manual recovery required.",
+                    "CheckpointNotFound");
+        }
+        return latestCheckpointOpt.map(
+                pointer ->
+                        Savepoint.of(
+                                pointer.getExternalPointer(),
+                                pointer.getTimestamp(),
+                                SavepointTriggerType.UNKNOWN));
+    }
+
+    @Override
+    public Tuple2<
+                    Optional<CheckpointHistoryWrapper.CompletedCheckpointInfo>,
+                    Optional<CheckpointHistoryWrapper.PendingCheckpointInfo>>
+            getCheckpointInfo(JobID jobId, Configuration conf) throws Exception {
         try (RestClusterClient<String> clusterClient =
                 (RestClusterClient<String>) getClusterClient(conf)) {
 
@@ -530,20 +554,9 @@ public abstract class AbstractFlinkService implements FlinkService {
                                     .getSeconds(),
                             TimeUnit.SECONDS);
 
-            var latestCheckpointOpt = checkpoints.getLatestCheckpointPath();
-
-            if (latestCheckpointOpt.isPresent()
-                    && latestCheckpointOpt
-                            .get()
-                            .equals(
-                                    NonPersistentMetadataCheckpointStorageLocation
-                                            .EXTERNAL_POINTER)) {
-                throw new RecoveryFailureException(
-                        "Latest checkpoint not externally addressable, manual recovery required.",
-                        "CheckpointNotFound");
-            }
-            return latestCheckpointOpt.map(
-                    pointer -> Savepoint.of(pointer, SavepointTriggerType.UNKNOWN));
+            return Tuple2.of(
+                    checkpoints.getLatestCompletedCheckpoint(),
+                    checkpoints.getInProgressCheckpoint());
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.service;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
@@ -91,6 +92,11 @@ public interface FlinkService {
     Optional<Savepoint> getLastCheckpoint(JobID jobId, Configuration conf) throws Exception;
 
     SavepointFetchResult fetchSavepointInfo(String triggerId, String jobId, Configuration conf);
+
+    Tuple2<
+                    Optional<CheckpointHistoryWrapper.CompletedCheckpointInfo>,
+                    Optional<CheckpointHistoryWrapper.PendingCheckpointInfo>>
+            getCheckpointInfo(JobID jobId, Configuration conf) throws Exception;
 
     void disposeSavepoint(String savepointPath, Configuration conf) throws Exception;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -248,6 +248,14 @@ public class DefaultValidator implements FlinkResourceValidator {
                         String.format(
                                 "Periodic savepoints cannot be enabled when config key[%s] is not set",
                                 CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
+            } else if (configuration.get(
+                            KubernetesOperatorConfigOptions
+                                    .OPERATOR_JOB_UPGRADE_LAST_STATE_CHECKPOINT_MAX_AGE)
+                    != null) {
+                return Optional.of(
+                        String.format(
+                                "In order to use max-checkpoint age functionality config key[%s] must be set to allow triggering savepoint upgrades.",
+                                CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
             }
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.client.program.ClusterClient;
 import org.apache.flink.configuration.Configuration;
@@ -42,6 +43,7 @@ import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.exception.RecoveryFailureException;
 import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
 import org.apache.flink.kubernetes.operator.service.AbstractFlinkService;
+import org.apache.flink.kubernetes.operator.service.CheckpointHistoryWrapper;
 import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfigOptionsInternal;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
@@ -65,6 +67,8 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.annotation.Nullable;
 
@@ -96,20 +100,27 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     private final List<Tuple3<String, JobStatusMessage, Configuration>> jobs = new ArrayList<>();
     private final Map<JobID, String> jobErrors = new HashMap<>();
-    private final Set<String> sessions = new HashSet<>();
-    private boolean isPortReady = true;
-    private boolean isFlinkJobNotFound = false;
-    private boolean isFlinkJobTerminatedWithoutCancellation = false;
-    private boolean haDataAvailable = true;
-    private boolean jobManagerReady = true;
-    private boolean deployFailure = false;
-    private Runnable sessionJobSubmittedCallback;
-    private PodList podList = new PodList();
-    private Consumer<Configuration> listJobConsumer = conf -> {};
+    @Getter private final Set<String> sessions = new HashSet<>();
+    @Setter private boolean isFlinkJobNotFound = false;
+    @Setter private boolean isFlinkJobTerminatedWithoutCancellation = false;
+    @Setter private boolean isPortReady = true;
+    @Setter private boolean haDataAvailable = true;
+    @Setter private boolean jobManagerReady = true;
+    @Setter private boolean deployFailure = false;
+    @Setter private Runnable sessionJobSubmittedCallback;
+    @Setter private PodList podList = new PodList();
+    @Setter private Consumer<Configuration> listJobConsumer = conf -> {};
     private final List<String> disposedSavepoints = new ArrayList<>();
     private final Map<String, Boolean> savepointTriggers = new HashMap<>();
-    private int desiredReplicas = 0;
-    private int cancelJobCallCount = 0;
+
+    @Getter private int desiredReplicas = 0;
+    @Getter private int cancelJobCallCount = 0;
+
+    @Setter
+    private Tuple2<
+                    Optional<CheckpointHistoryWrapper.CompletedCheckpointInfo>,
+                    Optional<CheckpointHistoryWrapper.PendingCheckpointInfo>>
+            checkpointInfo;
 
     private Map<String, String> metricsValues = new HashMap<>();
 
@@ -143,10 +154,6 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     public void clearJobsInTerminalState() {
         jobs.removeIf(job -> job.f1.getJobState().isTerminalState());
-    }
-
-    public Set<String> getSessions() {
-        return sessions;
     }
 
     @Override
@@ -196,22 +203,6 @@ public class TestingFlinkService extends AbstractFlinkService {
         return HighAvailabilityMode.isHighAvailabilityModeActivated(conf) && haDataAvailable;
     }
 
-    public void setHaDataAvailable(boolean haDataAvailable) {
-        this.haDataAvailable = haDataAvailable;
-    }
-
-    public void setJobManagerReady(boolean jmReady) {
-        this.jobManagerReady = jmReady;
-    }
-
-    public void setDeployFailure(boolean deployFailure) {
-        this.deployFailure = deployFailure;
-    }
-
-    public void setSessionJobSubmittedCallback(Runnable sessionJobSubmittedCallback) {
-        this.sessionJobSubmittedCallback = sessionJobSubmittedCallback;
-    }
-
     @Override
     public void submitSessionCluster(Configuration conf) throws Exception {
         if (deployFailure) {
@@ -252,10 +243,6 @@ public class TestingFlinkService extends AbstractFlinkService {
             throw new TimeoutException("JM port is unavailable");
         }
         return super.listJobs(conf);
-    }
-
-    public void setListJobConsumer(Consumer<Configuration> listJobConsumer) {
-        this.listJobConsumer = listJobConsumer;
     }
 
     public List<Tuple3<String, JobStatusMessage, Configuration>> listJobs() {
@@ -448,6 +435,30 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     @Override
     public Optional<Savepoint> getLastCheckpoint(JobID jobId, Configuration conf) throws Exception {
+        jobs.stream()
+                .filter(js -> js.f1.getJobId().equals(jobId))
+                .findAny()
+                .ifPresent(
+                        t -> {
+                            if (!t.f1.getJobState().isGloballyTerminalState()) {
+                                throw new RuntimeException(
+                                        "Checkpoint should not be queried if job is not in terminal state");
+                            }
+                        });
+
+        return super.getLastCheckpoint(jobId, conf);
+    }
+
+    @Override
+    public Tuple2<
+                    Optional<CheckpointHistoryWrapper.CompletedCheckpointInfo>,
+                    Optional<CheckpointHistoryWrapper.PendingCheckpointInfo>>
+            getCheckpointInfo(JobID jobId, Configuration conf) throws Exception {
+
+        if (checkpointInfo != null) {
+            return checkpointInfo;
+        }
+
         var jobOpt = jobs.stream().filter(js -> js.f1.getJobId().equals(jobId)).findAny();
 
         if (jobOpt.isEmpty()) {
@@ -455,33 +466,21 @@ public class TestingFlinkService extends AbstractFlinkService {
         }
 
         var t = jobOpt.get();
-        if (!t.f1.getJobState().isGloballyTerminalState()) {
-            throw new Exception("Checkpoint should not be queried if job is not in terminal state");
-        }
 
         if (t.f0 != null) {
-            return Optional.of(Savepoint.of(t.f0, SavepointTriggerType.UNKNOWN));
+            return Tuple2.of(
+                    Optional.of(
+                            new CheckpointHistoryWrapper.CompletedCheckpointInfo(
+                                    0L, t.f0, System.currentTimeMillis())),
+                    Optional.empty());
         } else {
-            return Optional.empty();
+            return Tuple2.of(Optional.empty(), Optional.empty());
         }
     }
 
     @Override
     public boolean isJobManagerPortReady(Configuration config) {
         return isPortReady;
-    }
-
-    public void setPortReady(boolean isPortReady) {
-        this.isPortReady = isPortReady;
-    }
-
-    public void setFlinkJobTerminatedWithoutCancellation(
-            boolean isFlinkJobTerminatedWithoutCancellation) {
-        this.isFlinkJobTerminatedWithoutCancellation = isFlinkJobTerminatedWithoutCancellation;
-    }
-
-    public void setFlinkJobNotFound(boolean isFlinkJobNotFound) {
-        this.isFlinkJobNotFound = isFlinkJobNotFound;
     }
 
     @Override
@@ -492,10 +491,6 @@ public class TestingFlinkService extends AbstractFlinkService {
     @Override
     protected PodList getJmPodList(String namespace, String clusterId) {
         return podList;
-    }
-
-    public void setJmPodList(PodList podList) {
-        this.podList = podList;
     }
 
     public void markApplicationJobFailedWithError(JobID jobID, String error) throws Exception {
@@ -545,10 +540,6 @@ public class TestingFlinkService extends AbstractFlinkService {
         return true;
     }
 
-    public int getDesiredReplicas() {
-        return desiredReplicas;
-    }
-
     public void setMetricValue(String name, String value) {
         metricsValues.put(name, value);
     }
@@ -557,9 +548,5 @@ public class TestingFlinkService extends AbstractFlinkService {
     public Map<String, String> getMetrics(
             Configuration conf, String jobId, List<String> metricNames) {
         return metricsValues;
-    }
-
-    public int getCancelJobCallCount() {
-        return cancelJobCallCount;
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -331,7 +331,7 @@ public class FlinkDeploymentControllerTest {
                 .andReply(validatingResponseProvider)
                 .once();
 
-        flinkService.setJmPodList(TestUtils.createFailedPodList(crashLoopMessage, reason));
+        flinkService.setPodList(TestUtils.createFailedPodList(crashLoopMessage, reason));
 
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
         UpdateControl<FlinkDeployment> updateControl;
@@ -908,7 +908,7 @@ public class FlinkDeploymentControllerTest {
     @Test
     public void testSuccessfulObservationShouldClearErrors() throws Exception {
         final String crashLoopMessage = "deploy errors";
-        flinkService.setJmPodList(
+        flinkService.setPodList(
                 TestUtils.createFailedPodList(
                         crashLoopMessage, DeploymentFailedException.REASON_CRASH_LOOP_BACKOFF));
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -621,7 +621,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
                 deployment.getStatus().getJobManagerDeploymentStatus());
         // simulate deployment failure
         String podFailedMessage = "list jobs error";
-        flinkService.setJmPodList(
+        flinkService.setPodList(
                 TestUtils.createFailedPodList(
                         podFailedMessage, DeploymentFailedException.REASON_CRASH_LOOP_BACKOFF));
         flinkService.setPortReady(false);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -172,6 +172,19 @@ public class DefaultValidatorTest {
                         "Periodic savepoints cannot be enabled when config key[%s] is not set",
                         CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
 
+        testError(
+                dep ->
+                        dep.getSpec()
+                                .setFlinkConfiguration(
+                                        Map.of(
+                                                KubernetesOperatorConfigOptions
+                                                        .OPERATOR_JOB_UPGRADE_LAST_STATE_CHECKPOINT_MAX_AGE
+                                                        .key(),
+                                                "1m")),
+                String.format(
+                        "In order to use max-checkpoint age functionality config key[%s] must be set to allow triggering savepoint upgrades.",
+                        CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
+
         // Test conf validation
         testSuccess(
                 dep ->


### PR DESCRIPTION
## What is the purpose of the change

Introduce config to block last-state upgrades if the checkpoint is too old and either wait for pending checkpoint completion or use savepoints instead.

When the max-age checkpoint age is configured we will do the following if the last completed checkpoint/savepoint is older:
 - If there is any pending checkpoint triggered within the max-age, we wait for it to complete
 - If the job started within max-age we use last-state restart
 - If no pending checkpoint and the job wasn't started recently, we fall back to savepoint upgrade mode.

We also introduce a validation to only allow the max-age config if savepoint dir is set.

As a followup improvement we could consider triggering chekpoint instead of savepoint for Flink 1.17 in the future.

## Brief change log

  - *Introduce new logic in available upgrade mode method*
  - *Add test for upgrademode*
  - *Add test for validation*
  - *Minor TestingFlinkService refactor*

## Verifying this change

New unit tests added for new functionality and existing tests guard against regressions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
