### PR TITLE
[FLINK-32272] Expose LOAD as autoscaler metric

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
@@ -239,7 +239,9 @@ public abstract class ScalingMetricCollector {
                     if (jobTopology.isSource(jobVertexID)) {
                         ScalingMetrics.computeLagMetrics(vertexFlinkMetrics, vertexScalingMetrics);
                     }
-                    ScalingMetrics.computeLoadMetrics(vertexFlinkMetrics, vertexScalingMetrics);
+
+                    ScalingMetrics.computeLoadMetrics(
+                            jobVertexID, vertexFlinkMetrics, vertexScalingMetrics, conf);
 
                     double lagGrowthRate =
                             computeLagGrowthRate(

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricEvaluator.java
@@ -45,6 +45,7 @@ import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerO
 import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.CATCH_UP_DATA_RATE;
 import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.CURRENT_PROCESSING_RATE;
 import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.LAG;
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.LOAD;
 import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.MAX_PARALLELISM;
 import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.PARALLELISM;
 import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.SCALE_DOWN_RATE_THRESHOLD;
@@ -136,6 +137,11 @@ public class ScalingMetricEvaluator {
                 new EvaluatedScalingMetric(
                         latestVertexMetrics.get(TRUE_PROCESSING_RATE),
                         getAverage(TRUE_PROCESSING_RATE, vertex, metricsHistory)));
+
+        evaluatedMetrics.put(
+                LOAD,
+                new EvaluatedScalingMetric(
+                        latestVertexMetrics.get(LOAD), getAverage(LOAD, vertex, metricsHistory)));
 
         evaluatedMetrics.put(
                 PARALLELISM, EvaluatedScalingMetric.of(topology.getParallelisms().get(vertex)));

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
@@ -23,11 +23,8 @@ package org.apache.flink.kubernetes.operator.autoscaler.metrics;
  */
 public enum ScalingMetric {
 
-    /** Max subtask load (busy time ratio 0 (idle) to 1 (fully utilized)). */
-    LOAD_MAX(true),
-
-    /** Average subtask load (busy time ratio 0 (idle) to 1 (fully utilized)). */
-    LOAD_AVG(true),
+    /** Subtask load (busy time ratio 0 (idle) to 1 (fully utilized)). */
+    LOAD(true),
 
     /** Processing rate at full capacity (records/sec). */
     TRUE_PROCESSING_RATE(true),

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetrics.java
@@ -39,21 +39,13 @@ public class ScalingMetrics {
     private static final Logger LOG = LoggerFactory.getLogger(ScalingMetrics.class);
 
     public static void computeLoadMetrics(
+            JobVertexID jobVertexID,
             Map<FlinkMetric, AggregatedMetric> flinkMetrics,
-            Map<ScalingMetric, Double> scalingMetrics) {
+            Map<ScalingMetric, Double> scalingMetrics,
+            Configuration conf) {
 
-        var busyTime = flinkMetrics.get(FlinkMetric.BUSY_TIME_PER_SEC);
-        if (busyTime == null) {
-            return;
-        }
-
-        if (!busyTime.getAvg().isNaN()) {
-            scalingMetrics.put(ScalingMetric.LOAD_AVG, busyTime.getAvg() / 1000);
-        }
-
-        if (!busyTime.getMax().isNaN()) {
-            scalingMetrics.put(ScalingMetric.LOAD_MAX, busyTime.getMax() / 1000);
-        }
+        double busyTimeMsPerSecond = getBusyTimeMsPerSecond(flinkMetrics, conf, jobVertexID);
+        scalingMetrics.put(ScalingMetric.LOAD, busyTimeMsPerSecond / 1000);
     }
 
     public static void computeDataRateMetrics(

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
@@ -377,12 +377,16 @@ public class BacklogBasedScalingTest extends OperatorTestBase {
                 Map.of(
                         source1,
                         Map.of(
+                                FlinkMetric.BUSY_TIME_PER_SEC,
+                                new AggregatedMetric("", Double.NaN, 850., Double.NaN, Double.NaN),
                                 FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
                                 new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 500.),
                                 FlinkMetric.NUM_RECORDS_IN_PER_SEC,
                                 new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 500.)),
                         sink,
                         Map.of(
+                                FlinkMetric.BUSY_TIME_PER_SEC,
+                                new AggregatedMetric("", Double.NaN, 850., Double.NaN, Double.NaN),
                                 FlinkMetric.NUM_RECORDS_IN_PER_SEC,
                                 new AggregatedMetric(
                                         "", Double.NaN, Double.NaN, Double.NaN, 500.))));

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetricsTest.java
@@ -194,15 +194,39 @@ public class ScalingMetricsTest {
 
     @Test
     public void testLoadMetrics() {
+        var source = new JobVertexID();
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
+        var conf = new Configuration();
+
+        conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.MAX);
         ScalingMetrics.computeLoadMetrics(
+                source,
                 Map.of(
                         FlinkMetric.BUSY_TIME_PER_SEC,
-                        new AggregatedMetric("", Double.NaN, 200., 100., Double.NaN)),
-                scalingMetrics);
+                        new AggregatedMetric("", 100., 200., 150., Double.NaN)),
+                scalingMetrics,
+                conf);
+        assertEquals(.2, scalingMetrics.get(ScalingMetric.LOAD));
 
-        assertEquals(0.2, scalingMetrics.get(ScalingMetric.LOAD_MAX));
-        assertEquals(0.1, scalingMetrics.get(ScalingMetric.LOAD_AVG));
+        conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.MIN);
+        ScalingMetrics.computeLoadMetrics(
+                source,
+                Map.of(
+                        FlinkMetric.BUSY_TIME_PER_SEC,
+                        new AggregatedMetric("", 100., 200., 150., Double.NaN)),
+                scalingMetrics,
+                conf);
+        assertEquals(.1, scalingMetrics.get(ScalingMetric.LOAD));
+
+        conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.AVG);
+        ScalingMetrics.computeLoadMetrics(
+                source,
+                Map.of(
+                        FlinkMetric.BUSY_TIME_PER_SEC,
+                        new AggregatedMetric("", 100., 200., 150., Double.NaN)),
+                scalingMetrics,
+                conf);
+        assertEquals(.15, scalingMetrics.get(ScalingMetric.LOAD));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

