### PR TITLE
[FLINK-32002] Autoscaler default config improvements

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -70,13 +70,13 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.autoscaler.scale-up.max-factor</h5></td>
-            <td style="word-wrap: break-word;">2.147483647E9</td>
+            <td style="word-wrap: break-word;">100000.0</td>
             <td>Double</td>
             <td>Max scale up factor. 2.0 means job can only be scaled up with 200% of the current parallelism.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.autoscaler.scaling.effectiveness.detection.enabled</h5></td>
-            <td style="word-wrap: break-word;">true</td>
+            <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Whether to enable detection of ineffective scaling operations and allowing the autoscaler to block further scale ups.</td>
         </tr>

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -102,7 +102,7 @@ public class AutoScalerOptions {
     public static final ConfigOption<Double> MAX_SCALE_UP_FACTOR =
             autoScalerConfig("scale-up.max-factor")
                     .doubleType()
-                    .defaultValue((double) Integer.MAX_VALUE)
+                    .defaultValue(100000.)
                     .withDescription(
                             "Max scale up factor. 2.0 means job can only be scaled up with 200% of the current parallelism.");
 
@@ -130,7 +130,7 @@ public class AutoScalerOptions {
     public static final ConfigOption<Boolean> SCALING_EFFECTIVENESS_DETECTION_ENABLED =
             autoScalerConfig("scaling.effectiveness.detection.enabled")
                     .booleanType()
-                    .defaultValue(true)
+                    .defaultValue(false)
                     .withDescription(
                             "Whether to enable detection of ineffective scaling operations and allowing the autoscaler to block further scale ups.");
 

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScalerTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScalerTest.java
@@ -245,6 +245,7 @@ public class JobVertexScalerTest {
     @Test
     public void testIneffectiveScalingDetection() {
         var op = new JobVertexID();
+        conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         conf.set(AutoScalerOptions.SCALE_UP_GRACE_PERIOD, Duration.ZERO);
 
@@ -312,6 +313,7 @@ public class JobVertexScalerTest {
     @Test
     public void testSendingIneffectiveScalingEvents() {
         var jobVertexID = new JobVertexID();
+        conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.0);
         conf.set(AutoScalerOptions.SCALE_UP_GRACE_PERIOD, Duration.ZERO);
 


### PR DESCRIPTION
Some further minor improvements to the autoscaler default config: 

 - Turn off ineffective scaling detection by default as it probed to be a little unstable
 - Set a large (but not too large) number for max scale up factor to improve the doc