### PR TITLE
[FLINK-32690] report Double.NAN instead of null for missing autoscaler metrics

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
@@ -36,9 +36,9 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.apache.flink.kubernetes.operator.autoscaler.AutoscalerFlinkMetrics.initRecommendedParallelism;
+import static org.apache.flink.kubernetes.operator.autoscaler.AutoscalerFlinkMetrics.resetRecommendedParallelism;
 import static org.apache.flink.kubernetes.operator.autoscaler.config.AutoScalerOptions.AUTOSCALER_ENABLED;
-import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.PARALLELISM;
-import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.RECOMMENDED_PARALLELISM;
 
 /** Application and SessionJob autoscaler. */
 public class JobAutoScalerImpl implements JobAutoScaler {
@@ -190,21 +190,5 @@ public class JobAutoScalerImpl implements JobAutoScaler {
                 id ->
                         new AutoscalerFlinkMetrics(
                                 ctx.getResourceMetricGroup().addGroup("AutoScaler")));
-    }
-
-    private void initRecommendedParallelism(
-            Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluatedMetrics) {
-        evaluatedMetrics.forEach(
-                (jobVertexID, evaluatedScalingMetricMap) ->
-                        evaluatedScalingMetricMap.put(
-                                RECOMMENDED_PARALLELISM,
-                                evaluatedScalingMetricMap.get(PARALLELISM)));
-    }
-
-    private void resetRecommendedParallelism(
-            Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluatedMetrics) {
-        evaluatedMetrics.forEach(
-                (jobVertexID, evaluatedScalingMetricMap) ->
-                        evaluatedScalingMetricMap.put(RECOMMENDED_PARALLELISM, null));
     }
 }

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerFlinkMetricsTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/AutoScalerFlinkMetricsTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.autoscaler;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.autoscaler.metrics.EvaluatedScalingMetric;
+import org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.kubernetes.operator.metrics.TestingMetricListener;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.kubernetes.operator.autoscaler.AutoscalerFlinkMetrics.AVERAGE;
+import static org.apache.flink.kubernetes.operator.autoscaler.AutoscalerFlinkMetrics.CURRENT;
+import static org.apache.flink.kubernetes.operator.autoscaler.AutoscalerFlinkMetrics.JOB_VERTEX_ID;
+import static org.apache.flink.kubernetes.operator.autoscaler.AutoscalerFlinkMetrics.initRecommendedParallelism;
+import static org.apache.flink.kubernetes.operator.autoscaler.AutoscalerFlinkMetrics.resetRecommendedParallelism;
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.PARALLELISM;
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.RECOMMENDED_PARALLELISM;
+import static org.apache.flink.kubernetes.operator.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_RATE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** {@link AutoscalerFlinkMetrics} tests. */
+public class AutoScalerFlinkMetricsTest {
+
+    private final Configuration configuration = new Configuration();
+    private final JobVertexID jobVertexID = new JobVertexID();
+    private ResourceID resourceID;
+    private TestingMetricListener listener;
+    private AutoscalerFlinkMetrics metrics;
+
+    @BeforeEach
+    public void init() {
+        listener = new TestingMetricListener(configuration);
+        metrics = new AutoscalerFlinkMetrics(listener.getMetricGroup());
+        resourceID = ResourceID.fromResource(TestUtils.buildApplicationCluster());
+    }
+
+    @Test
+    public void testMetricsRegistration() {
+        var evaluatedMetrics = Map.of(jobVertexID, testMetrics());
+        var lastEvaluatedMetrics =
+                new HashMap<
+                        ResourceID, Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>>();
+        initRecommendedParallelism(evaluatedMetrics);
+        lastEvaluatedMetrics.put(resourceID, evaluatedMetrics);
+
+        metrics.registerScalingMetrics(() -> lastEvaluatedMetrics.get(resourceID));
+        metrics.registerScalingMetrics(() -> lastEvaluatedMetrics.get(resourceID));
+
+        assertEquals(1.0, getCurrentMetricValue(PARALLELISM));
+        assertEquals(1.0, getCurrentMetricValue(RECOMMENDED_PARALLELISM));
+        assertEquals(1000., getCurrentMetricValue(TRUE_PROCESSING_RATE));
+        assertEquals(2000., getAverageMetricValue(TRUE_PROCESSING_RATE));
+    }
+
+    @Test
+    public void testMetricsCleanup() {
+        var evaluatedMetrics = Map.of(jobVertexID, testMetrics());
+        var lastEvaluatedMetrics =
+                new HashMap<
+                        ResourceID, Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>>();
+        initRecommendedParallelism(evaluatedMetrics);
+        lastEvaluatedMetrics.put(resourceID, evaluatedMetrics);
+        metrics.registerScalingMetrics(() -> lastEvaluatedMetrics.get(resourceID));
+
+        assertEquals(1.0, getCurrentMetricValue(PARALLELISM));
+        assertEquals(1.0, getCurrentMetricValue(RECOMMENDED_PARALLELISM));
+        assertEquals(1000., getCurrentMetricValue(TRUE_PROCESSING_RATE));
+        assertEquals(2000., getAverageMetricValue(TRUE_PROCESSING_RATE));
+
+        lastEvaluatedMetrics.remove(resourceID);
+        assertEquals(Double.NaN, getCurrentMetricValue(PARALLELISM));
+        assertEquals(Double.NaN, getCurrentMetricValue(RECOMMENDED_PARALLELISM));
+        assertEquals(Double.NaN, getCurrentMetricValue(TRUE_PROCESSING_RATE));
+        assertEquals(Double.NaN, getAverageMetricValue(TRUE_PROCESSING_RATE));
+    }
+
+    @Test
+    public void testRecommendedParallelismWithinMetricWindow() {
+        var evaluatedMetrics = Map.of(jobVertexID, testMetrics());
+        var lastEvaluatedMetrics =
+                new HashMap<
+                        ResourceID, Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>>();
+        initRecommendedParallelism(evaluatedMetrics);
+        resetRecommendedParallelism(evaluatedMetrics);
+        lastEvaluatedMetrics.put(resourceID, evaluatedMetrics);
+
+        metrics.registerScalingMetrics(() -> lastEvaluatedMetrics.get(resourceID));
+        assertEquals(1.0, getCurrentMetricValue(PARALLELISM));
+        assertEquals(Double.NaN, getCurrentMetricValue(RECOMMENDED_PARALLELISM));
+        assertEquals(1000., getCurrentMetricValue(TRUE_PROCESSING_RATE));
+        assertEquals(2000., getAverageMetricValue(TRUE_PROCESSING_RATE));
+    }
+
+    @Test
+    public void testRecommendedParallelismPastMetricWindow() {
+        var evaluatedMetrics = Map.of(jobVertexID, testMetrics());
+        var lastEvaluatedMetrics =
+                new HashMap<
+                        ResourceID, Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>>();
+        initRecommendedParallelism(evaluatedMetrics);
+        lastEvaluatedMetrics.put(resourceID, evaluatedMetrics);
+
+        metrics.registerScalingMetrics(() -> lastEvaluatedMetrics.get(resourceID));
+        assertEquals(1.0, getCurrentMetricValue(PARALLELISM));
+        assertEquals(1.0, getCurrentMetricValue(RECOMMENDED_PARALLELISM));
+        assertEquals(1000., getCurrentMetricValue(TRUE_PROCESSING_RATE));
+        assertEquals(2000., getAverageMetricValue(TRUE_PROCESSING_RATE));
+    }
+
+    private static Map<ScalingMetric, EvaluatedScalingMetric> testMetrics() {
+        var metrics = new HashMap<ScalingMetric, EvaluatedScalingMetric>();
+        metrics.put(PARALLELISM, EvaluatedScalingMetric.of(1));
+        metrics.put(ScalingMetric.TRUE_PROCESSING_RATE, new EvaluatedScalingMetric(1000., 2000.));
+
+        return metrics;
+    }
+
+    private Object getCurrentMetricValue(ScalingMetric metric) {
+        return listener.getGauge(getCurrentMetricId(metric)).orElse(() -> Double.NaN).getValue();
+    }
+
+    private Object getAverageMetricValue(ScalingMetric metric) {
+        return listener.getGauge(getAverageMetricId(metric)).get().getValue();
+    }
+
+    private String getCurrentMetricId(ScalingMetric metric) {
+        return getMetricId(metric, CURRENT);
+    }
+
+    private String getAverageMetricId(ScalingMetric metric) {
+        return getMetricId(metric, AVERAGE);
+    }
+
+    private String getMetricId(ScalingMetric metric, String classifier) {
+        return listener.getMetricId(
+                JOB_VERTEX_ID, jobVertexID.toHexString(), metric.name(), classifier);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Change null values to Double.NAN for autoscaler metrics during blackout periods when no data is gathered. This appears to be a more common practice then null. Also consistent with other metrics we have.

## Brief change log
This is a minor fix in `AutoscalerFlinkMetrics`

## Verifying this change
Manually + Unit tests

```
resource.default.autoscaling-example.FlinkDeployment.AutoScaler.jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.RECOMMENDED_PARALLELISM.Current: NaN
resource.default.autoscaling-example.FlinkDeployment.AutoScaler.jobVertexID.90bea66de1c231edf33913ecd54406c1.RECOMMENDED_PARALLELISM.Current: NaN
resource.default.autoscaling-example.FlinkDeployment.AutoScaler.jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.MAX_PARALLELISM.Current: NaN
resource.default.autoscaling-example.FlinkDeployment.AutoScaler.jobVertexID.90bea66de1c231edf33913ecd54406c1.CATCH_UP_DATA_RATE.Current: NaN
resource.default.autoscaling-example.FlinkDeployment.AutoScaler.jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.PARALLELISM.Current: NaN
resource.default.autoscaling-example.FlinkDeployment.AutoScaler.jobVertexID.90bea66de1c231edf33913ecd54406c1.TRUE_PROCESSING_RATE.Average: NaN
resource.default.autoscaling-example.FlinkDeployment.AutoScaler.jobVertexID.cbc357ccb763df2852fee8c4fc7d55f2.CATCH_UP_DATA_RATE.Current: NaN
resource.default.autoscaling-example.FlinkDeployment.AutoScaler.jobVertexID.90bea66de1c231edf33913ecd54406c1.MAX_PARALLELISM.Current: NaN
system.FlinkDeployment.Lifecycle.State.CREATED.TimeSeconds: count=0, min=0, max=0, mean=NaN, stddev=NaN, p50=NaN, p75=NaN, p95=NaN, p98=NaN, p99=NaN, p999=NaN
system.FlinkDeployment.Lifecycle.State.ROLLING_BACK.TimeSeconds: count=0, min=0, max=0, mean=NaN, stddev=NaN, p50=NaN, p75=NaN, p95=NaN, p98=NaN, p99=NaN, p999=NaN
namespace.default.FlinkDeployment.Lifecycle.State.STABLE.TimeSeconds: count=0, min=0, max=0, mean=NaN, stddev=NaN, p50=NaN, p75=NaN, p95=NaN, p98=NaN, p99=NaN, p999=NaN
namespace.default.FlinkDeployment.Lifecycle.State.ROLLING_BACK.TimeSeconds: count=0, min=0, max=0, mean=NaN, stddev=NaN, p50=NaN, p75=NaN, p95=NaN, p98=NaN, p99=NaN, p999=NaN
```
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable