### PR TITLE
[FLINK-32904] Support cron expressions for periodic snapshots triggering

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -123,16 +123,28 @@
             <td>Max allowed checkpoint age for initiating last-state upgrades on running jobs. If a checkpoint is not available within the desired age (and nothing in progress) a savepoint will be triggered.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.periodic.checkpoint.cron</h5></td>
+            <td style="word-wrap: break-word;">"0 0 0 29 2 ? 1999"</td>
+            <td>String</td>
+            <td>A cron expression that defines when to automatically trigger checkpoints. The precise triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. Periodic triggering with frequency higher than the reconciliation loop (kubernetes.operator.reconcile.interval) will lead to trigger omissions. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the interval-based periodic checkpoint triggering</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.periodic.checkpoint.interval</h5></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>
-            <td>Interval at which periodic checkpoints will be triggered. The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files.</td>
+            <td>Interval at which periodic checkpoints will be triggered. The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the cron-based periodic checkpoint triggering</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.periodic.savepoint.cron</h5></td>
+            <td style="word-wrap: break-word;">"0 0 0 29 2 ? 1999"</td>
+            <td>String</td>
+            <td>A cron expression that defines when to automatically trigger savepoints.The precise triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the interval-based periodic savepoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.periodic.savepoint.interval</h5></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>
-            <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop.</td>
+            <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the cron-based periodic savepoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.pod-template.merge-arrays-by-name</h5></td>

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -126,13 +126,13 @@
             <td><h5>kubernetes.operator.periodic.checkpoint.interval</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Option to enable automatic checkpoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression.The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the cron-based periodic checkpoint triggering</td>
