### PR TITLE
[FLINK-32005] Add a per-deployment error metric to signal about potential issues

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoscalerFlinkMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoscalerFlinkMetrics.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.autoscaler;
+
+import org.apache.flink.kubernetes.operator.autoscaler.metrics.EvaluatedScalingMetric;
+import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/** Autoscaler metrics for observability. */
+public class AutoscalerFlinkMetrics {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AutoscalerFlinkMetrics.class);
+
+    final Counter numScalings;
+
+    final Counter numErrors;
+
+    final Counter numBalanced;
+
+    private final MetricGroup metricGroup;
+
+    private final Set<JobVertexID> vertexMetrics = new HashSet<>();
+
+    public AutoscalerFlinkMetrics(MetricGroup metricGroup) {
+        this.numScalings = metricGroup.counter("scalings");
+        this.numErrors = metricGroup.counter("errors");
+        this.numBalanced = metricGroup.counter("balanced");
+        this.metricGroup = metricGroup;
+    }
+
+    public void registerScalingMetrics(
+            Supplier<Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>>
+                    currentVertexMetrics) {
+        currentVertexMetrics
+                .get()
+                .forEach(
+                        (jobVertexID, evaluated) -> {
+                            if (!vertexMetrics.add(jobVertexID)) {
+                                return;
+                            }
+                            LOG.info("Registering scaling metrics for job vertex {}", jobVertexID);
+                            var jobVertexMg =
+                                    metricGroup.addGroup("jobVertexID", jobVertexID.toHexString());
+
+                            evaluated.forEach(
+                                    (sm, esm) -> {
+                                        var smGroup = jobVertexMg.addGroup(sm.name());
+
+                                        smGroup.gauge(
+                                                "Current",
+                                                () ->
+                                                        Optional.ofNullable(
+                                                                        currentVertexMetrics.get())
+                                                                .map(m -> m.get(jobVertexID))
+                                                                .map(
+                                                                        metrics ->
+                                                                                metrics.get(sm)
+                                                                                        .getCurrent())
+                                                                .orElse(null));
+
+                                        if (sm.isCalculateAverage()) {
+                                            smGroup.gauge(
+                                                    "Average",
+                                                    () ->
+                                                            Optional.ofNullable(
+                                                                            currentVertexMetrics
+                                                                                    .get())
+                                                                    .map(m -> m.get(jobVertexID))
+                                                                    .map(
+                                                                            metrics ->
+                                                                                    metrics.get(sm)
+                                                                                            .getAverage())
+                                                                    .orElse(null));
+                                        }
+                                    });
+                        });
+    }
+}

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
@@ -70,9 +70,7 @@ public class JobAutoScalerImpl implements JobAutoScaler {
         metricsCollector.cleanup(cr);
         var resourceId = ResourceID.fromResource(cr);
         lastEvaluatedMetrics.remove(resourceId);
-        // We are not removing the metrics registered with Flink (flinkMetrics)
-        // because Flink metrics can only be registered once! When the deployment
-        // comes back we would not be able to register and report metrics.
+        flinkMetrics.remove(resourceId);
     }
 
     @Override

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImplTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImplTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.autoscaler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.OperatorTestBase;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import lombok.Getter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.AUTOSCALER_ENABLED;
+
+/** Tests for JobAutoScalerImpl. */
+@EnableKubernetesMockClient(crud = true)
+public class JobAutoScalerImplTest extends OperatorTestBase {
+
+    @Getter private KubernetesClient kubernetesClient;
+
+    private FlinkDeployment app;
+
+    @BeforeEach
+    public void setup() {
+        app = TestUtils.buildApplicationCluster();
+        app.getMetadata().setGeneration(1L);
+        app.getStatus().getJobStatus().setJobId(new JobID().toHexString());
+        kubernetesClient.resource(app).createOrReplace();
+
+        var defaultConf = new Configuration();
+        defaultConf.set(AUTOSCALER_ENABLED, true);
+        configManager = new FlinkConfigManager(defaultConf);
+        ReconciliationUtils.updateStatusForDeployedSpec(
+                app, configManager.getDeployConfig(app.getMetadata(), app.getSpec()));
+    }
+
+    @Test
+    void testErrorReporting() {
+        var autoscaler = new JobAutoScalerImpl(kubernetesClient, null, null, null, eventRecorder);
+        FlinkResourceContext<FlinkDeployment> resourceContext = getResourceContext(app);
+        ResourceID resourceId = ResourceID.fromResource(app);
+
+        autoscaler.scale(resourceContext);
+        Assertions.assertEquals(1, autoscaler.errorCounters.get(resourceId).getCount());
+
+        autoscaler.scale(resourceContext);
+        Assertions.assertEquals(2, autoscaler.errorCounters.get(resourceId).getCount());
+    }
+}

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImplTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImplTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.AUTOSCALER_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Tests for JobAutoScalerImpl. */
 @EnableKubernetesMockClient(crud = true)