LOAD can be used to identify the busiest vertices in a job graph, hence it's useful to have it as a metric. 

## Brief change log
  - Removing the seemingly obsolete? `LOAD_MAX` and `LOAD_AVG` scaling metrics
  - Storing the `busyTimeMsPerSecond`  Flink metric as `LOAD` instead as an  EvaluatedScalingMetrics. 
  
The auto scaler logic is using the `MetricAggregator.(MIN,MAX,AVG)` config option to determine with value to be used from the `busyTimeMsPerSecond` aggregates when calculating various rates for a given vertex. The same logic is reused when calculating the `LOAD` values.

## Verified by
  This change is already covered by existing tests, some extra test data and assertions where added
  - Manually by looking at the reported metrics:
  
```
AutoScaler.jobVertexID.90bea66de1c231edf33913ecd54406c1.LOAD.Average: 0.954
AutoScaler.jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.LOAD.Average: 0.371
AutoScaler.jobVertexID.90bea66de1c231edf33913ecd54406c1.LOAD.Current: 0.952
AutoScaler.jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.LOAD.Current: 0.375
AutoScaler.jobVertexID.90bea66de1c231edf33913ecd54406c1.LOAD.Average: 0.954
AutoScaler.jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.LOAD.Average: 0.371
AutoScaler.jobVertexID.90bea66de1c231edf33913ecd54406c1.LOAD.Current: 0.952
AutoScaler.jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.LOAD.Current: 0.375
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
