### PR TITLE
[FLINK-31680] Add priorityClassName to flink-operator's pods

### DIFF
--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -47,6 +47,9 @@ spec:
           {{- end }}
         {{- end }}
     spec:
+      {{- with .Values.operatorPod.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.operatorPod.nodeSelector }}

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -59,6 +59,7 @@ rbac:
     name: "flink-role-binding"
 
 operatorPod:
+  priorityClassName: null
   annotations: {}
   labels: {}
   env:


### PR DESCRIPTION
## What is the purpose of the change

This pr adds priorityClassName to operator pod.

## Brief change log

PR is simple and self-descriptive.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
