### PR TITLE
[FLINK-32606] Support FlinkVersion and Namespace level default configs

### DIFF
--- a/docs/content/docs/operations/configuration.md
+++ b/docs/content/docs/operations/configuration.md
@@ -50,6 +50,24 @@ defaultConfiguration:
 
 To learn more about metrics and logging configuration please refer to the dedicated [docs page]({{< ref "docs/operations/metrics-logging" >}}).
 
+### Flink Version and Namespace specific defaults
+
+The operator also supports default configuration overrides for selected Flink versions and namespaces. This can be important if some behaviour changed across Flink versions or we want to treat certain namespaces differently (such as reconcile it more or less frequently etc).
+
+```
+# Flink Version specific defaults 
+kubernetes.operator.default-configuration.flink-version.v1_17.k1: v1
+kubernetes.operator.default-configuration.flink-version.v1_17.k2: v2
+kubernetes.operator.default-configuration.flink-version.v1_17.k3: v3
+
+# Namespace specific defaults
+kubernetes.operator.default-configuration.namespace.ns1.k1: v1
+kubernetes.operator.default-configuration.namespace.ns1.k2: v2
+kubernetes.operator.default-configuration.namespace.ns2.k1: v1
+```
+
+Flink version specific defaults will have a higher precedence so namespace defaults would be overridden by the same key.
+
 ## Dynamic Operator Configuration
 
 The Kubernetes operator supports dynamic config changes through the operator ConfigMaps. Dynamic operator configuration is enabled by default, and can be disabled by setting `kubernetes.operator.dynamic.config.enabled` to false. Time interval for checking dynamic config changes is specified by `kubernetes.operator.dynamic.config.check.interval` of which default value is 5 minutes.

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -97,23 +97,20 @@ public class FlinkConfigBuilder {
     private final FlinkDeploymentSpec spec;
     private final Configuration effectiveConfig;
 
-    protected FlinkConfigBuilder(FlinkDeployment deployment, Configuration flinkConfig) {
+    protected FlinkConfigBuilder(FlinkDeployment deployment, Configuration flinkConf) {
         this(
                 deployment.getMetadata().getNamespace(),
                 deployment.getMetadata().getName(),
                 deployment.getSpec(),
-                flinkConfig);
+                flinkConf);
     }
 
     protected FlinkConfigBuilder(
-            String namespace,
-            String clusterId,
-            FlinkDeploymentSpec spec,
-            Configuration flinkConfig) {
+            String namespace, String clusterId, FlinkDeploymentSpec spec, Configuration flinkConf) {
         this.namespace = namespace;
         this.clusterId = clusterId;
         this.spec = spec;
-        this.effectiveConfig = new Configuration(flinkConfig);
+        this.effectiveConfig = flinkConf;
     }
 
     protected FlinkConfigBuilder applyImage() {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -37,6 +37,9 @@ public class KubernetesOperatorConfigOptions {
 
     public static final String K8S_OP_CONF_PREFIX = "kubernetes.operator.";
 
+    private static final String DEFAULT_CONF_PREFIX = K8S_OP_CONF_PREFIX + "default-configuration.";
+    public static final String VERSION_CONF_PREFIX = DEFAULT_CONF_PREFIX + "flink-version.";
+    public static final String NAMESPACE_CONF_PREFIX = DEFAULT_CONF_PREFIX + "namespace.";
     public static final String SECTION_SYSTEM = "system";
     public static final String SECTION_ADVANCED = "system_advanced";
     public static final String SECTION_DYNAMIC = "dynamic";

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentContext.java
@@ -21,29 +21,26 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkDeploymentSpec;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
-import lombok.Getter;
+
+import java.util.function.Function;
 
 /** Context for reconciling a Flink resource. * */
 public class FlinkDeploymentContext extends FlinkResourceContext<FlinkDeployment> {
-
-    private final FlinkConfigManager configManager;
-    @Getter private final FlinkService flinkService;
 
     public FlinkDeploymentContext(
             FlinkDeployment resource,
             Context<?> josdkContext,
             KubernetesResourceMetricGroup resourceMetricGroup,
-            FlinkService flinkService,
-            FlinkConfigManager configManager) {
-        super(resource, josdkContext, resourceMetricGroup);
-        this.configManager = configManager;
-        this.flinkService = flinkService;
+            FlinkConfigManager configManager,
+            Function<FlinkResourceContext<?>, FlinkService> flinkServiceFactory) {
+        super(resource, josdkContext, resourceMetricGroup, configManager, flinkServiceFactory);
     }
 
     @Override
@@ -60,5 +57,10 @@ public class FlinkDeploymentContext extends FlinkResourceContext<FlinkDeployment
     @Override
     public KubernetesDeploymentMode getDeploymentMode() {
         return KubernetesDeploymentMode.getDeploymentMode(getResource());
+    }
+
+    @Override
+    public FlinkVersion getFlinkVersion() {
+        return getResource().getSpec().getFlinkVersion();
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -21,7 +21,6 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.kubernetes.operator.exception.RecoveryFailureException;
@@ -62,8 +61,6 @@ public class FlinkDeploymentController
                 Cleaner<FlinkDeployment> {
     private static final Logger LOG = LoggerFactory.getLogger(FlinkDeploymentController.class);
 
-    private final FlinkConfigManager configManager;
-
     private final Set<FlinkResourceValidator> validators;
     private final FlinkResourceContextFactory ctxFactory;
     private final ReconcilerFactory reconcilerFactory;
@@ -73,7 +70,6 @@ public class FlinkDeploymentController
     private final CanaryResourceManager<FlinkDeployment> canaryResourceManager;
 
     public FlinkDeploymentController(
-            FlinkConfigManager configManager,
             Set<FlinkResourceValidator> validators,
             FlinkResourceContextFactory ctxFactory,
             ReconcilerFactory reconcilerFactory,
@@ -81,7 +77,6 @@ public class FlinkDeploymentController
             StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder,
             EventRecorder eventRecorder,
             CanaryResourceManager<FlinkDeployment> canaryResourceManager) {
-        this.configManager = configManager;
         this.validators = validators;
         this.ctxFactory = ctxFactory;
         this.reconcilerFactory = reconcilerFactory;
@@ -132,20 +127,17 @@ public class FlinkDeploymentController
         var ctx = ctxFactory.getResourceContext(flinkApp, josdkContext);
         try {
             observerFactory.getOrCreate(flinkApp).observe(ctx);
-            if (!validateDeployment(flinkApp)) {
+            if (!validateDeployment(ctx)) {
                 statusRecorder.patchAndCacheStatus(flinkApp);
                 return ReconciliationUtils.toUpdateControl(
-                        configManager.getOperatorConfiguration(),
-                        flinkApp,
-                        previousDeployment,
-                        false);
+                        ctx.getOperatorConfig(), flinkApp, previousDeployment, false);
             }
             statusRecorder.patchAndCacheStatus(flinkApp);
             reconcilerFactory.getOrCreate(flinkApp).reconcile(ctx);
         } catch (RecoveryFailureException rfe) {
-            handleRecoveryFailed(flinkApp, rfe);
+            handleRecoveryFailed(ctx, rfe);
         } catch (DeploymentFailedException dfe) {
-            handleDeploymentFailed(flinkApp, dfe);
+            handleDeploymentFailed(ctx, dfe);
         } catch (Exception e) {
             eventRecorder.triggerEvent(
                     flinkApp,
@@ -159,15 +151,16 @@ public class FlinkDeploymentController
         LOG.debug("End of reconciliation");
         statusRecorder.patchAndCacheStatus(flinkApp);
         return ReconciliationUtils.toUpdateControl(
-                configManager.getOperatorConfiguration(), flinkApp, previousDeployment, true);
+                ctx.getOperatorConfig(), flinkApp, previousDeployment, true);
     }
 
-    private void handleDeploymentFailed(FlinkDeployment flinkApp, DeploymentFailedException dfe) {
+    private void handleDeploymentFailed(
+            FlinkResourceContext<FlinkDeployment> ctx, DeploymentFailedException dfe) {
+        var flinkApp = ctx.getResource();
         LOG.error("Flink Deployment failed", dfe);
         flinkApp.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.ERROR);
         flinkApp.getStatus().getJobStatus().setState(JobStatus.RECONCILING.name());
-        ReconciliationUtils.updateForReconciliationError(
-                flinkApp, dfe, configManager.getOperatorConfiguration());
+        ReconciliationUtils.updateForReconciliationError(ctx, dfe);
         eventRecorder.triggerEvent(
                 flinkApp,
                 EventRecorder.Type.Warning,
@@ -176,10 +169,11 @@ public class FlinkDeploymentController
                 EventRecorder.Component.JobManagerDeployment);
     }
 
-    private void handleRecoveryFailed(FlinkDeployment flinkApp, RecoveryFailureException rfe) {
+    private void handleRecoveryFailed(
+            FlinkResourceContext<FlinkDeployment> ctx, RecoveryFailureException rfe) {
         LOG.error("Flink recovery failed", rfe);
-        ReconciliationUtils.updateForReconciliationError(
-                flinkApp, rfe, configManager.getOperatorConfiguration());
+        var flinkApp = ctx.getResource();
+        ReconciliationUtils.updateForReconciliationError(ctx, rfe);
         eventRecorder.triggerEvent(
                 flinkApp,
                 EventRecorder.Type.Warning,
@@ -199,15 +193,12 @@ public class FlinkDeploymentController
     @Override
     public ErrorStatusUpdateControl<FlinkDeployment> updateErrorStatus(
             FlinkDeployment flinkDeployment, Context<FlinkDeployment> context, Exception e) {
-        return ReconciliationUtils.toErrorStatusUpdateControl(
-                flinkDeployment,
-                context.getRetryInfo(),
-                e,
-                statusRecorder,
-                configManager.getOperatorConfiguration());
+        var ctx = ctxFactory.getResourceContext(flinkDeployment, context);
+        return ReconciliationUtils.toErrorStatusUpdateControl(ctx, e, statusRecorder);
     }
 
-    private boolean validateDeployment(FlinkDeployment deployment) {
+    private boolean validateDeployment(FlinkResourceContext<FlinkDeployment> ctx) {
+        var deployment = ctx.getResource();
         for (FlinkResourceValidator validator : validators) {
             Optional<String> validationError = validator.validateDeployment(deployment);
             if (validationError.isPresent()) {
@@ -218,9 +209,7 @@ public class FlinkDeploymentController
                         EventRecorder.Component.Operator,
                         validationError.get());
                 return ReconciliationUtils.applyValidationErrorAndResetSpec(
-                        deployment,
-                        validationError.get(),
-                        configManager.getOperatorConfiguration());
+                        ctx, validationError.get());
             }
         }
         return true;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
@@ -20,13 +20,18 @@ package org.apache.flink.kubernetes.operator.controller;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.function.Function;
 
 /** Context for reconciling a Flink resource. * */
 @RequiredArgsConstructor
@@ -35,8 +40,12 @@ public abstract class FlinkResourceContext<CR extends AbstractFlinkResource<?, ?
     @Getter private final CR resource;
     @Getter private final Context<?> josdkContext;
     @Getter private final KubernetesResourceMetricGroup resourceMetricGroup;
+    protected final FlinkConfigManager configManager;
+    private final Function<FlinkResourceContext<?>, FlinkService> flinkServiceFactory;
 
+    private FlinkOperatorConfiguration operatorConfig;
     private Configuration observeConfig;
+    private FlinkService flinkService;
 
     /**
      * Get the config that is currently deployed for the resource spec. The returned config may be
@@ -65,7 +74,16 @@ public abstract class FlinkResourceContext<CR extends AbstractFlinkResource<?, ?
      *
      * @return Flink service.
      */
-    public abstract FlinkService getFlinkService();
+    public FlinkService getFlinkService() {
+        if (flinkService != null) {
+            return flinkService;
+        }
+        return flinkService = createFlinkService();
+    }
+
+    protected FlinkService createFlinkService() {
+        return flinkServiceFactory.apply(this);
+    }
 
     /**
      * Generate the config that is currently deployed for the resource spec.
@@ -76,4 +94,17 @@ public abstract class FlinkResourceContext<CR extends AbstractFlinkResource<?, ?
 
     /** @return Cluster deployment mode. */
     public abstract KubernetesDeploymentMode getDeploymentMode();
+
+    /** @return Cluster Flink Version. */
+    public abstract FlinkVersion getFlinkVersion();
+
+    /** @return Operator configuration for this resource. */
+    public FlinkOperatorConfiguration getOperatorConfig() {
+        if (operatorConfig != null) {
+            return operatorConfig;
+        }
+        return operatorConfig =
+                configManager.getOperatorConfiguration(
+                        getResource().getMetadata().getNamespace(), getFlinkVersion());
+    }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/MetricManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/MetricManager.java
@@ -18,10 +18,10 @@
 package org.apache.flink.kubernetes.operator.metrics;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.metrics.lifecycle.LifecycleMetrics;
 
 import java.util.ArrayList;
@@ -44,56 +44,46 @@ public class MetricManager<CR extends AbstractFlinkResource<?, ?>> {
     }
 
     public static MetricManager<FlinkDeployment> createFlinkDeploymentMetricManager(
-            FlinkConfigManager configManager, KubernetesOperatorMetricGroup metricGroup) {
+            Configuration conf, KubernetesOperatorMetricGroup metricGroup) {
         MetricManager<FlinkDeployment> metricManager = new MetricManager<>();
-        registerFlinkDeploymentMetrics(configManager, metricGroup, metricManager);
-        registerLifecycleMetrics(configManager, metricGroup, metricManager);
+        registerFlinkDeploymentMetrics(conf, metricGroup, metricManager);
+        registerLifecycleMetrics(conf, metricGroup, metricManager);
         return metricManager;
     }
 
     public static MetricManager<FlinkSessionJob> createFlinkSessionJobMetricManager(
-            FlinkConfigManager configManager, KubernetesOperatorMetricGroup metricGroup) {
+            Configuration conf, KubernetesOperatorMetricGroup metricGroup) {
         MetricManager<FlinkSessionJob> metricManager = new MetricManager<>();
-        registerFlinkSessionJobMetrics(configManager, metricGroup, metricManager);
-        registerLifecycleMetrics(configManager, metricGroup, metricManager);
+        registerFlinkSessionJobMetrics(conf, metricGroup, metricManager);
+        registerLifecycleMetrics(conf, metricGroup, metricManager);
         return metricManager;
     }
 
     private static void registerFlinkDeploymentMetrics(
-            FlinkConfigManager configManager,
+            Configuration conf,
             KubernetesOperatorMetricGroup metricGroup,
             MetricManager<FlinkDeployment> metricManager) {
-        if (configManager
-                .getDefaultConfig()
-                .get(KubernetesOperatorMetricOptions.OPERATOR_RESOURCE_METRICS_ENABLED)) {
-            metricManager.register(
-                    new FlinkDeploymentMetrics(metricGroup, configManager.getDefaultConfig()));
+        if (conf.get(KubernetesOperatorMetricOptions.OPERATOR_RESOURCE_METRICS_ENABLED)) {
+            metricManager.register(new FlinkDeploymentMetrics(metricGroup, conf));
         }
     }
 
     private static void registerFlinkSessionJobMetrics(
-            FlinkConfigManager configManager,
+            Configuration conf,
             KubernetesOperatorMetricGroup metricGroup,
             MetricManager<FlinkSessionJob> metricManager) {
-        if (configManager
-                .getDefaultConfig()
-                .get(KubernetesOperatorMetricOptions.OPERATOR_RESOURCE_METRICS_ENABLED)) {
-            metricManager.register(
-                    new FlinkSessionJobMetrics(metricGroup, configManager.getDefaultConfig()));
+        if (conf.get(KubernetesOperatorMetricOptions.OPERATOR_RESOURCE_METRICS_ENABLED)) {
+            metricManager.register(new FlinkSessionJobMetrics(metricGroup, conf));
         }
     }
 
     private static <CR extends AbstractFlinkResource<?, ?>> void registerLifecycleMetrics(
-            FlinkConfigManager configManager,
+            Configuration conf,
             KubernetesOperatorMetricGroup metricGroup,
             MetricManager<CR> metricManager) {
-        if (configManager
-                        .getDefaultConfig()
-                        .get(KubernetesOperatorMetricOptions.OPERATOR_RESOURCE_METRICS_ENABLED)
-                && configManager
-                        .getDefaultConfig()
-                        .get(KubernetesOperatorMetricOptions.OPERATOR_LIFECYCLE_METRICS_ENABLED)) {
-            metricManager.register(new LifecycleMetrics<>(configManager, metricGroup));
+        if (conf.get(KubernetesOperatorMetricOptions.OPERATOR_RESOURCE_METRICS_ENABLED)
+                && conf.get(KubernetesOperatorMetricOptions.OPERATOR_LIFECYCLE_METRICS_ENABLED)) {
+            metricManager.register(new LifecycleMetrics<>(conf, metricGroup));
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
@@ -19,7 +19,6 @@ package org.apache.flink.kubernetes.operator.observer;
 
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
@@ -34,12 +33,9 @@ public abstract class AbstractFlinkResourceObserver<CR extends AbstractFlinkReso
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    protected final FlinkConfigManager configManager;
     protected final EventRecorder eventRecorder;
 
-    public AbstractFlinkResourceObserver(
-            FlinkConfigManager configManager, EventRecorder eventRecorder) {
-        this.configManager = configManager;
+    public AbstractFlinkResourceObserver(EventRecorder eventRecorder) {
         this.eventRecorder = eventRecorder;
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/FlinkDeploymentObserverFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/FlinkDeploymentObserverFactory.java
@@ -20,7 +20,6 @@ package org.apache.flink.kubernetes.operator.observer.deployment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.observer.Observer;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
@@ -31,14 +30,11 @@ import java.util.concurrent.ConcurrentHashMap;
 /** The factory to create the observer based on the {@link FlinkDeployment} mode. */
 public class FlinkDeploymentObserverFactory {
 
-    private final FlinkConfigManager configManager;
     private final EventRecorder eventRecorder;
     private final Map<Tuple2<Mode, KubernetesDeploymentMode>, Observer<FlinkDeployment>>
             observerMap;
 
-    public FlinkDeploymentObserverFactory(
-            FlinkConfigManager configManager, EventRecorder eventRecorder) {
-        this.configManager = configManager;
+    public FlinkDeploymentObserverFactory(EventRecorder eventRecorder) {
         this.eventRecorder = eventRecorder;
         this.observerMap = new ConcurrentHashMap<>();
     }
@@ -51,9 +47,9 @@ public class FlinkDeploymentObserverFactory {
                 modes -> {
                     switch (modes.f0) {
                         case SESSION:
-                            return new SessionObserver(configManager, eventRecorder);
+                            return new SessionObserver(eventRecorder);
                         case APPLICATION:
-                            return new ApplicationObserver(configManager, eventRecorder);
+                            return new ApplicationObserver(eventRecorder);
                         default:
                             throw new UnsupportedOperationException(
                                     String.format("Unsupported running mode: %s", modes.f0));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
@@ -19,7 +19,6 @@ package org.apache.flink.kubernetes.operator.observer.deployment;
 
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
@@ -28,8 +27,8 @@ import java.util.concurrent.TimeoutException;
 /** The observer of the {@link org.apache.flink.kubernetes.operator.config.Mode#SESSION} cluster. */
 public class SessionObserver extends AbstractFlinkDeploymentObserver {
 
-    public SessionObserver(FlinkConfigManager configManager, EventRecorder eventRecorder) {
-        super(configManager, eventRecorder);
+    public SessionObserver(EventRecorder eventRecorder) {
+        super(eventRecorder);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -35,6 +35,7 @@ import org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.api.status.TaskManagerInfo;
 import org.apache.flink.kubernetes.operator.api.utils.SpecUtils;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.exception.ValidationException;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
@@ -42,7 +43,6 @@ import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
 import io.fabric8.kubernetes.client.CustomResource;
 import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
-import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -50,7 +50,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
 import java.time.Duration;
-import java.util.Optional;
 
 import static org.apache.flink.api.common.JobStatus.FINISHED;
 import static org.apache.flink.api.common.JobStatus.RUNNING;
@@ -203,9 +202,8 @@ public class ReconciliationUtils {
         }
     }
 
-    public static void updateForReconciliationError(
-            AbstractFlinkResource<?, ?> target, Throwable error, FlinkOperatorConfiguration conf) {
-        updateFlinkResourceException(error, target, conf);
+    public static void updateForReconciliationError(FlinkResourceContext ctx, Throwable error) {
+        updateFlinkResourceException(error, ctx.getResource(), ctx.getOperatorConfig());
     }
 
     public static <T> T clone(T object) {
@@ -336,23 +334,22 @@ public class ReconciliationUtils {
      * <p>For in-flight application upgrades we need extra logic to set the desired job state to
      * running
      *
-     * @param deployment The current deployment to be reconciled
+     * @param ctx The current deployment context
      * @param validationError Validation error encountered for the current spec
-     * @param conf Operator config
      * @param <SPEC> Spec type.
      * @return True if the spec was reset and reconciliation can continue. False if nothing to
      *     reconcile.
      */
     public static <SPEC extends AbstractFlinkSpec> boolean applyValidationErrorAndResetSpec(
-            AbstractFlinkResource<SPEC, ?> deployment,
-            String validationError,
-            FlinkOperatorConfiguration conf) {
+            FlinkResourceContext<? extends AbstractFlinkResource<SPEC, ?>> ctx,
+            String validationError) {
 
+        var deployment = ctx.getResource();
         var status = deployment.getStatus();
         if (!validationError.equals(status.getError())) {
             LOG.error("Validation failed: " + validationError);
             ReconciliationUtils.updateForReconciliationError(
-                    deployment, new ValidationException(validationError), conf);
+                    ctx, new ValidationException(validationError));
         }
 
         var lastReconciledSpecWithMeta =
@@ -384,20 +381,18 @@ public class ReconciliationUtils {
      *
      * @param <STATUS> Status type.
      * @param <R> Resource type.
-     * @param resource Flink Resource to be updated
-     * @param retryInfo Current RetryInformation
+     * @param ctx Flink Resource context
      * @param e Exception that caused the retry
      * @param statusRecorder statusRecorder object for patching status
-     * @param operatorConfiguration Operator config
      * @return This always returns Empty optional currently, due to the status update logic
      */
     public static <STATUS extends CommonStatus<?>, R extends AbstractFlinkResource<?, STATUS>>
             ErrorStatusUpdateControl<R> toErrorStatusUpdateControl(
-                    R resource,
-                    Optional<RetryInfo> retryInfo,
+                    FlinkResourceContext<R> ctx,
                     Exception e,
-                    StatusRecorder<R, STATUS> statusRecorder,
-                    FlinkOperatorConfiguration operatorConfiguration) {
+                    StatusRecorder<R, STATUS> statusRecorder) {
+
+        var retryInfo = ctx.getJosdkContext().getRetryInfo();
 
         retryInfo.ifPresent(
                 r ->
@@ -406,9 +401,9 @@ public class ReconciliationUtils {
                                 r.getAttemptCount(),
                                 r.isLastAttempt()));
 
-        statusRecorder.updateStatusFromCache(resource);
-        ReconciliationUtils.updateForReconciliationError(resource, e, operatorConfiguration);
-        statusRecorder.patchAndCacheStatus(resource);
+        statusRecorder.updateStatusFromCache(ctx.getResource());
+        ReconciliationUtils.updateForReconciliationError(ctx, e);
+        statusRecorder.patchAndCacheStatus(ctx.getResource());
 
         // Status was updated already, no need to return anything
         return ErrorStatusUpdateControl.noStatusUpdate();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -142,11 +142,7 @@ public class SessionReconciler
                 LOG.warn(error);
             }
             return DeleteControl.noFinalizerRemoval()
-                    .rescheduleAfter(
-                            configManager
-                                    .getOperatorConfiguration()
-                                    .getReconcileInterval()
-                                    .toMillis());
+                    .rescheduleAfter(ctx.getOperatorConfig().getReconcileInterval().toMillis());
         } else {
             LOG.info("Stopping session cluster");
             var conf = ctx.getDeployConfig(ctx.getResource().getSpec());

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -122,10 +122,7 @@ public class SessionJobReconciler
                     }
 
                     final long delay =
-                            configManager
-                                    .getOperatorConfiguration()
-                                    .getProgressCheckInterval()
-                                    .toMillis();
+                            ctx.getOperatorConfig().getProgressCheckInterval().toMillis();
                     LOG.error(
                             "Failed to cancel job {}, will reschedule after {} milliseconds.",
                             jobID,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
@@ -29,7 +29,8 @@ import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.artifact.ArtifactManager;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.kubeclient.Fabric8FlinkStandaloneKubeClient;
@@ -58,8 +59,11 @@ public class StandaloneFlinkService extends AbstractFlinkService {
     private static final Logger LOG = LoggerFactory.getLogger(StandaloneFlinkService.class);
 
     public StandaloneFlinkService(
-            KubernetesClient kubernetesClient, FlinkConfigManager configManager) {
-        super(kubernetesClient, configManager);
+            KubernetesClient kubernetesClient,
+            ArtifactManager artifactManager,
+            ExecutorService executorService,
+            FlinkOperatorConfiguration operatorConfig) {
+        super(kubernetesClient, artifactManager, executorService, operatorConfig);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
@@ -35,11 +35,12 @@ public final class ValidatorUtils {
     private static final Logger LOG = LoggerFactory.getLogger(FlinkUtils.class);
 
     public static Set<FlinkResourceValidator> discoverValidators(FlinkConfigManager configManager) {
+        var conf = configManager.getDefaultConfig();
         Set<FlinkResourceValidator> resourceValidators = new HashSet<>();
         DefaultValidator defaultValidator = new DefaultValidator(configManager);
-        defaultValidator.configure(configManager.getDefaultConfig());
+        defaultValidator.configure(conf);
         resourceValidators.add(defaultValidator);
-        PluginUtils.createPluginManagerFromRootFolder(configManager.getDefaultConfig())
+        PluginUtils.createPluginManagerFromRootFolder(conf)
                 .load(FlinkResourceValidator.class)
                 .forEachRemaining(
                         validator -> {
@@ -50,7 +51,7 @@ public final class ValidatorUtils {
                                                     ConfigConstants.ENV_FLINK_PLUGINS_DIR,
                                                     ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS),
                                     validator.getClass().getName());
-                            validator.configure(configManager.getDefaultConfig());
+                            validator.configure(conf);
                             resourceValidators.add(validator);
                         });
         return resourceValidators;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -80,7 +80,11 @@ public class DefaultValidator implements FlinkResourceValidator {
     @Override
     public Optional<String> validateDeployment(FlinkDeployment deployment) {
         FlinkDeploymentSpec spec = deployment.getSpec();
-        Map<String, String> effectiveConfig = configManager.getDefaultConfig().toMap();
+        Map<String, String> effectiveConfig =
+                configManager
+                        .getDefaultConfig(
+                                deployment.getMetadata().getNamespace(), spec.getFlinkVersion())
+                        .toMap();
         if (spec.getFlinkConfiguration() != null) {
             effectiveConfig.putAll(spec.getFlinkConfiguration());
         }
@@ -472,7 +476,12 @@ public class DefaultValidator implements FlinkResourceValidator {
 
     private Optional<String> validateSessionJobWithCluster(
             FlinkSessionJob sessionJob, FlinkDeployment sessionCluster) {
-        Map<String, String> effectiveConfig = configManager.getDefaultConfig().toMap();
+        Map<String, String> effectiveConfig =
+                configManager
+                        .getDefaultConfig(
+                                sessionJob.getMetadata().getNamespace(),
+                                sessionCluster.getSpec().getFlinkVersion())
+                        .toMap();
         if (sessionCluster.getSpec().getFlinkConfiguration() != null) {
             effectiveConfig.putAll(sessionCluster.getSpec().getFlinkConfiguration());
         }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkResourceContextFactory.java
@@ -18,8 +18,8 @@
 package org.apache.flink.kubernetes.operator;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
@@ -46,7 +46,7 @@ public class TestingFlinkResourceContextFactory extends FlinkResourceContextFact
     }
 
     @Override
-    protected FlinkService getOrCreateFlinkService(FlinkDeployment deployment) {
+    protected FlinkService getFlinkService(FlinkResourceContext<?> ctx) {
         return flinkService;
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -40,7 +40,7 @@ import org.apache.flink.kubernetes.operator.api.status.SavepointFormatType;
 import org.apache.flink.kubernetes.operator.api.status.SavepointInfo;
 import org.apache.flink.kubernetes.operator.api.status.SavepointTriggerType;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.exception.RecoveryFailureException;
 import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
@@ -68,6 +68,7 @@ import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetricsResponseBody;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedSubtaskMetricsHeaders;
 import org.apache.flink.util.SerializedThrowable;
+import org.apache.flink.util.concurrent.Executors;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -141,11 +142,15 @@ public class TestingFlinkService extends AbstractFlinkService {
     @Setter private boolean scalingCompleted;
 
     public TestingFlinkService() {
-        super(null, new FlinkConfigManager(new Configuration()));
+        this(null);
     }
 
     public TestingFlinkService(KubernetesClient kubernetesClient) {
-        super(kubernetesClient, new FlinkConfigManager(new Configuration()));
+        super(
+                kubernetesClient,
+                null,
+                Executors.newDirectExecutorService(),
+                FlinkOperatorConfiguration.fromConfiguration(new Configuration()));
     }
 
     public <T extends HasMetadata> Context<T> getContext() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -219,7 +219,9 @@ public class FlinkConfigBuilderTest {
         inConfig.set(KubernetesOperatorConfigOptions.OPERATOR_JM_STARTUP_PROBE_ENABLED, false);
 
         var configuration =
-                new FlinkConfigBuilder(flinkDeployment, inConfig).applyPodTemplate().build();
+                new FlinkConfigBuilder(flinkDeployment, inConfig.clone())
+                        .applyPodTemplate()
+                        .build();
 
         Assertions.assertEquals(
                 configuration.getString(KubernetesConfigOptions.JOB_MANAGER_POD_TEMPLATE),
@@ -232,7 +234,9 @@ public class FlinkConfigBuilderTest {
         flinkDeployment.getSpec().getTaskManager().getResource().setEphemeralStorage("2G");
 
         configuration =
-                new FlinkConfigBuilder(flinkDeployment, inConfig).applyPodTemplate().build();
+                new FlinkConfigBuilder(flinkDeployment, inConfig.clone())
+                        .applyPodTemplate()
+                        .build();
         assertMainContainerEphemeralStorage(
                 getJmPod(configuration).getSpec().getContainers().get(1), "2G");
         Assertions.assertEquals(
@@ -249,7 +253,9 @@ public class FlinkConfigBuilderTest {
         inConfig.set(KubernetesOperatorConfigOptions.OPERATOR_JM_STARTUP_PROBE_ENABLED, true);
 
         configuration =
-                new FlinkConfigBuilder(flinkDeployment, inConfig).applyPodTemplate().build();
+                new FlinkConfigBuilder(flinkDeployment, inConfig.clone())
+                        .applyPodTemplate()
+                        .build();
 
         var jmPod = getJmPod(configuration);
         var tmPod = getTmPod(configuration);
@@ -265,7 +271,9 @@ public class FlinkConfigBuilderTest {
         // With completely empty podtemplates still generate startup probe
         flinkDeployment.getSpec().setPodTemplate(null);
         configuration =
-                new FlinkConfigBuilder(flinkDeployment, inConfig).applyPodTemplate().build();
+                new FlinkConfigBuilder(flinkDeployment, inConfig.clone())
+                        .applyPodTemplate()
+                        .build();
         Assertions.assertNull(
                 configuration.getString(KubernetesConfigOptions.TASK_MANAGER_POD_TEMPLATE));
         jmPod = getJmPod(configuration);
@@ -286,7 +294,9 @@ public class FlinkConfigBuilderTest {
                 .setPodTemplate(TestUtils.getTestPod("", "", List.of(container1)));
 
         configuration =
-                new FlinkConfigBuilder(flinkDeployment, inConfig).applyPodTemplate().build();
+                new FlinkConfigBuilder(flinkDeployment, inConfig.clone())
+                        .applyPodTemplate()
+                        .build();
 
         jmPod = getJmPod(configuration);
         tmPod = getTmPod(configuration);
@@ -307,7 +317,9 @@ public class FlinkConfigBuilderTest {
         flinkDeployment.getSpec().setPodTemplate(common);
 
         configuration =
-                new FlinkConfigBuilder(flinkDeployment, inConfig).applyPodTemplate().build();
+                new FlinkConfigBuilder(flinkDeployment, inConfig.clone())
+                        .applyPodTemplate()
+                        .build();
 
         jmPod = getJmPod(configuration);
         tmPod = getTmPod(configuration);
@@ -329,7 +341,9 @@ public class FlinkConfigBuilderTest {
         flinkDeployment.getSpec().setTaskManager(null);
         flinkDeployment.getSpec().setJobManager(null);
         configuration =
-                new FlinkConfigBuilder(flinkDeployment, inConfig).applyPodTemplate().build();
+                new FlinkConfigBuilder(flinkDeployment, inConfig.clone())
+                        .applyPodTemplate()
+                        .build();
         Assertions.assertFalse(
                 configuration.contains(KubernetesConfigOptions.KUBERNETES_POD_TEMPLATE));
         Assertions.assertFalse(
@@ -340,7 +354,9 @@ public class FlinkConfigBuilderTest {
         flinkDeployment.getSpec().setTaskManager(new TaskManagerSpec());
         flinkDeployment.getSpec().setJobManager(new JobManagerSpec());
         configuration =
-                new FlinkConfigBuilder(flinkDeployment, inConfig).applyPodTemplate().build();
+                new FlinkConfigBuilder(flinkDeployment, inConfig.clone())
+                        .applyPodTemplate()
+                        .build();
         Assertions.assertFalse(
                 configuration.contains(KubernetesConfigOptions.KUBERNETES_POD_TEMPLATE));
         Assertions.assertFalse(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContextTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContextTest.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.controller;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.TestingFlinkService;
+import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.service.FlinkService;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Resource Context tests. */
+public class FlinkResourceContextTest {
+
+    private Context<HasMetadata> josdkCtx;
+    private FlinkConfigManager configManager;
+    private Function<FlinkResourceContext<?>, FlinkService> serviceFactory;
+
+    @BeforeEach
+    void setup() {
+        josdkCtx = TestUtils.createContextWithReadyFlinkDeployment();
+        configManager = new FlinkConfigManager(new Configuration());
+        serviceFactory = ctx -> new TestingFlinkService();
+    }
+
+    @ParameterizedTest
+    @MethodSource("crTypes")
+    void testCreateService(AbstractFlinkResource<?, ?> cr) {
+        var counter = new AtomicInteger(0);
+        var service = new TestingFlinkService();
+        serviceFactory =
+                ctx -> {
+                    counter.incrementAndGet();
+                    return service;
+                };
+
+        var ctx = getContext(cr);
+        assertTrue(ctx.getFlinkService() == service);
+        assertTrue(ctx.getFlinkService() == service);
+        assertTrue(ctx.getFlinkService() == service);
+        assertEquals(1, counter.get());
+    }
+
+    @Test
+    void testOperatorConfigHandling() {
+        var counter = new AtomicInteger(0);
+        var conf = new Configuration();
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL, Duration.ofMinutes(1));
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_OBSERVER_REST_READY_DELAY,
+                Duration.ofMinutes(2));
+
+        conf.setString(
+                KubernetesOperatorConfigOptions.VERSION_CONF_PREFIX
+                        + "v1_17.kubernetes.operator.reconcile.interval",
+                "17m");
+        conf.setString(
+                KubernetesOperatorConfigOptions.VERSION_CONF_PREFIX
+                        + "v1_18.kubernetes.operator.reconcile.interval",
+                "18m");
+
+        configManager =
+                new FlinkConfigManager(conf) {
+
+                    @Override
+                    public Configuration getDefaultConfig(
+                            String namespace, FlinkVersion flinkVersion) {
+                        counter.incrementAndGet();
+                        return super.getDefaultConfig(namespace, flinkVersion);
+                    }
+                };
+
+        var ctx = getContext(TestUtils.buildApplicationCluster(FlinkVersion.v1_18));
+        assertEquals(Duration.ofMinutes(18), ctx.getOperatorConfig().getReconcileInterval());
+        assertEquals(Duration.ofMinutes(2), ctx.getOperatorConfig().getRestApiReadyDelay());
+
+        assertEquals(1, counter.get());
+
+        ctx = getContext(TestUtils.buildApplicationCluster(FlinkVersion.v1_17));
+        assertEquals(Duration.ofMinutes(17), ctx.getOperatorConfig().getReconcileInterval());
+        assertEquals(Duration.ofMinutes(2), ctx.getOperatorConfig().getRestApiReadyDelay());
+
+        assertEquals(2, counter.get());
+    }
+
+    @Test
+    void testObserveConfigHandling() {
+        var counter = new AtomicInteger(0);
+        var conf = new Configuration();
+        configManager =
+                new FlinkConfigManager(new Configuration()) {
+                    @Override
+                    public Configuration getObserveConfig(FlinkDeployment deployment) {
+                        counter.incrementAndGet();
+                        return conf;
+                    }
+                };
+
+        var deployCtx = getContext(TestUtils.buildApplicationCluster());
+        assertTrue(deployCtx.getObserveConfig() == conf);
+        assertTrue(deployCtx.getObserveConfig() == conf);
+        assertTrue(deployCtx.getObserveConfig() == conf);
+        assertEquals(1, counter.get());
+
+        josdkCtx = TestUtils.createEmptyContext();
+        var sessionJobCtx = getContext(TestUtils.buildSessionJob());
+        assertNull(sessionJobCtx.getObserveConfig());
+        assertEquals(1, counter.get());
+
+        josdkCtx = TestUtils.createContextWithReadyFlinkDeployment();
+        sessionJobCtx = getContext(TestUtils.buildSessionJob());
+        assertTrue(sessionJobCtx.getObserveConfig() == conf);
+        assertTrue(sessionJobCtx.getObserveConfig() == conf);
+        assertEquals(2, counter.get());
+    }
+
+    FlinkResourceContext getContext(AbstractFlinkResource<?, ?> cr) {
+        if (cr instanceof FlinkDeployment) {
+            return new FlinkDeploymentContext(
+                    (FlinkDeployment) cr, josdkCtx, null, configManager, serviceFactory);
+        } else {
+            return new FlinkSessionJobContext(
+                    (FlinkSessionJob) cr, josdkCtx, null, configManager, serviceFactory);
+        }
+    }
+
+    private static Stream<AbstractFlinkResource<?, ?>> crTypes() {
+        return Stream.of(TestUtils.buildApplicationCluster(), TestUtils.buildSessionJob());
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -105,11 +105,10 @@ public class TestingFlinkDeploymentController
         canaryResourceManager = new CanaryResourceManager<>(configManager, kubernetesClient);
         flinkDeploymentController =
                 new FlinkDeploymentController(
-                        configManager,
                         ValidatorUtils.discoverValidators(configManager),
                         contextFactory,
                         reconcilerFactory,
-                        new FlinkDeploymentObserverFactory(configManager, eventRecorder),
+                        new FlinkDeploymentObserverFactory(eventRecorder),
                         statusRecorder,
                         eventRecorder,
                         canaryResourceManager);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
@@ -93,12 +93,11 @@ public class TestingFlinkSessionJobController
 
         flinkSessionJobController =
                 new FlinkSessionJobController(
-                        configManager,
                         ValidatorUtils.discoverValidators(configManager),
                         ctxFactory,
                         new SessionJobReconciler(
                                 kubernetesClient, eventRecorder, statusRecorder, configManager),
-                        new FlinkSessionJobObserver(configManager, eventRecorder),
+                        new FlinkSessionJobObserver(eventRecorder),
                         statusRecorder,
                         eventRecorder,
                         canaryResourceManager);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetricsTest.java
@@ -21,7 +21,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.service.AbstractFlinkService;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.runtime.rest.messages.DashboardConfiguration;
@@ -55,7 +54,7 @@ public class FlinkDeploymentMetricsTest {
         listener = new TestingMetricListener(configuration);
         metricManager =
                 MetricManager.createFlinkDeploymentMetricManager(
-                        new FlinkConfigManager(configuration), listener.getMetricGroup());
+                        configuration, listener.getMetricGroup());
     }
 
     @Test
@@ -416,8 +415,7 @@ public class FlinkDeploymentMetricsTest {
         conf.set(OPERATOR_RESOURCE_METRICS_ENABLED, false);
         var listener = new TestingMetricListener(conf);
         var metricManager =
-                MetricManager.createFlinkDeploymentMetricManager(
-                        new FlinkConfigManager(conf), listener.getMetricGroup());
+                MetricManager.createFlinkDeploymentMetricManager(conf, listener.getMetricGroup());
 
         var namespace = TestUtils.TEST_NAMESPACE;
         var deployment = TestUtils.buildApplicationCluster("deployment", namespace);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/FlinkSessionJobMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/FlinkSessionJobMetricsTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.kubernetes.operator.metrics;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +41,7 @@ public class FlinkSessionJobMetricsTest {
         listener = new TestingMetricListener(configuration);
         metricManager =
                 MetricManager.createFlinkSessionJobMetricManager(
-                        new FlinkConfigManager(configuration), listener.getMetricGroup());
+                        configuration, listener.getMetricGroup());
     }
 
     @Test
@@ -115,8 +114,7 @@ public class FlinkSessionJobMetricsTest {
         conf.set(OPERATOR_RESOURCE_METRICS_ENABLED, false);
         var listener = new TestingMetricListener(conf);
         var metricManager =
-                MetricManager.createFlinkSessionJobMetricManager(
-                        new FlinkConfigManager(conf), listener.getMetricGroup());
+                MetricManager.createFlinkSessionJobMetricManager(conf, listener.getMetricGroup());
 
         var metricId =
                 listener.getNamespaceMetricId(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesClientMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesClientMetricsTest.java
@@ -20,7 +20,7 @@ package org.apache.flink.kubernetes.operator.metrics;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
 
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -95,11 +95,10 @@ public class KubernetesClientMetricsTest {
         var configuration = new Configuration();
         configuration.set(
                 KubernetesOperatorMetricOptions.OPERATOR_KUBERNETES_CLIENT_METRICS_ENABLED, false);
-        var flinkConfigManager = new FlinkConfigManager(configuration);
-        var listener = new TestingMetricListener(flinkConfigManager.getDefaultConfig());
+        var listener = new TestingMetricListener(configuration);
         var kubernetesClient =
                 KubernetesClientUtils.getKubernetesClient(
-                        flinkConfigManager.getOperatorConfiguration(),
+                        FlinkOperatorConfiguration.fromConfiguration(configuration),
                         listener.getMetricGroup(),
                         mockServer.createClient().getConfiguration());
 
@@ -119,11 +118,11 @@ public class KubernetesClientMetricsTest {
     @Test
     @Order(2)
     public void testMetricsEnabled() {
-        var flinkConfigManager = new FlinkConfigManager(new Configuration());
-        var listener = new TestingMetricListener(flinkConfigManager.getDefaultConfig());
+        var configuration = new Configuration();
+        var listener = new TestingMetricListener(configuration);
         var kubernetesClient =
                 KubernetesClientUtils.getKubernetesClient(
-                        flinkConfigManager.getOperatorConfiguration(),
+                        FlinkOperatorConfiguration.fromConfiguration(configuration),
                         listener.getMetricGroup(),
                         mockServer.createClient().getConfiguration());
 
@@ -239,11 +238,10 @@ public class KubernetesClientMetricsTest {
                 KubernetesOperatorMetricOptions
                         .OPERATOR_KUBERNETES_CLIENT_METRICS_HTTP_RESPONSE_CODE_GROUPS_ENABLED,
                 true);
-        var flinkConfigManager = new FlinkConfigManager(configuration);
         var listener = new TestingMetricListener(configuration);
         var kubernetesClient =
                 KubernetesClientUtils.getKubernetesClient(
-                        flinkConfigManager.getOperatorConfiguration(),
+                        FlinkOperatorConfiguration.fromConfiguration(configuration),
                         listener.getMetricGroup(),
                         mockServer.createClient().getConfiguration());
 
@@ -376,11 +374,11 @@ public class KubernetesClientMetricsTest {
     @Test
     @Order(3)
     public void testAPIServerIsDown() {
-        var flinkConfigManager = new FlinkConfigManager(new Configuration());
-        var listener = new TestingMetricListener(flinkConfigManager.getDefaultConfig());
+        var configuration = new Configuration();
+        var listener = new TestingMetricListener(configuration);
         var kubernetesClient =
                 KubernetesClientUtils.getKubernetesClient(
-                        flinkConfigManager.getOperatorConfiguration(),
+                        FlinkOperatorConfiguration.fromConfiguration(configuration),
                         listener.getMetricGroup(),
                         mockServer.createClient().getConfiguration());
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/ResourceLifecycleMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/ResourceLifecycleMetricsTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.metrics.CustomResourceMetrics;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricOptions;
@@ -162,7 +161,7 @@ public class ResourceLifecycleMetricsTest {
         var conf = new Configuration();
         var metricManager =
                 MetricManager.createFlinkDeploymentMetricManager(
-                        new FlinkConfigManager(conf), TestUtils.createTestMetricGroup(conf));
+                        conf, TestUtils.createTestMetricGroup(conf));
         var lifeCycleMetrics = getLifeCycleMetrics(metricManager);
 
         metricManager.onUpdate(dep1);
@@ -197,7 +196,7 @@ public class ResourceLifecycleMetricsTest {
                 false);
         metricManager =
                 MetricManager.createFlinkDeploymentMetricManager(
-                        new FlinkConfigManager(conf), TestUtils.createTestMetricGroup(conf));
+                        conf, TestUtils.createTestMetricGroup(conf));
         lifeCycleMetrics = getLifeCycleMetrics(metricManager);
 
         metricManager.onUpdate(dep1);
@@ -222,7 +221,7 @@ public class ResourceLifecycleMetricsTest {
         conf.set(KubernetesOperatorMetricOptions.OPERATOR_LIFECYCLE_METRICS_ENABLED, false);
         metricManager =
                 MetricManager.createFlinkDeploymentMetricManager(
-                        new FlinkConfigManager(conf), TestUtils.createTestMetricGroup(conf));
+                        conf, TestUtils.createTestMetricGroup(conf));
         assertNull(getLifeCycleMetrics(metricManager));
 
         metricManager.onUpdate(dep1);
@@ -236,14 +235,14 @@ public class ResourceLifecycleMetricsTest {
         var testingMetricListener = new TestingMetricListener(new Configuration());
         var deploymentMetricManager =
                 MetricManager.createFlinkDeploymentMetricManager(
-                        new FlinkConfigManager(conf), testingMetricListener.getMetricGroup());
+                        conf, testingMetricListener.getMetricGroup());
         var deploymentLifecycleMetrics = getLifeCycleMetrics(deploymentMetricManager);
         deploymentLifecycleMetrics.onUpdate(TestUtils.buildApplicationCluster());
         testGlobalHistoNames(testingMetricListener, FlinkDeployment.class);
 
         var sessionJobMetricManager =
                 MetricManager.createFlinkSessionJobMetricManager(
-                        new FlinkConfigManager(conf), testingMetricListener.getMetricGroup());
+                        conf, testingMetricListener.getMetricGroup());
         var sessionJobLifecycleMetrics = getLifeCycleMetrics(sessionJobMetricManager);
         sessionJobLifecycleMetrics.onUpdate(TestUtils.buildSessionJob());
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -73,9 +73,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
 
     @Override
     public void setup() {
-        observer =
-                new TestObserverAdapter<>(
-                        this, new ApplicationObserver(configManager, eventRecorder));
+        observer = new TestObserverAdapter<>(this, new ApplicationObserver(eventRecorder));
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -51,8 +51,7 @@ public class SessionObserverTest extends OperatorTestBase {
 
     @Override
     public void setup() {
-        observer =
-                new TestObserverAdapter<>(this, new SessionObserver(configManager, eventRecorder));
+        observer = new TestObserverAdapter<>(this, new SessionObserver(eventRecorder));
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/FlinkSessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/FlinkSessionJobObserverTest.java
@@ -62,9 +62,7 @@ public class FlinkSessionJobObserverTest extends OperatorTestBase {
 
     @Override
     public void setup() {
-        observer =
-                new TestObserverAdapter<>(
-                        this, new FlinkSessionJobObserver(configManager, eventRecorder));
+        observer = new TestObserverAdapter<>(this, new FlinkSessionJobObserver(eventRecorder));
         reconciler =
                 new TestReconcilerAdapter<>(
                         this,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -26,9 +26,11 @@ import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
+import org.apache.flink.kubernetes.operator.artifact.ArtifactManager;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.utils.StandaloneKubernetesUtils;
+import org.apache.flink.util.concurrent.Executors;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -69,7 +71,11 @@ public class StandaloneFlinkServiceTest {
 
         kubernetesClient = mockServer.createClient().inAnyNamespace();
         flinkStandaloneService =
-                new StandaloneFlinkService(kubernetesClient, new FlinkConfigManager(configuration));
+                new StandaloneFlinkService(
+                        kubernetesClient,
+                        new ArtifactManager(configManager),
+                        Executors.newDirectExecutorService(),
+                        configManager.getOperatorConfiguration());
         flinkDeployment = TestUtils.buildSessionCluster();
         flinkDeployment
                 .getStatus()
@@ -244,7 +250,11 @@ public class StandaloneFlinkServiceTest {
         int nbCall = 0;
 
         public TestingStandaloneFlinkService(StandaloneFlinkService service) {
-            super(service.kubernetesClient, service.configManager);
+            super(
+                    service.kubernetesClient,
+                    service.artifactManager,
+                    service.executorService,
+                    service.operatorConfig);
         }
 
         public Configuration getRuntimeConfig() {

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
@@ -58,9 +58,9 @@ public class FlinkOperatorWebhook {
         EnvUtils.logEnvironmentInfo(LOG, "Flink Kubernetes Webhook", args);
         var informerManager = new InformerManager(new KubernetesClientBuilder().build());
         var configManager = new FlinkConfigManager(informerManager::setNamespaces);
-        if (!configManager.getOperatorConfiguration().isDynamicNamespacesEnabled()) {
-            informerManager.setNamespaces(
-                    configManager.getOperatorConfiguration().getWatchedNamespaces());
+        var operatorConfig = configManager.getOperatorConfiguration();
+        if (!operatorConfig.isDynamicNamespacesEnabled()) {
+            informerManager.setNamespaces(operatorConfig.getWatchedNamespaces());
         }
         Set<FlinkResourceValidator> validators = ValidatorUtils.discoverValidators(configManager);
 


### PR DESCRIPTION
## What is the purpose of the change

The main goal is to support setting default configuration on a per-namespace and per-flink version level. 
This would allow us for example to set config defaults differently for Flink 1.18 (enable adaptive scheduler by default)

Or to use different reconciliation/operator settings for different namespaces.

Syntax:

```yaml
# Version Specific Defaults
kubernetes.operator.default-configuration.flink-version.v1_17.key: value

# Namespace Specific Defaults
kubernetes.operator.default-configuration.namespace.ns1.key: value
```

Flink version specific defaults will have a higher precedence so namespace defaults would be overridden by the same key.

## Brief change log

  - *Add logic to FlinkConfigManager*
  - *Rework config access through resource context*
  - *Add unit tests*

## Verifying this change

New unit tests have been added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes 

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? [TODO]
