### PR TITLE
[FLINK-32529] Add startup probe for JM deployment

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -63,6 +63,12 @@
             <td>Time after which jobmanager pods of terminal application deployments are shut down.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.jm-deployment.startup.probe.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Enable job manager startup probe to allow detecting when the jobmanager could not submit the job.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.restart.failed</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -147,6 +147,12 @@
             <td>Time after which jobmanager pods of terminal application deployments are shut down.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.jm-deployment.startup.probe.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Enable job manager startup probe to allow detecting when the jobmanager could not submit the job.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.restart.failed</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -39,6 +39,7 @@ import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
 import org.apache.flink.kubernetes.operator.api.spec.Resource;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfigOptionsInternal;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.utils.Constants;
@@ -190,11 +191,56 @@ public class FlinkConfigBuilder {
         return this;
     }
 
-    protected FlinkConfigBuilder applyCommonPodTemplate() throws IOException {
-        if (spec.getPodTemplate() != null) {
-            effectiveConfig.setString(
-                    "kubernetes.pod-template-file", createTempFile(spec.getPodTemplate()));
+    protected FlinkConfigBuilder applyPodTemplate() throws IOException {
+        Pod commonPodTemplate = spec.getPodTemplate();
+        boolean mergeByName =
+                effectiveConfig.get(KubernetesOperatorConfigOptions.POD_TEMPLATE_MERGE_BY_NAME);
+
+        Pod jmPodTemplate;
+        if (spec.getJobManager() != null) {
+            jmPodTemplate =
+                    mergePodTemplates(
+                            commonPodTemplate, spec.getJobManager().getPodTemplate(), mergeByName);
+
+            jmPodTemplate =
+                    applyResourceToPodTemplate(jmPodTemplate, spec.getJobManager().getResource());
+        } else {
+            jmPodTemplate = ReconciliationUtils.clone(commonPodTemplate);
         }
+
+        if (effectiveConfig.get(
+                KubernetesOperatorConfigOptions.OPERATOR_JM_STARTUP_PROBE_ENABLED)) {
+            if (jmPodTemplate == null) {
+                jmPodTemplate = new Pod();
+            }
+            FlinkUtils.addStartupProbe(jmPodTemplate);
+        }
+
+        String jmTemplateFile = null;
+        if (jmPodTemplate != null) {
+            jmTemplateFile = createTempFile(jmPodTemplate);
+            effectiveConfig.set(KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE, jmTemplateFile);
+        }
+
+        Pod tmPodTemplate;
+        if (spec.getTaskManager() != null) {
+            tmPodTemplate =
+                    mergePodTemplates(
+                            commonPodTemplate, spec.getTaskManager().getPodTemplate(), mergeByName);
+            tmPodTemplate =
+                    applyResourceToPodTemplate(tmPodTemplate, spec.getTaskManager().getResource());
+        } else {
+            tmPodTemplate = ReconciliationUtils.clone(commonPodTemplate);
+        }
+
+        if (tmPodTemplate != null) {
+            effectiveConfig.set(
+                    KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE,
+                    tmPodTemplate.equals(jmPodTemplate)
+                            ? jmTemplateFile
+                            : createTempFile(tmPodTemplate));
+        }
+
         return this;
     }
 
@@ -216,15 +262,9 @@ public class FlinkConfigBuilder {
         return this;
     }
 
-    protected FlinkConfigBuilder applyJobManagerSpec() throws IOException {
+    protected FlinkConfigBuilder applyJobManagerSpec() {
         if (spec.getJobManager() != null) {
             setResource(spec.getJobManager().getResource(), effectiveConfig, true);
-            setPodTemplate(
-                    spec.getPodTemplate(),
-                    spec.getJobManager().getPodTemplate(),
-                    spec.getJobManager().getResource(),
-                    effectiveConfig,
-                    true);
             if (spec.getJobManager().getReplicas() > 0) {
                 effectiveConfig.set(
                         KubernetesConfigOptions.KUBERNETES_JOBMANAGER_REPLICAS,
@@ -234,16 +274,9 @@ public class FlinkConfigBuilder {
         return this;
     }
 
-    protected FlinkConfigBuilder applyTaskManagerSpec() throws IOException {
+    protected FlinkConfigBuilder applyTaskManagerSpec() {
         if (spec.getTaskManager() != null) {
             setResource(spec.getTaskManager().getResource(), effectiveConfig, false);
-            setPodTemplate(
-                    spec.getPodTemplate(),
-                    spec.getTaskManager().getPodTemplate(),
-                    spec.getTaskManager().getResource(),
-                    effectiveConfig,
-                    false);
-
             if (spec.getTaskManager().getReplicas() != null
                     && spec.getTaskManager().getReplicas() > 0) {
                 effectiveConfig.set(
@@ -369,7 +402,7 @@ public class FlinkConfigBuilder {
                 .applyImage()
                 .applyImagePullPolicy()
                 .applyServiceAccount()
-                .applyCommonPodTemplate()
+                .applyPodTemplate()
                 .applyIngressDomain()
                 .applyJobManagerSpec()
                 .applyTaskManagerSpec()
@@ -418,39 +451,6 @@ public class FlinkConfigBuilder {
             }
         }
         conf.setDouble(configKey, resource.getCpu());
-    }
-
-    private static void setPodTemplate(
-            Pod basicPod,
-            Pod appendPod,
-            Resource resource,
-            Configuration effectiveConfig,
-            boolean isJM)
-            throws IOException {
-
-        // Avoid to create temporary pod template files for JobManager and TaskManager if it is not
-        // configured explicitly via .spec.JobManagerSpec.podTemplate or
-        // .spec.TaskManagerSpec.podTemplate.
-        final ConfigOption<String> podConfigOption =
-                isJM
-                        ? KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE
-                        : KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE;
-
-        Pod podTemplate;
-        if (basicPod != null || appendPod != null) {
-            Pod mergedPodTemplate =
-                    mergePodTemplates(
-                            basicPod,
-                            appendPod,
-                            effectiveConfig.get(
-                                    KubernetesOperatorConfigOptions.POD_TEMPLATE_MERGE_BY_NAME));
-            podTemplate = applyResourceToPodTemplate(mergedPodTemplate, resource);
-        } else {
-            podTemplate = applyResourceToPodTemplate(null, resource);
-        }
-        if (podTemplate != null) {
-            effectiveConfig.setString(podConfigOption, createTempFile(podTemplate));
-        }
     }
 
     @VisibleForTesting
@@ -542,9 +542,6 @@ public class FlinkConfigBuilder {
     }
 
     protected static void cleanupTmpFiles(Configuration configuration) {
-        configuration
-                .getOptional(KubernetesConfigOptions.KUBERNETES_POD_TEMPLATE)
-                .ifPresent(FlinkConfigBuilder::deleteSilentlyIfGenerated);
         configuration
                 .getOptional(KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE)
                 .ifPresent(FlinkConfigBuilder::deleteSilentlyIfGenerated);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -492,6 +492,14 @@ public class KubernetesOperatorConfigOptions {
                             "Allowed max time between spec update and reconciliation for canary resources.");
 
     @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> OPERATOR_JM_STARTUP_PROBE_ENABLED =
+            operatorConfig("jm-deployment.startup.probe.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Enable job manager startup probe to allow detecting when the jobmanager could not submit the job.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> POD_TEMPLATE_MERGE_BY_NAME =
             operatorConfig("pod-template.merge-arrays-by-name")
                     .booleanType()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -134,9 +134,6 @@ public class FlinkConfigManagerTest {
                 deployConfig.contains(KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL));
         assertTrue(new File(deployConfig.get(DeploymentOptionsInternal.CONF_DIR)).exists());
         assertTrue(
-                new File(deployConfig.get(KubernetesConfigOptions.KUBERNETES_POD_TEMPLATE))
-                        .exists());
-        assertTrue(
                 new File(deployConfig.get(KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE))
                         .exists());
         assertTrue(
@@ -147,9 +144,6 @@ public class FlinkConfigManagerTest {
 
         assertTrue(new File(deployConfig.get(DeploymentOptionsInternal.CONF_DIR)).exists());
         assertTrue(
-                new File(deployConfig.get(KubernetesConfigOptions.KUBERNETES_POD_TEMPLATE))
-                        .exists());
-        assertTrue(
                 new File(deployConfig.get(KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE))
                         .exists());
         assertTrue(
@@ -159,9 +153,6 @@ public class FlinkConfigManagerTest {
         configManager.getCache().invalidateAll();
 
         assertFalse(new File(deployConfig.get(DeploymentOptionsInternal.CONF_DIR)).exists());
-        assertFalse(
-                new File(deployConfig.get(KubernetesConfigOptions.KUBERNETES_POD_TEMPLATE))
-                        .exists());
         assertFalse(
                 new File(deployConfig.get(KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE))
                         .exists());


### PR DESCRIPTION
## What is the purpose of the change

There are certain cases where the JM enters a startup crash loop for example due to incorrect HA config setup. With the current operator logic these cases require manual user intervention as we don't have HA metadata available for the last checkpoint and it also seems like the JM actually started already.

To solve this properly we suggest adding a default JM startup probe that queries the rest api (/config) endpoint. This simple mechanism allows us to piggyback on the existing mechanism that allows the operator to simply delete the JM deployment when it never successfully started.

## Brief change log

  - *Add configurable startup probe for JM deployments to detect failed start*
  - *Unit tests for startup probe config*

## Verifying this change

Unit tests + manual tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
