### PR TITLE
[FLINK-31885] Trigger event on autoscaler error

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoscalerFactoryImpl.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoscalerFactoryImpl.java
@@ -36,6 +36,7 @@ public class JobAutoscalerFactoryImpl implements JobAutoScalerFactory {
                 kubernetesClient,
                 new RestApiMetricsCollector(),
                 new ScalingMetricEvaluator(),
-                new ScalingExecutor(kubernetesClient, eventRecorder));
+                new ScalingExecutor(kubernetesClient, eventRecorder),
+                eventRecorder);
     }
 }

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
@@ -83,6 +83,8 @@ public class ScalingMetrics {
             scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, numRecordsInPerSecond);
         } else {
             LOG.error("Cannot compute true processing rate without numRecordsInPerSecond");
+            scalingMetrics.put(ScalingMetric.TRUE_PROCESSING_RATE, Double.NaN);
+            scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, Double.NaN);
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -130,6 +130,7 @@ public class EventRecorder {
         RecoverDeployment,
         RestartUnhealthyJob,
         ScalingReport,
-        IneffectiveScaling
+        IneffectiveScaling,
+        AutoscalerError
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
@@ -96,6 +96,16 @@ public class EventUtilsTest {
         Assertions.assertNotNull(event);
         Assertions.assertEquals(eventConsumed, event);
         Assertions.assertEquals(2, event.getCount());
+
+        Assertions.assertTrue(
+                EventUtils.createOrUpdateEvent(
+                        kubernetesClient,
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        null,
+                        EventRecorder.Component.Operator,
+                        consumer));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Currently when there is an error in the atuoscaler logic due to some misconfiguration / invalid metrics etc we only log the problem in the operator side but don't show this to the user. From the user's perspective the autoscaler simply doesnt do anything in these cases if they dont have access to the operator logs.

This PR triggers a CR event in case an error happens in the autoscaler logic.

## Brief change log

 - Add error when exception happens
 - Add test

## Verifying this change

new unit test added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable