### PR TITLE
[FLINK-32317] Enrich metadata in CR error field

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -51,6 +51,12 @@
             <td>Whether to enable rolling back failed deployment upgrades.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.exception.label.mapper</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>Map</td>
+            <td>Key-Value pair where key is the REGEX to filter through the exception messages and value is the string to be included in CR status error label field if the REGEX matches. Expected format: headerKey1:headerValue1,headerKey2:headerValue2.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.jm-deployment-recovery.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -87,6 +87,12 @@
             <td>Maximum length of each exception field including stack trace to be included in CR status error field.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.exception.label.mapper</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>Map</td>
+            <td>Key-Value pair where key is the REGEX to filter through the exception messages and value is the string to be included in CR status error label field if the REGEX matches. Expected format: headerKey1:headerValue1,headerKey2:headerValue2.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.exception.stacktrace.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -66,6 +67,7 @@ public class FlinkOperatorConfiguration {
     int exceptionStackTraceLengthThreshold;
     int exceptionFieldLengthThreshold;
     int exceptionThrowableCountThreshold;
+    Map<String, String> exceptionLabelMapper;
     String labelSelector;
     LeaderElectionConfiguration leaderElectionConfiguration;
     DeletionPropagation deletionPropagation;
@@ -122,6 +124,8 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions
                                 .OPERATOR_EXCEPTION_THROWABLE_LIST_MAX_COUNT);
+        Map<String, String> exceptionLabelMapper =
+                operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_EXCEPTION_LABEL_MAPPER);
 
         String flinkServiceHostOverride = null;
         if (getEnv(ENV_KUBERNETES_SERVICE_HOST).isEmpty()) {
@@ -200,6 +204,7 @@ public class FlinkOperatorConfiguration {
                 exceptionStackTraceLengthThreshold,
                 exceptionFieldLengthThreshold,
                 exceptionThrowableCountThreshold,
+                exceptionLabelMapper,
                 labelSelector,
                 getLeaderElectionConfig(operatorConfig),
                 deletionPropagation);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -29,6 +29,7 @@ import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 
 /** This class holds configuration constants used by flink operator. */
@@ -258,6 +259,14 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(2)
                     .withDescription(
                             "Maximum number of throwable to be included in CR status error field.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Map<String, String>> OPERATOR_EXCEPTION_LABEL_MAPPER =
+            operatorConfig("exception.label.mapper")
+                    .mapType()
+                    .defaultValue(new HashMap<>())
+                    .withDescription(
+                            "Key-Value pair where key is the REGEX to filter through the exception messages and value is the string to be included in CR status error label field if the REGEX matches. Expected format: headerKey1:headerValue1,headerKey2:headerValue2.");
 
     @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD =

--- a/helm/flink-kubernetes-operator/conf/flink-conf.yaml
+++ b/helm/flink-kubernetes-operator/conf/flink-conf.yaml
@@ -43,6 +43,7 @@ parallelism.default: 1
 # kubernetes.operator.exception.stacktrace.max.length: 2048
 # kubernetes.operator.exception.field.max.length: 2048
 # kubernetes.operator.exception.throwable.list.max.count: 2
+# kubernetes.operator.exception.label.mapper: Job has already been submitted:duplicatedJobFound,Server returned HTTP response code:httpResponseCodeFound
 # kubernetes.operator.leader-election.enabled: false
 # kubernetes.operator.leader-election.lease-name: flink-operator-lease
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change



CR Error field is improved in https://issues.apache.org/jira/browse/FLINK-29708.

The error field is more structured with exception type, stackTrace, additionalMetadata, etc.

 

This ticket is a proposal to expose a config ("kubernetes.operator.exception.metadata.mapper") to enrich the additionalMetadata further.

 

The config consists of key-value pairs, for example:

```
kubernetes.operator.exception.metadata.mapper: IOException:Found IOException,403:Found 403 error code
```

The key is a REGEX string that will be used to match against the whole stack trace and if found, the value will be added to additionalMetadata. For example:

```
apiVersion: flink.apache.org/v1beta1
kind: FlinkSessionJob
....
  name: basic-session-job-example
  namespace: default
  resourceVersion: "70206149"
  uid: 916ea8f5-0821-4839-9953-2db9678c3fc9
spec:
  deploymentName: basic-session-deployment-example
  job:
    args: []
    jarURI: https://test-s3.s3.amazonaws.com/doubleExecute.jar
    parallelism: 4
    state: running
    upgradeMode: stateless
status:
  error: '{"type":"org.apache.flink.kubernetes.operator.exception.ReconciliationException","message":"java.io.IOException:
    Server returned HTTP response code: 403 for URL: https://test-s3.s3.amazonaws.com/doubleExecute.jar","additionalMetadata":{"exceptionMapper":["Found
    403 error code","Found IOException"]},"throwableList":[{"type":"java.io.IOException","message":"Server
    returned HTTP response code: 403 for URL: https://test-s3.s3.amazonaws.com/doubleExecute.jar","additionalMetadata":{"exceptionMapper":["Found
    403 error code"]}}]}'
...
```
 



## Brief change log

- Added new operator config for user to specify REGEX to extract info from exception and enrich CR error field with it.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
- Added unit test
- Sanity test by building image and testing in minikube

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
