### PR TITLE
[FLINK-31860] Ignore Event creation errors during cleanup

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
@@ -110,7 +110,7 @@ public class JobAutoScalerImpl implements JobAutoScaler {
             registerResourceScalingMetrics(resource, ctx.getResourceMetricGroup());
 
             var specAdjusted =
-                    scalingExecutor.scaleResource(resource, autoScalerInfo, conf, evaluatedMetrics);
+                    scalingExecutor.scaleResource(ctx, autoScalerInfo, conf, evaluatedMetrics);
             autoScalerInfo.replaceInKubernetes(kubernetesClient);
             return specAdjusted;
         } catch (Exception e) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
@@ -26,6 +26,7 @@ import org.apache.flink.kubernetes.operator.service.FlinkService;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 /** Context for reconciling a Flink resource. * */
 @RequiredArgsConstructor
@@ -34,6 +35,7 @@ public abstract class FlinkResourceContext<CR extends AbstractFlinkResource<?, ?
     @Getter private final CR resource;
     @Getter private final Context<?> josdkContext;
     @Getter private final KubernetesResourceMetricGroup resourceMetricGroup;
+    @Getter @Setter private boolean ignoreEventErrors;
 
     private Configuration observeConfig;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
@@ -52,7 +52,7 @@ public abstract class AbstractFlinkResourceObserver<CR extends AbstractFlinkReso
         // Trigger resource specific observe logic
         observeInternal(ctx);
 
