### PR TITLE
[FLINK-32148] Make operator logging less noisy

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
@@ -83,7 +83,7 @@ public class JobAutoScalerImpl implements JobAutoScaler {
         try {
 
             if (resource.getSpec().getJob() == null || !conf.getBoolean(AUTOSCALER_ENABLED)) {
-                LOG.info("Job autoscaler is disabled");
+                LOG.debug("Job autoscaler is disabled");
                 return false;
             }
 

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScaler.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScaler.java
@@ -221,7 +221,7 @@ public class JobVertexScaler {
                 message);
 
         if (conf.get(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED)) {
-            LOG.info(
+            LOG.warn(
                     "Ineffective scaling detected for {}, expected increase {}, actual {}",
                     vertex,
                     expectedIncrease,

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
@@ -228,7 +228,7 @@ public class ScalingExecutor {
         evaluatedMetrics.forEach(
                 (v, metrics) -> {
                     if (excludeVertexIdList.contains(v.toHexString())) {
-                        LOG.info(
+                        LOG.debug(
                                 "Vertex {} is part of `vertex.exclude.ids` config, Ignoring it for scaling",
                                 v);
                     } else {

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
@@ -72,7 +72,7 @@ public class ScalingMetrics {
 
         if (isSource) {
             double sourceDataRate = Math.max(0, numRecordsInPerSecond + lagGrowthRate);
-            LOG.info("Using computed source data rate {} for {}", sourceDataRate, jobVertexID);
+            LOG.debug("Using computed source data rate {} for {}", sourceDataRate, jobVertexID);
             scalingMetrics.put(ScalingMetric.SOURCE_DATA_RATE, sourceDataRate);
             scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, numRecordsInPerSecond);
         }
@@ -82,7 +82,7 @@ public class ScalingMetrics {
             scalingMetrics.put(ScalingMetric.TRUE_PROCESSING_RATE, trueProcessingRate);
             scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, numRecordsInPerSecond);
         } else {
-            LOG.error("Cannot compute true processing rate without numRecordsInPerSecond");
+            LOG.warn("Cannot compute true processing rate without numRecordsInPerSecond");
             scalingMetrics.put(ScalingMetric.TRUE_PROCESSING_RATE, Double.NaN);
             scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, Double.NaN);
         }
@@ -140,7 +140,7 @@ public class ScalingMetrics {
         var busyTimeMsPerSecond =
                 busyTimeAggregator.get(flinkMetrics.get(FlinkMetric.BUSY_TIME_PER_SEC));
         if (!Double.isFinite(busyTimeMsPerSecond)) {
-            LOG.error(
+            LOG.warn(
                     "No busyTimeMsPerSecond metric available for {}. No scaling will be performed for this vertex.",
                     jobVertexId);
             excludeVertexFromScaling(conf, jobVertexId);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -219,7 +219,7 @@ public class FlinkConfigManager {
 
     private Configuration generateConfig(Key key) {
         try {
-            LOG.info("Generating new config");
+            LOG.debug("Generating new config");
             return FlinkConfigBuilder.buildFrom(
                     key.namespace,
                     key.name,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -125,7 +125,7 @@ public class FlinkDeploymentController
             return UpdateControl.noUpdate();
         }
 
-        LOG.info("Starting reconciliation");
+        LOG.debug("Starting reconciliation");
 
         statusRecorder.updateStatusFromCache(flinkApp);
         FlinkDeployment previousDeployment = ReconciliationUtils.clone(flinkApp);
@@ -156,7 +156,7 @@ public class FlinkDeploymentController
             throw new ReconciliationException(e);
         }
 
-        LOG.info("End of reconciliation");
+        LOG.debug("End of reconciliation");
         statusRecorder.patchAndCacheStatus(flinkApp);
         return ReconciliationUtils.toUpdateControl(
                 configManager.getOperatorConfiguration(), flinkApp, previousDeployment, true);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/ClusterHealthObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/ClusterHealthObserver.java
@@ -49,7 +49,7 @@ public class ClusterHealthObserver {
     public void observe(FlinkResourceContext<FlinkDeployment> ctx) {
         var flinkApp = ctx.getResource();
         try {
-            LOG.info("Observing cluster health");
+            LOG.debug("Observing cluster health");
             var deploymentStatus = flinkApp.getStatus();
             var jobStatus = deploymentStatus.getJobStatus();
             var jobId = jobStatus.getJobId();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -60,7 +60,7 @@ public abstract class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
     public boolean observe(FlinkResourceContext<R> ctx) {
         var resource = ctx.getResource();
         var jobStatus = resource.getStatus().getJobStatus();
-        LOG.info("Observing job status");
+        LOG.debug("Observing job status");
         var previousJobStatus = jobStatus.getState();
 
         List<JobStatusMessage> clusterJobStatuses;
@@ -168,7 +168,7 @@ public abstract class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
 
         if (jobStatus.getJobId().equals(previousJobId)
                 && jobStatus.getState().equals(previousJobStatus)) {
-            LOG.info("Job status ({}) unchanged", previousJobStatus);
+            LOG.debug("Job status ({}) unchanged", previousJobStatus);
         } else {
             jobStatus.setUpdateTime(String.valueOf(System.currentTimeMillis()));
             var message =
@@ -177,7 +177,6 @@ public abstract class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
                             : String.format(
                                     "Job status changed from %s to %s",
                                     previousJobStatus, jobStatus.getState());
-            LOG.info(message);
 
             setErrorIfPresent(ctx, clusterJobStatus);
             eventRecorder.triggerEvent(


### PR DESCRIPTION
## What is the purpose of the change

Reduce logging noise from the operator by changing the log level to debug in many cases. Currently the operator is very noisy and outputs a lot of redundant / usless logs during normal operations.

## Verifying this change

Tested locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
