### PR TITLE
[FLINK-32572] Do not collect metrics for finished vertices

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/FlinkMetric.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/metrics/FlinkMetric.java
@@ -21,6 +21,7 @@ import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -39,11 +40,20 @@ public enum FlinkMetric {
             s -> s.startsWith("Source__") && s.endsWith(".numRecordsInPerSecond")),
     PENDING_RECORDS(s -> s.endsWith(".pendingRecords"));
 
+    public static final Map<FlinkMetric, AggregatedMetric> FINISHED_METRICS =
+            Map.of(
+                    FlinkMetric.BUSY_TIME_PER_SEC, zero(),
+                    FlinkMetric.PENDING_RECORDS, zero(),
+                    FlinkMetric.NUM_RECORDS_IN_PER_SEC, zero(),
+                    FlinkMetric.NUM_RECORDS_OUT_PER_SEC, zero(),
+                    FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC, zero(),
+                    FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC, zero());
+
+    public final Predicate<String> predicate;
+
     FlinkMetric(Predicate<String> predicate) {
         this.predicate = predicate;
     }
-
-    public final Predicate<String> predicate;
 
     public Optional<String> findAny(Collection<AggregatedMetric> metrics) {
         return metrics.stream().map(AggregatedMetric::getId).filter(predicate).findAny();
@@ -54,5 +64,9 @@ public enum FlinkMetric {
                 .map(AggregatedMetric::getId)
                 .filter(predicate)
                 .collect(Collectors.toList());
+    }
+
+    private static AggregatedMetric zero() {
+        return new AggregatedMetric("", 0., 0., 0., 0.);
     }
 }

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/topology/VertexInfo.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/topology/VertexInfo.java
@@ -19,12 +19,14 @@ package org.apache.flink.kubernetes.operator.autoscaler.topology;
 
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
 import java.util.Set;
 
 /** Job vertex information. */
 @Value
+@RequiredArgsConstructor
 public class VertexInfo {
 
     JobVertexID id;
@@ -34,4 +36,11 @@ public class VertexInfo {
     int parallelism;
 
     int maxParallelism;
+
+    boolean finished;
+
+    public VertexInfo(
+            JobVertexID id, Set<JobVertexID> inputs, int parallelism, int maxParallelism) {
+        this(id, inputs, parallelism, maxParallelism, false);
+    }
 }

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobTopologyTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobTopologyTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Set;
 
@@ -72,7 +73,8 @@ public class JobTopologyTest {
                             : SchedulerBase.getDefaultMaxParallelism(vertex));
         }
 
-        JobTopology jobTopology = JobTopology.fromJsonPlan(jsonPlan, maxParallelism);
+        JobTopology jobTopology =
+                JobTopology.fromJsonPlan(jsonPlan, maxParallelism, Collections.emptySet());
 
         assertTrue(jobTopology.getOutputs().get(vertices.get("Sink: sink1")).isEmpty());
         assertTrue(jobTopology.getOutputs().get(vertices.get("Sink: sink2")).isEmpty());

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/utils/AutoScalerUtilsTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/utils/AutoScalerUtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.autoscaler.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test for AutoScalerUtils. */
+public class AutoScalerUtilsTest {
+    @Test
+    public void testVertexExclusion() {
+        var conf = new Configuration();
+        var v1 = new JobVertexID();
+        var v2 = new JobVertexID();
+        var v3 = new JobVertexID();
+
+        assertTrue(AutoScalerUtils.excludeVertexFromScaling(conf, v1));
+        assertEquals(List.of(v1.toString()), conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS));
+
+        assertFalse(AutoScalerUtils.excludeVertexFromScaling(conf, v1));
+        assertEquals(List.of(v1.toString()), conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS));
+
+        assertTrue(AutoScalerUtils.excludeVerticesFromScaling(conf, List.of(v1, v2, v3)));
+        assertEquals(
+                Set.of(v1.toString(), v2.toString(), v3.toString()),
+                new HashSet<>(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS)));
+
+        assertFalse(AutoScalerUtils.excludeVerticesFromScaling(conf, List.of(v1, v2)));
+        assertEquals(
+                Set.of(v1.toString(), v2.toString(), v3.toString()),
+                new HashSet<>(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS)));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Improve the autoscaler metric collection logic to be aware of finished vertices and do not collect metrics from them. Simplify topology handling. 

For finished metrics we use hardcoded metrics that show 0 incoming data / lag etc in order to allow downstream operators to be scaled accordingly even if they have other inputs.

## Brief change log

  - *Add finished flag to VertexInfo*
  - *Exclude finished vertices from scaling metric collection*
  - *Simplify topology and metric name collection*
  - *Unit test*

## Verifying this change

New unit tests 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
