### PR TITLE
[FLINK-32271] Report RECOMMENDED_PARALLELISM as an autoscaler metric V2

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoscalerFlinkMetrics.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoscalerFlinkMetrics.java
@@ -78,10 +78,10 @@ public class AutoscalerFlinkMetrics {
                                                         Optional.ofNullable(
                                                                         currentVertexMetrics.get())
                                                                 .map(m -> m.get(jobVertexID))
+                                                                .map(metrics -> metrics.get(sm))
                                                                 .map(
-                                                                        metrics ->
-                                                                                metrics.get(sm)
-                                                                                        .getCurrent())
+                                                                        EvaluatedScalingMetric
+                                                                                ::getCurrent)
                                                                 .orElse(null));
 
                                         if (sm.isCalculateAverage()) {
@@ -92,10 +92,10 @@ public class AutoscalerFlinkMetrics {
                                                                             currentVertexMetrics
                                                                                     .get())
                                                                     .map(m -> m.get(jobVertexID))
+                                                                    .map(metrics -> metrics.get(sm))
                                                                     .map(
-                                                                            metrics ->
-                                                                                    metrics.get(sm)
-                                                                                            .getAverage())
+                                                                            EvaluatedScalingMetric
+                                                                                    ::getAverage)
                                                                     .orElse(null));
                                         }
                                     });

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
@@ -101,6 +101,8 @@ public class ScalingExecutor {
             return false;
         }
 
+        updateRecommendedParallelism(evaluatedMetrics, scalingSummaries);
+
         var scalingEnabled = conf.get(SCALING_ENABLED);
 
         var scalingReport = scalingReport(scalingSummaries, scalingEnabled);