-        SavepointUtils.resetTriggerIfJobNotRunning(ctx.getResource(), eventRecorder);
+        SavepointUtils.resetTriggerIfJobNotRunning(ctx, eventRecorder);
     }
 
     /**

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SavepointObserver.java
@@ -111,7 +111,7 @@ public class SavepointObserver<
                 LOG.warn("Savepoint failed within grace period, retrying: " + err);
             }
             eventRecorder.triggerEvent(
-                    resource,
+                    ctx,
                     EventRecorder.Type.Warning,
                     EventRecorder.Reason.SavepointError,
                     EventRecorder.Component.Operator,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -155,7 +155,7 @@ public abstract class AbstractFlinkDeploymentObserver
 
         if (previousJmStatus != JobManagerDeploymentStatus.MISSING
                 && previousJmStatus != JobManagerDeploymentStatus.ERROR) {
-            onMissingDeployment(flinkApp);
+            onMissingDeployment(ctx);
         }
     }
 
@@ -217,15 +217,15 @@ public abstract class AbstractFlinkDeploymentObserver
                 && lastReconciledSpec.getJob().getState() == JobState.SUSPENDED;
     }
 
-    private void onMissingDeployment(FlinkDeployment deployment) {
+    private void onMissingDeployment(FlinkResourceContext<FlinkDeployment> ctx) {
         String err = "Missing JobManager deployment";
         logger.error(err);
         ReconciliationUtils.updateForReconciliationError(
-                deployment,
+                ctx.getResource(),
                 new MissingJobManagerException(err),
                 configManager.getOperatorConfiguration());
         eventRecorder.triggerEvent(
-                deployment,
+                ctx,
                 EventRecorder.Type.Warning,
                 EventRecorder.Reason.Missing,
                 EventRecorder.Component.JobManagerDeployment,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -143,7 +143,7 @@ public abstract class AbstractFlinkResourceReconciler<
             LOG.info(specChangeMessage);
             if (reconciliationStatus.getState() != ReconciliationState.UPGRADING) {
                 eventRecorder.triggerEvent(
-                        cr,
+                        ctx,
                         EventRecorder.Type.Normal,
                         EventRecorder.Reason.SpecChanged,
                         EventRecorder.Component.JobManagerDeployment,
@@ -168,7 +168,7 @@ public abstract class AbstractFlinkResourceReconciler<
             }
             LOG.warn(MSG_ROLLBACK);
             eventRecorder.triggerEvent(
-                    cr,
+                    ctx,
                     EventRecorder.Type.Normal,
                     EventRecorder.Reason.Rollback,
                     EventRecorder.Component.JobManagerDeployment,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -108,7 +108,7 @@ public abstract class AbstractJobReconciler<
             }
 
             eventRecorder.triggerEvent(
-                    resource,
+                    ctx,
                     EventRecorder.Type.Normal,
                     EventRecorder.Reason.Suspended,
                     EventRecorder.Component.JobManagerDeployment,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -175,7 +175,7 @@ public class ApplicationReconciler
         setJobIdIfNecessary(spec, relatedResource, deployConfig);
 
         eventRecorder.triggerEvent(
-                relatedResource,
+                ctx,
                 EventRecorder.Type.Normal,
                 EventRecorder.Reason.Submit,
                 EventRecorder.Component.JobManagerDeployment,
@@ -265,7 +265,7 @@ public class ApplicationReconciler
         if (shouldRestartJobBecauseUnhealthy || shouldRecoverDeployment) {
             if (shouldRecoverDeployment) {
                 eventRecorder.triggerEvent(
-                        deployment,
+                        ctx,
                         EventRecorder.Type.Warning,
                         EventRecorder.Reason.RecoverDeployment,
                         EventRecorder.Component.Job,
@@ -274,7 +274,7 @@ public class ApplicationReconciler
 
             if (shouldRestartJobBecauseUnhealthy) {
                 eventRecorder.triggerEvent(
-                        deployment,
+                        ctx,
                         EventRecorder.Type.Warning,
                         EventRecorder.Reason.RestartUnhealthyJob,
                         EventRecorder.Component.Job,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -150,7 +150,7 @@ public class SessionReconciler
                                     .map(job -> job.getMetadata().getName())
                                     .collect(Collectors.toList()));
             if (eventRecorder.triggerEvent(
-                    deployment,
+                    ctx,
                     EventRecorder.Type.Warning,
                     EventRecorder.Reason.CleanupFailed,
                     EventRecorder.Component.Operator,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SavepointUtils.java
@@ -26,6 +26,7 @@ import org.apache.flink.kubernetes.operator.api.status.JobStatus;
 import org.apache.flink.kubernetes.operator.api.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
@@ -190,7 +191,8 @@ public class SavepointUtils {
     }
 
     public static void resetTriggerIfJobNotRunning(
-            AbstractFlinkResource<?, ?> resource, EventRecorder eventRecorder) {
+            FlinkResourceContext<?> ctx, EventRecorder eventRecorder) {
+        var resource = ctx.getResource();
         var status = resource.getStatus();
         var jobStatus = status.getJobStatus();
         if (!ReconciliationUtils.isJobRunning(status)
@@ -200,7 +202,7 @@ public class SavepointUtils {
             savepointInfo.resetTrigger();
             LOG.error("Job is not running, cancelling savepoint operation");
             eventRecorder.triggerEvent(
-                    resource,
+                    ctx,
                     EventRecorder.Type.Warning,
                     EventRecorder.Reason.SavepointError,
                     EventRecorder.Component.Operator,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.listener.FlinkResourceListener;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentContext;
 import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
@@ -100,15 +101,16 @@ public class FlinkResourceListenerTest {
                 JobManagerDeploymentStatus.DEPLOYING,
                 updateContext.getNewStatus().getJobManagerDeploymentStatus());
 
+        var ctx = new FlinkDeploymentContext(deployment, null, null, null, null);
         eventRecorder.triggerEvent(
-                deployment,
+                ctx,
                 EventRecorder.Type.Warning,
                 EventRecorder.Reason.SavepointError,
                 EventRecorder.Component.Operator,
                 "err");
         assertEquals(1, listener1.events.size());
         eventRecorder.triggerEvent(
-                deployment,
+                ctx,
                 EventRecorder.Type.Warning,
                 EventRecorder.Reason.SavepointError,
                 EventRecorder.Component.Operator,


### PR DESCRIPTION
## What is the purpose of the change

The current logic tries to create Kubernetes events even during cleanup steps, failing to create them leads to a retry loop and a stuck delete operation on the CR.

However in many cases it's not possible to create events at this stage such as when a namepsace deletion triggered the CR deletion. Currently this means that namespace deletion will be blocked by the stuck cleanup/delete operation.

This PR addresses this by allowing us to ignore event creation errors during the cleanup phase.

## Brief change log

  - *Use FlinkResourceContext in the event recorder*
  - *Add flag to resource context to allow ignoring errors*
  - *Add tests*

## Verifying this change

New tests added for the FlinkDeployment and FlinkSessionJob controllers

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
