### PR TITLE
[FLINK-32773] Support PEM certificates in the SQL Runner example

### DIFF
--- a/examples/flink-sql-runner-example/src/main/java/org/apache/flink/examples/SqlRunner.java
+++ b/examples/flink-sql-runner-example/src/main/java/org/apache/flink/examples/SqlRunner.java
@@ -43,6 +43,11 @@ public class SqlRunner {
     private static final Pattern SET_STATEMENT_PATTERN =
             Pattern.compile("SET\\s+'(\\S+)'\\s+=\\s+'(.*)';", Pattern.CASE_INSENSITIVE);
 
+    private static final String BEGIN_CERTIFICATE = "-----BEGIN CERTIFICATE-----";
+    private static final String END_CERTIFICATE = "-----END CERTIFICATE-----";
+    private static final String ESCAPED_BEGIN_CERTIFICATE = "======BEGIN CERTIFICATE=====";
+    private static final String ESCAPED_END_CERTIFICATE = "=====END CERTIFICATE=====";
+
     public static void main(String[] args) throws Exception {
         if (args.length != 1) {
             throw new Exception("Exactly one argument is expected.");
@@ -68,7 +73,13 @@ public class SqlRunner {
     }
 
     public static List<String> parseStatements(String script) {
-        var formatted = formatSqlFile(script).replaceAll(COMMENT_PATTERN, "");
+        var formatted = formatSqlFile(script)
+                .replaceAll(BEGIN_CERTIFICATE, ESCAPED_BEGIN_CERTIFICATE)
+                .replaceAll(END_CERTIFICATE, ESCAPED_END_CERTIFICATE)
+                .replaceAll(COMMENT_PATTERN, "")
+                .replaceAll(ESCAPED_BEGIN_CERTIFICATE, BEGIN_CERTIFICATE)
+                .replaceAll(ESCAPED_END_CERTIFICATE, END_CERTIFICATE);
+
         var statements = new ArrayList<String>();
 
         StringBuilder current = null;

--- a/examples/flink-sql-runner-example/src/main/java/org/apache/flink/examples/SqlRunner.java
+++ b/examples/flink-sql-runner-example/src/main/java/org/apache/flink/examples/SqlRunner.java
@@ -73,12 +73,13 @@ public class SqlRunner {
     }
 
     public static List<String> parseStatements(String script) {
-        var formatted = formatSqlFile(script)
-                .replaceAll(BEGIN_CERTIFICATE, ESCAPED_BEGIN_CERTIFICATE)
-                .replaceAll(END_CERTIFICATE, ESCAPED_END_CERTIFICATE)
-                .replaceAll(COMMENT_PATTERN, "")
-                .replaceAll(ESCAPED_BEGIN_CERTIFICATE, BEGIN_CERTIFICATE)
-                .replaceAll(ESCAPED_END_CERTIFICATE, END_CERTIFICATE);
+        var formatted =
+                formatSqlFile(script)
+                        .replaceAll(BEGIN_CERTIFICATE, ESCAPED_BEGIN_CERTIFICATE)
+                        .replaceAll(END_CERTIFICATE, ESCAPED_END_CERTIFICATE)
+                        .replaceAll(COMMENT_PATTERN, "")
+                        .replaceAll(ESCAPED_BEGIN_CERTIFICATE, BEGIN_CERTIFICATE)
+                        .replaceAll(ESCAPED_END_CERTIFICATE, END_CERTIFICATE);
 
         var statements = new ArrayList<String>();
 


### PR DESCRIPTION
## What is the purpose of the change

Fixing bug in Flink SQL Runner example preventing the user to provide a PEM certificate.

## Brief change log

Changes in the sample code to avoid removing the BEGIN/END from PEM certificates.

## Verifying this change

This change can be verified as follows (for Kafka) when having ssl enabled in Kafka.
- In https://github.com/apache/flink-kubernetes-operator/blob/main/examples/flink-sql-runner-example/sql-scripts/statement-set.sql you should have the property `properties.ssl.truststore.certificates`

**Example**
```
WITH (
    'connector' = 'kafka',
    ...
    'properties.ssl.truststore.certificates' = '-----BEGIN CERTIFICATE-----
    ...
    -----END CERTIFICATE-----
    '
);
```
- Deploy and check that there is no error to create the Kafka producer/consumer.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) **no**
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no) **no**
  - Core observer or reconciler logic that is regularly executed: (yes / no) **no**

## Documentation

  - Does this pull request introduce a new feature? (yes / no) **no**
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) **not applicable but it may be worth mentioning it in the release notes of the future operator version**
