### PR TITLE
 [hotfix][docs] Fix ArgoCD CRDs application

### DIFF
--- a/docs/content/docs/operations/helm.md
+++ b/docs/content/docs/operations/helm.md
@@ -165,6 +165,7 @@ spec:
     repoURL: https://github.com/apache/flink-kubernetes-operator
     targetRevision: main
     path: helm/flink-kubernetes-operator/crds
+  syncPolicy:
     syncOptions:
     - Replace=true
 ...


### PR DESCRIPTION
`syncOptions` field should reside under `.spec.syncPolicy`

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  no
