### PR TITLE
[FLINK-31684] Report autoscaling metrics before metric window is full

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/CollectedMetricHistory.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/CollectedMetricHistory.java
@@ -19,14 +19,16 @@ package org.apache.flink.kubernetes.operator.autoscaler.metrics;
 
 import org.apache.flink.kubernetes.operator.autoscaler.topology.JobTopology;
 
-import lombok.Value;
+import lombok.Data;
+import lombok.Setter;
 
 import java.time.Instant;
 import java.util.SortedMap;
 
 /** Topology and collected metric history. */
-@Value
+@Data
 public class CollectedMetricHistory {
-    JobTopology jobTopology;
-    SortedMap<Instant, CollectedMetrics> metricHistory;
+    final JobTopology jobTopology;
+    final SortedMap<Instant, CollectedMetrics> metricHistory;
+    @Setter private boolean fullyCollected;
 }


### PR DESCRIPTION
The metrics get reported only after the metric window is full. This is not helpful for observability after rescaling. We need to make sure that metrics are reported even when the metric window is not yet full.