### PR TITLE
[FLINK-32774] Improve checking for already upgraded deployments

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -232,6 +232,11 @@ public abstract class AbstractFlinkDeploymentObserver
         var flinkDep = ctx.getResource();
         var status = flinkDep.getStatus();
 
+        if (status.getJobManagerDeploymentStatus() != JobManagerDeploymentStatus.MISSING) {
+            // We know that the current deployment is not missing, nothing to check
+            return false;
+        }
+
         // We are performing a full upgrade
         Optional<Deployment> depOpt = ctx.getJosdkContext().getSecondaryResource(Deployment.class);
 
@@ -241,6 +246,10 @@ public abstract class AbstractFlinkDeploymentObserver
         }
 
         var deployment = depOpt.get();
+        if (deployment.isMarkedForDeletion()) {
+            logger.debug("Deployment already marked for deletion, ignoring...");
+            return false;
+        }
 
         Map<String, String> annotations = deployment.getMetadata().getAnnotations();
         if (annotations == null) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/OperatorTestBase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/OperatorTestBase.java
@@ -24,7 +24,6 @@ import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
 import org.apache.flink.kubernetes.operator.utils.EventCollector;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
-import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
@@ -38,7 +37,7 @@ public abstract class OperatorTestBase {
     protected TestingFlinkService flinkService;
     protected EventCollector eventCollector = new EventCollector();
     protected EventRecorder eventRecorder;
-    protected StatusRecorder statusRecorder = new TestingStatusRecorder();
+    protected TestingStatusRecorder statusRecorder = new TestingStatusRecorder();
     protected KubernetesOperatorMetricGroup operatorMetricGroup;
 
     protected Context<?> context;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -806,12 +806,15 @@ public class ApplicationObserverTest extends OperatorTestBase {
         assertEquals(status.getReconciliationStatus().getState(), ReconciliationState.UPGRADING);
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
 
+        // Kubernetes Deployment is not there yet
         observer.observe(deployment, TestUtils.createEmptyContext());
         assertEquals(JobManagerDeploymentStatus.MISSING, status.getJobManagerDeploymentStatus());
 
+        // Kubernetes Deployment is there but without the correct label
         observer.observe(deployment, context);
         assertEquals(JobManagerDeploymentStatus.MISSING, status.getJobManagerDeploymentStatus());
 
+        // We set the correct generation label on the kubernetes deployment
         kubernetesDeployment
                 .getMetadata()
                 .getAnnotations()
@@ -820,8 +823,28 @@ public class ApplicationObserverTest extends OperatorTestBase {
         deployment.getMetadata().setGeneration(322L);
         deployment.getSpec().getJob().setParallelism(4);
 
+        // Simulate marked for deletion, make sure we don't recognize this as a valid deployment
+        kubernetesDeployment.getMetadata().setDeletionTimestamp(Instant.now().toString());
+        observer.observe(deployment, context);
+        assertEquals(ReconciliationState.UPGRADING, reconStatus.getState());
+        assertEquals(JobManagerDeploymentStatus.MISSING, status.getJobManagerDeploymentStatus());
+
+        // Reset deletion flag
+        kubernetesDeployment.getMetadata().setDeletionTimestamp(null);
+
+        // Simulate non-missing deployment, this happens in the middle of savepoint upgrades
+        status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
         observer.observe(deployment, context);
 
+        assertEquals(ReconciliationState.UPGRADING, reconStatus.getState());
+        assertEquals(JobManagerDeploymentStatus.READY, status.getJobManagerDeploymentStatus());
+
+        // Reset to missing
+        status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
+
+        // Deployment is missing and kubernetes deployment matches the target generation
+        // should be recognized as deployed
+        observer.observe(deployment, context);
         assertEquals(ReconciliationState.DEPLOYED, reconStatus.getState());
         assertEquals(
                 JobManagerDeploymentStatus.DEPLOYED_NOT_READY,


### PR DESCRIPTION
## What is the purpose of the change

Fix some corner cases introduced by the combination of the observe already upgraded checks and autoscaler parallelism override logic that may cause stuck upgrades. 

## Brief change log

  - *Fix already upgraded observe logic to ignore deployments that are pending deletion*
  - *Do not run check already upgraded logic in the middle of savepoint upgrades*
  - *Add unit tests*

## Verifying this change

New unit test added and manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