+            <td>Option to enable automatic checkpoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression in Quartz format (6 or 7 positions, see http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the cron-based periodic checkpoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.periodic.savepoint.interval</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Option to enable automatic savepoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression.The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the cron-based periodic savepoint triggering</td>
+            <td>Option to enable automatic savepoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression in Quartz format (6 or 7 positions, see http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the cron-based periodic savepoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.pod-template.merge-arrays-by-name</h5></td>

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -123,28 +123,16 @@
             <td>Max allowed checkpoint age for initiating last-state upgrades on running jobs. If a checkpoint is not available within the desired age (and nothing in progress) a savepoint will be triggered.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.periodic.checkpoint.cron</h5></td>
-            <td style="word-wrap: break-word;">"0 0 0 29 2 ? 1999"</td>
-            <td>String</td>
-            <td>A cron expression that defines when to automatically trigger checkpoints. The precise triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. Periodic triggering with frequency higher than the reconciliation loop (kubernetes.operator.reconcile.interval) will lead to trigger omissions. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the interval-based periodic checkpoint triggering</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.periodic.checkpoint.interval</h5></td>
-            <td style="word-wrap: break-word;">0 ms</td>
-            <td>Duration</td>
-            <td>Interval at which periodic checkpoints will be triggered. The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the cron-based periodic checkpoint triggering</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.periodic.savepoint.cron</h5></td>
-            <td style="word-wrap: break-word;">"0 0 0 29 2 ? 1999"</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>A cron expression that defines when to automatically trigger savepoints.The precise triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the interval-based periodic savepoint triggering</td>
+            <td>Option to enable automatic checkpoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression.The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the cron-based periodic checkpoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.periodic.savepoint.interval</h5></td>
-            <td style="word-wrap: break-word;">0 ms</td>
-            <td>Duration</td>
-            <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the cron-based periodic savepoint triggering</td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Option to enable automatic savepoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression.The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the cron-based periodic savepoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.pod-template.merge-arrays-by-name</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -255,16 +255,28 @@
             <td>Final delay before deployment is marked ready after port becomes accessible.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.periodic.checkpoint.cron</h5></td>
+            <td style="word-wrap: break-word;">"0 0 0 29 2 ? 1999"</td>
+            <td>String</td>
+            <td>A cron expression that defines when to automatically trigger checkpoints. The precise triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. Periodic triggering with frequency higher than the reconciliation loop (kubernetes.operator.reconcile.interval) will lead to trigger omissions. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the interval-based periodic checkpoint triggering</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.periodic.checkpoint.interval</h5></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>
-            <td>Interval at which periodic checkpoints will be triggered. The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files.</td>
+            <td>Interval at which periodic checkpoints will be triggered. The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the cron-based periodic checkpoint triggering</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.periodic.savepoint.cron</h5></td>
+            <td style="word-wrap: break-word;">"0 0 0 29 2 ? 1999"</td>
+            <td>String</td>
+            <td>A cron expression that defines when to automatically trigger savepoints.The precise triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the interval-based periodic savepoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.periodic.savepoint.interval</h5></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>
-            <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop.</td>
+            <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the cron-based periodic savepoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.pod-template.merge-arrays-by-name</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -255,28 +255,16 @@
             <td>Final delay before deployment is marked ready after port becomes accessible.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.periodic.checkpoint.cron</h5></td>
-            <td style="word-wrap: break-word;">"0 0 0 29 2 ? 1999"</td>
-            <td>String</td>
-            <td>A cron expression that defines when to automatically trigger checkpoints. The precise triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. Periodic triggering with frequency higher than the reconciliation loop (kubernetes.operator.reconcile.interval) will lead to trigger omissions. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the interval-based periodic checkpoint triggering</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.periodic.checkpoint.interval</h5></td>
-            <td style="word-wrap: break-word;">0 ms</td>
-            <td>Duration</td>
-            <td>Interval at which periodic checkpoints will be triggered. The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the cron-based periodic checkpoint triggering</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.periodic.savepoint.cron</h5></td>
-            <td style="word-wrap: break-word;">"0 0 0 29 2 ? 1999"</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>A cron expression that defines when to automatically trigger savepoints.The precise triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the interval-based periodic savepoint triggering</td>
+            <td>Option to enable automatic checkpoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression.The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the cron-based periodic checkpoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.periodic.savepoint.interval</h5></td>
-            <td style="word-wrap: break-word;">0 ms</td>
-            <td>Duration</td>
-            <td>Interval at which periodic savepoints will be triggered. The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the cron-based periodic savepoint triggering</td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Option to enable automatic savepoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression.The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the cron-based periodic savepoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.pod-template.merge-arrays-by-name</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -258,13 +258,13 @@
             <td><h5>kubernetes.operator.periodic.checkpoint.interval</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Option to enable automatic checkpoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression.The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the cron-based periodic checkpoint triggering</td>
+            <td>Option to enable automatic checkpoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression in Quartz format (6 or 7 positions, see http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).The triggering schedule is not guaranteed, checkpoints will be triggered as part of the regular reconcile loop. NOTE: checkpoints are generally managed by Flink. This setting isn't meant to replace Flink's checkpoint settings, but to complement them in special cases. For instance, a full checkpoint might need to be occasionally triggered to break the chain of incremental checkpoints and consolidate the partial incremental files. WARNING: not intended to be used together with the cron-based periodic checkpoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.periodic.savepoint.interval</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>Option to enable automatic savepoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression.The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the cron-based periodic savepoint triggering</td>
+            <td>Option to enable automatic savepoint triggering. Can be specified either as a Duration type (i.e. '10m') or as a cron expression in Quartz format (6 or 7 positions, see http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).The triggering schedule is not guaranteed, savepoints will be triggered as part of the regular reconcile loop. WARNING: not intended to be used together with the cron-based periodic savepoint triggering</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.pod-template.merge-arrays-by-name</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -305,7 +305,22 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Interval at which periodic savepoints will be triggered. "
                                     + "The triggering schedule is not guaranteed, savepoints will be "
-                                    + "triggered as part of the regular reconcile loop.");
+                                    + "triggered as part of the regular reconcile loop. "
+                                    + "WARNING: not intended to be used together with the cron-based "
+                                    + "periodic savepoint triggering");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<String> PERIODIC_SAVEPOINT_CRON =
+            operatorConfig("periodic.savepoint.cron")
+                    .stringType()
+                    .defaultValue(
+                            "0 0 0 29 2 ? 1999") // Default value that is guaranteed not to trigger
+                    .withDescription(
+                            "A cron expression that defines when to automatically trigger savepoints."
+                                    + "The precise triggering schedule is not guaranteed, savepoints will be "
+                                    + "triggered as part of the regular reconcile loop. "
+                                    + "WARNING: not intended to be used together with the interval-based "
+                                    + "periodic savepoint triggering");
 
     @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Duration> PERIODIC_CHECKPOINT_INTERVAL =
