### PR TITLE
[FLINK-31866] Start metric window with timestamp of first observation

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfo.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfo.java
@@ -65,7 +65,6 @@ public class AutoScalerInfo {
 
     protected static final String COLLECTED_METRICS_KEY = "collectedMetrics";
     protected static final String SCALING_HISTORY_KEY = "scalingHistory";
-    protected static final String JOB_UPDATE_TS_KEY = "jobUpdateTs";
 
     protected static final int MAX_CM_BYTES = 1000000;
 
@@ -103,13 +102,11 @@ public class AutoScalerInfo {
     }
 
     @SneakyThrows
-    public void updateMetricHistory(
-            Instant jobUpdateTs, SortedMap<Instant, CollectedMetrics> history) {
+    public void updateMetricHistory(SortedMap<Instant, CollectedMetrics> history) {
 
         configMap
                 .getData()
                 .put(COLLECTED_METRICS_KEY, compress(YAML_MAPPER.writeValueAsString(history)));
-        configMap.getData().put(JOB_UPDATE_TS_KEY, jobUpdateTs.toString());
     }
 
     @SneakyThrows
@@ -122,13 +119,8 @@ public class AutoScalerInfo {
         }
     }
 
-    public void clearMetricHistory() {
+    public void resetMetricHistory() {
         configMap.getData().remove(COLLECTED_METRICS_KEY);
-        configMap.getData().remove(JOB_UPDATE_TS_KEY);
-    }
-
-    public Optional<Instant> getJobUpdateTs() {
-        return Optional.ofNullable(configMap.getData().get(JOB_UPDATE_TS_KEY)).map(Instant::parse);
     }
 
     @SneakyThrows

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfo.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfo.java
@@ -119,7 +119,7 @@ public class AutoScalerInfo {
         }
     }
 
-    public void resetMetricHistory() {
+    public void clearMetricHistory() {
         configMap.getData().remove(COLLECTED_METRICS_KEY);
     }
 

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
@@ -67,7 +67,7 @@ public abstract class ScalingMetricCollector {
     private final Map<ResourceID, Tuple2<Long, Map<JobVertexID, Map<String, FlinkMetric>>>>
             availableVertexMetricNames = new ConcurrentHashMap<>();
 
-    protected final Map<ResourceID, SortedMap<Instant, CollectedMetrics>> histories =
+    private final Map<ResourceID, SortedMap<Instant, CollectedMetrics>> histories =
             new ConcurrentHashMap<>();
 
     private final Map<ResourceID, JobTopology> topologies = new ConcurrentHashMap<>();

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
@@ -57,7 +57,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -68,7 +67,7 @@ public abstract class ScalingMetricCollector {
     private final Map<ResourceID, Tuple2<Long, Map<JobVertexID, Map<String, FlinkMetric>>>>
             availableVertexMetricNames = new ConcurrentHashMap<>();
 
-    private final Map<ResourceID, SortedMap<Instant, CollectedMetrics>> histories =
+    protected final Map<ResourceID, SortedMap<Instant, CollectedMetrics>> histories =
             new ConcurrentHashMap<>();
 
     private final Map<ResourceID, JobTopology> topologies = new ConcurrentHashMap<>();
@@ -77,49 +76,40 @@ public abstract class ScalingMetricCollector {
 
     public CollectedMetricHistory updateMetrics(
             AbstractFlinkResource<?, ?> cr,
-            AutoScalerInfo scalingInformation,
+            AutoScalerInfo autoscalerInfo,
             FlinkService flinkService,
             Configuration conf)
             throws Exception {
 
+        var topology = getJobTopology(flinkService, cr, conf, autoscalerInfo);
         var resourceID = ResourceID.fromResource(cr);
-        var jobStatus = cr.getStatus().getJobStatus();
-        var currentJobUpdateTs = Instant.ofEpochMilli(Long.parseLong(jobStatus.getUpdateTime()));
         var now = clock.instant();
 
-        if (!currentJobUpdateTs.equals(
-                scalingInformation.getJobUpdateTs().orElse(currentJobUpdateTs))) {
-            scalingInformation.clearMetricHistory();
+        var metricHistory =
+                histories.computeIfAbsent(resourceID, (k) -> autoscalerInfo.getMetricHistory());
+
+        // The timestamp of the first metric observation marks the start
+        // If we haven't collected any metrics, we are starting now
+        var metricCollectionStartTs = metricHistory.isEmpty() ? now : metricHistory.firstKey();
+        var jobUpdateTs = getJobUpdateTs(cr);
+        if (jobUpdateTs.isAfter(metricCollectionStartTs)) {
+            LOG.info("Job updated. Clearing metrics.");
+            autoscalerInfo.resetMetricHistory();
             cleanup(cr);
+            metricHistory.clear();
+            metricCollectionStartTs = now;
         }
 
-        var topology = getJobTopology(flinkService, cr, conf, scalingInformation);
+        // Trim metrics outside the metric window from metrics history
+        var metricWindowSize = getMetricWindowSize(conf);
+        metricHistory.headMap(now.minus(metricWindowSize)).clear();
 
-        var stabilizationDuration = conf.get(AutoScalerOptions.STABILIZATION_INTERVAL);
-        var stableTime = currentJobUpdateTs.plus(stabilizationDuration);
+        var stableTime = jobUpdateTs.plus(conf.get(AutoScalerOptions.STABILIZATION_INTERVAL));
         if (now.isBefore(stableTime)) {
             // As long as we are stabilizing, collect no metrics at all
             LOG.info("Skipping metric collection during stabilization period until {}", stableTime);
             return new CollectedMetricHistory(topology, Collections.emptySortedMap());
         }
-
-        // Adjust the window size until it reaches the max size
-        var metricsWindowSize =
-                Duration.ofMillis(
-                        Math.min(
-                                now.toEpochMilli() - stableTime.toEpochMilli(),
-                                conf.get(AutoScalerOptions.METRICS_WINDOW).toMillis()));
-
-        // Extract metrics history for metric window size
-        var scalingMetricHistory =
-                histories.compute(
-                        resourceID,
-                        (k, h) -> {
-                            if (h == null) {
-                                h = scalingInformation.getMetricHistory();
-                            }
-                            return new TreeMap<>(h.tailMap(now.minus(metricsWindowSize)));
-                        });
 
         // The filtered list of metrics we want to query for each vertex
         var filteredVertexMetricNames = queryFilteredMetricNames(flinkService, cr, conf, topology);
@@ -133,10 +123,10 @@ public abstract class ScalingMetricCollector {
                 convertToScalingMetrics(resourceID, collectedVertexMetrics, topology, conf);
 
         // Add scaling metrics to history if they were computed successfully
-        scalingMetricHistory.put(clock.instant(), scalingMetrics);
-        scalingInformation.updateMetricHistory(currentJobUpdateTs, scalingMetricHistory);
+        metricHistory.put(now, scalingMetrics);
+        autoscalerInfo.updateMetricHistory(metricHistory);
 
-        var windowFullTime = stableTime.plus(conf.get(AutoScalerOptions.METRICS_WINDOW));
+        var windowFullTime = metricCollectionStartTs.plus(metricWindowSize);
         if (now.isBefore(windowFullTime)) {
             // As long as we haven't had time to collect a full window,
             // collect metrics but do not return any metrics
@@ -146,7 +136,15 @@ public abstract class ScalingMetricCollector {
             return new CollectedMetricHistory(topology, Collections.emptySortedMap());
         }
 
-        return new CollectedMetricHistory(topology, scalingMetricHistory);
+        return new CollectedMetricHistory(topology, metricHistory);
+    }
+
+    protected Duration getMetricWindowSize(Configuration conf) {
+        return conf.get(AutoScalerOptions.METRICS_WINDOW);
+    }
+
+    private static Instant getJobUpdateTs(AbstractFlinkResource<?, ?> cr) {
+        return Instant.ofEpochMilli(Long.parseLong(cr.getStatus().getJobStatus().getUpdateTime()));
     }
 
     protected JobTopology getJobTopology(

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
@@ -94,7 +94,7 @@ public abstract class ScalingMetricCollector {
         var jobUpdateTs = getJobUpdateTs(cr);
         if (jobUpdateTs.isAfter(metricCollectionStartTs)) {
             LOG.info("Job updated. Clearing metrics.");
-            autoscalerInfo.resetMetricHistory();
+            autoscalerInfo.clearMetricHistory();
             cleanup(cr);
             metricHistory.clear();
             metricCollectionStartTs = now;

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfoTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfoTest.java
@@ -134,7 +134,6 @@ public class AutoScalerInfoTest {
         data.put(
                 AutoScalerInfo.COLLECTED_METRICS_KEY,
                 AutoScalerInfo.YAML_MAPPER.writeValueAsString(metricHistory));
-        data.put(AutoScalerInfo.JOB_UPDATE_TS_KEY, jobUpdateTs.toString());
         data.put(
                 AutoScalerInfo.SCALING_HISTORY_KEY,
                 AutoScalerInfo.YAML_MAPPER.writeValueAsString(scalingHistory));
@@ -145,7 +144,7 @@ public class AutoScalerInfoTest {
 
         // Override with compressed data
         var newTs = Instant.now();
-        info.updateMetricHistory(newTs, metricHistory);
+        info.updateMetricHistory(metricHistory);
         info.addToScalingHistory(newTs, Map.of(), new Configuration());
 
         // Make sure we can still access everything
@@ -189,7 +188,7 @@ public class AutoScalerInfoTest {
                                 1, 2, Map.of(ScalingMetric.LAG, EvaluatedScalingMetric.of(2.)))),
                 new Configuration());
 
-        info.updateMetricHistory(Instant.now(), metricHistory);
+        info.updateMetricHistory(metricHistory);
 
         assertFalse(
                 data.get(AutoScalerInfo.COLLECTED_METRICS_KEY).length()

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/TestingMetricsCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/TestingMetricsCollector.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
 
 import lombok.Setter;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,6 +39,8 @@ import java.util.Map;
 public class TestingMetricsCollector extends ScalingMetricCollector {
 
     @Setter private JobTopology jobTopology;
+
+    @Setter private Duration testMetricWindowSize;
 
     @Setter
     private Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>> currentMetrics = new HashMap<>();
@@ -75,5 +78,13 @@ public class TestingMetricsCollector extends ScalingMetricCollector {
     protected Collection<AggregatedMetric> queryAggregatedMetricNames(
             RestClusterClient<?> restClient, JobID jobID, JobVertexID jobVertexID) {
         return metricNames.getOrDefault(jobVertexID, Collections.emptyList());
+    }
+
+    @Override
+    protected Duration getMetricWindowSize(Configuration conf) {
+        if (testMetricWindowSize != null) {
+            return testMetricWindowSize;
+        }
+        return super.getMetricWindowSize(conf);
     }
 }


### PR DESCRIPTION
The autoscaler uses a ConfigMap to store past metric observations which is used to re-initialize the autoscaler state in case of failures or upgrades.

Whenever trimming of the ConfigMap occurs, we need to make sure we also update the timestamp for the start of the metric collection, so any removed observations can be compensated with by collecting new ones. If we don't do this, the metric window will effectively shrink due to removing observations.

This can lead to triggering scaling decisions when the operator gets redeployed due to the removed items.

The solution we are opting here is to treat the first metric observation timestamp as the start of the metric collection.
