### PR TITLE
[FLINK-32729] allow starting a flink job in a suspended state.

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -395,14 +395,6 @@ public class DefaultValidator implements FlinkResourceValidator {
             FlinkDeployment deployment, Map<String, String> effectiveConfig) {
         FlinkDeploymentSpec newSpec = deployment.getSpec();
 
-        if (deployment.getStatus().getReconciliationStatus().isBeforeFirstDeployment()) {
-            if (newSpec.getJob() != null && !newSpec.getJob().getState().equals(JobState.RUNNING)) {
-                return Optional.of("Job must start in running state");
-            }
-
-            return Optional.empty();
-        }
-
         FlinkDeploymentSpec oldSpec =
                 deployment.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
 
@@ -531,24 +523,12 @@ public class DefaultValidator implements FlinkResourceValidator {
     private Optional<String> validateSpecChange(FlinkSessionJob sessionJob) {
         FlinkSessionJobSpec newSpec = sessionJob.getSpec();
 
-        if (sessionJob.getStatus().getReconciliationStatus().isBeforeFirstDeployment()) {
-            // New job
-            if (newSpec.getJob() != null && !newSpec.getJob().getState().equals(JobState.RUNNING)) {
-                return Optional.of("Job must start in running state");
-            }
-
-            return Optional.empty();
-        } else {
-            var lastReconciledSpec =
-                    sessionJob
-                            .getStatus()
-                            .getReconciliationStatus()
-                            .deserializeLastReconciledSpec();
-            if (!lastReconciledSpec
-                    .getDeploymentName()
-                    .equals(sessionJob.getSpec().getDeploymentName())) {
-                return Optional.of("The deploymentName can't be changed");
-            }
+        var lastReconciledSpec =
+                sessionJob.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
+        if (!lastReconciledSpec
+                .getDeploymentName()
+                .equals(sessionJob.getSpec().getDeploymentName())) {
+            return Optional.of("The deploymentName can't be changed");
         }
 
         return Optional.empty();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -83,10 +83,6 @@ public class DefaultValidatorTest {
                 "The FlinkDeployment name: session-cluster-1.13 is invalid, must consist of lower case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123'), and the length must be no more than 45 characters.");
 
         testError(
-                dep -> dep.getSpec().getJob().setState(JobState.SUSPENDED),
-                "Job must start in running state");
-
-        testError(
                 dep -> dep.getSpec().getJob().setParallelism(0),
                 "Job parallelism must be larger than 0");
 
@@ -614,11 +610,6 @@ public class DefaultValidatorTest {
                 sessionJob -> sessionJob.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE),
                 flinkDeployment -> {},
                 "The LAST_STATE upgrade mode is not supported in session job now.");
-
-        testSessionJobValidateWithModifier(
-                sessionJob -> sessionJob.getSpec().getJob().setState(JobState.SUSPENDED),
-                flinkDeployment -> {},
-                "Job must start in running state");
 
         testSessionJobValidateWithModifier(
                 sessionJob ->


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request adds a new feature to periodically create and maintain savepoints through the `FlinkDeployment` custom resource.)*

In our setup we intend migrating flinkDeployments from one cluster to the other, as part of doing this we want to start the flinkDeploments in a suspended state with an initialSavePoint configured, and only configure it to start after we must have stopped flinkDeployment in the source cluster. This patch was agreed upon in this [slack thread](https://apache-flink.slack.com/archives/C03GV7L3G2C/p1690825041612599).


## Brief change log

allow starting a flink job in a suspended state. 

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
