### PR TITLE
[FLINK-32652] Add deployments/scale to RBAC rules

### DIFF
--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -43,6 +43,7 @@ rules:
       - apps
     resources:
       - deployments
+      - deployments/scale
       - deployments/finalizers
       - replicasets
     verbs:


### PR DESCRIPTION
## What is the purpose of the change

Adds `deployments/scale` to RBAC rules so the operator can scale deployments with the /scale API

## Brief change log

- Add new RBAC rule

## Verifying this change

Manually tested after editing ClusterRole `flink-operator` by hand

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
