### PR TITLE
[FLINK-32057] Support 1.18 rescale api for applying parallelism overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
           - test_sessionjob_kubernetes_ha.sh
           - test_sessionjob_operations.sh
           - test_multi_sessionjob.sh
+          - test_autoscaler.sh
         include:
           - namespace: flink
             extraArgs: '--create-namespace --set "watchNamespaces={default,flink}"'
@@ -94,6 +95,18 @@ jobs:
         exclude:
           - namespace: default
             test: test_multi_sessionjob.sh
+          - namespace: default
+            test: test_autoscaler.sh
+          - mode: standalone
+            test: test_autoscaler.sh
+          - version: v1_13
+            test: test_autoscaler.sh
+          - version: v1_14
+            test: test_autoscaler.sh
+          - version: v1_15
+            test: test_autoscaler.sh
+          - version: v1_16
+            test: test_autoscaler.sh
     name: e2e_ci
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["v1_17","v1_16","v1_15","v1_14","v1_13"]
+        version: ["v1_18","v1_17","v1_16","v1_15","v1_14","v1_13"]
         namespace: ["default","flink"]
         mode: ["native", "standalone"]
         test:
@@ -79,6 +79,8 @@ jobs:
         include:
           - namespace: flink
             extraArgs: '--create-namespace --set "watchNamespaces={default,flink}"'
+          - version: v1_18
+            image: ghcr.io\/apache\/flink-docker:1.18-SNAPSHOT-scala_2.12-java11-debian
           - version: v1_17
             image: flink:1.17
           - version: v1_16

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -83,6 +83,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | v1_15 |  |
 | v1_16 |  |
 | v1_17 |  |
+| v1_18 |  |
 
 ### IngressSpec
 **Class**: org.apache.flink.kubernetes.operator.api.spec.IngressSpec

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -75,6 +75,12 @@
             <td>Whether to ignore pending savepoint during job upgrade.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.upgrade.inplace-scaling.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable inplace scaling for Flink 1.18+ using the resource requirements API. On failure or earlier Flink versions it falls back to regular full redeployment.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.upgrade.last-state-fallback.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -159,6 +159,12 @@
             <td>Whether to ignore pending savepoint during job upgrade.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.upgrade.inplace-scaling.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable inplace scaling for Flink 1.18+ using the resource requirements API. On failure or earlier Flink versions it falls back to regular full redeployment.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.upgrade.last-state-fallback.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/e2e-tests/data/autoscaler.yaml
+++ b/e2e-tests/data/autoscaler.yaml
@@ -20,10 +20,10 @@ apiVersion: flink.apache.org/v1beta1
 kind: FlinkDeployment
 metadata:
   namespace: default
-  name: flink-example-statemachine
+  name: flink-autoscaler-e2e
 spec:
-  image: flink:1.17
-  flinkVersion: v1_17
+  image: flink:1.18
+  flinkVersion: v1_18
   ingress:
     template: "/{{namespace}}/{{name}}(/|$)(.*)"
     className: "nginx"
@@ -31,22 +31,20 @@ spec:
       nginx.ingress.kubernetes.io/rewrite-target: "/$2"
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
-    high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
+    high-availability.type: kubernetes
     high-availability.storageDir: file:///opt/flink/volume/flink-ha
     state.checkpoints.dir: file:///opt/flink/volume/flink-cp
     state.savepoints.dir: file:///opt/flink/volume/flink-sp
+
+    kubernetes.operator.job.autoscaler.enabled: "true"
+    kubernetes.operator.job.autoscaler.scaling.enabled: "true"
+    kubernetes.operator.job.autoscaler.stabilization.interval: "5s"
+    kubernetes.operator.job.autoscaler.metrics.window: "1m"
+
+    jobmanager.scheduler: adaptive
   serviceAccount: flink
   podTemplate:
     spec:
-      initContainers:
-        - name: artifacts-fetcher
-          image: busybox:1.35.0
-          imagePullPolicy: IfNotPresent
-          # Use wget or other tools to get user jars from remote storage
-          command: [ 'wget', 'https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.14.4/flink-examples-streaming_2.12-1.14.4.jar', '-O', '/flink-artifact/myjob.jar' ]
-          volumeMounts:
-            - mountPath: /flink-artifact
-              name: flink-artifact
       containers:
         # Do not change the main container name
         - name: flink-main-container
@@ -56,16 +54,12 @@ spec:
             limits:
               ephemeral-storage: 2048Mi
           volumeMounts:
-            - mountPath: /opt/flink/usrlib
-              name: flink-artifact
             - mountPath: /opt/flink/volume
               name: flink-volume
       volumes:
-        - name: flink-artifact
-          emptyDir: { }
         - name: flink-volume
           persistentVolumeClaim:
-            claimName: flink-example-statemachine
+            claimName: flink-autoscaler-e2e
   jobManager:
     resource:
       memory: "1024m"
@@ -75,8 +69,7 @@ spec:
       memory: "1024m"
       cpu: 0.5
   job:
-    jarURI: local:///opt/flink/usrlib/myjob.jar
-    entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
     parallelism: 2
     upgradeMode: last-state
   mode: native
@@ -85,7 +78,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: flink-example-statemachine
+  name: flink-autoscaler-e2e
 spec:
   accessModes:
     - ReadWriteOnce

--- a/e2e-tests/data/multi-sessionjob.yaml
+++ b/e2e-tests/data/multi-sessionjob.yaml
@@ -37,10 +37,6 @@ spec:
     state.savepoints.dir: file:///opt/flink/volume/flink-sp
   serviceAccount: flink
   podTemplate:
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: pod-template
     spec:
       containers:
         # Do not change the main container name

--- a/e2e-tests/data/sessionjob-cr.yaml
+++ b/e2e-tests/data/sessionjob-cr.yaml
@@ -37,10 +37,6 @@ spec:
     state.savepoints.dir: file:///opt/flink/volume/flink-sp
   serviceAccount: flink
   podTemplate:
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: pod-template
     spec:
       containers:
         # Do not change the main container name

--- a/e2e-tests/test_autoscaler.sh
+++ b/e2e-tests/test_autoscaler.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_DIR}/utils.sh"
+
+CLUSTER_ID="flink-autoscaler-e2e"
+APPLICATION_YAML="${SCRIPT_DIR}/data/autoscaler.yaml"
+APPLICATION_IDENTIFIER="flinkdep/$CLUSTER_ID"
+TIMEOUT=300
+
+on_exit cleanup_and_exit "$APPLICATION_YAML" $TIMEOUT $CLUSTER_ID
+
+retry_times 5 30 "kubectl apply -f $APPLICATION_YAML" || exit 1
+
+wait_for_jobmanager_running $CLUSTER_ID $TIMEOUT
+jm_pod_name=$(get_jm_pod_name $CLUSTER_ID)
+
+wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
+wait_for_status $APPLICATION_IDENTIFIER '.status.lifecycleState' STABLE ${TIMEOUT} || exit 1
+wait_for_event FlinkDeployment $CLUSTER_ID .reason==\"ScalingReport\" ${TIMEOUT} || exit 1
+wait_for_event FlinkDeployment $CLUSTER_ID .reason==\"SpecChanged\" ${TIMEOUT} || exit 1
+
+FLINK_VERSION=$(get_flink_version $APPLICATION_IDENTIFIER)
+echo "Flink version: $FLINK_VERSION"
+if [ "$FLINK_VERSION" = "v1_17" ]; then
+  echo "Verifying full upgrade triggered"
+  wait_for_event FlinkDeployment $CLUSTER_ID .reason==\"Suspended\" ${TIMEOUT} || exit 1
+else
+  echo "Verifying inplace scaling triggered"
+  wait_for_event FlinkDeployment $CLUSTER_ID .reason==\"Scaling\" ${TIMEOUT} || exit 1
+fi
+wait_for_status $APPLICATION_IDENTIFIER '.status.lifecycleState' STABLE ${TIMEOUT} || exit 1
+
+check_operator_log_for_errors || exit 1
+
+echo "Successfully run the autoscaler test"

--- a/examples/autoscaling/Dockerfile
+++ b/examples/autoscaling/Dockerfile
@@ -16,5 +16,5 @@
 # limitations under the License.
 ################################################################################
 
-FROM flink:1.17
+FROM ghcr.io/apache/flink-docker:1.18-SNAPSHOT-scala_2.12-java11-debian
 COPY ./target/autoscaling*.jar /opt/flink/usrlib/autoscaling.jar

