### PR TITLE
[FLINK-31867] Enforce a minimum number of observations within a metric window

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -52,6 +52,13 @@ public class AutoScalerOptions {
                     .defaultValue(Duration.ofMinutes(5))
                     .withDescription("Scaling metrics aggregation window size.");
 
+    public static final ConfigOption<Integer> METRICS_WINDOW_MIN_OBSERVATIONS =
+            autoScalerConfig("metrics.window.min-observations")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "The minimum number of observations to collect during a metric window");
+
     public static final ConfigOption<Duration> STABILIZATION_INTERVAL =
             autoScalerConfig("stabilization.interval")
                     .durationType()

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
@@ -99,6 +99,7 @@ public class BacklogBasedScalingTest extends OperatorTestBase {
         defaultConf.set(AutoScalerOptions.RESTART_TIME, Duration.ofSeconds(1));
         defaultConf.set(AutoScalerOptions.CATCH_UP_DURATION, Duration.ofSeconds(2));
         defaultConf.set(AutoScalerOptions.SCALING_ENABLED, true);
+        defaultConf.set(AutoScalerOptions.METRICS_WINDOW_MIN_OBSERVATIONS, 2);
         defaultConf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 1.);
         defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.8);
         defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.1);


### PR DESCRIPTION
This makes sure that a minimum number of observations have been taken within the metric window. Otherwise the metrics won't be returned to prevent decision making on too few observations.