### PR TITLE
[FLINK-32527] Fix build failure on windows

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/validation/CrdCompatibilityChecker.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/validation/CrdCompatibilityChecker.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -63,7 +64,14 @@ public class CrdCompatibilityChecker {
     }
 
     private static JsonNode getSchema(String url) throws IOException {
-        JsonNode crd = objectMapper.readTree(new URL(url));
+        var target = new URL(url);
+        var protocol = target.getProtocol();
+        JsonNode crd;
+        if ("file".equals(protocol)) {
+            crd = objectMapper.readTree(new File(url.substring(7)));
+        } else {
+            crd = objectMapper.readTree(target);
+        }
         return crd.get("spec").get("versions").get(0).get("schema").get("openAPIV3Schema");
     }
 

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/validation/CrdCompatibilityCheckerTest.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/validation/CrdCompatibilityCheckerTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -268,6 +269,20 @@ public class CrdCompatibilityCheckerTest {
                 objectMapper.readValue(
                         new File("src/test/resources/test-deployment.yaml"), FlinkDeployment.class);
         assertEquals(flinkDeploymentWithUnknownFields.toString(), flinkDeployment.toString());
+    }
+
+    @Test
+    public void testGetSchemaFromUrl() throws IOException {
+        var fileUrl =
+                "file://" + new File("src/test/resources/test-deployment.yaml").getAbsolutePath();
+        var httpUrl =
+                "https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.4.0/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml";
+        assertEquals("file", new URL(fileUrl).getProtocol());
+        assertEquals("https", new URL(httpUrl).getProtocol());
+        var fileNode = objectMapper.readTree(new File(fileUrl.substring(7)));
+        var httpNode = objectMapper.readTree(new URL(httpUrl));
+        assertEquals("FlinkDeployment", fileNode.get("kind").asText());
+        assertEquals("CustomResourceDefinition", httpNode.get("kind").asText());
     }
 
     private void expectSuccess(String oldSchema, String newSchema) throws JsonProcessingException {


### PR DESCRIPTION
## What is the purpose of the change

Fix build failure on windows via `mvn clean package -DskipTests`.

## Brief change log
  - Modify  method `getSchema` in `CrdCompatibilityChecker`.

## Verifying this change
- Added unit test to verify CrdCompatibilityCheckerTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (yes )

## Documentation

  - Does this pull request introduce a new feature? (no)
