### PR TITLE
[FLINK-31815] Bump jackson version to eliminate snakeyaml vulnerability

### DIFF
--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.14.0
-- com.fasterxml.jackson.core:jackson-core:2.14.0
-- com.fasterxml.jackson.core:jackson-databind:2.14.0
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.14.0
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.14.0
+- com.fasterxml.jackson.core:jackson-annotations:2.15.0
+- com.fasterxml.jackson.core:jackson-core:2.15.0
+- com.fasterxml.jackson.core:jackson-databind:2.15.0
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.0
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.15.0
 - com.google.code.findbugs:jsr305:1.3.9
 - com.squareup.okhttp3:logging-interceptor:4.10.0
 - com.squareup.okhttp3:okhttp:4.10.0
@@ -65,7 +65,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.slf4j:slf4j-api:1.7.36
 - org.snakeyaml:snakeyaml-engine:jar:2.6
 - org.xerial.snappy:snappy-java:1.1.7
-- org.yaml:snakeyaml:1.33
+- org.yaml:snakeyaml:2.0
 
 This project bundles the following dependencies under the BSD License.
 See bundled license files for details.

--- a/flink-kubernetes-standalone/pom.xml
+++ b/flink-kubernetes-standalone/pom.xml
@@ -46,7 +46,8 @@ under the License.
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>${snakeyaml.version}</version>
+            <!-- Cannot upgrade to 2.0 due to flink incompatibility -->
+            <version>1.33</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,6 @@ under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <okhttp.version>4.10.0</okhttp.version>
-        <snakeyaml.version>1.33</snakeyaml.version>
         <curator-test.version>5.2.0</curator-test.version>
     </properties>
 
@@ -104,7 +103,7 @@ under the License.
                 <artifactId>jackson-bom</artifactId>
                 <type>pom</type>
                 <scope>import</scope>
-                <version>2.14.0</version>
+                <version>2.15.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## What is the purpose of the change

Eliminates a vulnerability related to snakeyaml 1.33 by bumping the jackson version.

## Brief change log

 - Bump version
 - Update NOTICE

## Verifying this change

Change covered by CI and e2es

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