@@ -65,9 +66,11 @@ public class JobAutoScalerImplTest extends OperatorTestBase {
         ResourceID resourceId = ResourceID.fromResource(app);
 
         autoscaler.scale(resourceContext);
-        Assertions.assertEquals(1, autoscaler.errorCounters.get(resourceId).getCount());
+        Assertions.assertEquals(1, autoscaler.flinkMetrics.get(resourceId).numErrors.getCount());
 
         autoscaler.scale(resourceContext);
-        Assertions.assertEquals(2, autoscaler.errorCounters.get(resourceId).getCount());
+        Assertions.assertEquals(2, autoscaler.flinkMetrics.get(resourceId).numErrors.getCount());
+
+        assertEquals(0, autoscaler.flinkMetrics.get(resourceId).numScalings.getCount());
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -113,6 +113,7 @@ public class FlinkDeploymentController
             // ignore during cleanup
         }
         statusRecorder.removeCachedStatus(flinkApp);
+        ctxFactory.cleanup(flinkApp);
         return reconcilerFactory.getOrCreate(flinkApp).cleanup(ctx);
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkResourceContextFactory.java
@@ -17,13 +17,18 @@
 
 package org.apache.flink.kubernetes.operator;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
+import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+
+import java.util.Map;
 
 /** Flink service factory mock for tests. */
 public class TestingFlinkResourceContextFactory extends FlinkResourceContextFactory {
@@ -41,5 +46,9 @@ public class TestingFlinkResourceContextFactory extends FlinkResourceContextFact
     @Override
     protected FlinkService getOrCreateFlinkService(FlinkDeployment deployment) {
         return flinkService;
+    }
+
+    public Map<Tuple2<Class<?>, ResourceID>, KubernetesResourceMetricGroup> getMetricGroups() {
+        return resourceMetricGroups;
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -991,8 +991,15 @@ public class FlinkDeploymentControllerTest {
     @Test
     public void cleanUpNewDeployment() {
         FlinkDeployment flinkDeployment = TestUtils.buildApplicationCluster();
+        var resourceMetricGroup =
+                testController
+                        .getContextFactory()
+                        .getResourceContext(flinkDeployment, context)
+                        .getResourceMetricGroup();
         var deleteControl = testController.cleanup(flinkDeployment, context);
         assertNotNull(deleteControl);
+        assertTrue(resourceMetricGroup.isClosed());
+        assertTrue(testController.getContextFactory().getMetricGroups().isEmpty());
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -67,6 +67,9 @@ public class TestingFlinkDeploymentController
     private EventCollector eventCollector = new EventCollector();
 
     private EventRecorder eventRecorder;
+
+    @Getter private TestingFlinkResourceContextFactory contextFactory;
+
     private StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder;
     @Getter private CanaryResourceManager<FlinkDeployment> canaryResourceManager;
 
@@ -74,7 +77,8 @@ public class TestingFlinkDeploymentController
             FlinkConfigManager configManager,
             KubernetesClient kubernetesClient,
             TestingFlinkService flinkService) {
-        var ctxFactory =
+
+        contextFactory =
                 new TestingFlinkResourceContextFactory(
                         kubernetesClient,
                         configManager,
@@ -96,7 +100,7 @@ public class TestingFlinkDeploymentController
                 new FlinkDeploymentController(
                         configManager,
                         ValidatorUtils.discoverValidators(configManager),
-                        ctxFactory,
+                        contextFactory,
                         reconcilerFactory,
                         new FlinkDeploymentObserverFactory(configManager, eventRecorder),
                         statusRecorder,


### PR DESCRIPTION
If any of the autoscaled deployment produce errors they are only visible in the logs or in the k8s events. Additionally, it would be good to have metrics to detect any potential issues.