### PR TITLE
[FLINK-31716] Event UID field is missing the first time that an event…

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -76,8 +76,7 @@ public class EventUtils {
             existing.setLastTimestamp(Instant.now().toString());
             existing.setCount(existing.getCount() + 1);
             existing.setMessage(message);
-            client.resource(existing).createOrReplace();
-            eventListener.accept(existing);
+            eventListener.accept(client.resource(existing).createOrReplace());
             return false;
         } else {
             var event =
@@ -104,10 +103,7 @@ public class EventUtils {
                             .withNamespace(target.getMetadata().getNamespace())
                             .endMetadata()
                             .build();
-
-            var ev = client.resource(event).createOrReplace();
-            event.getMetadata().setUid(ev.getMetadata().getUid());
-            eventListener.accept(event);
+            eventListener.accept(client.resource(event).createOrReplace());
             return true;
         }
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
@@ -72,6 +72,7 @@ public class EventUtilsTest {
                         .withName(eventName)
                         .get();
         Assertions.assertEquals(event.getMetadata().getUid(), eventConsumed.getMetadata().getUid());
+        Assertions.assertEquals(eventConsumed, event);
         eventConsumed = null;
         Assertions.assertNotNull(event);
         Assertions.assertEquals(1, event.getCount());
@@ -93,7 +94,7 @@ public class EventUtilsTest {
                         .inNamespace(flinkApp.getMetadata().getNamespace())
                         .withName(eventName)
                         .get();
-        Assertions.assertEquals(event.getMetadata().getUid(), eventConsumed.getMetadata().getUid());
+        Assertions.assertEquals(eventConsumed, event);
         Assertions.assertEquals(2, event.getCount());
     }
 


### PR DESCRIPTION

What is the purpose of the change

Fixes a bug reported on https://issues.apache.org/jira/browse/FLINK-31716 where the event being consumed for the first time didn't have an UID field

This ticket was reopened for two reasons:
1. Before the check was only being done when the event was created for the first time, and not on updates
2. We are now accepting the actual return value of the `.createOrReplace` call. Before we were only using the `uid` field of it.

Brief change log

Fixes a bug on EventUtils where the event consumed was missing the UID field
Verifying this change

This change modified existing unit tests.

Does this pull request potentially affect one of the following parts:

Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changes to the CustomResourceDescriptors: no
Core observer or reconciler logic that is regularly executed: no
Documentation

Does this pull request introduce a new feature? no
If yes, how is the feature documented? not applicable