### PR TITLE
[FLINK-30920] Prevent clearing any manually defined vertex exclusions

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
@@ -128,8 +128,6 @@ public class ScalingMetrics {
             excludeVertexFromScaling(conf, jobVertexId);
             // Pretend that the load is balanced because we don't know any better
             busyTimeMsPerSecond = conf.get(AutoScalerOptions.TARGET_UTILIZATION) * 1000;
-        } else {
-            includeVertexForScaling(conf, jobVertexId);
         }
         return busyTimeMsPerSecond;
     }
@@ -197,15 +195,10 @@ public class ScalingMetrics {
         return rate / (busyTimeMsPerSecond / 1000);
     }
 
+    /** Temporarily exclude vertex from scaling for this run. This does not update the spec. */
     private static void excludeVertexFromScaling(Configuration conf, JobVertexID jobVertexId) {
         Set<String> excludedIds = new HashSet<>(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS));
         excludedIds.add(jobVertexId.toHexString());
-        conf.set(AutoScalerOptions.VERTEX_EXCLUDE_IDS, new ArrayList<>(excludedIds));
-    }
-
-    private static void includeVertexForScaling(Configuration conf, JobVertexID jobVertexId) {
-        Set<String> excludedIds = new HashSet<>(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS));
-        excludedIds.remove(jobVertexId.toHexString());
         conf.set(AutoScalerOptions.VERTEX_EXCLUDE_IDS, new ArrayList<>(excludedIds));
     }
 

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -177,6 +178,8 @@ public class ScalingMetricsTest {
                         new VertexInfo(sink, Collections.singleton(source), 10, 100));
 
         Configuration conf = new Configuration();
+        assertTrue(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS).isEmpty());
+        conf.set(AutoScalerOptions.VERTEX_EXCLUDE_IDS, List.of(sink.toHexString()));
 
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
         ScalingMetrics.computeDataRateMetrics(
@@ -196,6 +199,8 @@ public class ScalingMetricsTest {
 
         // Make sure vertex won't be scaled
         assertTrue(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS).contains(source.toHexString()));
+        // Existing overrides should be preserved
+        assertTrue(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS).contains(sink.toHexString()));
         // Legacy source rates are computed based on the current rate and a balanced utilization
         assertEquals(
                 2000 / conf.get(AutoScalerOptions.TARGET_UTILIZATION),


### PR DESCRIPTION
This fixes an unreleased bug which would clear user-set vertex exclusions from the config for non-legacy sources.