### PR TITLE
[FLINK-31827] Discard old format scaling history

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfo.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfo.java
@@ -98,6 +98,7 @@ public class AutoScalerInfo {
         } catch (JacksonException e) {
             LOG.error(
                     "Could not deserialize metric history, possibly the format changed. Discarding...");
+            configMap.getData().remove(COLLECTED_METRICS_KEY);
             return new TreeMap<>();
         }
     }
@@ -105,7 +106,6 @@ public class AutoScalerInfo {
     @SneakyThrows
     public void updateMetricHistory(
             Instant jobUpdateTs, SortedMap<Instant, CollectedMetrics> history) {
-
         configMap
                 .getData()
                 .put(COLLECTED_METRICS_KEY, compress(YAML_MAPPER.writeValueAsString(history)));
@@ -146,6 +146,7 @@ public class AutoScalerInfo {
         } catch (JacksonException e) {
             LOG.error(
                     "Could not deserialize scaling history, possibly the format changed. Discarding...");
+            configMap.getData().remove(SCALING_HISTORY_KEY);
             scalingHistory = new HashMap<>();
         }
         return scalingHistory;

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfoTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerInfoTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -40,6 +41,7 @@ import java.util.TreeMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test for AutoScalerInfo. */
@@ -205,14 +207,22 @@ public class AutoScalerInfoTest {
 
     @Test
     public void testDiscardInvalidHistory() {
-        var info =
-                new AutoScalerInfo(
+        ConfigMap configMap = new ConfigMap();
+        configMap.setData(
+                new HashMap<>(
                         Map.of(
                                 AutoScalerInfo.COLLECTED_METRICS_KEY,
                                 "invalid",
                                 AutoScalerInfo.SCALING_HISTORY_KEY,
-                                "invalid2"));
+                                "invalid2")));
+
+        var info = new AutoScalerInfo(configMap);
+        assertEquals(2, configMap.getData().size());
+
         assertEquals(new TreeMap<>(), info.getMetricHistory());
+        assertNull(configMap.getData().get(AutoScalerInfo.COLLECTED_METRICS_KEY));
+
         assertEquals(new TreeMap<>(), info.getScalingHistory());
+        assertNull(configMap.getData().get(AutoScalerInfo.SCALING_HISTORY_KEY));
     }
 }


### PR DESCRIPTION
We recently change the format for the metric history but this also affects the scaling history because it contains new / old scaling metrics.
