### PR TITLE
[FLINK-30609] Add ephemeral storage to CRD

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -152,6 +152,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | cpu | java.lang.Double | Amount of CPU allocated to the pod. |
 | memory | java.lang.String | Amount of memory allocated to the pod. Example: 1024m, 1g |
+| ephemeralStorage | java.lang.String | Amount of ephemeral storage allocated to the pod. Example: 1024m, 2G |
 
 ### TaskManagerSpec
 **Class**: org.apache.flink.kubernetes.operator.api.spec.TaskManagerSpec

--- a/examples/kubernetes-client-examples/src/main/java/org/apache/flink/examples/Basic.java
+++ b/examples/kubernetes-client-examples/src/main/java/org/apache/flink/examples/Basic.java
@@ -52,10 +52,10 @@ public class Basic {
         flinkDeployment.setSpec(flinkDeploymentSpec);
         flinkDeploymentSpec.setServiceAccount("flink");
         JobManagerSpec jobManagerSpec = new JobManagerSpec();
-        jobManagerSpec.setResource(new Resource(1.0, "2048m"));
+        jobManagerSpec.setResource(new Resource(1.0, "2048m", "2G"));
         flinkDeploymentSpec.setJobManager(jobManagerSpec);
         TaskManagerSpec taskManagerSpec = new TaskManagerSpec();
-        taskManagerSpec.setResource(new Resource(1.0, "2048m"));
+        taskManagerSpec.setResource(new Resource(1.0, "2048m", "2G"));
         flinkDeploymentSpec.setTaskManager(taskManagerSpec);
         flinkDeployment
                 .getSpec()

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/CrdConstants.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/CrdConstants.java
@@ -25,4 +25,6 @@ public class CrdConstants {
     public static final String KIND_FLINK_DEPLOYMENT = "FlinkDeployment";
 
     public static final String LABEL_TARGET_SESSION = "target.session";
+
+    public static final String EPHEMERAL_STORAGE = "ephemeral-storage";
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/Resource.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/Resource.java
@@ -34,4 +34,7 @@ public class Resource {
 
     /** Amount of memory allocated to the pod. Example: 1024m, 1g */
     private String memory;
+
+    /** Amount of ephemeral storage allocated to the pod. Example: 1024m, 2G */
+    private String ephemeralStorage;
 }

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
@@ -160,8 +160,8 @@ public class BaseTestUtils {
                 .serviceAccount(SERVICE_ACCOUNT)
                 .flinkVersion(version)
                 .flinkConfiguration(conf)
-                .jobManager(new JobManagerSpec(new Resource(1.0, "2048m"), 1, null))
-                .taskManager(new TaskManagerSpec(new Resource(1.0, "2048m"), null, null))
+                .jobManager(new JobManagerSpec(new Resource(1.0, "2048m", "2G"), 1, null))
+                .taskManager(new TaskManagerSpec(new Resource(1.0, "2048m", "2G"), null, null))
                 .build();
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorITCase.java
@@ -129,6 +129,7 @@ public class FlinkOperatorITCase {
         Resource resource = new Resource();
         resource.setMemory("2048m");
         resource.setCpu(1.0);
+        resource.setEphemeralStorage("2G");
         JobManagerSpec jm = new JobManagerSpec();
         jm.setResource(resource);
         jm.setReplicas(1);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -496,6 +496,18 @@ public class DefaultValidatorTest {
                                     // dependency to 1.16
                                     "kubernetes");
                 });
+
+        testError(
+                dep -> {
+                    dep.getSpec().getJobManager().getResource().setEphemeralStorage("abc");
+                },
+                "JobManager resource ephemeral storage parse error: Character a is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark.");
+
+        testError(
+                dep -> {
+                    dep.getSpec().getTaskManager().getResource().setEphemeralStorage("abc");
+                },
+                "TaskManager resource ephemeral storage parse error: Character a is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark.");
     }
 
     @Test

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -3113,6 +3113,8 @@ spec:
                         type: number
                       memory:
                         type: string
+                      ephemeralStorage:
+                        type: string
                     type: object
                   replicas:
                     type: integer
@@ -6175,6 +6177,8 @@ spec:
                       cpu:
                         type: number
                       memory:
+                        type: string
+                      ephemeralStorage:
                         type: string
                     type: object
                   replicas:


### PR DESCRIPTION
## What is the purpose of the change
Add ephemeral storage to CRD, so that users can apply ephemeral storage as resource requirement to containers of JM and TM.

## Brief change log 

  - Add ephemeral storage to Resource of flink deployment spec

## Verifying this change
This change added tests and can be verified as follows:

  - Changes are tested in unit test in FlinkConfigBuilderTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes)
  - Core observer or reconciler logic that is regularly executed: ( no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