@@ -127,6 +129,19 @@ public class ScalingExecutor {
         scalingInformation.addToScalingHistory(clock.instant(), scalingSummaries, conf);
 
         return true;
+    }
+
+    private void updateRecommendedParallelism(
+            Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluatedMetrics,
+            Map<JobVertexID, ScalingSummary> scalingSummaries) {
+        scalingSummaries.forEach(
+                (jobVertexID, scalingSummary) -> {
+                    evaluatedMetrics
+                            .get(jobVertexID)
+                            .put(
+                                    ScalingMetric.RECOMMENDED_PARALLELISM,
+                                    EvaluatedScalingMetric.of(scalingSummary.getNewParallelism()));
+                });
     }
 
     private static String scalingReport(

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricCollector.java
@@ -83,7 +83,6 @@ public abstract class ScalingMetricCollector {
             Configuration conf)
             throws Exception {
 
-        var topology = getJobTopology(flinkService, cr, conf, autoscalerInfo);
         var resourceID = ResourceID.fromResource(cr);
         var now = clock.instant();
 
@@ -101,6 +100,7 @@ public abstract class ScalingMetricCollector {
             metricHistory.clear();
             metricCollectionStartTs = now;
         }
+        var topology = getJobTopology(flinkService, cr, conf, autoscalerInfo);
 
         // Trim metrics outside the metric window from metrics history
         var metricWindowSize = getMetricWindowSize(conf);

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingMetricEvaluator.java
@@ -139,10 +139,10 @@ public class ScalingMetricEvaluator {
 
         evaluatedMetrics.put(
                 PARALLELISM, EvaluatedScalingMetric.of(topology.getParallelisms().get(vertex)));
+
         evaluatedMetrics.put(
                 MAX_PARALLELISM,
                 EvaluatedScalingMetric.of(topology.getMaxParallelisms().get(vertex)));
-
         computeProcessingRateThresholds(evaluatedMetrics, conf, processingBacklog);
         return evaluatedMetrics;
     }

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/ScalingMetric.java
@@ -49,8 +49,13 @@ public enum ScalingMetric {
 
     /** Total number of pending records. */
     LAG(false),
+
     /** Job vertex parallelism. */
     PARALLELISM(false),
+
+    /** Recommended job vertex parallelism. */
+    RECOMMENDED_PARALLELISM(false),
+
     /** Job vertex max parallelism. */
     MAX_PARALLELISM(false),
     /** Upper boundary of the target data rate range. */

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/RecommendedParallelismTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/RecommendedParallelismTest.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.autoscaler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.OperatorTestBase;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.kubernetes.operator.autoscaler.metrics.FlinkMetric;
+import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.kubernetes.operator.autoscaler.topology.JobTopology;
+import org.apache.flink.kubernetes.operator.autoscaler.topology.VertexInfo;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+import org.apache.flink.kubernetes.operator.utils.EventCollector;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.PARALLELISM;
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.RECOMMENDED_PARALLELISM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/** Test for recommended parallelism. */
+@EnableKubernetesMockClient(crud = true)
+public class RecommendedParallelismTest extends OperatorTestBase {
+
+    @Getter private KubernetesClient kubernetesClient;
+
+    private ScalingMetricEvaluator evaluator;
+    private TestingMetricsCollector metricsCollector;
+    private ScalingExecutor scalingExecutor;
+
+    private FlinkDeployment app;
+    private JobVertexID source, sink;
+
+    private JobAutoScalerImpl autoscaler;
+
+    private EventCollector eventCollector = new EventCollector();
+
+    @BeforeEach
+    public void setup() {
+        evaluator = new ScalingMetricEvaluator();
+        scalingExecutor =
+                new ScalingExecutor(
+                        kubernetesClient,
+                        new EventRecorder(kubernetesClient, new EventCollector()));
+
+        app = TestUtils.buildApplicationCluster();
+        app.getMetadata().setGeneration(1L);
+        app.getStatus().getJobStatus().setJobId(new JobID().toHexString());
+        kubernetesClient.resource(app).createOrReplace();
+
+        source = new JobVertexID();
+        sink = new JobVertexID();
+
+        metricsCollector =
+                new TestingMetricsCollector(
+                        new JobTopology(
+                                new VertexInfo(source, Set.of(), 1, 720),
+                                new VertexInfo(sink, Set.of(source), 1, 720)));
+
+        var defaultConf = new Configuration();
+        defaultConf.set(AutoScalerOptions.AUTOSCALER_ENABLED, true);
+        defaultConf.set(AutoScalerOptions.STABILIZATION_INTERVAL, Duration.ZERO);
+        defaultConf.set(AutoScalerOptions.RESTART_TIME, Duration.ofSeconds(1));
+        defaultConf.set(AutoScalerOptions.CATCH_UP_DURATION, Duration.ofSeconds(2));
+        defaultConf.set(AutoScalerOptions.SCALING_ENABLED, true);
+        defaultConf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 1.);
+        defaultConf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, (double) Integer.MAX_VALUE);
+        defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.8);
+        defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.1);
+        defaultConf.set(AutoScalerOptions.SCALE_UP_GRACE_PERIOD, Duration.ZERO);
+
+        configManager = new FlinkConfigManager(defaultConf);
+        ReconciliationUtils.updateStatusForDeployedSpec(
+                app, configManager.getDeployConfig(app.getMetadata(), app.getSpec()));
+        app.getStatus().getJobStatus().setState(JobStatus.RUNNING.name());
+
+        autoscaler =
+                new JobAutoScalerImpl(
+                        kubernetesClient,
+                        metricsCollector,
+                        evaluator,
+                        scalingExecutor,
+                        new EventRecorder(kubernetesClient, eventCollector));
+
+        // Reset custom window size to default
+        metricsCollector.setTestMetricWindowSize(null);
+    }
+
+    @Test
+    public void endToEnd() throws Exception {
+
+        // we start the autoscaler in advisor mode
+        app.getSpec().getFlinkConfiguration().put(AutoScalerOptions.SCALING_ENABLED.key(), "false");
+        var ctx = createAutoscalerTestContext();
+
+        // initially the last evaluated metrics are empty
+        assertNull(autoscaler.lastEvaluatedMetrics.get(ResourceID.fromResource(app)));
+
+        var now = Instant.ofEpochMilli(0);
+        setClocksTo(now);
+        running(now);
+
+        metricsCollector.setTestMetricWindowSize(Duration.ofSeconds(2));
+        metricsCollector.setCurrentMetrics(
+                Map.of(
+                        source,
+                        Map.of(
+                                FlinkMetric.BUSY_TIME_PER_SEC,
+                                new AggregatedMetric("", Double.NaN, 850., Double.NaN, Double.NaN),
+                                FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
+                                new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 500.),
+                                FlinkMetric.NUM_RECORDS_IN_PER_SEC,
+                                new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 500.),
+                                FlinkMetric.PENDING_RECORDS,
+                                new AggregatedMetric(
+                                        "", Double.NaN, Double.NaN, Double.NaN, 2000.)),
+                        sink,
+                        Map.of(
+                                FlinkMetric.BUSY_TIME_PER_SEC,
+                                new AggregatedMetric("", Double.NaN, 850., Double.NaN, Double.NaN),
+                                FlinkMetric.NUM_RECORDS_IN_PER_SEC,
+                                new AggregatedMetric(
+                                        "", Double.NaN, Double.NaN, Double.NaN, 500.))));
+
+        // the recommended parallelism values are empty initially
+        autoscaler.scale(getResourceContext(app, ctx));
+        assertEquals(
+                1, AutoScalerInfo.forResource(app, kubernetesClient).getMetricHistory().size());
+        assertNull(getCurrentMetricValue(source, RECOMMENDED_PARALLELISM));
+        assertNull(getCurrentMetricValue(sink, RECOMMENDED_PARALLELISM));
+        assertEquals(1., getCurrentMetricValue(source, PARALLELISM));
+        assertEquals(1., getCurrentMetricValue(sink, PARALLELISM));
+        // the auto scaler is running in recommendation mode
+        assertNull(ScalingExecutorTest.getScaledParallelism(app));
+
+        now = now.plus(Duration.ofSeconds(1));
+        setClocksTo(now);
+
+        // it stays empty until the metric window is full
+        autoscaler.scale(getResourceContext(app, ctx));
+        assertEquals(
+                2, AutoScalerInfo.forResource(app, kubernetesClient).getMetricHistory().size());
+        assertNull(getCurrentMetricValue(source, RECOMMENDED_PARALLELISM));
+        assertNull(getCurrentMetricValue(sink, RECOMMENDED_PARALLELISM));
+        assertEquals(1., getCurrentMetricValue(source, PARALLELISM));
+        assertEquals(1., getCurrentMetricValue(sink, PARALLELISM));
+        assertNull(ScalingExecutorTest.getScaledParallelism(app));
+
+        now = now.plus(Duration.ofSeconds(1));
+        setClocksTo(now);
+
+        // then the recommended parallelism can change according to the evaluated metrics
+        autoscaler.scale(getResourceContext(app, ctx));
+        assertEquals(
+                3, AutoScalerInfo.forResource(app, kubernetesClient).getMetricHistory().size());
+        assertEquals(1., getCurrentMetricValue(source, PARALLELISM));
+        assertEquals(1., getCurrentMetricValue(sink, PARALLELISM));
+        assertEquals(4., getCurrentMetricValue(source, RECOMMENDED_PARALLELISM));
+        assertEquals(4., getCurrentMetricValue(sink, RECOMMENDED_PARALLELISM));
+        assertNull(ScalingExecutorTest.getScaledParallelism(app));
+
+        // once scaling is enabled
+        app.getSpec().getFlinkConfiguration().put(AutoScalerOptions.SCALING_ENABLED.key(), "true");
+
+        now = now.plus(Duration.ofSeconds(1));
+        setClocksTo(now);
+
+        // the scaled parallelism will pick up the recommended parallelism values
+        autoscaler.scale(getResourceContext(app, ctx));
+        assertEquals(
+                3, AutoScalerInfo.forResource(app, kubernetesClient).getMetricHistory().size());
+        assertEquals(4., getCurrentMetricValue(source, RECOMMENDED_PARALLELISM));
+        assertEquals(4., getCurrentMetricValue(sink, RECOMMENDED_PARALLELISM));
+        var scaledParallelism = ScalingExecutorTest.getScaledParallelism(app);
+        assertEquals(4, scaledParallelism.get(source));
+        assertEquals(4, scaledParallelism.get(sink));
+
+        // updating the topology to reflect the scale
+        metricsCollector.setJobTopology(
+                new JobTopology(
+                        new VertexInfo(source, Set.of(), 4, 24),
+                        new VertexInfo(sink, Set.of(source), 4, 720)));
+
+        now = now.plus(Duration.ofSeconds(10));
+        setClocksTo(now);
+        restart(now);
+
+        // after restart while the job is not running the evaluated metrics are gone
+        autoscaler.scale(getResourceContext(app, ctx));
+        assertEquals(
+                3, AutoScalerInfo.forResource(app, kubernetesClient).getMetricHistory().size());
+        assertNull(autoscaler.lastEvaluatedMetrics.get(ResourceID.fromResource(app)));
+        scaledParallelism = ScalingExecutorTest.getScaledParallelism(app);
+        assertEquals(4, scaledParallelism.get(source));
+        assertEquals(4, scaledParallelism.get(sink));
+
+        now = now.plus(Duration.ofSeconds(1));
+        setClocksTo(now);
+        running(now);
+
+        // once the job is running we got back the evaluated metric except the recommended
+        // parallelisms (until the metric window is full again)
+        autoscaler.scale(getResourceContext(app, ctx));
+        assertEquals(
+                1, AutoScalerInfo.forResource(app, kubernetesClient).getMetricHistory().size());
+        assertEquals(4., getCurrentMetricValue(source, PARALLELISM));
+        assertEquals(4., getCurrentMetricValue(sink, PARALLELISM));
+        assertNull(getCurrentMetricValue(source, RECOMMENDED_PARALLELISM));
+        assertNull(getCurrentMetricValue(sink, RECOMMENDED_PARALLELISM));
+        scaledParallelism = ScalingExecutorTest.getScaledParallelism(app);
+        assertEquals(4, scaledParallelism.get(source));
+        assertEquals(4, scaledParallelism.get(sink));
+    }
+
+    private Double getCurrentMetricValue(JobVertexID jobVertexID, ScalingMetric scalingMetric) {
+        var metric =
+                autoscaler
+                        .lastEvaluatedMetrics
+                        .get(ResourceID.fromResource(app))
+                        .get(jobVertexID)
+                        .get(scalingMetric);
+        return metric == null ? null : metric.getCurrent();
+    }
+
+    private void restart(Instant now) {
+        app.getStatus().getJobStatus().setUpdateTime(String.valueOf(now.toEpochMilli()));
+        app.getStatus().getJobStatus().setState(JobStatus.CREATED.name());
+    }
+
+    private void running(Instant now) {
+        app.getStatus().getJobStatus().setUpdateTime(String.valueOf(now.toEpochMilli()));
+        app.getStatus().getJobStatus().setState(JobStatus.RUNNING.name());
+    }
+
+    private void setClocksTo(Instant time) {
+        var clock = Clock.fixed(time, ZoneId.systemDefault());
+        metricsCollector.setClock(clock);
+        scalingExecutor.setClock(clock);
+    }
+
+    @NotNull
+    private TestUtils.TestingContext<HasMetadata> createAutoscalerTestContext() {
+        return new TestUtils.TestingContext<>() {
+            public <T1> Set<T1> getSecondaryResources(Class<T1> aClass) {
+                return (Set)
+                        kubernetesClient.configMaps().inAnyNamespace().list().getItems().stream()
+                                .collect(Collectors.toSet());
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

It is beneficial to report the recommended parallelism and overlay it with the current parallelism on the same chart when auto scaler is running in advisor mode.

## Brief change log
- Added a new `RECOMMENDED_PARALLELISM` entry to `ScalingMetric`
- And the latest recommended parallelisms are now being reported as evaluated scaling metric
- Recommended parallelisms follow the logic below:
  - On job start all scaling metrics are registered to null until the job is in RUNNING state
  - `RECOMMENDED_PARALLELISM` will be kept `null` while the metric window is filling up
  - `RECOMMENDED_PARALLELISM` will be populated only after the metric window is full
  -  `RECOMMENDED_PARALLELISM` will pick up the PARALLELISM value by default
  -  `RECOMMENDED_PARALLELISM` on each vertex can be updated according to the calculated scaling logic

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
- Added unit test for recommended parallelisms
- Manual by checking the actual metrics being reported

```
# first deploy scaling disabled
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.RECOMMENDED_PARALLELISM.Current: null
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.PARALLELISM.Current: null
jobVertexID.90bea66de1c231edf33913ecd54406c1.RECOMMENDED_PARALLELISM.Current: null
jobVertexID.90bea66de1c231edf33913ecd54406c1.PARALLELISM.Current: null

# metric window filling up
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.RECOMMENDED_PARALLELISM.Current: null
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.PARALLELISM.Current: 1.0
jobVertexID.90bea66de1c231edf33913ecd54406c1.RECOMMENDED_PARALLELISM.Current: null
jobVertexID.90bea66de1c231edf33913ecd54406c1.PARALLELISM.Current: 1.0

# metric window full
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.RECOMMENDED_PARALLELISM.Current: 1.0
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.PARALLELISM.Current: 1.0
jobVertexID.90bea66de1c231edf33913ecd54406c1.RECOMMENDED_PARALLELISM.Current: 2.0
jobVertexID.90bea66de1c231edf33913ecd54406c1.PARALLELISM.Current: 1.0

# scaling enabled
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.RECOMMENDED_PARALLELISM.Current: null
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.PARALLELISM.Current: null
jobVertexID.90bea66de1c231edf33913ecd54406c1.RECOMMENDED_PARALLELISM.Current: null
jobVertexID.90bea66de1c231edf33913ecd54406c1.PARALLELISM.Current: null

# metric window filling up
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.RECOMMENDED_PARALLELISM.Current: null
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.PARALLELISM.Current: 1.0
jobVertexID.90bea66de1c231edf33913ecd54406c1.RECOMMENDED_PARALLELISM.Current: null
jobVertexID.90bea66de1c231edf33913ecd54406c1.PARALLELISM.Current: 2.0

# metric window full
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.RECOMMENDED_PARALLELISM.Current: 1.0
jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.PARALLELISM.Current: 1.0
jobVertexID.90bea66de1c231edf33913ecd54406c1.RECOMMENDED_PARALLELISM.Current: 2.0
jobVertexID.90bea66de1c231edf33913ecd54406c1.PARALLELISM.Current: 2.0
```

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: ( no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
