### PR TITLE
[FLINK-31303] Expose Flink application resource usage via metrics and status

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetrics.java
@@ -20,6 +20,9 @@ package org.apache.flink.kubernetes.operator.metrics;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.service.AbstractFlinkService;
+
+import org.apache.commons.lang3.math.NumberUtils;
 
 import java.util.Map;
 import java.util.Set;
@@ -30,10 +33,19 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
 
     private final KubernetesOperatorMetricGroup parentMetricGroup;
     private final Configuration configuration;
-    private final Map<String, Map<JobManagerDeploymentStatus, Set<String>>> deployments =
+
+    // map(namespace, map(status, set(deployment))
+    private final Map<String, Map<JobManagerDeploymentStatus, Set<String>>> deploymentStatuses =
             new ConcurrentHashMap<>();
+    // map(namespace, map(deployment, cpu))
+    private final Map<String, Map<String, Double>> deploymentCpuUsage = new ConcurrentHashMap<>();
+    // map(namespace, map(deployment, memory))
+    private final Map<String, Map<String, Long>> deploymentMemoryUsage = new ConcurrentHashMap<>();
     public static final String STATUS_GROUP_NAME = "JmDeploymentStatus";
+    public static final String RESOURCE_USAGE_GROUP_NAME = "ResourceUsage";
     public static final String COUNTER_NAME = "Count";
+    public static final String CPU_NAME = "Cpu";
+    public static final String MEMORY_NAME = "Memory";
 
     public FlinkDeploymentMetrics(
             KubernetesOperatorMetricGroup parentMetricGroup, Configuration configuration) {
@@ -43,26 +55,60 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
 
     public void onUpdate(FlinkDeployment flinkApp) {
         onRemove(flinkApp);
-        deployments
+
+        var namespace = flinkApp.getMetadata().getNamespace();
+        var clusterInfo = flinkApp.getStatus().getClusterInfo();
+        var deploymentName = flinkApp.getMetadata().getName();
+
+        deploymentStatuses
                 .computeIfAbsent(
-                        flinkApp.getMetadata().getNamespace(),
+                        namespace,
                         ns -> {
                             initNamespaceDeploymentCounts(ns);
                             initNamespaceStatusCounts(ns);
                             return createDeploymentStatusMap();
                         })
                 .get(flinkApp.getStatus().getJobManagerDeploymentStatus())
-                .add(flinkApp.getMetadata().getName());
+                .add(deploymentName);
+
+        deploymentCpuUsage
+                .computeIfAbsent(
+                        namespace,
+                        ns -> {
+                            initNamespaceCpuUsage(ns);
+                            return new ConcurrentHashMap<>();
+                        })
+                .put(
+                        deploymentName,
+                        NumberUtils.toDouble(
+                                clusterInfo.getOrDefault(
+                                        AbstractFlinkService.FIELD_NAME_TOTAL_CPU, "0")));
+
+        deploymentMemoryUsage
+                .computeIfAbsent(
+                        namespace,
+                        ns -> {
+                            initNamespaceMemoryUsage(ns);
+                            return new ConcurrentHashMap<>();
+                        })
+                .put(
+                        deploymentName,
+                        NumberUtils.toLong(
+                                clusterInfo.getOrDefault(
+                                        AbstractFlinkService.FIELD_NAME_TOTAL_MEMORY, "0")));
     }
 
     public void onRemove(FlinkDeployment flinkApp) {
-        if (!deployments.containsKey(flinkApp.getMetadata().getNamespace())) {
+        var namespace = flinkApp.getMetadata().getNamespace();
+        var name = flinkApp.getMetadata().getName();
+
+        if (!deploymentStatuses.containsKey(namespace)) {
             return;
         }
-        deployments
-                .get(flinkApp.getMetadata().getNamespace())
-                .values()
-                .forEach(names -> names.remove(flinkApp.getMetadata().getName()));
+        deploymentStatuses.get(namespace).values().forEach(names -> names.remove(name));
+
+        deploymentCpuUsage.get(namespace).remove(name);
+        deploymentMemoryUsage.get(namespace).remove(name);
     }
 
     private void initNamespaceDeploymentCounts(String ns) {
@@ -70,7 +116,10 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
                 .createResourceNamespaceGroup(configuration, FlinkDeployment.class, ns)
                 .gauge(
                         COUNTER_NAME,
-                        () -> deployments.get(ns).values().stream().mapToInt(Set::size).sum());
+                        () ->
+                                deploymentStatuses.get(ns).values().stream()
+                                        .mapToInt(Set::size)
+                                        .sum());
     }
 
     private void initNamespaceStatusCounts(String ns) {
@@ -79,8 +128,30 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
                     .createResourceNamespaceGroup(configuration, FlinkDeployment.class, ns)
                     .addGroup(STATUS_GROUP_NAME)
                     .addGroup(status.toString())
-                    .gauge(COUNTER_NAME, () -> deployments.get(ns).get(status).size());
+                    .gauge(COUNTER_NAME, () -> deploymentStatuses.get(ns).get(status).size());
         }
+    }
+
+    private void initNamespaceCpuUsage(String ns) {
+        parentMetricGroup
+                .createResourceNamespaceGroup(configuration, FlinkDeployment.class, ns)
+                .addGroup(RESOURCE_USAGE_GROUP_NAME)
+                .gauge(
+                        CPU_NAME,
+                        () ->
+                                deploymentCpuUsage.get(ns).values().stream()
+                                        .reduce(0.0, Double::sum));
+    }
+
+    private void initNamespaceMemoryUsage(String ns) {
+        parentMetricGroup
+                .createResourceNamespaceGroup(configuration, FlinkDeployment.class, ns)
+                .addGroup(RESOURCE_USAGE_GROUP_NAME)
+                .gauge(
+                        MEMORY_NAME,
+                        () ->
+                                deploymentMemoryUsage.get(ns).values().stream()
+                                        .reduce(0L, Long::sum));
     }
 
     private Map<JobManagerDeploymentStatus, Set<String>> createDeploymentStatusMap() {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetrics.java
@@ -71,6 +71,12 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
                 .get(flinkApp.getStatus().getJobManagerDeploymentStatus())
                 .add(deploymentName);
 
+        var totalCpu =
+                NumberUtils.toDouble(
+                        clusterInfo.getOrDefault(AbstractFlinkService.FIELD_NAME_TOTAL_CPU, "0"));
+        if (!Double.isFinite(totalCpu)) {
+            totalCpu = 0;
+        }
         deploymentCpuUsage
                 .computeIfAbsent(
                         namespace,
@@ -78,11 +84,7 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
                             initNamespaceCpuUsage(ns);
                             return new ConcurrentHashMap<>();
                         })
-                .put(
-                        deploymentName,
-                        NumberUtils.toDouble(
-                                clusterInfo.getOrDefault(
-                                        AbstractFlinkService.FIELD_NAME_TOTAL_CPU, "0")));
+                .put(deploymentName, totalCpu);
 
         deploymentMemoryUsage
                 .computeIfAbsent(


### PR DESCRIPTION
## Brief change log

  - *Exposed JobManager and TaskManager resource usage to clusterInfo in status of the CR*
  - *The clusterInfo is then used to populate the metrics for the FlinkDeployment*

## Verifying this change

Manually verified via submitting applications to a local cluster. TODO to add suitable unit tests, ideally extending `FlinkDeploymentMetricsTest` however given my reliance on the status of the CR this is more involved than ideal.