--- a/examples/autoscaling/autoscaling.yaml
+++ b/examples/autoscaling/autoscaling.yaml
@@ -31,7 +31,7 @@ spec:
     taskmanager.numberOfTaskSlots: "4"
     state.savepoints.dir: file:///flink-data/savepoints
     state.checkpoints.dir: file:///flink-data/checkpoints
-    high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
+    high-availability.type: kubernetes
     high-availability.storageDir: file:///flink-data/ha
     execution.checkpointing.interval: "1m"
     jobmanager.scheduler: adaptive

--- a/examples/autoscaling/autoscaling.yaml
+++ b/examples/autoscaling/autoscaling.yaml
@@ -22,7 +22,7 @@ metadata:
   name: autoscaling-example
 spec:
   image: autoscaling-example
-  flinkVersion: v1_17
+  flinkVersion: v1_18
   flinkConfiguration:
     kubernetes.operator.job.autoscaler.enabled: "true"
     kubernetes.operator.job.autoscaler.stabilization.interval: "1m"
@@ -34,6 +34,8 @@ spec:
     high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
     high-availability.storageDir: file:///flink-data/ha
     execution.checkpointing.interval: "1m"
+    jobmanager.scheduler: adaptive
+    kubernetes.operator.job.autoscaler.target.utilization.boundary: "0.1"
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -22,7 +22,6 @@ metadata:
   name: basic-example
 spec:
   image: flink:1.17