@@ -321,7 +336,32 @@ public class KubernetesOperatorConfigOptions {
                                     + "but to complement them in special cases. For instance, a "
                                     + "full checkpoint might need to be occasionally triggered to "
                                     + "break the chain of incremental checkpoints and consolidate "
-                                    + "the partial incremental files.");
+                                    + "the partial incremental files. "
+                                    + "WARNING: not intended to be used together with the cron-based "
+                                    + "periodic checkpoint triggering");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<String> PERIODIC_CHECKPOINT_CRON =
+            operatorConfig("periodic.checkpoint.cron")
+                    .stringType()
+                    .defaultValue(
+                            "0 0 0 29 2 ? 1999") // Default value that is guaranteed not to trigger (not a leap year)
+                    .withDescription(
+                            "A cron expression that defines when to automatically trigger checkpoints. "
+                                    + "The precise triggering schedule is not guaranteed, checkpoints will "
+                                    + "be triggered as part of the regular reconcile loop. Periodic triggering "
+                                    + "with frequency higher than the reconciliation loop "
+                                    + "("
+                                    + OPERATOR_RECONCILE_INTERVAL.key()
+                                    + ") will lead to trigger omissions. "
+                                    + "NOTE: checkpoints are generally managed by Flink. This "
+                                    + "setting isn't meant to replace Flink's checkpoint settings, "
+                                    + "but to complement them in special cases. For instance, a "
+                                    + "full checkpoint might need to be occasionally triggered to "
+                                    + "break the chain of incremental checkpoints and consolidate "
+                                    + "the partial incremental files. "
+                                    + "WARNING: not intended to be used together with the interval-based "
+                                    + "periodic checkpoint triggering");
 
     @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<String> OPERATOR_WATCHED_NAMESPACES =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -304,7 +304,9 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue("")
                     .withDescription(
                             "Option to enable automatic savepoint triggering. Can be specified "
-                                    + "either as a Duration type (i.e. '10m') or as a cron expression."
+                                    + "either as a Duration type (i.e. '10m') or as a cron expression "
+                                    + "in Quartz format (6 or 7 positions, see "
+                                    + "http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html)."
                                     + "The triggering schedule is not guaranteed, savepoints will be "
                                     + "triggered as part of the regular reconcile loop. "
                                     + "WARNING: not intended to be used together with the cron-based "
@@ -317,7 +319,9 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue("")
                     .withDescription(
                             "Option to enable automatic checkpoint triggering. Can be specified "
-                                    + "either as a Duration type (i.e. '10m') or as a cron expression."
+                                    + "either as a Duration type (i.e. '10m') or as a cron expression "
+                                    + "in Quartz format (6 or 7 positions, see "
+                                    + "http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html)."
                                     + "The triggering schedule is not guaranteed, checkpoints will "
                                     + "be triggered as part of the regular reconcile loop. "
                                     + "NOTE: checkpoints are generally managed by Flink. This "

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -298,37 +298,26 @@ public class KubernetesOperatorConfigOptions {
                                     + "Expected format: headerKey1:headerValue1,headerKey2:headerValue2.");
 
     @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<Duration> PERIODIC_SAVEPOINT_INTERVAL =
+    public static final ConfigOption<String> PERIODIC_SAVEPOINT_INTERVAL =
             operatorConfig("periodic.savepoint.interval")
-                    .durationType()
-                    .defaultValue(Duration.ZERO)
+                    .stringType()
+                    .defaultValue("")
                     .withDescription(
-                            "Interval at which periodic savepoints will be triggered. "
+                            "Option to enable automatic savepoint triggering. Can be specified "
+                                    + "either as a Duration type (i.e. '10m') or as a cron expression."
                                     + "The triggering schedule is not guaranteed, savepoints will be "
                                     + "triggered as part of the regular reconcile loop. "
                                     + "WARNING: not intended to be used together with the cron-based "
                                     + "periodic savepoint triggering");
 
     @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<String> PERIODIC_SAVEPOINT_CRON =
-            operatorConfig("periodic.savepoint.cron")
-                    .stringType()
-                    .defaultValue(
-                            "0 0 0 29 2 ? 1999") // Default value that is guaranteed not to trigger
-                    .withDescription(
-                            "A cron expression that defines when to automatically trigger savepoints."
-                                    + "The precise triggering schedule is not guaranteed, savepoints will be "
-                                    + "triggered as part of the regular reconcile loop. "
-                                    + "WARNING: not intended to be used together with the interval-based "
-                                    + "periodic savepoint triggering");
-
-    @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<Duration> PERIODIC_CHECKPOINT_INTERVAL =
+    public static final ConfigOption<String> PERIODIC_CHECKPOINT_INTERVAL =
             operatorConfig("periodic.checkpoint.interval")
-                    .durationType()
-                    .defaultValue(Duration.ZERO)
+                    .stringType()
+                    .defaultValue("")
                     .withDescription(
-                            "Interval at which periodic checkpoints will be triggered. "
+                            "Option to enable automatic checkpoint triggering. Can be specified "
+                                    + "either as a Duration type (i.e. '10m') or as a cron expression."
                                     + "The triggering schedule is not guaranteed, checkpoints will "
                                     + "be triggered as part of the regular reconcile loop. "
                                     + "NOTE: checkpoints are generally managed by Flink. This "
@@ -338,29 +327,6 @@ public class KubernetesOperatorConfigOptions {
                                     + "break the chain of incremental checkpoints and consolidate "
                                     + "the partial incremental files. "
                                     + "WARNING: not intended to be used together with the cron-based "
-                                    + "periodic checkpoint triggering");
-
-    @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<String> PERIODIC_CHECKPOINT_CRON =
-            operatorConfig("periodic.checkpoint.cron")
-                    .stringType()
-                    .defaultValue(
-                            "0 0 0 29 2 ? 1999") // Default value that is guaranteed not to trigger (not a leap year)
-                    .withDescription(
-                            "A cron expression that defines when to automatically trigger checkpoints. "
-                                    + "The precise triggering schedule is not guaranteed, checkpoints will "
-                                    + "be triggered as part of the regular reconcile loop. Periodic triggering "
-                                    + "with frequency higher than the reconciliation loop "
-                                    + "("
-                                    + OPERATOR_RECONCILE_INTERVAL.key()
-                                    + ") will lead to trigger omissions. "
-                                    + "NOTE: checkpoints are generally managed by Flink. This "
-                                    + "setting isn't meant to replace Flink's checkpoint settings, "
-                                    + "but to complement them in special cases. For instance, a "
-                                    + "full checkpoint might need to be occasionally triggered to "
-                                    + "break the chain of incremental checkpoints and consolidate "
-                                    + "the partial incremental files. "
-                                    + "WARNING: not intended to be used together with the interval-based "
                                     + "periodic checkpoint triggering");
 
     @Documentation.Section(SECTION_SYSTEM)

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
@@ -45,7 +45,7 @@ import java.util.List;
 
 import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.CHECKPOINT;
 import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.SAVEPOINT;
-import static org.apache.flink.kubernetes.operator.utils.SnapshotUtils.isCheckpointsTriggeringSupported;
+import static org.apache.flink.kubernetes.operator.utils.SnapshotUtils.isSnapshotTriggeringSupported;
 
 /** An observer of savepoint progress. */
 public class SnapshotObserver<
@@ -81,7 +81,7 @@ public class SnapshotObserver<
     }
 
     public void observeCheckpointStatus(FlinkResourceContext<CR> ctx) {
-        if (!isCheckpointsTriggeringSupported(ctx.getObserveConfig())) {
+        if (!isSnapshotTriggeringSupported(ctx.getObserveConfig())) {
             return;
         }
         var resource = ctx.getResource();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -23,10 +23,15 @@ import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
+import org.apache.flink.kubernetes.operator.api.status.Checkpoint;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.api.status.Savepoint;
+import org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType;
 import org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.health.CanaryResourceManager;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
+import org.apache.flink.kubernetes.operator.reconciler.SnapshotType;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
 
@@ -66,6 +71,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -321,6 +327,54 @@ public class TestUtils extends BaseTestUtils {
         meta.setNamespace("default");
         cr.setMetadata(meta);
         return cr;
+    }
+
+    public static void reconcileSpec(FlinkDeployment deployment) {
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
+    }
+
+    /**
+     * Sets up an active cron trigger by ensuring that the latest successful snapshot happened
+     * earlier than the scheduled trigger.
+     */
+    public static void setupCronTrigger(SnapshotType snapshotType, FlinkDeployment deployment) {
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2022, Calendar.JUNE, 5, 11, 0);
+        long lastCheckpointTimestamp = calendar.getTimeInMillis();
+
+        String cronOptionKey;
+
+        switch (snapshotType) {
+            case SAVEPOINT:
+                Savepoint lastSavepoint =
+                        Savepoint.of("", lastCheckpointTimestamp, SnapshotTriggerType.PERIODIC);
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getSavepointInfo()
+                        .updateLastSavepoint(lastSavepoint);
+                cronOptionKey = KubernetesOperatorConfigOptions.PERIODIC_SAVEPOINT_CRON.key();
+                break;
+            case CHECKPOINT:
+                Checkpoint lastCheckpoint =
+                        Checkpoint.of(lastCheckpointTimestamp, SnapshotTriggerType.PERIODIC);
+                deployment
+                        .getStatus()
+                        .getJobStatus()
+                        .getCheckpointInfo()
+                        .updateLastCheckpoint(lastCheckpoint);
+                cronOptionKey = KubernetesOperatorConfigOptions.PERIODIC_CHECKPOINT_CRON.key();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported snapshot type: " + snapshotType);
+        }
+
+        deployment.getSpec().getFlinkConfiguration().put(cronOptionKey, "0 0 12 5 6 ? 2022");
+        reconcileSpec(deployment);
     }
 
     /** Testing ResponseProvider. */

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -357,7 +357,7 @@ public class TestUtils extends BaseTestUtils {
                         .getJobStatus()
                         .getSavepointInfo()
                         .updateLastSavepoint(lastSavepoint);
-                cronOptionKey = KubernetesOperatorConfigOptions.PERIODIC_SAVEPOINT_CRON.key();
+                cronOptionKey = KubernetesOperatorConfigOptions.PERIODIC_SAVEPOINT_INTERVAL.key();
                 break;
             case CHECKPOINT:
                 Checkpoint lastCheckpoint =
@@ -367,7 +367,7 @@ public class TestUtils extends BaseTestUtils {
                         .getJobStatus()
                         .getCheckpointInfo()
                         .updateLastCheckpoint(lastCheckpoint);
-                cronOptionKey = KubernetesOperatorConfigOptions.PERIODIC_CHECKPOINT_CRON.key();
+                cronOptionKey = KubernetesOperatorConfigOptions.PERIODIC_CHECKPOINT_INTERVAL.key();
                 break;
             default:
                 throw new IllegalArgumentException("Unsupported snapshot type: " + snapshotType);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtilsTest.java
@@ -45,7 +45,6 @@ import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.SAVEP
 import static org.apache.flink.kubernetes.operator.utils.SnapshotUtils.shouldTriggerAutomaticSnapshot;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for {@link SnapshotUtils}. */
@@ -142,20 +141,18 @@ public class SnapshotUtilsTest {
 
     @Test
     public void testShouldTriggerIntervalBasedSnapshot_InvalidExpression() {
-        assertThrows(
-                ParseException.class,
-                () ->
-                        SnapshotUtils.shouldTriggerIntervalBasedSnapshot(
-                                SnapshotType.CHECKPOINT, "INVALID_DURATION", Instant.now()));
+        Instant lastTrigger = Instant.now().minus(Duration.ofMinutes(5));
+        assertFalse(
+                SnapshotUtils.shouldTriggerIntervalBasedSnapshot(
+                        SnapshotType.CHECKPOINT, "INVALID_DURATION", Instant.now()));
     }
 
     @Test
     public void testShouldTriggerIntervalBasedSnapshot_EmptyExpression() {
-        assertThrows(
-                ParseException.class,
-                () ->
-                        SnapshotUtils.shouldTriggerIntervalBasedSnapshot(
-                                SnapshotType.CHECKPOINT, "", Instant.now()));
+        Instant lastTrigger = Instant.now().minus(Duration.ofMinutes(5));
+        assertFalse(
+                SnapshotUtils.shouldTriggerIntervalBasedSnapshot(
+                        SnapshotType.CHECKPOINT, "", lastTrigger));
     }
 
     @Test
@@ -241,11 +238,9 @@ public class SnapshotUtilsTest {
         Instant now = Instant.now();
         Instant lastTrigger = now.minus(Duration.ofDays(365));
 
-        assertThrows(
-                ParseException.class,
-                () ->
-                        SnapshotUtils.shouldTriggerCronBasedSnapshot(
-                                CHECKPOINT, cronExpression, lastTrigger, now));
+        assertFalse(
+                SnapshotUtils.shouldTriggerCronBasedSnapshot(
+                        CHECKPOINT, cronExpression, lastTrigger, now));
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtilsTest.java
@@ -101,7 +101,7 @@ public class SnapshotUtilsTest {
     private void testSnapshotTriggering(
             FlinkDeployment deployment,
             SnapshotType snapshotType,
-            ConfigOption<Duration> periodicSnapshotIntervalOption) {
+            ConfigOption<String> periodicSnapshotIntervalOption) {
         reconcileSpec(deployment);
         assertEquals(
                 Optional.empty(),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtilsTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
@@ -25,16 +26,24 @@ import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
-import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.reconciler.SnapshotType;
 
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Calendar;
 import java.util.Optional;
 
+import static org.apache.flink.kubernetes.operator.TestUtils.reconcileSpec;
+import static org.apache.flink.kubernetes.operator.TestUtils.setupCronTrigger;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.PERIODIC_CHECKPOINT_INTERVAL;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.PERIODIC_SAVEPOINT_INTERVAL;
+import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.CHECKPOINT;
+import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.SAVEPOINT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for {@link SnapshotUtils}. */
 public class SnapshotUtilsTest {
@@ -43,37 +52,19 @@ public class SnapshotUtilsTest {
 
     @Test
     public void testSavepointTriggering() {
-        SnapshotType snapshotType = SnapshotType.SAVEPOINT;
         FlinkDeployment deployment = initDeployment(FlinkVersion.v1_15);
-        reconcileSpec(deployment);
+        testSnapshotTriggering(deployment, SAVEPOINT, PERIODIC_SAVEPOINT_INTERVAL);
+    }
 
-        assertEquals(
-                Optional.empty(),
-                SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
-
-        deployment
-                .getSpec()
-                .getFlinkConfiguration()
-                .put(KubernetesOperatorConfigOptions.PERIODIC_SAVEPOINT_INTERVAL.key(), "10m");
-        reconcileSpec(deployment);
-
-        assertEquals(
-                Optional.of(SnapshotTriggerType.PERIODIC),
-                SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
-        deployment.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
-
-        deployment.getSpec().getJob().setSavepointTriggerNonce(123L);
-        assertEquals(
-                Optional.of(SnapshotTriggerType.MANUAL),
-                SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+    @Test
+    public void testCheckpointTriggeringPost1_17() {
+        FlinkDeployment deployment = initDeployment(FlinkVersion.v1_17);
+        testSnapshotTriggering(deployment, CHECKPOINT, PERIODIC_CHECKPOINT_INTERVAL);
     }
 
     @Test
     public void testCheckpointTriggeringPre1_17() {
-        SnapshotType snapshotType = SnapshotType.CHECKPOINT;
+        SnapshotType snapshotType = CHECKPOINT;
         FlinkDeployment deployment = initDeployment(FlinkVersion.v1_16);
         reconcileSpec(deployment);
 
@@ -83,31 +74,35 @@ public class SnapshotUtilsTest {
                 SnapshotUtils.shouldTriggerSnapshot(
                         deployment, configManager.getObserveConfig(deployment), snapshotType));
 
-        deployment
-                .getSpec()
-                .getFlinkConfiguration()
-                .put(KubernetesOperatorConfigOptions.PERIODIC_CHECKPOINT_INTERVAL.key(), "10m");
+        deployment.getSpec().getFlinkConfiguration().put(PERIODIC_CHECKPOINT_INTERVAL.key(), "10m");
         reconcileSpec(deployment);
 
         assertEquals(
                 Optional.empty(),
                 SnapshotUtils.shouldTriggerSnapshot(
                         deployment, configManager.getObserveConfig(deployment), snapshotType));
-        deployment.getStatus().getJobStatus().getCheckpointInfo().resetTrigger();
+        resetTrigger(deployment, snapshotType);
 
-        deployment.getSpec().getJob().setCheckpointTriggerNonce(123L);
+        setTriggerNonce(deployment, snapshotType, 123L);
         assertEquals(
                 Optional.empty(),
                 SnapshotUtils.shouldTriggerSnapshot(
                         deployment, configManager.getObserveConfig(deployment), snapshotType));
+        resetTrigger(deployment, snapshotType);
+
+        setupCronTrigger(snapshotType, deployment);
+        assertEquals(
+                Optional.empty(),
+                SnapshotUtils.shouldTriggerSnapshot(
+                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+        resetTrigger(deployment, snapshotType);
     }
 
-    @Test
-    public void testCheckpointTriggeringPost1_17() {
-        SnapshotType snapshotType = SnapshotType.CHECKPOINT;
-        FlinkDeployment deployment = initDeployment(FlinkVersion.v1_17);
+    private void testSnapshotTriggering(
+            FlinkDeployment deployment,
+            SnapshotType snapshotType,
+            ConfigOption<Duration> periodicSnapshotIntervalOption) {
         reconcileSpec(deployment);
-
         assertEquals(
                 Optional.empty(),
                 SnapshotUtils.shouldTriggerSnapshot(
@@ -116,20 +111,119 @@ public class SnapshotUtilsTest {
         deployment
                 .getSpec()
                 .getFlinkConfiguration()
-                .put(KubernetesOperatorConfigOptions.PERIODIC_CHECKPOINT_INTERVAL.key(), "10m");
+                .put(periodicSnapshotIntervalOption.key(), "10m");
         reconcileSpec(deployment);
 
         assertEquals(
                 Optional.of(SnapshotTriggerType.PERIODIC),
                 SnapshotUtils.shouldTriggerSnapshot(
                         deployment, configManager.getObserveConfig(deployment), snapshotType));
-        deployment.getStatus().getJobStatus().getCheckpointInfo().resetTrigger();
+        resetTrigger(deployment, snapshotType);
+        deployment.getSpec().getFlinkConfiguration().put(periodicSnapshotIntervalOption.key(), "0");
+        reconcileSpec(deployment);
 
-        deployment.getSpec().getJob().setCheckpointTriggerNonce(123L);
+        setTriggerNonce(deployment, snapshotType, 123L);
         assertEquals(
                 Optional.of(SnapshotTriggerType.MANUAL),
                 SnapshotUtils.shouldTriggerSnapshot(
                         deployment, configManager.getObserveConfig(deployment), snapshotType));
+        resetTrigger(deployment, snapshotType);
+        reconcileSpec(deployment);
+
+        setupCronTrigger(snapshotType, deployment);
+        assertEquals(
+                Optional.of(SnapshotTriggerType.PERIODIC),
+                SnapshotUtils.shouldTriggerSnapshot(
+                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+    }
+
+    @Test
+    public void testShouldTriggerCronBasedSnapshot_NextValidTimeBeforeCurrent() {
+        String cronExpression = "0 */10 * * * ?"; // Every 10th minute
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2022, Calendar.JUNE, 5, 11, 5); // 11:05
+
+        Instant now = calendar.getTime().toInstant();
+        Instant lastTrigger =
+                now.minus(Duration.ofMinutes(10)); // 10:05, should have fired at 11:00
+
+        boolean result =
+                SnapshotUtils.shouldTriggerCronBasedSnapshot(
+                        CHECKPOINT, cronExpression, lastTrigger, now);
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testShouldTriggerCronBasedSnapshot_NextValidTimeAfterCurrent() {
+        String cronExpression = "0 */10 * * * ?"; // Every 10th minute
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2022, Calendar.JUNE, 5, 11, 5);
+
+        Instant now = calendar.getTime().toInstant(); // 11:05
+        Instant lastTrigger = now.minus(Duration.ofMinutes(4)); // 11:01, next trigger at 11:10
+
+        boolean result =
+                SnapshotUtils.shouldTriggerCronBasedSnapshot(
+                        CHECKPOINT, cronExpression, lastTrigger, now);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testShouldTriggerCronBasedSnapshot_NoNextValidTime() {
+        String cronExpression =
+                "0 0 0 29 2 ? 1999"; // An impossible time (Feb 29, 1999 was not a leap year)
+
+        Instant now = Instant.now();
+        Instant lastTrigger = now.minus(Duration.ofDays(365));
+
+        boolean result =
+                SnapshotUtils.shouldTriggerCronBasedSnapshot(
+                        CHECKPOINT, cronExpression, lastTrigger, now);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testShouldTriggerCronBasedSnapshot_InvalidCron() {
+        String cronExpression = "invalidCron";
+
+        Instant now = Instant.now();
+        Instant lastTrigger = now.minus(Duration.ofDays(365));
+
+        boolean result =
+                SnapshotUtils.shouldTriggerCronBasedSnapshot(
+                        CHECKPOINT, cronExpression, lastTrigger, now);
+
+        assertFalse(result);
+    }
+
+    private static void resetTrigger(FlinkDeployment deployment, SnapshotType snapshotType) {
+        switch (snapshotType) {
+            case SAVEPOINT:
+                deployment.getStatus().getJobStatus().getSavepointInfo().resetTrigger();
+                break;
+            case CHECKPOINT:
+                deployment.getStatus().getJobStatus().getCheckpointInfo().resetTrigger();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported snapshot type: " + snapshotType);
+        }
+    }
+
+    private static void setTriggerNonce(
+            FlinkDeployment deployment, SnapshotType snapshotType, long nonce) {
+        switch (snapshotType) {
+            case SAVEPOINT:
+                deployment.getSpec().getJob().setSavepointTriggerNonce(nonce);
+                break;
+            case CHECKPOINT:
+                deployment.getSpec().getJob().setCheckpointTriggerNonce(nonce);
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported snapshot type: " + snapshotType);
+        }
     }
 
     private static FlinkDeployment initDeployment(FlinkVersion flinkVersion) {
@@ -140,13 +234,7 @@ public class SnapshotUtilsTest {
 
         deployment.getStatus().getJobStatus().setState(JobStatus.RUNNING.name());
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+        reconcileSpec(deployment);
         return deployment;
-    }
-
-    private static void reconcileSpec(FlinkDeployment deployment) {
-        deployment
-                .getStatus()
-                .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Current functionality to trigger savepoints and checkpoints is based on specifying a fixed interval. This approach gives little control to prevent potentially overlapping snapshots running simultaneously in adjacent deployments and can cause issues for high scale, large state jobs. Moreover, lastTrigger information is not retained across deployment restarts which leads to immediate firing based on creation time. In order to have better control over the exact schedule, triggering based on cron expressions should be added.

## Brief change log

  - Adds cron expression config options for checkpoint and savepoint triggering
  - Extends SnapshotUtils logic to process both interval- and cron-based triggers

## Verifying this change
  -  Added unit and integration tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / **no**)
  - Core observer or reconciler logic that is regularly executed: (**yes** / no)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? generated config docs
