### PR TITLE
[FLINK-32814] Make terminal JM shutdown configurable

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -521,6 +521,14 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription("Leader election retry period.");
 
     @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> OPERATOR_JM_SHUTDOWN_ENABLED =
+            operatorConfig("jm-deployment.shutdown.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Enable shutdown of jobmanager pods of terminal application deployments.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Duration> OPERATOR_JM_SHUTDOWN_TTL =
             operatorConfig("jm-deployment.shutdown-ttl")
                     .durationType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -329,11 +329,13 @@ public class ApplicationReconciler
     private boolean cleanupTerminalJmAfterTtl(
             FlinkService flinkService, FlinkDeployment deployment, Configuration observeConfig) {
         var status = deployment.getStatus();
+        boolean shutdownEnabled =
+                observeConfig.get(KubernetesOperatorConfigOptions.OPERATOR_JM_SHUTDOWN_ENABLED);
         boolean terminal = ReconciliationUtils.isJobInTerminalState(status);
         boolean jmStillRunning =
                 status.getJobManagerDeploymentStatus() != JobManagerDeploymentStatus.MISSING;
 
-        if (terminal && jmStillRunning) {
+        if (shutdownEnabled && terminal && jmStillRunning) {
             var ttl = observeConfig.get(KubernetesOperatorConfigOptions.OPERATOR_JM_SHUTDOWN_TTL);
             boolean ttlPassed =
                     clock.instant()


### PR DESCRIPTION
## What is the purpose of the change

Making it possible to configure JM shutdown of terminal applications. 

## Brief change log

  - Added a new config option `kubernetes.operator.jm-deployment.shutdown.enabled`
  - Using this new option during the reconciliation

## Verifying this change

Added a new test: `ApplicationReconcilerTest.testTerminalJmTtlDisabled`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
