### PR TITLE
fix : enable operatorVolumeMounts mountPath repeat

### DIFF
--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -121,10 +121,11 @@ spec:
           volumeMounts:
             - name: flink-operator-config-volume
               mountPath: /opt/flink/conf
-            - name: flink-artifacts-volume
-              mountPath: /opt/flink/artifacts
             {{- if .Values.operatorVolumeMounts.create }}
                 {{- toYaml .Values.operatorVolumeMounts.data | nindent 12 }}
+            {{- else }}
+            - name: flink-artifacts-volume
+              mountPath: /opt/flink/artifacts
             {{- end }}
           {{- if and (index .Values "operatorHealth") (index .Values.operatorHealth "livenessProbe") }}
           livenessProbe:
@@ -208,6 +209,9 @@ spec:
                 path: log4j-console.properties
         {{- if .Values.operatorVolumes.create }}
               {{- toYaml .Values.operatorVolumes.data | nindent 8 }}
+        {{- else }}
+        - name: flink-artifacts-volume
+          emptyDir: {}            
         {{- end }}
         {{- if eq (include "flink-operator.webhook-enabled" .) "true" }}
         - name: keystore
@@ -217,8 +221,6 @@ spec:
             - key: keystore.p12
               path: keystore.p12
         {{- end }}
-        - name: flink-artifacts-volume
-          emptyDir: {}
 ---
 {{- if .Values.defaultConfiguration.create }}
 apiVersion: v1


### PR DESCRIPTION

<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

mountPath repeats when operatorVolumeMounts persistence is turned on.
when operatorVolumeMounts turned on, mountPath conflict with flink-operator.yaml  flink-artifacts-volume, flink-artifacts-volume emptyDir No need.

**values.yaml config**
```yaml
operatorVolumeMounts:
  create: true
  data:
    - name: flink-artifacts
      mountPath: /opt/flink/artifacts  #  when true , mountPath conflict with flink-operator.yaml  flink-artifacts-volume.

operatorVolumes:
  create: true
  data:
    - name: flink-artifacts
      persistentVolumeClaim:
        claimName: flink-artifacts-pvc
```
