### PR TITLE
[FLINK-32164] LifecycleState count metrics are not reported correctly by namespace

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/LifecycleMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/LifecycleMetrics.java
@@ -144,9 +144,13 @@ public class LifecycleMetrics<CR extends AbstractFlinkResource<?, ?>>
                     .gauge(
                             "Count",
                             () ->
-                                    lifecycleTrackers.values().stream()
-                                            .map(ResourceLifecycleMetricTracker::getCurrentState)
-                                            .filter(s -> s == state)
+                                    lifecycleTrackers.entrySet().stream()
+                                            .filter(
+                                                    tracker ->
+                                                            tracker.getKey().f0.equals(namespace)
+                                                                    && tracker.getValue()
+                                                                                    .getCurrentState()
+                                                                            == state)
                                             .count());
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

The per namespace lifecycle state count metrics are incorrectly show a global count at [LifecycleMetrics.java#L145](https://github.com/apache/flink-kubernetes-operator/blob/main/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/LifecycleMetrics.java#L145). LifecycleState count metrics should be reported by namespace.

## Brief change log

  - Corrects the LifecycleState count metrics of per namespace for `LifecycleMetrics`.

## Verifying this change

  - Updates `FlinkDeploymentMetricsTest#testMetricsMultiNamespace` to verify the LifecycleState count metrics of per namespace.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / **no**)
  - Core observer or reconciler logic that is regularly executed: (yes / **no**)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)