### PR TITLE
[FLINK-32067] Do not configure invalid null podTemplate

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -415,6 +415,7 @@ public class FlinkConfigBuilder {
                         ? KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE
                         : KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE;
 
+        Pod podTemplate;
         if (basicPod != null || appendPod != null) {
             Pod mergedPodTemplate =
                     mergePodTemplates(
@@ -422,11 +423,12 @@ public class FlinkConfigBuilder {
                             appendPod,
                             effectiveConfig.get(
                                     KubernetesOperatorConfigOptions.POD_TEMPLATE_MERGE_BY_NAME));
-            Pod newPodTemplate = applyResourceToPodTemplate(mergedPodTemplate, resource);
-            effectiveConfig.setString(podConfigOption, createTempFile(newPodTemplate));
+            podTemplate = applyResourceToPodTemplate(mergedPodTemplate, resource);
         } else {
-            Pod newPodTemplate = applyResourceToPodTemplate(null, resource);
-            effectiveConfig.setString(podConfigOption, createTempFile(newPodTemplate));
+            podTemplate = applyResourceToPodTemplate(null, resource);
+        }
+        if (podTemplate != null) {
+            effectiveConfig.setString(podConfigOption, createTempFile(podTemplate));
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Recent changes broke the podTemplate configuration logic when no pod template or ephemeral storage is configured resulting in an invalid null object serialized and set.

## Brief change log

 - Fix invalid logic
 - Add unit test

## Verifying this change

New unit test case has been added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
