### PR TITLE
[FLINK-32700] Support job drain for Savepoint upgrade mode

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -99,6 +99,12 @@
             <td>Indicate whether a savepoint must be taken when deleting a FlinkDeployment or FlinkSessionJob.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.drain-on-savepoint-deletion</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Indicate whether the job should be drained when stopping with savepoint.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.upgrade.ignore-pending-savepoint</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -87,6 +87,12 @@
             <td>Enable job manager startup probe to allow detecting when the jobmanager could not submit the job.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.drain-on-savepoint-deletion</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Indicate whether the job should be drained when stopping with savepoint.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.restart.failed</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -97,12 +103,6 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Indicate whether a savepoint must be taken when deleting a FlinkDeployment or FlinkSessionJob.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.job.drain-on-savepoint-deletion</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Indicate whether the job should be drained when stopping with savepoint.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.upgrade.ignore-pending-savepoint</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -183,6 +183,12 @@
             <td>Indicate whether a savepoint must be taken when deleting a FlinkDeployment or FlinkSessionJob.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.drain-on-savepoint-deletion</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Indicate whether the job should be drained when stopping with savepoint.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.upgrade.ignore-pending-savepoint</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -171,6 +171,12 @@
             <td>Enable job manager startup probe to allow detecting when the jobmanager could not submit the job.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.drain-on-savepoint-deletion</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Indicate whether the job should be drained when stopping with savepoint.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.restart.failed</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -181,12 +187,6 @@
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Indicate whether a savepoint must be taken when deleting a FlinkDeployment or FlinkSessionJob.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.job.drain-on-savepoint-deletion</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>Indicate whether the job should be drained when stopping with savepoint.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.upgrade.ignore-pending-savepoint</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -576,4 +576,12 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(false)
                     .withDescription(
                             "Indicate whether a savepoint must be taken when deleting a FlinkDeployment or FlinkSessionJob.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> DRAIN_ON_SAVEPOINT_DELETION =
+            operatorConfig("job.drain-on-savepoint-deletion")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Indicate whether the job should be drained when stopping with savepoint.");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -309,7 +309,9 @@ public abstract class AbstractFlinkService implements FlinkService {
                                     clusterClient
                                             .stopWithSavepoint(
                                                     Preconditions.checkNotNull(jobId),
-                                                    false,
+                                                    conf.getBoolean(
+                                                            KubernetesOperatorConfigOptions
+                                                                    .DRAIN_ON_SAVEPOINT_DELETION),
                                                     savepointDirectory,
                                                     conf.get(FLINK_VERSION)
                                                                     .isNewerVersionThan(
@@ -416,7 +418,9 @@ public abstract class AbstractFlinkService implements FlinkService {
                                         clusterClient
                                                 .stopWithSavepoint(
                                                         jobId,
-                                                        false,
+                                                        conf.getBoolean(
+                                                                KubernetesOperatorConfigOptions
+                                                                        .DRAIN_ON_SAVEPOINT_DELETION),
                                                         savepointDirectory,
                                                         conf.get(FLINK_VERSION)
                                                                         .isNewerVersionThan(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -340,6 +340,125 @@ public class AbstractFlinkServiceTest {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void cancelJobWithDrainOnSavepointUpgradeModeTest(boolean drainOnSavepoint)
+            throws Exception {
+        var testingClusterClient =
+                new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
+        CompletableFuture<Tuple3<JobID, Boolean, String>> stopWithSavepointFuture =
+                new CompletableFuture<>();
+        var savepointPath = "file:///path/of/svp-1";
+        configuration.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointPath);
+
+        testingClusterClient.setStopWithSavepointFunction(
+                (jobID, advanceToEndOfEventTime, savepointDir) -> {
+                    stopWithSavepointFuture.complete(
+                            new Tuple3<>(jobID, advanceToEndOfEventTime, savepointDir));
+                    return CompletableFuture.completedFuture(savepointPath);
+                });
+
+        var flinkService = new TestingService(testingClusterClient);
+
+        JobID jobID = JobID.generate();
+        FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(CheckpointingOptions.SAVEPOINT_DIRECTORY.key(), savepointPath);
+        deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+        JobStatus jobStatus = deployment.getStatus().getJobStatus();
+        jobStatus.setJobId(jobID.toHexString());
+        jobStatus.setState(org.apache.flink.api.common.JobStatus.RUNNING.name());
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
+
+        if (drainOnSavepoint) {
+            deployment
+                    .getSpec()
+                    .getFlinkConfiguration()
+                    .put(KubernetesOperatorConfigOptions.SAVEPOINT_ON_DELETION.key(), "true");
+            deployment
+                    .getSpec()
+                    .getFlinkConfiguration()
+                    .put(KubernetesOperatorConfigOptions.DRAIN_ON_SAVEPOINT_DELETION.key(), "true");
+        }
+
+        flinkService.cancelJob(
+                deployment,
+                UpgradeMode.SAVEPOINT,
+                configManager.getObserveConfig(deployment),
+                true);
+        assertTrue(stopWithSavepointFuture.isDone());
+        assertEquals(jobID, stopWithSavepointFuture.get().f0);
+        assertEquals(savepointPath, jobStatus.getSavepointInfo().getLastSavepoint().getLocation());
+        assertEquals(jobStatus.getState(), org.apache.flink.api.common.JobStatus.FINISHED.name());
+
+        if (drainOnSavepoint) {
+            assertTrue(stopWithSavepointFuture.get().f1);
+        } else {
+            assertFalse(stopWithSavepointFuture.get().f1);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void cancelSessionJobWithDrainOnSavepointUpgradeModeTest(boolean drainOnSavepoint)
+            throws Exception {
+        var testingClusterClient =
+                new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
+        CompletableFuture<Tuple3<JobID, Boolean, String>> stopWithSavepointFuture =
+                new CompletableFuture<>();
+        var savepointPath = "file:///path/of/svp-1";
+        configuration.set(CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointPath);
+
+        testingClusterClient.setStopWithSavepointFunction(
+                (jobID, advanceToEndOfEventTime, savepointDir) -> {
+                    stopWithSavepointFuture.complete(
+                            new Tuple3<>(jobID, advanceToEndOfEventTime, savepointDir));
+                    return CompletableFuture.completedFuture(savepointPath);
+                });
+
+        var flinkService = new TestingService(testingClusterClient);
+
+        JobID jobID = JobID.generate();
+        var session = TestUtils.buildSessionCluster(configuration.get(FLINK_VERSION));
+        session.getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(session.getSpec(), session);
+        var job = TestUtils.buildSessionJob();
+
+        job.getSpec()
+                .getFlinkConfiguration()
+                .put(CheckpointingOptions.SAVEPOINT_DIRECTORY.key(), savepointPath);
+
+        JobStatus jobStatus = job.getStatus().getJobStatus();
+        jobStatus.setJobId(jobID.toHexString());
+        jobStatus.setState(org.apache.flink.api.common.JobStatus.RUNNING.name());
+        ReconciliationUtils.updateStatusForDeployedSpec(job, new Configuration());
+
+        if (drainOnSavepoint) {
+            job.getSpec()
+                    .getFlinkConfiguration()
+                    .put(KubernetesOperatorConfigOptions.SAVEPOINT_ON_DELETION.key(), "true");
+            job.getSpec()
+                    .getFlinkConfiguration()
+                    .put(KubernetesOperatorConfigOptions.DRAIN_ON_SAVEPOINT_DELETION.key(), "true");
+        }
+        var deployConf = configManager.getSessionJobConfig(session, job.getSpec());
+
+        flinkService.cancelSessionJob(job, UpgradeMode.SAVEPOINT, deployConf);
+        assertTrue(stopWithSavepointFuture.isDone());
+        assertEquals(jobID, stopWithSavepointFuture.get().f0);
+        assertEquals(savepointPath, jobStatus.getSavepointInfo().getLastSavepoint().getLocation());
+        assertEquals(jobStatus.getState(), org.apache.flink.api.common.JobStatus.FINISHED.name());
+
+        if (drainOnSavepoint) {
+            assertTrue(stopWithSavepointFuture.get().f1);
+        } else {
+            assertFalse(stopWithSavepointFuture.get().f1);
+        }
+    }
+
     @Test
     public void cancelJobWithLastStateUpgradeModeTest() throws Exception {
         var deployment = TestUtils.buildApplicationCluster();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request adds an option called `kubernetes.operator.job.drain-on-savepoint-deletion` to indicate whether a job should be drained before deleting a FlinkDeployment or FlinkSessionJob, only if savepoint on deletion is enabled.


## Brief change log

  - Add new configurable option to drain a job before deletion, if the savepoint on deletion is enabled

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change added tests and can be verified as follows:

  - Added unit tests with the new configuration option enabled `testSubmitAndDrainOnCleanUpWithSavepoint` in `ApplicationReconcilerTest` and `SessionJobReconcilerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
