### PR TITLE
[FLINK-32412] Reduce JobID collision chance

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/FlinkSessionJobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/FlinkSessionJobObserver.java
@@ -43,6 +43,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.kubernetes.operator.utils.FlinkUtils.generateSessionJobFixedJobID;
+
 /** The observer of {@link FlinkSessionJob}. */
 public class FlinkSessionJobObserver extends AbstractFlinkResourceObserver<FlinkSessionJob> {
 
@@ -84,7 +86,9 @@ public class FlinkSessionJobObserver extends AbstractFlinkResourceObserver<Flink
         var matchedJobs = new ArrayList<JobID>();
         for (JobStatusMessage jobStatusMessage : jobStatusMessages) {
             var jobId = jobStatusMessage.getJobId();
-            if (jobId.getLowerPart() == uid.hashCode()
+            if (jobId.getLowerPart()
+                            == generateSessionJobFixedJobID(uid, jobId.getUpperPart() + 1L)
+                                    .getLowerPart()
                     && !jobStatusMessage.getJobState().isGloballyTerminalState()) {
                 matchedJobs.add(jobId);
             }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -55,6 +55,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 
@@ -363,7 +364,8 @@ public class FlinkUtils {
      */
     public static JobID generateSessionJobFixedJobID(String uid, Long generation) {
         return new JobID(
-                Preconditions.checkNotNull(uid).hashCode(), Preconditions.checkNotNull(generation));
+                UUID.fromString(Preconditions.checkNotNull(uid)).getMostSignificantBits(),
+                Preconditions.checkNotNull(generation));
     }
 
     /**

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
@@ -313,6 +313,13 @@ public class FlinkUtilsTest {
         assertEquals(List.of(v1merged, volume2, volume3), mergedPod.getSpec().getVolumes());
     }
 
+    @Test
+    public void testJobIDGeneration() {
+        JobID jobID =
+                FlinkUtils.generateSessionJobFixedJobID("ffffffff-ffff-ffff-aaaa-aaaaaaaaaaaa", 2L);
+        assertEquals("ffffffffffffffff0000000000000002", jobID.toString());
+    }
+
     private void createHAConfigMapWithData(
             String configMapName, String namespace, String clusterId, Map<String, String> data) {
         final ConfigMap kubernetesConfigMap =


### PR DESCRIPTION
Instead of using Java's hashCode, which is an integer value (32bit), a long representation of the uid is used. This decreases the chance for an ID collision drastically:

For a 50% collision chance with random integers, 77000 numbers need to be generated. For a long value (64 bit) a 50% change of a collision needs 5.1×10^9 random longs. For details look up: "the birthday problem".

A test is added to increase awareness of the problem when changing this part of the code.


## What is the purpose of the change

Lower the chance of JobID collisions in session job deployments.


## Brief change log

  - *Increase the lower part of the JobID to use the 64 most significant bits of the ressources uid instead of the 32 bit hashCode of the uid*

## Verifying this change

  - *Added unit test*
  - *Adapted existing tests*
  - *Manually tested the upgrade of the operator when having a job deployed with the old JobID generation and then switching to a operator with the fix. Upgrading the job after this worked without any problems.*

## Does this pull request potentially affect one of the following parts:

  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
