### PR TITLE
[FLINK-32282] Migrate to webhook framework

### DIFF
--- a/flink-kubernetes-webhook/pom.xml
+++ b/flink-kubernetes-webhook/pom.xml
@@ -41,8 +41,8 @@ under the License.
 
         <dependency>
             <groupId>io.javaoperatorsdk</groupId>
-            <artifactId>operator-framework-framework-core</artifactId>
-            <version>${operator.sdk.admission-controller.version}</version>
+            <artifactId>kubernetes-webhooks-framework-core</artifactId>
+            <version>${operator.sdk.webhook-framework.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -114,7 +114,7 @@ under the License.
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <artifactSet>
                                 <includes combine.children="append">
-                                    <include>io.javaoperatorsdk:operator-framework-framework-core</include>
+                                    <include>io.javaoperatorsdk:kubernetes-webhooks-framework-core</include>
                                 </includes>
                             </artifactSet>
                             <transformers combine.children="append">

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandler.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandler.java
@@ -41,9 +41,9 @@ import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.QueryStringDec
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
-import io.javaoperatorsdk.admissioncontroller.AdmissionController;
-import io.javaoperatorsdk.admissioncontroller.mutation.Mutator;
-import io.javaoperatorsdk.admissioncontroller.validation.Validator;
+import io.javaoperatorsdk.webhook.admission.AdmissionController;
+import io.javaoperatorsdk.webhook.admission.mutation.Mutator;
+import io.javaoperatorsdk.webhook.admission.validation.Validator;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkValidator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkValidator.java
@@ -28,9 +28,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.client.informers.cache.Cache;
-import io.javaoperatorsdk.admissioncontroller.NotAllowedException;
-import io.javaoperatorsdk.admissioncontroller.Operation;
-import io.javaoperatorsdk.admissioncontroller.validation.Validator;
+import io.javaoperatorsdk.webhook.admission.NotAllowedException;
+import io.javaoperatorsdk.webhook.admission.Operation;
+import io.javaoperatorsdk.webhook.admission.validation.Validator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/DefaultRequestMutator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/DefaultRequestMutator.java
@@ -24,25 +24,25 @@ import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionResponse;
 import io.fabric8.zjsonpatch.JsonDiff;
-import io.javaoperatorsdk.admissioncontroller.AdmissionUtils;
-import io.javaoperatorsdk.admissioncontroller.NotAllowedException;
-import io.javaoperatorsdk.admissioncontroller.Operation;
-import io.javaoperatorsdk.admissioncontroller.RequestHandler;
-import io.javaoperatorsdk.admissioncontroller.clone.Cloner;
-import io.javaoperatorsdk.admissioncontroller.clone.ObjectMapperCloner;
-import io.javaoperatorsdk.admissioncontroller.mutation.Mutator;
+import io.javaoperatorsdk.webhook.admission.AdmissionRequestHandler;
+import io.javaoperatorsdk.webhook.admission.AdmissionUtils;
+import io.javaoperatorsdk.webhook.admission.NotAllowedException;
+import io.javaoperatorsdk.webhook.admission.Operation;
+import io.javaoperatorsdk.webhook.admission.mutation.Mutator;
+import io.javaoperatorsdk.webhook.clone.Cloner;
+import io.javaoperatorsdk.webhook.clone.ObjectMapperCloner;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 /**
- * The default request mutator. It's copied from the {@link
- * io.javaoperatorsdk.admissioncontroller.mutation.DefaultRequestMutator} with a modified path diff
- * util to serialize out include non-null.
+ * The default request mutator. It's copied from the {@link DefaultRequestMutator} with a modified
+ * path diff util to serialize out include non-null.
  *
  * @param <T> Resource type.
  */
-public class DefaultRequestMutator<T extends KubernetesResource> implements RequestHandler {
+public class DefaultRequestMutator<T extends KubernetesResource>
+        implements AdmissionRequestHandler {
     private static final ObjectMapper mapper =
             new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
     private final Mutator<T> mutator;

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
@@ -22,9 +22,9 @@ import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.javaoperatorsdk.admissioncontroller.NotAllowedException;
-import io.javaoperatorsdk.admissioncontroller.Operation;
-import io.javaoperatorsdk.admissioncontroller.mutation.Mutator;
+import io.javaoperatorsdk.webhook.admission.NotAllowedException;
+import io.javaoperatorsdk.webhook.admission.Operation;
+import io.javaoperatorsdk.webhook.admission.mutation.Mutator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-kubernetes-webhook/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-webhook/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.javaoperatorsdk:operator-framework-framework-core:jar:0.2.0
+- io.javaoperatorsdk:kubernetes-webhooks-framework-core:jar:1.1.1

--- a/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
+++ b/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Base64;
 
-import static io.javaoperatorsdk.admissioncontroller.Operation.CREATE;
+import static io.javaoperatorsdk.webhook.admission.Operation.CREATE;
 import static org.apache.flink.kubernetes.operator.admission.AdmissionHandler.MUTATOR_REQUEST_PATH;
 import static org.apache.flink.kubernetes.operator.admission.AdmissionHandler.VALIDATE_REQUEST_PATH;
 import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpMethod.GET;

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,7 @@ under the License.
         <git-commit-id-maven-plugin.version>5.0.0</git-commit-id-maven-plugin.version>
 
         <operator.sdk.version>4.3.5</operator.sdk.version>
-        <operator.sdk.admission-controller.version>0.2.0</operator.sdk.admission-controller.version>
-        <operator.sdk.jenvtest.version>0.9.1</operator.sdk.jenvtest.version>
+        <operator.sdk.webhook-framework.version>1.1.1</operator.sdk.webhook-framework.version>
 
         <fabric8.version>6.7.0</fabric8.version>
 


### PR DESCRIPTION
## What is the purpose of the change

Replace the deprecated admission controller framework with the equivalent web hook library

## Brief change log

 - Replace maven dependency / imports

## Verifying this change

No new functionality added, covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
