### PR TITLE
[FLINK-32041] - Allow operator to manage leases when using watchNamespaces

### DIFF
--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -71,17 +71,12 @@ rules:
       - ingresses
     verbs:
       - "*"
-{{/*
-watchNamespaces doesn't need this since the operator handles it
-*/}}
-{{- if not .Values.watchNamespaces }}
   - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
     verbs:
       - "*"
-{{- end }}
 {{- end }}
 
 {{/*
@@ -179,7 +174,7 @@ subjects:
 {{/*
 Give operator the ability to operate on leases in the release namespace
 */}}
-{{- if .Values.rbac.operatorRole.create }}
+{{- if and .Values.rbac.operatorRole.create (not (has .Release.Namespace .Values.watchNamespaces)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -196,7 +191,7 @@ rules:
       - "*"
 {{- end }}
 ---
-{{- if .Values.rbac.operatorRoleBinding.create }}
+{{- if and .Values.rbac.operatorRole.create (not (has .Release.Namespace .Values.watchNamespaces)) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -71,12 +71,17 @@ rules:
       - ingresses
     verbs:
       - "*"
+{{/*
+watchNamespaces doesn't need this since the operator handles it
+*/}}
+{{- if not .Values.watchNamespaces }}
   - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
     verbs:
       - "*"
+{{- end }}
 {{- end }}
 
 {{/*
@@ -170,6 +175,43 @@ subjects:
     namespace: {{ . }}
 {{- end }}
 ---
+{{- end }}
+{{/*
+Give operator the ability to operate on leases in the release namespace
+*/}}
+{{- if .Values.rbac.operatorRole.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "flink-operator.roleName" $ }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flink-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - "*"
+{{- end }}
+---
+{{- if .Values.rbac.operatorRoleBinding.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "flink-operator.roleBindingName" $ }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flink-operator.labels" $ | nindent 4 }}
+roleRef:
+  kind: Role
+  name: {{ include "flink-operator.roleName" $ }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "flink-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}
 {{ else }}
 {{/*


### PR DESCRIPTION
## What is the purpose of the change

The operator doesn't have the ability to manage leases in its own namespace when using `watchNamespaces`. This fixes that by adding a `Role` and `RoleBinding` for it when `watchNamespaces` is set.

## Brief change log

  - Add Role and RoleBinding for the operator in release namespace when using namespace-scoped RBAC
  - Remove the ability to create leases from `watchNamespaces` when using namespace-scoped RBAC

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage. We do, however, currently have this change [deployed](https://github.com/wikimedia/operations-deployment-charts/commit/e06d57b5bdf06f827e4e1ca081320aee4cc82cb0) in our production setup

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
