### PR TITLE
[FLINK-31845] Make KubernetesStepDecorator Pluggable

### DIFF
--- a/flink-kubernetes-standalone/pom.xml
+++ b/flink-kubernetes-standalone/pom.xml
@@ -128,6 +128,26 @@ under the License.
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>create-test-plugin-jar</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>test-plugins</finalName>
+                            <attach>false</attach>
+                            <descriptors>
+                                <descriptor>src/test/assembly/test-plugins-assembly.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/decorators/KubernetesStepDecoratorPlugin.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/decorators/KubernetesStepDecoratorPlugin.java
@@ -1,0 +1,18 @@
+package org.apache.flink.kubernetes.operator.decorators;
+
+import org.apache.flink.core.plugin.Plugin;
+import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator;
+
+/** KubernetesStepDecorator Plugin Interface. */
+public interface KubernetesStepDecoratorPlugin extends KubernetesStepDecorator, Plugin {
+
+    /** Flink Component to be decorated. */
+    enum DecoratorComponent {
+        JOB_MANAGER,
+        TASK_MANAGER
+    }
+
+    default DecoratorComponent getDecoratorComponent() {
+        return DecoratorComponent.JOB_MANAGER;
+    }
+}

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/utils/DecoratorUtils.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/utils/DecoratorUtils.java
@@ -1,0 +1,49 @@
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator;
+import org.apache.flink.kubernetes.operator.decorators.KubernetesStepDecoratorPlugin;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** Decorator utilities. */
+public final class DecoratorUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(DecoratorUtils.class);
+
+    public static Set<KubernetesStepDecorator> discoverDecorators(
+            Configuration configuration,
+            KubernetesStepDecoratorPlugin.DecoratorComponent decoratorComponent) {
+        Set<KubernetesStepDecorator> decorators = new HashSet<>();
+        LOG.info(
+                "Discovering kubernetes decorator from plugin directory[{}].",
+                System.getenv()
+                        .getOrDefault(
+                                ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+                                ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS));
+
+        PluginUtils.createPluginManagerFromRootFolder(configuration)
+                .load(KubernetesStepDecoratorPlugin.class)
+                .forEachRemaining(
+                        decorator -> {
+                            if (decorator.getDecoratorComponent() == decoratorComponent) {
+                                LOG.info(
+                                        "Discovered kubernetes decorator for component: {} from plugin directory[{}]: {}.",
+                                        decoratorComponent,
+                                        System.getenv()
+                                                .getOrDefault(
+                                                        ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+                                                        ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS),
+                                        decorator.getClass().getName());
+
+                                decorators.add(decorator);
+                            }
+                        });
+        return decorators;
+    }
+}

--- a/flink-kubernetes-standalone/src/test/assembly/test-plugins-assembly.xml
+++ b/flink-kubernetes-standalone/src/test/assembly/test-plugins-assembly.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+    <id>test-jar</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.testOutputDirectory}</directory>
+            <outputDirectory>/</outputDirectory>
+            <!-- the service impl -->
+            <includes>
+                <include>org/apache/flink/kubernetes/operator/kubeclient/decorators/TestKubernetesStepDecoratorPlugin.class</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <!-- declaring the service impl -->
+            <directory>${project.basedir}/src/test/resources/META-INF/services</directory>
+            <outputDirectory>/META-INF/services</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/TestKubernetesStepDecoratorPlugin.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/TestKubernetesStepDecoratorPlugin.java
@@ -1,0 +1,26 @@
+package org.apache.flink.kubernetes.operator.kubeclient.decorators;
+
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.operator.decorators.KubernetesStepDecoratorPlugin;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/** KubernetesStepDecoratorPlugin mock for tests. */
+public class TestKubernetesStepDecoratorPlugin implements KubernetesStepDecoratorPlugin {
+    @Override
+    public DecoratorComponent getDecoratorComponent() {
+        return DecoratorComponent.JOB_MANAGER;
+    }
+
+    public FlinkPod decorateFlinkPod(FlinkPod flinkPod) {
+        return flinkPod;
+    }
+
+    public List<HasMetadata> buildAccompanyingKubernetesResources() throws IOException {
+        return Collections.emptyList();
+    }
+}

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/utils/DecoratorUtilsTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/utils/DecoratorUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.kubeclient.utils;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.decorators.KubernetesStepDecoratorPlugin;
+import org.apache.flink.kubernetes.operator.kubeclient.decorators.TestKubernetesStepDecoratorPlugin;
+import org.apache.flink.kubernetes.operator.utils.DecoratorUtils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test class for {@link DecoratorUtils}. */
+public class DecoratorUtilsTest {
+
+    @TempDir public Path temporaryFolder;
+
+    @Test
+    public void testDiscoverDecorators() throws IOException {
+        Map<String, String> originalEnv = System.getenv();
+        try {
+            Map<String, String> systemEnv = new HashMap<>(originalEnv);
+            systemEnv.put(
+                    ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+                    TestUtils.getTestPluginsRootDir(temporaryFolder));
+            TestUtils.setEnv(systemEnv);
+            assertEquals(
+                    new HashSet<>(
+                            Collections.singleton(
+                                    TestKubernetesStepDecoratorPlugin.class.getName())),
+                    DecoratorUtils.discoverDecorators(
+                                    new Configuration(),
+                                    KubernetesStepDecoratorPlugin.DecoratorComponent.JOB_MANAGER)
+                            .stream()
+                            .map(v -> v.getClass().getName())
+                            .collect(Collectors.toSet()));
+        } finally {
+            TestUtils.setEnv(originalEnv);
+        }
+    }
+}

--- a/flink-kubernetes-standalone/src/test/resources/META-INF/services/org.apache.flink.kubernetes.operator.decorators.KubernetesStepDecoratorPlugin
+++ b/flink-kubernetes-standalone/src/test/resources/META-INF/services/org.apache.flink.kubernetes.operator.decorators.KubernetesStepDecoratorPlugin
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.kubernetes.operator.kubeclient.decorators.TestKubernetesStepDecoratorPlugin


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR extends KubernetesStepDecorator interface to make it pluggable for custom decorators to be loaded as JARs.

## Brief change log

- Added DecoratorUtils to discover CustomDecorators in flink plugin folder to be loaded as JAR.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

- Added Unit Test.
- Manual tested by creating a custom Decorator plugin JAR that is copied over in DockerFile. Validated that the created JM container name is changed as per custom Decorator specification.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
