### PR TITLE
[FLINK-32147] Deduplicate scaling report messages

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
@@ -119,7 +119,8 @@ public class ScalingExecutor {
                 EventRecorder.Type.Normal,
                 EventRecorder.Reason.ScalingReport,
                 EventRecorder.Component.Operator,
-                scalingReport);
+                scalingReport,
+                "ScalingExecutor");
 
         if (!scalingEnabled) {
             return false;

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutorTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutorTest.java
@@ -242,6 +242,14 @@ public class ScalingExecutorTest {
                                         ? SCALING_SUMMARY_HEADER_SCALING_ENABLED
                                         : SCALING_SUMMARY_HEADER_SCALING_DISABLED));
         assertEquals(EventRecorder.Reason.ScalingReport.name(), event.getReason());
+
+        metrics = Map.of(jobVertexID, evaluated(1, 110, 101));
+        assertEquals(
+                scalingEnabled,
+                scalingDecisionExecutor.scaleResource(flinkDep, scalingInfo, conf, metrics));
+        var event2 = eventCollector.events.poll();
+        assertEquals(event.getMetadata().getUid(), event2.getMetadata().getUid());
+        assertEquals(2, event2.getCount());
     }
 
     private Map<ScalingMetric, EvaluatedScalingMetric> evaluated(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -23,6 +23,8 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
+import javax.annotation.Nullable;
+
 import java.time.Instant;
 import java.util.function.Consumer;
 
@@ -57,8 +59,13 @@ public class EventUtils {
             String reason,
             String message,
             EventRecorder.Component component,
-            Consumer<Event> eventListener) {
-        var eventName = generateEventName(target, type, reason, message, component);
+            Consumer<Event> eventListener,
+            @Nullable String messageKey) {
+
+        if (messageKey == null) {
+            messageKey = message;
+        }
+        var eventName = generateEventName(target, type, reason, messageKey, component);
 
         var existing =
                 client.v1()


### PR DESCRIPTION
## What is the purpose of the change

The operator currently always uses the event message content to generate the event name/uid. This is good in most cases and does not lead to duplicate events but in case of the scaling reports we include metrics in the event message that change all the time.

## Brief change log

  - *Introduce mechanism to replace message with key for event recorder*
  - *Add tests*
  - *Use dedicated key for scaling report events*

## Verifying this change

New unit tests have been added.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
