### PR TITLE
fix: flink account cannot get resource "services" in API group

### DIFF
--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -87,6 +87,7 @@ rules:
     resources:
       - pods
       - configmaps
+      - services
     verbs:
       - '*'
   - apiGroups:


### PR DESCRIPTION
## What is the purpose of the change

When I remotely connected to the Flink cluster using local SQL client, I encountered an error while submitting an SQL statement:
```
[ERROR] Could not execute SQL statement. Reason:
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://10.53.0.1/api/v1/namespaces/flink-operator/services/basic-example-rest. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "basic-example-rest" is forbidden: User "system:serviceaccount:flink-operator:flink" cannot get resource "services" in API group "" in the namespace "flink-operator".
```
this error indicating that Flink account lacks permission to operate services resource, missing permissions should be added to the Flink account in chart templates.