### PR TITLE
[FLINK-32890] Correct HA patch check for zookeeper metadata store

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -268,8 +268,13 @@ public class FlinkUtils {
 
     public static boolean isZookeeperHaMetadataAvailable(Configuration conf) {
         try (var curator = ZooKeeperUtils.startCuratorFramework(conf, exception -> {})) {
-            if (curator.asCuratorFramework().checkExists().forPath("/") != null) {
-                return curator.asCuratorFramework().getChildren().forPath("/").size() != 0;
+            if (curator.asCuratorFramework().checkExists().forPath(ZooKeeperUtils.getJobsPath())
+                    != null) {
+                return curator.asCuratorFramework()
+                                .getChildren()
+                                .forPath(ZooKeeperUtils.getJobsPath())
+                                .size()
+                        != 0;
             }
             return false;
         } catch (Exception e) {
@@ -277,7 +282,8 @@ public class FlinkUtils {
                     "Could not check whether the HA metadata exists at path {} in Zookeeper",
                     ZooKeeperUtils.generateZookeeperPath(
                             conf.get(HighAvailabilityOptions.HA_ZOOKEEPER_ROOT),
-                            conf.get(HighAvailabilityOptions.HA_CLUSTER_ID)),
+                            conf.get(HighAvailabilityOptions.HA_CLUSTER_ID),
+                            ZooKeeperUtils.getJobsPath()),
                     e);
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsZookeeperHATest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsZookeeperHATest.java
@@ -85,6 +85,10 @@ public class FlinkUtilsZookeeperHATest {
         jobGraph.setJobID(jobID);
         jobGraphStore.putJobGraph(jobGraph);
         jobGraphStore.stop();
+
+        // Create jobs znode
+        curator.create().forPath(ZooKeeperUtils.getJobsPath());
+        curator.create().forPath(ZooKeeperUtils.getLeaderPathForJob(new JobID()));
     }
 
     @AfterEach


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

* This pull request correct the path used to check if HA metadata are available in zookeeper. Previous path check was leading to operator taking action based on availability of those metadata while the jobs one were not available see https://issues.apache.org/jira/browse/FLINK-32890 for some case leading to bad action


## Brief change log

  - Correct HA patch check for zookeeper metadata store

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
*(Please pick either of the following options)*

This change is already covered by existing tests, such as `FlinkUtilsZookeeperHATest.zookeeperHaMetaDataCheckTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
