### PR TITLE
[FLINK-32551] Add option to take a savepoint on flinkdeployment/flinksessionjob deletion

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -123,6 +123,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | initialSavepointPath | java.lang.String | Savepoint path used by the job the first time it is deployed. Upgrades/redeployments will not be affected. |
 | upgradeMode | org.apache.flink.kubernetes.operator.api.spec.UpgradeMode | Upgrade mode of the Flink job. |
 | allowNonRestoredState | java.lang.Boolean | Allow checkpoint state that cannot be mapped to any job vertex in tasks. |
+| savepointOnDeletion | java.lang.Boolean | Indicate if a savepoint must be taken on FlinkDeployment/FlinkSessionJob deletion. |
 
 ### JobState
 **Class**: org.apache.flink.kubernetes.operator.api.spec.JobState

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
@@ -80,4 +80,8 @@ public class JobSpec implements Diffable<JobSpec> {
     /** Allow checkpoint state that cannot be mapped to any job vertex in tasks. */
     @SpecDiff(DiffType.IGNORE)
     private Boolean allowNonRestoredState;
+
+    /** Indicate if a savepoint must be taken on FlinkDeployment/FlinkSessionJob deletion. */
+    @SpecDiff(DiffType.IGNORE)
+    private boolean savepointOnDeletion;
 }

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
@@ -87,15 +87,15 @@ public class BaseTestUtils {
     }
 
     public static FlinkDeployment buildApplicationCluster(String name, String namespace) {
-        return buildApplicationCluster(name, namespace, FlinkVersion.v1_17);
+        return buildApplicationCluster(name, namespace, FlinkVersion.v1_17, false);
     }
 
     public static FlinkDeployment buildApplicationCluster(FlinkVersion version) {
-        return buildApplicationCluster(TEST_DEPLOYMENT_NAME, TEST_NAMESPACE, version);
+        return buildApplicationCluster(TEST_DEPLOYMENT_NAME, TEST_NAMESPACE, version, false);
     }
 
     public static FlinkDeployment buildApplicationCluster(
-            String name, String namespace, FlinkVersion version) {
+            String name, String namespace, FlinkVersion version, boolean savepointOnDeletion) {
         FlinkDeployment deployment = buildSessionCluster(name, namespace, version);
         deployment
                 .getSpec()
@@ -105,12 +105,14 @@ public class BaseTestUtils {
                                 .parallelism(1)
                                 .upgradeMode(UpgradeMode.STATELESS)
                                 .state(JobState.RUNNING)
+                                .savepointOnDeletion(savepointOnDeletion)
                                 .build());
         deployment.setStatus(deployment.initStatus());
         return deployment;
     }
 
-    public static FlinkSessionJob buildSessionJob(String name, String namespace) {
+    public static FlinkSessionJob buildSessionJob(
+            String name, String namespace, boolean savepointOnDeletion) {
         FlinkSessionJob sessionJob = new FlinkSessionJob();
         sessionJob.setStatus(new FlinkSessionJobStatus());
         sessionJob.setMetadata(
@@ -134,14 +136,19 @@ public class BaseTestUtils {
                                         .parallelism(1)
                                         .upgradeMode(UpgradeMode.STATELESS)
                                         .state(JobState.RUNNING)
+                                        .savepointOnDeletion(savepointOnDeletion)
                                         .build())
                         .flinkConfiguration(conf)
                         .build());
         return sessionJob;
     }
 
+    public static FlinkSessionJob buildSessionJob(String name, String namespace) {
+        return buildSessionJob(name, namespace, false);
+    }
+
     public static FlinkSessionJob buildSessionJob() {
-        return buildSessionJob(TEST_SESSION_JOB_NAME, TEST_NAMESPACE);
+        return buildSessionJob(TEST_SESSION_JOB_NAME, TEST_NAMESPACE, false);
     }
 
     public static FlinkDeploymentSpec getTestFlinkDeploymentSpec(FlinkVersion version) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -358,12 +358,15 @@ public class ApplicationReconciler
         var deployment = ctx.getResource();
         var status = deployment.getStatus();
         var conf = ctx.getDeployConfig(ctx.getResource().getSpec());
+        var cleanupUpgradeMode =
+                deployment.getSpec().getJob().isSavepointOnDeletion()
+                        ? UpgradeMode.SAVEPOINT
+                        : UpgradeMode.STATELESS;
         if (status.getReconciliationStatus().isBeforeFirstDeployment()) {
             ctx.getFlinkService()
                     .deleteClusterDeployment(deployment.getMetadata(), status, conf, true);
         } else {
-            ctx.getFlinkService()
-                    .cancelJob(deployment, UpgradeMode.STATELESS, ctx.getObserveConfig());
+            ctx.getFlinkService().cancelJob(deployment, cleanupUpgradeMode, ctx.getObserveConfig());
         }
         return DeleteControl.defaultDelete();
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -107,7 +107,11 @@ public class SessionJobReconciler
             String jobID = ctx.getResource().getStatus().getJobStatus().getJobId();
             if (jobID != null) {
                 try {
-                    cancelJob(ctx, UpgradeMode.STATELESS);
+                    var cleanupUpgradeMode =
+                            ctx.getResource().getSpec().getJob().isSavepointOnDeletion()
+                                    ? UpgradeMode.SAVEPOINT
+                                    : UpgradeMode.STATELESS;
+                    cancelJob(ctx, cleanupUpgradeMode);
                 } catch (ExecutionException e) {
                     final var cause = e.getCause();
 

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9274,6 +9274,8 @@ spec:
                     type: string
                   allowNonRestoredState:
                     type: boolean
+                  savepointOnDeletion:
+                    type: boolean
                 type: object
               restartNonce:
                 type: integer

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -60,6 +60,8 @@ spec:
                     type: string
                   allowNonRestoredState:
                     type: boolean
+                  savepointOnDeletion:
+                    type: boolean
                 type: object
               restartNonce:
                 type: integer


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request add an option `savepointOnDeletion` on `JobSpec` to indicate if the operator must take a savepoint on flinkdeployment/flinksessionjob deletion

## Brief change log

  - *Add option to take a savepoint on flinkdeployment/flinksessionjob deletion

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
Unit tests + manual tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes, it add `savepointOnDeletion` on `JobSpec`
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs added in the custom-resource reference
