### PR TITLE
[FLINK-32134] Autoscaler min/max parallelism configs should respect current parallelism

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScaler.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScaler.java
@@ -120,8 +120,8 @@ public class JobVertexScaler {
                         currentParallelism,
                         (int) evaluatedMetrics.get(MAX_PARALLELISM).getCurrent(),
                         scaleFactor,
-                        conf.getInteger(VERTEX_MIN_PARALLELISM),
-                        conf.getInteger(VERTEX_MAX_PARALLELISM));
+                        Math.min(currentParallelism, conf.getInteger(VERTEX_MIN_PARALLELISM)),
+                        Math.max(currentParallelism, conf.getInteger(VERTEX_MAX_PARALLELISM)));
 
         if (newParallelism == currentParallelism
                 || blockScalingBasedOnPastActions(

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScalerTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScalerTest.java
@@ -187,6 +187,16 @@ public class JobVertexScalerTest {
                         new JobVertexID(),
                         evaluated(10, 100, 500),
                         Collections.emptySortedMap()));
+
+        // Make sure we respect current parallelism in case it's lower
+        assertEquals(
+                4,
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep,
+                        conf,
+                        new JobVertexID(),
+                        evaluated(4, 100, 500),
+                        Collections.emptySortedMap()));
     }
 
     @Test
@@ -200,6 +210,16 @@ public class JobVertexScalerTest {
                         conf,
                         new JobVertexID(),
                         evaluated(10, 500, 100),
+                        Collections.emptySortedMap()));
+
+        // Make sure we respect current parallelism in case it's higher
+        assertEquals(
+                12,
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep,
+                        conf,
+                        new JobVertexID(),
+                        evaluated(12, 500, 100),
                         Collections.emptySortedMap()));
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Currently the min/max parallelism configs for the autoscaler are handled strictly and they can potentially override the user defined current parallelism. This is incorrect and the limits should be adjusted by the current parallelism

## Verifying this change

New unit test cases added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
