### PR TITLE
[FLINK-32012] Rely on savepoint mechanism when performing rollback with saveoint upgrade mode

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -384,6 +384,12 @@ public abstract class AbstractFlinkResourceReconciler<
             return false;
         }
 
+        if (resource.getSpec().getJob() != null
+                && resource.getSpec().getJob().getUpgradeMode() == UpgradeMode.SAVEPOINT) {
+            // HA data is not available during rollback for savepoint upgrade mode
+            return true;
+        }
+
         var haDataAvailable = flinkService.isHaMetadataAvailable(configuration);
         if (!haDataAvailable) {
             LOG.warn("Rollback is not possible due to missing HA metadata");

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -270,17 +270,13 @@ public abstract class AbstractJobReconciler<
 
         UpgradeMode upgradeMode = resource.getSpec().getJob().getUpgradeMode();
 
-        cancelJob(
-                ctx,
-                upgradeMode == UpgradeMode.STATELESS
-                        ? UpgradeMode.STATELESS
-                        : UpgradeMode.LAST_STATE);
+        cancelJob(ctx, upgradeMode);
 
         restoreJob(
                 ctx,
                 rollbackSpec,
                 ctx.getDeployConfig(rollbackSpec),
-                upgradeMode != UpgradeMode.STATELESS);
+                upgradeMode == UpgradeMode.LAST_STATE);
 
         reconciliationStatus.setState(ReconciliationState.ROLLED_BACK);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -36,6 +36,7 @@ import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.api.status.Savepoint;
 import org.apache.flink.kubernetes.operator.api.status.SavepointFormatType;
 import org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType;
@@ -338,6 +339,10 @@ public abstract class AbstractFlinkService implements FlinkService {
                     } else if (ReconciliationUtils.isJobInTerminalState(deploymentStatus)) {
                         LOG.info(
                                 "Job is already in terminal state skipping cancel-with-savepoint operation.");
+                    } else if (deployment.getStatus().getReconciliationStatus().getState()
+                            == ReconciliationState.ROLLING_BACK) {
+                        LOG.info(
+                                "Job reconciliation status is in rolling back state. Job is expecting to not be in running or terminal state");
                     } else {
                         throw new RuntimeException(
                                 "Unexpected non-terminal status: " + deploymentStatus);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Operator failed to rollback due to missing HA data.
This is due to data being removed by flink job when relying on savepoint upgrade mode.

As performed by upgrade mechanism we should rely on savepoint to do rollback and not on HA data

## Brief change log

During savepoint rollback the HA data is not mandatory. Do not ensure it is available when rollbacking:
- during check if shouldRollback
- during restore of the job

Also enforce deletion of the HA data as performed during upgrade mechanism for savepoint upgrade mode

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

- This change is covered by change performed in RollbackTest.testStatefulRollback.SAVEPOINT
The flinkService now return false for haDataAvailable as if the HA data was deleted during upgrade phase and not recreated due to failure during upgrade phase.
Still the rollback reconcile work fine and the job has well taken in account the last savepoint.

- Also tested on one of our flinkdeployment
  - redeploy flinkdeployment with increase of parallelism work fine
  - then redeploy the flinkdeployment with a service account which didn't have access to s3 savepoint path. The operator successfully rollbacked to previous working state

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes for rollback event with savepoint upgrade mode

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