-  mode: standalone
   flinkVersion: v1_17
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/diff/SpecDiff.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/diff/SpecDiff.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.api.diff;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -30,6 +31,8 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SpecDiff {
     DiffType value() default DiffType.UPGRADE;
+
+    KubernetesDeploymentMode[] mode() default {};
 
     /** Spec diff config annotation. */
     @Target(ElementType.FIELD)
@@ -45,5 +48,7 @@ public @interface SpecDiff {
         String prefix();
 
         DiffType type();
+
+        KubernetesDeploymentMode[] mode() default {};
     }
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
@@ -50,6 +50,10 @@ public abstract class AbstractFlinkSpec implements Diffable<AbstractFlinkSpec> {
     @SpecDiff.Config({
         @SpecDiff.Entry(prefix = "parallelism.default", type = DiffType.IGNORE),
         @SpecDiff.Entry(prefix = "kubernetes.operator", type = DiffType.IGNORE),
+        @SpecDiff.Entry(
+                prefix = "pipeline.jobvertex-parallelism-overrides",
+                type = DiffType.SCALE,
+                mode = KubernetesDeploymentMode.NATIVE)
     })
     private Map<String, String> flinkConfiguration;
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkVersion.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkVersion.java
@@ -27,7 +27,8 @@ public enum FlinkVersion {
     v1_14,
     v1_15,
     v1_16,
-    v1_17;
+    v1_17,
+    v1_18;
 
     public boolean isNewerVersionThan(FlinkVersion otherVersion) {
         return this.ordinal() > otherVersion.ordinal();

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
@@ -47,7 +47,7 @@ public class JobSpec implements Diffable<JobSpec> {
     private String jarURI;
 
     /** Parallelism of the Flink job. */
-    @SpecDiff(DiffType.SCALE)
+    @SpecDiff(value = DiffType.SCALE, mode = KubernetesDeploymentMode.STANDALONE)
     private int parallelism;
 
     /** Fully qualified main class name of the Flink job. */

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/TaskManagerSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/TaskManagerSpec.java
@@ -42,7 +42,7 @@ public class TaskManagerSpec implements Diffable<TaskManagerSpec> {
     private Resource resource;
 
     /** Number of TaskManager replicas. If defined, takes precedence over parallelism */
-    @SpecDiff(DiffType.SCALE)
+    @SpecDiff(value = DiffType.SCALE, mode = KubernetesDeploymentMode.STANDALONE)
     @SpecReplicas
     private Integer replicas;
 

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/ReconciliationStatus.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.api.status;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
+import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.utils.SpecUtils;
 import org.apache.flink.kubernetes.operator.api.utils.SpecWithMeta;
 
@@ -97,5 +98,15 @@ public abstract class ReconciliationStatus<SPEC extends AbstractFlinkSpec> {
     @JsonIgnore
     public boolean isBeforeFirstDeployment() {
         return lastReconciledSpec == null;
+    }
+
+    @JsonIgnore
+    public boolean scalingInProgress() {
+        if (isBeforeFirstDeployment() || state != ReconciliationState.UPGRADING) {
+            return false;
+        }
+        var job = deserializeLastReconciledSpec().getJob();
+        // For regular full upgrades the jobstate is suspended in UPGRADING state
+        return job != null && job.getState() == JobState.RUNNING;
     }
 }

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/RestApiMetricsCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/RestApiMetricsCollector.java
@@ -18,7 +18,6 @@
 package org.apache.flink.kubernetes.operator.autoscaler;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.autoscaler.metrics.FlinkMetric;
@@ -83,7 +82,7 @@ public class RestApiMetricsCollector extends ScalingMetricCollector {
                 .next()
                 .resolveFromString(StringUtils.join(metrics.keySet(), ","));
 
-        try (var restClient = (RestClusterClient<String>) flinkService.getClusterClient(conf)) {
+        try (var restClient = flinkService.getClusterClient(conf)) {
 
             var responseBody =
                     restClient

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImplTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImplTest.java
@@ -57,6 +57,7 @@ public class JobAutoScalerImplTest extends OperatorTestBase {
         configManager = new FlinkConfigManager(defaultConf);
         ReconciliationUtils.updateStatusForDeployedSpec(
                 app, configManager.getDeployConfig(app.getMetadata(), app.getSpec()));
+        app.getStatus().getReconciliationStatus().markReconciledSpecAsStable();
     }
 
     @Test

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -124,8 +124,7 @@ public class MetricsCollectionAndEvaluationTest {
         clock = Clock.fixed(Instant.ofEpochSecond(0), ZoneId.systemDefault());
         metricsCollector.setClock(clock);
         startTime = clock.instant();
-        app.getStatus().getJobStatus().setStartTime(String.valueOf(startTime.toEpochMilli()));
-        app.getStatus().getJobStatus().setUpdateTime(String.valueOf(startTime.toEpochMilli()));
+        metricsCollector.setJobUpdateTs(startTime);
         app.getStatus().getJobStatus().setState(JobStatus.RUNNING.name());
     }
 
@@ -171,6 +170,7 @@ public class MetricsCollectionAndEvaluationTest {
 
         // Test resetting the collector and make sure we can deserialize the scalingInfo correctly
         metricsCollector = new TestingMetricsCollector(topology);
+        metricsCollector.setJobUpdateTs(startTime);
         metricsCollector.setClock(clock);
         setDefaultMetrics(metricsCollector);
         collectedMetrics = metricsCollector.updateMetrics(app, scalingInfo, service, conf);
@@ -350,10 +350,7 @@ public class MetricsCollectionAndEvaluationTest {
         assertEquals(1, metricsHistory.getMetricHistory().size());
 
         // Existing metrics should be cleared on job updates
-        app.getStatus()
-                .getJobStatus()
-                .setUpdateTime(
-                        String.valueOf(clock.instant().plus(Duration.ofDays(10)).toEpochMilli()));
+        metricsCollector.setJobUpdateTs(clock.instant().plus(Duration.ofDays(10)));
         metricsHistory = metricsCollector.updateMetrics(app, scalingInfo, service, conf);
         assertEquals(0, metricsHistory.getMetricHistory().size());
     }
@@ -376,6 +373,7 @@ public class MetricsCollectionAndEvaluationTest {
         var topology = new JobTopology(new VertexInfo(source1, Set.of(), 5, 720));
 
         metricsCollector = new TestingMetricsCollector(topology);
+        metricsCollector.setJobUpdateTs(startTime);
         metricsCollector.setCurrentMetrics(
                 Map.of(
                         // Set source1 metrics without the PENDING_RECORDS metric
@@ -415,6 +413,7 @@ public class MetricsCollectionAndEvaluationTest {
         var topology = new JobTopology(new VertexInfo(source1, Set.of(), 10, 720));
 
         metricsCollector = new TestingMetricsCollector(topology);
+        metricsCollector.setJobUpdateTs(startTime);
         metricsCollector.setCurrentMetrics(
                 Map.of(
                         // Set source1 metrics without the PENDING_RECORDS metric

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/RecommendedParallelismTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/RecommendedParallelismTest.java
@@ -112,6 +112,7 @@ public class RecommendedParallelismTest extends OperatorTestBase {
         ReconciliationUtils.updateStatusForDeployedSpec(
                 app, configManager.getDeployConfig(app.getMetadata(), app.getSpec()));
         app.getStatus().getJobStatus().setState(JobStatus.RUNNING.name());
+        app.getStatus().getReconciliationStatus().markReconciledSpecAsStable();
 
         autoscaler =
                 new JobAutoScalerImpl(
@@ -262,12 +263,12 @@ public class RecommendedParallelismTest extends OperatorTestBase {
     }
 
     private void restart(Instant now) {
-        app.getStatus().getJobStatus().setUpdateTime(String.valueOf(now.toEpochMilli()));
+        metricsCollector.setJobUpdateTs(now);
         app.getStatus().getJobStatus().setState(JobStatus.CREATED.name());
     }
 
     private void running(Instant now) {
-        app.getStatus().getJobStatus().setUpdateTime(String.valueOf(now.toEpochMilli()));
+        metricsCollector.setJobUpdateTs(now);
         app.getStatus().getJobStatus().setState(JobStatus.RUNNING.name());
     }
 

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/TestingMetricsCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/TestingMetricsCollector.java
@@ -25,11 +25,13 @@ import org.apache.flink.kubernetes.operator.autoscaler.metrics.FlinkMetric;
 import org.apache.flink.kubernetes.operator.autoscaler.topology.JobTopology;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
 
 import lombok.Setter;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +44,8 @@ public class TestingMetricsCollector extends ScalingMetricCollector {
 
     @Setter private Duration testMetricWindowSize;
 
+    @Setter private Instant jobUpdateTs;
+
     @Setter
     private Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>> currentMetrics = new HashMap<>();
 
@@ -52,7 +56,7 @@ public class TestingMetricsCollector extends ScalingMetricCollector {
     }
 
     @Override
-    protected JobTopology queryJobTopology(RestClusterClient<String> restClient, JobID jobId) {
+    protected JobTopology getJobTopology(JobDetailsInfo jobDetailsInfo) {
         return jobTopology;
     }
 
@@ -86,5 +90,10 @@ public class TestingMetricsCollector extends ScalingMetricCollector {
             return testMetricWindowSize;
         }
         return super.getMetricWindowSize(conf);
+    }
+
+    @Override
+    protected Instant getJobUpdateTs(JobDetailsInfo jobDetailsInfo) {
+        return jobUpdateTs;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -150,6 +150,14 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(false)
                     .withDescription("Whether to ignore pending savepoint during job upgrade.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> JOB_UPGRADE_INPLACE_SCALING_ENABLED =
+            operatorConfig("job.upgrade.inplace-scaling.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to enable inplace scaling for Flink 1.18+ using the resource requirements API. On failure or earlier Flink versions it falls back to regular full redeployment.");
+
     @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Boolean> OPERATOR_DYNAMIC_CONFIG_ENABLED =
             operatorConfig("dynamic.config.enabled")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentContext.java
@@ -21,6 +21,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkDeploymentSpec;
+import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
@@ -54,5 +55,10 @@ public class FlinkDeploymentContext extends FlinkResourceContext<FlinkDeployment
     @Override
     protected Configuration createObserveConfig() {
         return configManager.getObserveConfig(getResource());
+    }
+
+    @Override
+    public KubernetesDeploymentMode getDeploymentMode() {
+        return KubernetesDeploymentMode.getDeploymentMode(getResource());
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.controller;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
+import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
@@ -72,4 +73,7 @@ public abstract class FlinkResourceContext<CR extends AbstractFlinkResource<?, ?
      * @return Deployed config.
      */
     protected abstract Configuration createObserveConfig();
+
+    /** @return Cluster deployment mode. */
+    public abstract KubernetesDeploymentMode getDeploymentMode();
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobContext.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkSessionJobSpec;
+import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
@@ -76,5 +77,11 @@ public class FlinkSessionJobContext extends FlinkResourceContext<FlinkSessionJob
     @Override
     protected Configuration createObserveConfig() {
         return getDeployConfig(getResource().getSpec());
+    }
+
+    @Override
+    public KubernetesDeploymentMode getDeploymentMode() {
+        return KubernetesDeploymentMode.getDeploymentMode(
+                getJosdkContext().getSecondaryResource(FlinkDeployment.class).get());
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffBuilder.java
@@ -53,25 +53,6 @@ public class DiffBuilder<T> implements Builder<DiffResult<?>> {
         this.triviallyEqual = before == after || before.equals(after);
     }
 
-    public DiffBuilder<T> testTriviallyEqual(boolean testTriviallyEqual) {
-        this.triviallyEqual = this.triviallyEqual && testTriviallyEqual;
-        return this;
-    }
-
-    public DiffBuilder<T> append(
-            @NonNull final String fieldName,
-            final boolean left,
-            final boolean right,
-            DiffType type) {
-        if (triviallyEqual) {
-            return this;
-        }
-        if (left != right) {
-            diffs.add(new Diff<>(fieldName, left, right, type));
-        }
-        return this;
-    }
-
     public DiffBuilder<T> append(
             @NonNull final String fieldName,
             final boolean[] left,
@@ -81,17 +62,6 @@ public class DiffBuilder<T> implements Builder<DiffResult<?>> {
             return this;
         }
         if (!Arrays.equals(left, right)) {
-            diffs.add(new Diff<>(fieldName, left, right, type));
-        }
-        return this;
-    }
-
-    public DiffBuilder<T> append(
-            @NonNull final String fieldName, final byte left, final byte right, DiffType type) {
-        if (triviallyEqual) {
-            return this;
-        }
-        if (left != right) {
             diffs.add(new Diff<>(fieldName, left, right, type));
         }
         return this;
@@ -110,36 +80,12 @@ public class DiffBuilder<T> implements Builder<DiffResult<?>> {
     }
 
     public DiffBuilder<T> append(
-            @NonNull final String fieldName, final char left, final char right, DiffType type) {
-
-        if (triviallyEqual) {
-            return this;
-        }
-        if (left != right) {
-            diffs.add(new Diff<>(fieldName, left, right, type));
-        }
-        return this;
-    }
-
-    public DiffBuilder<T> append(
             @NonNull final String fieldName, final char[] left, final char[] right, DiffType type) {
 
         if (triviallyEqual) {
             return this;
         }
         if (!Arrays.equals(left, right)) {
-            diffs.add(new Diff<>(fieldName, left, right, type));
-        }
-        return this;
-    }
-
-    public DiffBuilder<T> append(
-            @NonNull final String fieldName, final double left, final double right, DiffType type) {
-
-        if (triviallyEqual) {
-            return this;
-        }
-        if (Double.doubleToLongBits(left) != Double.doubleToLongBits(right)) {
             diffs.add(new Diff<>(fieldName, left, right, type));
         }
         return this;
@@ -161,18 +107,6 @@ public class DiffBuilder<T> implements Builder<DiffResult<?>> {
     }
 
     public DiffBuilder<T> append(
-            @NonNull final String fieldName, final float left, final float right, DiffType type) {
-
-        if (triviallyEqual) {
-            return this;
-        }
-        if (Float.floatToIntBits(left) != Float.floatToIntBits(right)) {
-            diffs.add(new Diff<>(fieldName, left, right, type));
-        }
-        return this;
-    }
-
-    public DiffBuilder<T> append(
             @NonNull final String fieldName,
             final float[] left,
             final float[] right,
@@ -182,18 +116,6 @@ public class DiffBuilder<T> implements Builder<DiffResult<?>> {
             return this;
         }
         if (!Arrays.equals(left, right)) {
-            diffs.add(new Diff<>(fieldName, left, right, type));
-        }
-        return this;
-    }
-
-    public DiffBuilder<T> append(
-            @NonNull final String fieldName, final int left, final int right, DiffType type) {
-
-        if (triviallyEqual) {
-            return this;
-        }
-        if (left != right) {
             diffs.add(new Diff<>(fieldName, left, right, type));
         }
         return this;
@@ -212,36 +134,12 @@ public class DiffBuilder<T> implements Builder<DiffResult<?>> {
     }
 
     public DiffBuilder<T> append(
-            @NonNull final String fieldName, final long left, final long right, DiffType type) {
-
-        if (triviallyEqual) {
-            return this;
-        }
-        if (left != right) {
-            diffs.add(new Diff<>(fieldName, left, right, type));
-        }
-        return this;
-    }
-
-    public DiffBuilder<T> append(
             @NonNull final String fieldName, final long[] left, final long[] right, DiffType type) {
 
         if (triviallyEqual) {
             return this;
         }
         if (!Arrays.equals(left, right)) {
-            diffs.add(new Diff<>(fieldName, left, right, type));
-        }
-        return this;
-    }
-
-    public DiffBuilder<T> append(
-            @NonNull final String fieldName, final short left, final short right, DiffType type) {
-
-        if (triviallyEqual) {
-            return this;
-        }
-        if (left != right) {
             diffs.add(new Diff<>(fieldName, left, right, type));
         }
         return this;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -480,8 +480,7 @@ public abstract class AbstractFlinkService implements FlinkService {
             Configuration conf)
             throws Exception {
         LOG.info("Triggering new savepoint");
-        try (RestClusterClient<String> clusterClient =
-                (RestClusterClient<String>) getClusterClient(conf)) {
+        try (var clusterClient = getClusterClient(conf)) {
             var savepointTriggerHeaders = SavepointTriggerHeaders.getInstance();
             var savepointTriggerMessageParameters =
                     savepointTriggerHeaders.getUnresolvedMessageParameters();
@@ -543,8 +542,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                     Optional<CheckpointHistoryWrapper.CompletedCheckpointInfo>,
                     Optional<CheckpointHistoryWrapper.PendingCheckpointInfo>>
             getCheckpointInfo(JobID jobId, Configuration conf) throws Exception {
-        try (RestClusterClient<String> clusterClient =
-                (RestClusterClient<String>) getClusterClient(conf)) {
+        try (var clusterClient = getClusterClient(conf)) {
 
             var headers = CustomCheckpointingStatisticsHeaders.getInstance();
             var params = headers.getUnresolvedMessageParameters();
@@ -569,8 +567,7 @@ public abstract class AbstractFlinkService implements FlinkService {
 
     @Override
     public void disposeSavepoint(String savepointPath, Configuration conf) throws Exception {
-        try (RestClusterClient<String> clusterClient =
-                (RestClusterClient<String>) getClusterClient(conf)) {
+        try (var clusterClient = getClusterClient(conf)) {
             clusterClient
                     .sendRequest(
                             SavepointDisposalTriggerHeaders.getInstance(),
@@ -631,8 +628,7 @@ public abstract class AbstractFlinkService implements FlinkService {
     public Map<String, String> getClusterInfo(Configuration conf) throws Exception {
         Map<String, String> clusterInfo = new HashMap<>();
 
-        try (RestClusterClient<String> clusterClient =
-                (RestClusterClient<String>) getClusterClient(conf)) {
+        try (var clusterClient = getClusterClient(conf)) {
 
             CustomDashboardConfiguration dashboardConfiguration =
                     clusterClient
@@ -685,7 +681,7 @@ public abstract class AbstractFlinkService implements FlinkService {
     }
 
     @Override
-    public ClusterClient<String> getClusterClient(Configuration conf) throws Exception {
+    public RestClusterClient<String> getClusterClient(Configuration conf) throws Exception {
         final String clusterId = conf.get(KubernetesConfigOptions.CLUSTER_ID);
         final String namespace = conf.get(KubernetesConfigOptions.NAMESPACE);
         final int port = conf.getInteger(RestOptions.PORT);
@@ -708,8 +704,7 @@ public abstract class AbstractFlinkService implements FlinkService {
             String savepoint) {
         String jarId =
                 response.getFilename().substring(response.getFilename().lastIndexOf("/") + 1);
-        try (RestClusterClient<String> clusterClient =
-                (RestClusterClient<String>) getClusterClient(conf)) {
+        try (var clusterClient = getClusterClient(conf)) {
             JarRunHeaders headers = JarRunHeaders.getInstance();
             JarRunMessageParameters parameters = headers.getUnresolvedMessageParameters();
             parameters.jarIdPathParameter.resolve(jarId);
@@ -797,8 +792,7 @@ public abstract class AbstractFlinkService implements FlinkService {
     @VisibleForTesting
     protected void deleteJar(Configuration conf, String jarId) {
         LOG.debug("Deleting the jar: {}", jarId);
-        try (RestClusterClient<String> clusterClient =
-                (RestClusterClient<String>) getClusterClient(conf)) {
+        try (var clusterClient = getClusterClient(conf)) {
             JarDeleteHeaders headers = JarDeleteHeaders.getInstance();
             JarDeleteMessageParameters parameters = headers.getUnresolvedMessageParameters();
             parameters.jarIdPathParameter.resolve(jarId);
@@ -937,7 +931,7 @@ public abstract class AbstractFlinkService implements FlinkService {
 
     public Map<String, String> getMetrics(
             Configuration conf, String jobId, List<String> metricNames) throws Exception {
-        try (var clusterClient = (RestClusterClient<String>) getClusterClient(conf)) {
+        try (var clusterClient = getClusterClient(conf)) {
             var jobMetricsMessageParameters =
                     JobMetricsHeaders.getInstance().getUnresolvedMessageParameters();
             jobMetricsMessageParameters.jobPathParameter.resolve(JobID.fromHexString(jobId));
@@ -961,7 +955,7 @@ public abstract class AbstractFlinkService implements FlinkService {
     }
 
     public TaskManagersInfo getTaskManagersInfo(Configuration conf) throws Exception {
-        try (var clusterClient = (RestClusterClient<String>) getClusterClient(conf)) {
+        try (var clusterClient = getClusterClient(conf)) {
             return clusterClient
                     .sendRequest(
                             TaskManagersHeaders.getInstance(),

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -62,6 +62,7 @@ import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
 import org.apache.flink.runtime.rest.messages.TriggerId;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.metrics.JobMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalRequest;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalTriggerHeaders;
@@ -806,6 +807,21 @@ public abstract class AbstractFlinkService implements FlinkService {
                             TimeUnit.SECONDS);
         } catch (Exception e) {
             LOG.error("Failed to delete the jar: {}.", jarId, e);
+        }
+    }
+
+    @Override
+    public JobDetailsInfo getJobDetailsInfo(JobID jobID, Configuration conf) throws Exception {
+
+        try (var restClient = getClusterClient(conf)) {
+            return restClient
+                    .getJobDetails(jobID)
+                    .get(
+                            configManager
+                                    .getOperatorConfiguration()
+                                    .getFlinkClientTimeout()
+                                    .toSeconds(),
+                            TimeUnit.SECONDS);
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
@@ -111,11 +111,7 @@ public class FlinkResourceContextFactory {
 
     @VisibleForTesting
     protected FlinkService getOrCreateFlinkService(FlinkDeployment deployment) {
-        return getOrCreateFlinkService(getDeploymentMode(deployment));
-    }
-
-    private KubernetesDeploymentMode getDeploymentMode(FlinkDeployment deployment) {
-        return KubernetesDeploymentMode.getDeploymentMode(deployment);
+        return getOrCreateFlinkService(KubernetesDeploymentMode.getDeploymentMode(deployment));
     }
 
     public <CR extends AbstractFlinkResource<?, ?>> void cleanup(CR flinkApp) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
@@ -30,6 +30,7 @@ import org.apache.flink.kubernetes.operator.controller.FlinkSessionJobContext;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.metrics.OperatorMetricUtils;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -48,6 +49,8 @@ public class FlinkResourceContextFactory {
     private final KubernetesClient kubernetesClient;
     private final FlinkConfigManager configManager;
     private final KubernetesOperatorMetricGroup operatorMetricGroup;
+
+    private final EventRecorder eventRecorder;
     private final Map<KubernetesDeploymentMode, FlinkService> serviceMap;
 
     protected final Map<Tuple2<Class<?>, ResourceID>, KubernetesResourceMetricGroup>
@@ -56,10 +59,12 @@ public class FlinkResourceContextFactory {
     public FlinkResourceContextFactory(
             KubernetesClient kubernetesClient,
             FlinkConfigManager configManager,
-            KubernetesOperatorMetricGroup operatorMetricGroup) {
+            KubernetesOperatorMetricGroup operatorMetricGroup,
+            EventRecorder eventRecorder) {
         this.kubernetesClient = kubernetesClient;
         this.configManager = configManager;
         this.operatorMetricGroup = operatorMetricGroup;
+        this.eventRecorder = eventRecorder;
         this.serviceMap = new ConcurrentHashMap<>();
     }
 
@@ -98,7 +103,8 @@ public class FlinkResourceContextFactory {
                     switch (mode) {
                         case NATIVE:
                             LOG.debug("Using NativeFlinkService");
-                            return new NativeFlinkService(kubernetesClient, configManager);
+                            return new NativeFlinkService(
+                                    kubernetesClient, configManager, eventRecorder);
                         case STANDALONE:
                             LOG.debug("Using StandaloneFlinkService");
                             return new StandaloneFlinkService(kubernetesClient, configManager);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -19,7 +19,7 @@ package org.apache.flink.kubernetes.operator.service;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
@@ -30,6 +30,7 @@ import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.Savepoint;
 import org.apache.flink.kubernetes.operator.api.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType;
+import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobmaster.JobResult;
@@ -106,12 +107,12 @@ public interface FlinkService {
 
     void waitForClusterShutdown(Configuration conf);
 
-    default boolean scale(ObjectMeta meta, JobSpec jobSpec, Configuration conf) {
-        return false;
-    }
+    boolean scale(FlinkResourceContext<?> resourceContext) throws Exception;
+
+    boolean scalingCompleted(FlinkResourceContext<?> resourceContext);
 
     Map<String, String> getMetrics(Configuration conf, String jobId, List<String> metricNames)
             throws Exception;
 
-    ClusterClient<String> getClusterClient(Configuration conf) throws Exception;
+    RestClusterClient<String> getClusterClient(Configuration conf) throws Exception;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -34,6 +34,7 @@ import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobmaster.JobResult;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -115,4 +116,6 @@ public interface FlinkService {
             throws Exception;
 
     RestClusterClient<String> getClusterClient(Configuration conf) throws Exception;
+
+    JobDetailsInfo getJobDetailsInfo(JobID jobID, Configuration conf) throws Exception;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -38,6 +38,7 @@ import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
@@ -176,11 +177,14 @@ public class NativeFlinkService extends AbstractFlinkService {
         var resource = ctx.getResource();
         var spec = resource.getSpec();
 
-        if (spec.getJob() == null) {
+        var observeConfig = ctx.getObserveConfig();
+
+        if (spec.getJob() == null
+                || !observeConfig.get(
+                        KubernetesOperatorConfigOptions.JOB_UPGRADE_INPLACE_SCALING_ENABLED)) {
             return false;
         }
 
-        var observeConfig = ctx.getObserveConfig();
         if (!observeConfig.get(FLINK_VERSION).isNewerVersionThan(FlinkVersion.v1_17)) {
             LOG.debug("In-place rescaling is only available starting from Flink 1.18");
             return false;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -52,6 +52,16 @@ public class EventRecorder {
         return triggerEvent(resource, type, reason, component, message, null);
     }
 
+    public boolean triggerEventOnce(
+            AbstractFlinkResource<?, ?> resource,
+            Type type,
+            Reason reason,
+            Component component,
+            String message,
+            String messageKey) {
+        return triggerEventOnce(resource, type, reason.toString(), message, component, messageKey);
+    }
+
     public boolean triggerEvent(
             AbstractFlinkResource<?, ?> resource,
             Type type,
@@ -70,6 +80,24 @@ public class EventRecorder {
             Component component,
             String messageKey) {
         return EventUtils.createOrUpdateEvent(
+                client,
+                resource,
+                type,
+                reason,
+                message,
+                component,
+                e -> eventListener.accept(resource, e),
+                messageKey);
+    }
+
+    public boolean triggerEventOnce(
+            AbstractFlinkResource<?, ?> resource,
+            Type type,
+            String reason,
+            String message,
+            Component component,
+            String messageKey) {
+        return EventUtils.createIfNotExists(
                 client,
                 resource,
                 type,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -182,6 +182,7 @@ public class EventRecorder {
         RestartUnhealthyJob,
         ScalingReport,
         IneffectiveScaling,
-        AutoscalerError
+        AutoscalerError,
+        Scaling
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/jobgraph/JobResourceRequirements.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/jobgraph/JobResourceRequirements.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Copied from Flink. Should be removed once the client dependency is upgraded to 1.18. */
+public class JobResourceRequirements implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /** Builder. * */
+    public static final class Builder {
+
+        private final Map<JobVertexID, JobVertexResourceRequirements> vertexResources =
+                new HashMap<>();
+
+        public Builder setParallelismForJobVertex(
+                JobVertexID jobVertexId, int lowerBound, int upperBound) {
+            vertexResources.put(
+                    jobVertexId,
+                    new JobVertexResourceRequirements(
+                            new JobVertexResourceRequirements.Parallelism(lowerBound, upperBound)));
+            return this;
+        }
+
+        public JobResourceRequirements build() {
+            return new JobResourceRequirements(vertexResources);
+        }
+    }
+
+    private final Map<JobVertexID, JobVertexResourceRequirements> vertexResources;
+
+    public JobResourceRequirements(
+            Map<JobVertexID, JobVertexResourceRequirements> vertexResources) {
+        this.vertexResources =
+                Collections.unmodifiableMap(new HashMap<>(checkNotNull(vertexResources)));
+    }
+
+    public JobVertexResourceRequirements.Parallelism getParallelism(JobVertexID jobVertexId) {
+        return Optional.ofNullable(vertexResources.get(jobVertexId))
+                .map(JobVertexResourceRequirements::getParallelism)
+                .orElseThrow(
+                        () ->
+                                new IllegalStateException(
+                                        "No requirement set for vertex " + jobVertexId));
+    }
+
+    public Map<JobVertexID, JobVertexResourceRequirements> getJobVertexParallelisms() {
+        return vertexResources;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final JobResourceRequirements that = (JobResourceRequirements) o;
+        return Objects.equals(vertexResources, that.vertexResources);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(vertexResources);
+    }
+
+    @Override
+    public String toString() {
+        return "JobResourceRequirements{" + "vertexResources=" + vertexResources + '}';
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexResourceRequirements.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/jobgraph/JobVertexResourceRequirements.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.jobgraph;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Copied from Flink. Should be removed once the client dependency is upgraded to 1.18. */
+public class JobVertexResourceRequirements implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String FIELD_NAME_PARALLELISM = "parallelism";
+
+    /** Parallelisms. * */
+    public static class Parallelism implements Serializable {
+
+        private static final String FIELD_NAME_LOWER_BOUND = "lowerBound";
+        private static final String FIELD_NAME_UPPER_BOUND = "upperBound";
+
+        @JsonProperty(FIELD_NAME_LOWER_BOUND)
+        private final int lowerBound;
+
+        @JsonProperty(FIELD_NAME_UPPER_BOUND)
+        private final int upperBound;
+
+        @JsonCreator
+        public Parallelism(
+                @JsonProperty(FIELD_NAME_LOWER_BOUND) int lowerBound,
+                @JsonProperty(FIELD_NAME_UPPER_BOUND) int upperBound) {
+            this.lowerBound = lowerBound;
+            this.upperBound = upperBound;
+        }
+
+        public int getLowerBound() {
+            return lowerBound;
+        }
+
+        public int getUpperBound() {
+            return upperBound;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final Parallelism that = (Parallelism) o;
+            return lowerBound == that.lowerBound && upperBound == that.upperBound;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(lowerBound, upperBound);
+        }
+
+        @Override
+        public String toString() {
+            return "Parallelism{" + "lowerBound=" + lowerBound + ", upperBound=" + upperBound + '}';
+        }
+    }
+
+    @JsonProperty(FIELD_NAME_PARALLELISM)
+    private final Parallelism parallelism;
+
+    public JobVertexResourceRequirements(
+            @JsonProperty(FIELD_NAME_PARALLELISM) Parallelism parallelism) {
+        this.parallelism = checkNotNull(parallelism);
+    }
+
+    public Parallelism getParallelism() {
+        return parallelism;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final JobVertexResourceRequirements that = (JobVertexResourceRequirements) o;
+        return parallelism.equals(that.parallelism);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parallelism);
+    }
+
+    @Override
+    public String toString() {
+        return "JobVertexResourceRequirements{" + "parallelism=" + parallelism + '}';
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/job/JobResourceRequirementsBody.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/job/JobResourceRequirementsBody.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.jobgraph.JobResourceRequirements;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.JobVertexResourceRequirements;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+import org.apache.flink.runtime.rest.messages.json.JobVertexIDKeyDeserializer;
+import org.apache.flink.runtime.rest.messages.json.JobVertexIDKeySerializer;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonAnyGetter;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonAnySetter;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Copied from Flink. Should be removed once the client dependency is upgraded to 1.18. */
+public class JobResourceRequirementsBody implements RequestBody, ResponseBody {
+
+    @JsonAnySetter
+    @JsonAnyGetter
+    @JsonSerialize(keyUsing = JobVertexIDKeySerializer.class)
+    @JsonDeserialize(keyUsing = JobVertexIDKeyDeserializer.class)
+    private final Map<JobVertexID, JobVertexResourceRequirements> jobVertexResourceRequirements;
+
+    public JobResourceRequirementsBody() {
+        this(null);
+    }
+
+    public JobResourceRequirementsBody(@Nullable JobResourceRequirements jobResourceRequirements) {
+        if (jobResourceRequirements != null) {
+            this.jobVertexResourceRequirements = jobResourceRequirements.getJobVertexParallelisms();
+        } else {
+            this.jobVertexResourceRequirements = new HashMap<>();
+        }
+    }
+
+    @JsonIgnore
+    public Optional<JobResourceRequirements> asJobResourceRequirements() {
+        if (jobVertexResourceRequirements.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(new JobResourceRequirements(jobVertexResourceRequirements));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final JobResourceRequirementsBody that = (JobResourceRequirementsBody) o;
+        return Objects.equals(jobVertexResourceRequirements, that.jobVertexResourceRequirements);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jobVertexResourceRequirements);
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/job/JobResourceRequirementsHeaders.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/job/JobResourceRequirementsHeaders.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/** Copied from Flink. Should be removed once the client dependency is upgraded to 1.18. */
+public class JobResourceRequirementsHeaders
+        implements RuntimeMessageHeaders<
+                EmptyRequestBody, JobResourceRequirementsBody, JobMessageParameters> {
+
+    public static final JobResourceRequirementsHeaders INSTANCE =
+            new JobResourceRequirementsHeaders();
+
+    private static final String URL = "/jobs/:" + JobIDPathParameter.KEY + "/resource-requirements";
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.GET;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    @Override
+    public Class<JobResourceRequirementsBody> getResponseClass() {
+        return JobResourceRequirementsBody.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Request details on the job's resource requirements.";
+    }
+
+    @Override
+    public Class<EmptyRequestBody> getRequestClass() {
+        return EmptyRequestBody.class;
+    }
+
+    @Override
+    public JobMessageParameters getUnresolvedMessageParameters() {
+        return new JobMessageParameters();
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/job/JobResourcesRequirementsUpdateHeaders.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/job/JobResourcesRequirementsUpdateHeaders.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.messages.job;
+
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+/** Copied from Flink. Should be removed once the client dependency is upgraded to 1.18. */
+public class JobResourcesRequirementsUpdateHeaders
+        implements RuntimeMessageHeaders<
+                JobResourceRequirementsBody, EmptyResponseBody, JobMessageParameters> {
+
+    public static final JobResourcesRequirementsUpdateHeaders INSTANCE =
+            new JobResourcesRequirementsUpdateHeaders();
+
+    private static final String URL = "/jobs/:" + JobIDPathParameter.KEY + "/resource-requirements";
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.PUT;
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return URL;
+    }
+
+    @Override
+    public Class<EmptyResponseBody> getResponseClass() {
+        return EmptyResponseBody.class;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Request to update job's resource requirements.";
+    }
+
+    @Override
+    public Class<JobResourceRequirementsBody> getRequestClass() {
+        return JobResourceRequirementsBody.class;
+    }
+
+    @Override
+    public JobMessageParameters getUnresolvedMessageParameters() {
+        return new JobMessageParameters();
+    }
+
+    @Override
+    public String operationId() {
+        return "updateJobResourceRequirements";
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/OperatorTestBase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/OperatorTestBase.java
@@ -66,7 +66,11 @@ public abstract class OperatorTestBase {
             CR cr, Context josdkContext) {
         var ctxFactory =
                 new TestingFlinkResourceContextFactory(
-                        getKubernetesClient(), configManager, operatorMetricGroup, flinkService);
+                        getKubernetesClient(),
+                        configManager,
+                        operatorMetricGroup,
+                        flinkService,
+                        eventRecorder);
         return ctxFactory.getResourceContext(cr, josdkContext);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkResourceContextFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGrou
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
@@ -38,8 +39,9 @@ public class TestingFlinkResourceContextFactory extends FlinkResourceContextFact
             KubernetesClient kubernetesClient,
             FlinkConfigManager configManager,
             KubernetesOperatorMetricGroup operatorMetricGroup,
-            FlinkService flinkService) {
-        super(kubernetesClient, configManager, operatorMetricGroup);
+            FlinkService flinkService,
+            EventRecorder eventRecorder) {
+        super(kubernetesClient, configManager, operatorMetricGroup, eventRecorder);
         this.flinkService = flinkService;
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -89,7 +89,8 @@ public class TestingFlinkDeploymentController
                         kubernetesClient,
                         configManager,
                         TestUtils.createTestMetricGroup(new Configuration()),
-                        flinkService);
+                        flinkService,
+                        eventRecorder);
 
         eventRecorder = new EventRecorder(kubernetesClient, eventCollector);
         statusRecorder =

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
@@ -81,7 +81,8 @@ public class TestingFlinkSessionJobController
                         kubernetesClient,
                         configManager,
                         TestUtils.createTestMetricGroup(new Configuration()),
-                        flinkService);
+                        flinkService,
+                        eventRecorder);
 
         eventRecorder = new EventRecorder(kubernetesClient, eventCollector);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.observer.deployment;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.kubernetes.operator.OperatorTestBase;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
@@ -35,7 +36,6 @@ import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptio
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.observer.TestObserverAdapter;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
-import org.apache.flink.kubernetes.operator.service.NativeFlinkService;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.SavepointUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
@@ -714,7 +714,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
 
         var conf = new Configuration();
         var v1 = new JobVertexID();
-        conf.set(NativeFlinkService.PARALLELISM_OVERRIDES, Map.of(v1.toHexString(), "2"));
+        conf.set(PipelineOptions.PARALLELISM_OVERRIDES, Map.of(v1.toHexString(), "2"));
         deployment.getSpec().setFlinkConfiguration(conf.toMap());
 
         // Update status after triggering scale operation

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/diff/SpecDiffTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/diff/SpecDiffTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.reconciler.diff;
 
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.api.diff.DiffType;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkDeploymentSpec;
@@ -30,7 +31,6 @@ import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils;
 import org.apache.flink.kubernetes.operator.api.utils.SpecUtils;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
-import org.apache.flink.kubernetes.operator.service.NativeFlinkService;
 
 import io.fabric8.kubernetes.api.model.HostAlias;
 import org.junit.jupiter.api.Test;
@@ -155,7 +155,7 @@ public class SpecDiffTest {
         // verify parallelism override handling for native/standalone
         left = TestUtils.buildApplicationCluster().getSpec();
         right = TestUtils.buildApplicationCluster().getSpec();
-        left.getFlinkConfiguration().put(NativeFlinkService.PARALLELISM_OVERRIDES.key(), "new");
+        left.getFlinkConfiguration().put(PipelineOptions.PARALLELISM_OVERRIDES.key(), "new");
 
         diff = new ReflectiveDiffBuilder<>(KubernetesDeploymentMode.NATIVE, left, right).build();
         assertEquals(DiffType.SCALE, diff.getType());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -661,6 +661,20 @@ public class NativeFlinkServiceTest {
         testScaleConditionDep(flinkDep, service, d -> {}, true);
         testScaleConditionLastSpec(flinkDep, service, d -> {}, true);
 
+        // Do not scale if config disabled
+        testScaleConditionDep(
+                flinkDep,
+                service,
+                d ->
+                        d.getSpec()
+                                .getFlinkConfiguration()
+                                .put(
+                                        KubernetesOperatorConfigOptions
+                                                .JOB_UPGRADE_INPLACE_SCALING_ENABLED
+                                                .key(),
+                                        "false"),
+                false);
+
         // Do not scale without adaptive scheduler deployed
         testScaleConditionLastSpec(
                 flinkDep,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -143,7 +143,8 @@ public class StandaloneFlinkServiceTest {
                 new FlinkResourceContextFactory(
                                 kubernetesClient,
                                 configManager,
-                                TestUtils.createTestMetricGroup(new Configuration()))
+                                TestUtils.createTestMetricGroup(new Configuration()),
+                                null)
                         .getResourceContext(flinkDeployment, TestUtils.createEmptyContext());
         assertTrue(flinkStandaloneService.scale(ctx));
         assertEquals(
@@ -184,7 +185,8 @@ public class StandaloneFlinkServiceTest {
                 new FlinkResourceContextFactory(
                                 kubernetesClient,
                                 configManager,
-                                TestUtils.createTestMetricGroup(new Configuration()))
+                                TestUtils.createTestMetricGroup(new Configuration()),
+                                null)
                         .getResourceContext(flinkDeployment, TestUtils.createEmptyContext());
         assertTrue(flinkStandaloneService.scale(ctx));
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -24,8 +24,8 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.utils.StandaloneKubernetesUtils;
@@ -35,7 +35,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
@@ -55,56 +54,42 @@ public class StandaloneFlinkServiceTest {
     KubernetesMockServer mockServer;
 
     private NamespacedKubernetesClient kubernetesClient;
-
-    TestStandaloneFlinkService flinkStandaloneService;
-    Configuration configuration = new Configuration();
-
-    class TestStandaloneFlinkService extends StandaloneFlinkService {
-        int nbCall = 0;
-
-        public TestStandaloneFlinkService(
-                KubernetesClient kubernetesClient, FlinkConfigManager configManager) {
-            super(kubernetesClient, configManager);
-        }
-
-        @Override
-        protected PodList getTmPodList(String namespace, String clusterId) {
-            nbCall++;
-            PodList podList = new PodList();
-            if (nbCall == 1) {
-                Pod pod = new Pod();
-                podList.setItems(List.of(pod));
-            }
-            return podList;
-        }
-    }
+    StandaloneFlinkService flinkStandaloneService;
+    FlinkConfigManager configManager;
+    FlinkDeployment flinkDeployment;
 
     @BeforeEach
     public void setup() {
+        var configuration = new Configuration();
         configuration.set(KubernetesConfigOptions.CLUSTER_ID, TestUtils.TEST_DEPLOYMENT_NAME);
         configuration.set(KubernetesConfigOptions.NAMESPACE, TestUtils.TEST_NAMESPACE);
         configuration.set(OPERATOR_HEALTH_PROBE_PORT, 80);
 
+        configManager = new FlinkConfigManager(configuration);
+
         kubernetesClient = mockServer.createClient().inAnyNamespace();
         flinkStandaloneService =
-                new TestStandaloneFlinkService(
-                        kubernetesClient, new FlinkConfigManager(configuration));
+                new StandaloneFlinkService(kubernetesClient, new FlinkConfigManager(configuration));
+        flinkDeployment = TestUtils.buildSessionCluster();
+        flinkDeployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(flinkDeployment.getSpec(), flinkDeployment);
+        createDeployments(flinkDeployment);
     }
 
     @Test
     public void testDeleteClusterDeployment() throws Exception {
-        FlinkDeployment flinkDeployment = TestUtils.buildSessionCluster();
-        configuration = buildConfig(flinkDeployment, configuration);
-
-        createDeployments(flinkDeployment);
-
         List<Deployment> deployments = kubernetesClient.apps().deployments().list().getItems();
 
         assertEquals(2, deployments.size());
 
         var requestsBeforeDelete = mockServer.getRequestCount();
         flinkStandaloneService.deleteClusterDeployment(
-                flinkDeployment.getMetadata(), flinkDeployment.getStatus(), configuration, false);
+                flinkDeployment.getMetadata(),
+                flinkDeployment.getStatus(),
+                new Configuration(),
+                false);
 
         assertEquals(2, mockServer.getRequestCount() - requestsBeforeDelete);
         assertTrue(mockServer.getLastRequest().getPath().contains("taskmanager"));
@@ -115,19 +100,20 @@ public class StandaloneFlinkServiceTest {
     }
 
     @Test
-    public void testDeleteClusterDeploymentWithHADelete() throws Exception {
-        FlinkDeployment flinkDeployment = TestUtils.buildSessionCluster();
-        configuration = buildConfig(flinkDeployment, configuration);
-
+    public void testDeleteClusterDeploymentWithHADelete() {
+        var service = new TestingStandaloneFlinkService(flinkStandaloneService);
         createDeployments(flinkDeployment);
 
         List<Deployment> deployments = kubernetesClient.apps().deployments().list().getItems();
         assertEquals(2, deployments.size());
 
-        flinkStandaloneService.deleteClusterDeployment(
-                flinkDeployment.getMetadata(), flinkDeployment.getStatus(), configuration, true);
+        service.deleteClusterDeployment(
+                flinkDeployment.getMetadata(),
+                flinkDeployment.getStatus(),
+                new Configuration(),
+                true);
 
-        assertEquals(2, flinkStandaloneService.nbCall);
+        assertEquals(2, service.nbCall);
 
         deployments = kubernetesClient.apps().deployments().list().getItems();
 
@@ -135,8 +121,8 @@ public class StandaloneFlinkServiceTest {
     }
 
     @Test
-    public void testTMReplicaScaleApplication() throws Exception {
-        var flinkDeployment = TestUtils.buildApplicationCluster();
+    public void testTMReplicaScaleApplication() {
+        flinkDeployment.getSpec().setJob(new JobSpec());
         var clusterId = flinkDeployment.getMetadata().getName();
         var namespace = flinkDeployment.getMetadata().getNamespace();
         flinkDeployment.getSpec().setMode(KubernetesDeploymentMode.STANDALONE);
@@ -148,15 +134,20 @@ public class StandaloneFlinkServiceTest {
                 .put(
                         JobManagerOptions.SCHEDULER_MODE.key(),
                         SchedulerExecutionMode.REACTIVE.name());
-        flinkDeployment.getSpec().getJob().setParallelism(4);
-        createDeployments(flinkDeployment);
-        assertTrue(
-                flinkStandaloneService.scale(
-                        flinkDeployment.getMetadata(),
-                        flinkDeployment.getSpec().getJob(),
-                        buildConfig(flinkDeployment, configuration)));
+        flinkDeployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(flinkDeployment.getSpec(), flinkDeployment);
+        flinkDeployment.getSpec().getTaskManager().setReplicas(5);
+        var ctx =
+                new FlinkResourceContextFactory(
+                                kubernetesClient,
+                                configManager,
+                                TestUtils.createTestMetricGroup(new Configuration()))
+                        .getResourceContext(flinkDeployment, TestUtils.createEmptyContext());
+        assertTrue(flinkStandaloneService.scale(ctx));
         assertEquals(
-                2,
+                5,
                 kubernetesClient
                         .apps()
                         .deployments()
@@ -166,60 +157,36 @@ public class StandaloneFlinkServiceTest {
                         .getSpec()
                         .getReplicas());
 
-        // Add parallelism and replica change, verify if replica change is honoured in reactive mode
-        flinkDeployment.getSpec().getJob().setParallelism(100);
-        flinkDeployment.getSpec().getTaskManager().setReplicas(2);
-        assertTrue(
-                flinkStandaloneService.scale(
-                        flinkDeployment.getMetadata(),
-                        flinkDeployment.getSpec().getJob(),
-                        buildConfig(flinkDeployment, configuration)));
-        assertEquals(
-                2,
-                kubernetesClient
-                        .apps()
-                        .deployments()
-                        .inNamespace(namespace)
-                        .withName(StandaloneKubernetesUtils.getTaskManagerDeploymentName(clusterId))
-                        .get()
-                        .getSpec()
-                        .getReplicas());
-
-        // Verify that any change in parallelism doesnt scale the cluster without reactive mode
-        flinkDeployment.getSpec().getJob().setParallelism(100);
         flinkDeployment
                 .getSpec()
                 .getFlinkConfiguration()
                 .remove(JobManagerOptions.SCHEDULER_MODE.key());
-        assertFalse(
-                flinkStandaloneService.scale(
-                        flinkDeployment.getMetadata(),
-                        flinkDeployment.getSpec().getJob(),
-                        buildConfig(flinkDeployment, configuration)));
 
         // Add replicas and verify that the scaling is not honoured as reactive mode not enabled
         flinkDeployment.getSpec().getTaskManager().setReplicas(10);
-        assertFalse(
-                flinkStandaloneService.scale(
-                        flinkDeployment.getMetadata(),
-                        flinkDeployment.getSpec().getJob(),
-                        buildConfig(flinkDeployment, configuration)));
+        assertFalse(flinkStandaloneService.scale(ctx));
     }
 
     @Test
-    public void testTMReplicaScaleSession() throws Exception {
-        var flinkDeployment = TestUtils.buildSessionCluster();
+    public void testTMReplicaScaleSession() {
         var clusterId = flinkDeployment.getMetadata().getName();
         var namespace = flinkDeployment.getMetadata().getNamespace();
         flinkDeployment.getSpec().setMode(KubernetesDeploymentMode.STANDALONE);
         // Add replicas
         flinkDeployment.getSpec().getTaskManager().setReplicas(3);
-        createDeployments(flinkDeployment);
-        assertTrue(
-                flinkStandaloneService.scale(
-                        flinkDeployment.getMetadata(),
-                        flinkDeployment.getSpec().getJob(),
-                        buildConfig(flinkDeployment, configuration)));
+        flinkDeployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(
+                        JobManagerOptions.SCHEDULER_MODE.key(),
+                        SchedulerExecutionMode.REACTIVE.name());
+        var ctx =
+                new FlinkResourceContextFactory(
+                                kubernetesClient,
+                                configManager,
+                                TestUtils.createTestMetricGroup(new Configuration()))
+                        .getResourceContext(flinkDeployment, TestUtils.createEmptyContext());
+        assertTrue(flinkStandaloneService.scale(ctx));
 
         assertEquals(
                 3,
@@ -235,11 +202,7 @@ public class StandaloneFlinkServiceTest {
         // Scale the replica count of the task managers
         flinkDeployment.getSpec().getTaskManager().setReplicas(10);
         createDeployments(flinkDeployment);
-        assertTrue(
-                flinkStandaloneService.scale(
-                        flinkDeployment.getMetadata(),
-                        flinkDeployment.getSpec().getJob(),
-                        buildConfig(flinkDeployment, configuration)));
+        assertTrue(flinkStandaloneService.scale(ctx));
 
         assertEquals(
                 10,
@@ -257,21 +220,26 @@ public class StandaloneFlinkServiceTest {
     public void testSubmitSessionClusterConfigRemoval() throws Exception {
         TestingStandaloneFlinkService service =
                 new TestingStandaloneFlinkService(flinkStandaloneService);
-        service.submitSessionCluster(configuration);
+        service.submitSessionCluster(
+                configManager.getDeployConfig(
+                        flinkDeployment.getMetadata(), flinkDeployment.getSpec()));
         assertFalse(service.getRuntimeConfig().containsKey(OPERATOR_HEALTH_PROBE_PORT.key()));
     }
 
     @Test
     public void testDeployApplicationClusterConfigRemoval() throws Exception {
-        var flinkDeployment = TestUtils.buildApplicationCluster();
         TestingStandaloneFlinkService service =
                 new TestingStandaloneFlinkService(flinkStandaloneService);
-        service.deployApplicationCluster(flinkDeployment.getSpec().getJob(), configuration);
+        service.deployApplicationCluster(
+                flinkDeployment.getSpec().getJob(),
+                configManager.getDeployConfig(
+                        flinkDeployment.getMetadata(), flinkDeployment.getSpec()));
         assertFalse(service.getRuntimeConfig().containsKey(OPERATOR_HEALTH_PROBE_PORT.key()));
     }
 
     class TestingStandaloneFlinkService extends StandaloneFlinkService {
-        private Configuration runtimeConfig;
+        Configuration runtimeConfig;
+        int nbCall = 0;
 
         public TestingStandaloneFlinkService(StandaloneFlinkService service) {
             super(service.kubernetesClient, service.configManager);
@@ -285,15 +253,17 @@ public class StandaloneFlinkServiceTest {
         protected void submitClusterInternal(Configuration conf, Mode mode) {
             this.runtimeConfig = conf;
         }
-    }
 
-    private Configuration buildConfig(FlinkDeployment flinkDeployment, Configuration configuration)
-            throws Exception {
-        return FlinkConfigBuilder.buildFrom(
-                flinkDeployment.getMetadata().getNamespace(),
-                flinkDeployment.getMetadata().getName(),
-                flinkDeployment.getSpec(),
-                configuration);
+        @Override
+        protected PodList getTmPodList(String namespace, String clusterId) {
+            nbCall++;
+            PodList podList = new PodList();
+            if (nbCall == 1) {
+                Pod pod = new Pod();
+                podList.setItems(List.of(pod));
+            }
+            return podList;
+        }
     }
 
     private void createDeployments(AbstractFlinkResource cr) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventCollector.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventCollector.java
@@ -26,13 +26,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedList;
-import java.util.Queue;
 import java.util.function.BiConsumer;
 
 /** Simple consumer that collects triggered events for tests. */
 public class EventCollector implements BiConsumer<AbstractFlinkResource<?, ?>, Event> {
     private static final Logger LOG = LoggerFactory.getLogger(EventCollector.class);
-    public final Queue<Event> events = new LinkedList<>();
+    public final LinkedList<Event> events = new LinkedList<>();
 
     @Override
     public void accept(AbstractFlinkResource<?, ?> abstractFlinkResource, Event event) {

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -42,6 +42,7 @@ spec:
                 - v1_15
                 - v1_16
                 - v1_17
+                - v1_18
                 type: string
               ingress:
                 properties:


### PR DESCRIPTION
## What is the purpose of the change

The goal here is to use the newly introduced declarative resource management REST API endpoints in Flink 1.18 to execute parallelism override config changes for job vertexes. This allows us to rescale jobs without performing costly full upgrades (restarting all pods and resources). This will make the autoscaler module much more stable and reliable.

The operator already supported something slightly similar for standalone mode and reactive scheduler configuration where on TM replica change we would simply add new replicas.

## Brief change log

### Add required REST api request/response classes for 1.18

In order to not rely on unreleased Flink 1.18 libraries, we simply copied the request/response classes for the new rest api.
Combined with e2e tests this should be a good approach.

### Async scaling logic

The rescale mechanism in Flink 1.18 is asynchronous and might take a non-defined time to complete. To track progress we trigger the scaling through the `FlinkService#scale` method and afterwards update the `lastReconciledSpec` and change the ReconciliationState to `UPGRADING`.

The observer will subsequently detect an in-progress scaling operation and will check the vertex parallelisms using `FlinkService#scalingCompleted` to move a `DEPLOYED` reconciliation state.

*Note: The rescale api logic is currently only implemented for the native mode. In the standalone mode it would not work as efficiently as the user would need to manually add more TM replicas before the scaling can succeed anyways.*

### Changes to `@SpecDiff` annotations

Previously some spec fields were marked for SCALE difftype using the annotation, now it was required to separate what is SCALE / UPGRADE in the different deployment types (Standalone/Native). In native mode we do not support replica/global parallelism changes as scale operations (those rely on standalone + reactive mode).

### Required autoscaler changes

We have to improve how we track the job update ts because with in-place rescaling the job can restart without the operator observer noticing (and thus not updating the updateTs). To implement this more robustly we use the Max (last state transition timestamps) from the JobDetailsInfo which we query in every metric collection step. This guarantees that we clear metrics on job restarts / upgrades / failures.

### New Resource event and event triggering fixes

The PR contains a fix for the event triggering of spec change events. Currently spec change events are not triggered whenever the job is already in an upgrading state. This is incorrect as new spec changes can happen during an upgrade and those would not be visible to the user. The fix ensures that we trigger spec change events for each different spec generation (whenever the spec changes).

For in-place scaling we introduce a new `Scaling` event which signals the chosen scaling behaviour to the user.

## Verifying this change

 - Manual testing using the autoscaler example on local k8s cluster
 - New unit tests added for:
  - DiffType / SpecDiff changes
  - Native Flink service rescale logic
  - Reconciler changes for triggering rescale and updating status
  - Observer changes for detecting compeleted scale operations
  - New events triggered
  - Configs
 - E2E test added for autoscaler together with verification for in-place scaling for 1.18+

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? TODO
