### PR TITLE
[FLINK-33008] Refactor to use KubernetesClient from JOSDK Context

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoscalerFactoryImpl.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoscalerFactoryImpl.java
@@ -22,7 +22,6 @@ import org.apache.flink.kubernetes.operator.reconciler.deployment.JobAutoScalerF
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
 import com.google.auto.service.AutoService;
-import io.fabric8.kubernetes.client.KubernetesClient;
 
 /**
  * Factory for loading JobAutoScalerImpl included in this module. This class will be dynamically
@@ -31,9 +30,8 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 @AutoService(JobAutoScalerFactory.class)
 public class JobAutoscalerFactoryImpl implements JobAutoScalerFactory {
     @Override
-    public JobAutoScaler create(KubernetesClient kubernetesClient, EventRecorder eventRecorder) {
+    public JobAutoScaler create(EventRecorder eventRecorder) {
         return new JobAutoScalerImpl(
-                kubernetesClient,
                 new RestApiMetricsCollector(),
                 new ScalingMetricEvaluator(),
                 new ScalingExecutor(eventRecorder),

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/AutoscalerTestUtils.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/AutoscalerTestUtils.java
@@ -28,6 +28,6 @@ public class AutoscalerTestUtils {
     @SneakyThrows
     public static AutoScalerInfo getOrCreateInfo(
             AbstractFlinkResource<?, ?> cr, KubernetesClient client) {
-        return new AutoscalerInfoManager(client).getOrCreateInfo(cr);
+        return new AutoscalerInfoManager().getOrCreateInfo(cr, client);
     }
 }

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
@@ -76,8 +76,7 @@ public class BacklogBasedScalingTest extends OperatorTestBase {
     @BeforeEach
     public void setup() {
         evaluator = new ScalingMetricEvaluator();
-        scalingExecutor =
-                new ScalingExecutor(new EventRecorder(kubernetesClient, new EventCollector()));
+        scalingExecutor = new ScalingExecutor(new EventRecorder(new EventCollector()));
 
         app = TestUtils.buildApplicationCluster();
         app.getMetadata().setGeneration(1L);
@@ -113,11 +112,10 @@ public class BacklogBasedScalingTest extends OperatorTestBase {
 
         autoscaler =
                 new JobAutoScalerImpl(
-                        kubernetesClient,
                         metricsCollector,
                         evaluator,
                         scalingExecutor,
-                        new EventRecorder(kubernetesClient, eventCollector));
+                        new EventRecorder(eventCollector));
 
         // Reset custom window size to default
         metricsCollector.setTestMetricWindowSize(null);
@@ -428,10 +426,17 @@ public class BacklogBasedScalingTest extends OperatorTestBase {
     @NotNull
     private TestUtils.TestingContext<HasMetadata> createAutoscalerTestContext() {
         return new TestUtils.TestingContext<>() {
+
+            @Override
             public <T1> Set<T1> getSecondaryResources(Class<T1> aClass) {
                 return (Set)
                         kubernetesClient.configMaps().inAnyNamespace().list().getItems().stream()
                                 .collect(Collectors.toSet());
+            }
+
+            @Override
+            public KubernetesClient getClient() {
+                return kubernetesClient;
             }
         };
     }

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScalerTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/JobVertexScalerTest.java
@@ -63,7 +63,7 @@ public class JobVertexScalerTest {
         flinkDep = TestUtils.buildApplicationCluster();
         kubernetesClient.resource(flinkDep).createOrReplace();
         eventCollector = new EventCollector();
-        vertexScaler = new JobVertexScaler(new EventRecorder(kubernetesClient, eventCollector));
+        vertexScaler = new JobVertexScaler(new EventRecorder(eventCollector));
         conf = new Configuration();
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, (double) Integer.MAX_VALUE);
@@ -77,68 +77,123 @@ public class JobVertexScalerTest {
         assertEquals(
                 5,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(10, 50, 100), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(10, 50, 100),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
                 8,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(10, 50, 100), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(10, 50, 100),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(10, 80, 100), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(10, 80, 100),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
                 8,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(10, 60, 100), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(10, 60, 100),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         assertEquals(
                 8,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(10, 59, 100), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(10, 59, 100),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.5);
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(2, 100, 40), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(2, 100, 40),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
         assertEquals(
                 4,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(2, 100, 100), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(2, 100, 100),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.5);
         assertEquals(
                 5,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(10, 10, 100), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(10, 10, 100),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.6);
         assertEquals(
                 4,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(10, 10, 100), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(10, 10, 100),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.5);
         assertEquals(
                 15,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(10, 200, 10), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(10, 200, 10),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.6);
         assertEquals(
                 16,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, op, evaluated(10, 200, 10), Collections.emptySortedMap()));
+                        flinkDep,
+                        conf,
+                        op,
+                        evaluated(10, 200, 10),
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
     }
 
     @Test
@@ -186,7 +241,8 @@ public class JobVertexScalerTest {
                         conf,
                         new JobVertexID(),
                         evaluated(10, 100, 500),
-                        Collections.emptySortedMap()));
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         // Make sure we respect current parallelism in case it's lower
         assertEquals(
@@ -196,7 +252,8 @@ public class JobVertexScalerTest {
                         conf,
                         new JobVertexID(),
                         evaluated(4, 100, 500),
-                        Collections.emptySortedMap()));
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
     }
 
     @Test
@@ -210,7 +267,8 @@ public class JobVertexScalerTest {
                         conf,
                         new JobVertexID(),
                         evaluated(10, 500, 100),
-                        Collections.emptySortedMap()));
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
 
         // Make sure we respect current parallelism in case it's higher
         assertEquals(
@@ -220,7 +278,8 @@ public class JobVertexScalerTest {
                         conf,
                         new JobVertexID(),
                         evaluated(12, 500, 100),
-                        Collections.emptySortedMap()));
+                        Collections.emptySortedMap(),
+                        kubernetesClient));
     }
 
     @Test
@@ -235,7 +294,8 @@ public class JobVertexScalerTest {
         var history = new TreeMap<Instant, ScalingSummary>();
         assertEquals(
                 10,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
 
         history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
 
@@ -243,7 +303,8 @@ public class JobVertexScalerTest {
         evaluated = evaluated(10, 50, 100);
         assertEquals(
                 10,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
 
         // Pass some time...
         clock = Clock.offset(Clock.systemDefaultZone(), Duration.ofSeconds(61));
@@ -251,14 +312,16 @@ public class JobVertexScalerTest {
 
         assertEquals(
                 5,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
         history.put(clock.instant(), new ScalingSummary(10, 5, evaluated));
 
         // Allow immediate scale up
         evaluated = evaluated(5, 100, 50);
         assertEquals(
                 10,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
         history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
     }
 
@@ -273,7 +336,8 @@ public class JobVertexScalerTest {
         var history = new TreeMap<Instant, ScalingSummary>();
         assertEquals(
                 10,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
@@ -281,7 +345,8 @@ public class JobVertexScalerTest {
         evaluated = evaluated(10, 180, 90);
         assertEquals(
                 20,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
 
@@ -290,27 +355,31 @@ public class JobVertexScalerTest {
         evaluated = evaluated(20, 180, 94);
         assertEquals(
                 20,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Still considered ineffective (less than <10%)
         evaluated = evaluated(20, 180, 98);
         assertEquals(
                 20,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Allow scale up if current parallelism doesnt match last (user rescaled manually)
         evaluated = evaluated(10, 180, 90);
         assertEquals(
                 20,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
 
         // Over 10%, effective
         evaluated = evaluated(20, 180, 100);
         assertEquals(
                 36,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Ineffective but detection is turned off
@@ -318,7 +387,8 @@ public class JobVertexScalerTest {
         evaluated = evaluated(20, 180, 90);
         assertEquals(
                 40,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
 
@@ -326,7 +396,8 @@ public class JobVertexScalerTest {
         evaluated = evaluated(20, 45, 90);
         assertEquals(
                 10,
-                vertexScaler.computeScaleTargetParallelism(flinkDep, conf, op, evaluated, history));
+                vertexScaler.computeScaleTargetParallelism(
+                        flinkDep, conf, op, evaluated, history, kubernetesClient));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
     }
 
@@ -342,7 +413,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, jobVertexID, evaluated, history));
+                        flinkDep, conf, jobVertexID, evaluated, history, kubernetesClient));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
@@ -351,7 +422,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, jobVertexID, evaluated, history));
+                        flinkDep, conf, jobVertexID, evaluated, history, kubernetesClient));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
         assertEquals(0, eventCollector.events.size());
@@ -361,7 +432,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        flinkDep, conf, jobVertexID, evaluated, history));
+                        flinkDep, conf, jobVertexID, evaluated, history, kubernetesClient));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(1, eventCollector.events.size());
         var event = eventCollector.events.poll();

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -87,8 +87,7 @@ public class MetricsCollectionAndEvaluationTest {
     @BeforeEach
     public void setup() {
         evaluator = new ScalingMetricEvaluator();
-        scalingExecutor =
-                new ScalingExecutor(new EventRecorder(kubernetesClient, new EventCollector()));
+        scalingExecutor = new ScalingExecutor(new EventRecorder(new EventCollector()));
         service = new TestingFlinkService();
 
         app = TestUtils.buildApplicationCluster();
@@ -176,7 +175,7 @@ public class MetricsCollectionAndEvaluationTest {
         assertTrue(collectedMetrics.isFullyCollected());
 
         var evaluation = evaluator.evaluate(conf, collectedMetrics);
-        scalingExecutor.scaleResource(app, scalingInfo, conf, evaluation);
+        scalingExecutor.scaleResource(app, scalingInfo, conf, evaluation, kubernetesClient);
 
         var scaledParallelism = ScalingExecutorTest.getScaledParallelism(scalingInfo);
         assertEquals(4, scaledParallelism.size());
@@ -190,7 +189,7 @@ public class MetricsCollectionAndEvaluationTest {
         conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.);
 
         evaluation = evaluator.evaluate(conf, collectedMetrics);
-        scalingExecutor.scaleResource(app, scalingInfo, conf, evaluation);
+        scalingExecutor.scaleResource(app, scalingInfo, conf, evaluation, kubernetesClient);
 
         scaledParallelism = ScalingExecutorTest.getScaledParallelism(scalingInfo);
         assertEquals(4, scaledParallelism.get(source1));
@@ -398,7 +397,7 @@ public class MetricsCollectionAndEvaluationTest {
                 500.,
                 evaluation.get(source1).get(ScalingMetric.SCALE_UP_RATE_THRESHOLD).getCurrent());
 
-        scalingExecutor.scaleResource(app, scalingInfo, conf, evaluation);
+        scalingExecutor.scaleResource(app, scalingInfo, conf, evaluation, kubernetesClient);
         var scaledParallelism = ScalingExecutorTest.getScaledParallelism(scalingInfo);
         assertEquals(1, scaledParallelism.get(source1));
     }
@@ -478,7 +477,7 @@ public class MetricsCollectionAndEvaluationTest {
                 0.,
                 evaluation.get(source1).get(ScalingMetric.SCALE_UP_RATE_THRESHOLD).getCurrent());
 
-        scalingExecutor.scaleResource(app, scalingInfo, conf, evaluation);
+        scalingExecutor.scaleResource(app, scalingInfo, conf, evaluation, kubernetesClient);
         var scaledParallelism = ScalingExecutorTest.getScaledParallelism(scalingInfo);
         assertEquals(1, scaledParallelism.get(source1));
     }

--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/RecommendedParallelismTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/RecommendedParallelismTest.java
@@ -79,8 +79,7 @@ public class RecommendedParallelismTest extends OperatorTestBase {
     @BeforeEach
     public void setup() {
         evaluator = new ScalingMetricEvaluator();
-        scalingExecutor =
-                new ScalingExecutor(new EventRecorder(kubernetesClient, new EventCollector()));
+        scalingExecutor = new ScalingExecutor(new EventRecorder(new EventCollector()));
 
         app = TestUtils.buildApplicationCluster();
         app.getMetadata().setGeneration(1L);
@@ -116,11 +115,10 @@ public class RecommendedParallelismTest extends OperatorTestBase {
 
         autoscaler =
                 new JobAutoScalerImpl(
-                        kubernetesClient,
                         metricsCollector,
                         evaluator,
                         scalingExecutor,
-                        new EventRecorder(kubernetesClient, eventCollector));
+                        new EventRecorder(eventCollector));
 
         // Reset custom window size to default
         metricsCollector.setTestMetricWindowSize(null);
@@ -275,10 +273,16 @@ public class RecommendedParallelismTest extends OperatorTestBase {
     @NotNull
     private TestUtils.TestingContext<HasMetadata> createAutoscalerTestContext() {
         return new TestUtils.TestingContext<>() {
+            @Override
             public <T1> Set<T1> getSecondaryResources(Class<T1> aClass) {
                 return (Set)
                         kubernetesClient.configMaps().inAnyNamespace().list().getItems().stream()
                                 .collect(Collectors.toSet());
+            }
+
+            @Override
+            public KubernetesClient getClient() {
+                return kubernetesClient;
             }
         };
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -101,7 +101,7 @@ public class FlinkOperator {
         this.listeners = ListenerUtils.discoverListeners(configManager);
         this.eventRecorder = EventRecorder.create(client, listeners);
         this.ctxFactory =
-                new FlinkResourceContextFactory(client, configManager, metricGroup, eventRecorder);
+                new FlinkResourceContextFactory(configManager, metricGroup, eventRecorder);
         PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(baseConfig);
         FileSystem.initialize(baseConfig, pluginManager);
         this.operatorHealthService = OperatorHealthService.fromConfig(configManager);
@@ -163,10 +163,9 @@ public class FlinkOperator {
         var autoscalerFactory = AutoscalerLoader.loadJobAutoscalerFactory();
         var reconcilerFactory =
                 new ReconcilerFactory(
-                        client, configManager, eventRecorder, statusRecorder, autoscalerFactory);
+                        configManager, eventRecorder, statusRecorder, autoscalerFactory);
         var observerFactory = new FlinkDeploymentObserverFactory(eventRecorder);
-        var canaryResourceManager =
-                new CanaryResourceManager<FlinkDeployment>(configManager, client);
+        var canaryResourceManager = new CanaryResourceManager<FlinkDeployment>(configManager);
         HealthProbe.INSTANCE.registerCanaryResourceManager(canaryResourceManager);
 
         var controller =
@@ -187,10 +186,9 @@ public class FlinkOperator {
         var metricManager =
                 MetricManager.createFlinkSessionJobMetricManager(baseConfig, metricGroup);
         var statusRecorder = StatusRecorder.create(client, metricManager, listeners);
-        var reconciler = new SessionJobReconciler(client, eventRecorder, statusRecorder);
+        var reconciler = new SessionJobReconciler(eventRecorder, statusRecorder);
         var observer = new FlinkSessionJobObserver(eventRecorder);
-        var canaryResourceManager =
-                new CanaryResourceManager<FlinkSessionJob>(configManager, client);
+        var canaryResourceManager = new CanaryResourceManager<FlinkSessionJob>(configManager);
         HealthProbe.INSTANCE.registerCanaryResourceManager(canaryResourceManager);
 
         var controller =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
@@ -27,6 +27,7 @@ import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -106,5 +107,14 @@ public abstract class FlinkResourceContext<CR extends AbstractFlinkResource<?, ?
         return operatorConfig =
                 configManager.getOperatorConfiguration(
                         getResource().getMetadata().getNamespace(), getFlinkVersion());
+    }
+
+    /**
+     * Get KubernetesClient available from JOSDK Context.
+     *
+     * @return KubernetesClient.
+     */
+    public KubernetesClient getKubernetesClient() {
+        return getJosdkContext().getClient();
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
@@ -48,7 +48,8 @@ public abstract class AbstractFlinkResourceObserver<CR extends AbstractFlinkReso
         // Trigger resource specific observe logic
         observeInternal(ctx);
 
-        SnapshotUtils.resetSnapshotTriggers(ctx.getResource(), eventRecorder);
+        SnapshotUtils.resetSnapshotTriggers(
+                ctx.getResource(), eventRecorder, ctx.getKubernetesClient());
     }
 
     /**

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -178,7 +178,8 @@ public abstract class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
                     EventRecorder.Type.Normal,
                     EventRecorder.Reason.JobStatusChanged,
                     EventRecorder.Component.Job,
-                    message);
+                    message,
+                    ctx.getKubernetesClient());
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
@@ -132,7 +132,8 @@ public class SnapshotObserver<
                     EventRecorder.Reason.SavepointError,
                     EventRecorder.Component.Operator,
                     savepointInfo.formatErrorMessage(
-                            resource.getSpec().getJob().getSavepointTriggerNonce()));
+                            resource.getSpec().getJob().getSavepointTriggerNonce()),
+                    ctx.getKubernetesClient());
             savepointInfo.resetTrigger();
             return;
         }
@@ -190,7 +191,8 @@ public class SnapshotObserver<
                     EventRecorder.Reason.CheckpointError,
                     EventRecorder.Component.Operator,
                     checkpointInfo.formatErrorMessage(
-                            resource.getSpec().getJob().getCheckpointTriggerNonce()));
+                            resource.getSpec().getJob().getCheckpointTriggerNonce()),
+                    ctx.getKubernetesClient());
             checkpointInfo.resetTrigger();
             return;
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -224,7 +224,8 @@ public abstract class AbstractFlinkDeploymentObserver
                 EventRecorder.Type.Warning,
                 EventRecorder.Reason.Missing,
                 EventRecorder.Component.JobManagerDeployment,
-                err);
+                err,
+                ctx.getKubernetesClient());
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserver.java
@@ -111,7 +111,8 @@ public class ApplicationObserver extends AbstractFlinkDeploymentObserver {
                     EventRecorder.Type.Warning,
                     EventRecorder.Reason.Missing,
                     EventRecorder.Component.Job,
-                    err);
+                    err,
+                    ctx.getKubernetesClient());
         }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/FlinkSessionJobObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/sessionjob/FlinkSessionJobObserver.java
@@ -193,7 +193,8 @@ public class FlinkSessionJobObserver extends AbstractFlinkResourceObserver<Flink
                     EventRecorder.Type.Warning,
                     EventRecorder.Reason.Missing,
                     EventRecorder.Component.Job,
-                    MISSING_SESSION_JOB_ERR);
+                    MISSING_SESSION_JOB_ERR,
+                    ctx.getKubernetesClient());
         }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -444,7 +444,7 @@ public class ReconciliationUtils {
 
         statusRecorder.updateStatusFromCache(ctx.getResource());
         ReconciliationUtils.updateForReconciliationError(ctx, e);
-        statusRecorder.patchAndCacheStatus(ctx.getResource());
+        statusRecorder.patchAndCacheStatus(ctx.getResource(), ctx.getKubernetesClient());
 
         // Status was updated already, no need to return anything
         return ErrorStatusUpdateControl.noStatusUpdate();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/JobAutoScalerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/JobAutoScalerFactory.java
@@ -19,10 +19,8 @@ package org.apache.flink.kubernetes.operator.reconciler.deployment;
 
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
-
 /** Factory to construct a new autoscaler instance. */
 public interface JobAutoScalerFactory {
 
-    JobAutoScaler create(KubernetesClient kubernetesClient, EventRecorder eventRecorder);
+    JobAutoScaler create(EventRecorder eventRecorder);
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/NoopJobAutoscalerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/NoopJobAutoscalerFactory.java
@@ -20,15 +20,13 @@ package org.apache.flink.kubernetes.operator.reconciler.deployment;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
-
 import java.util.Map;
 
 /** An autoscaler implementation which does nothing. */
 public class NoopJobAutoscalerFactory implements JobAutoScalerFactory, JobAutoScaler {
 
     @Override
-    public JobAutoScaler create(KubernetesClient kubernetesClient, EventRecorder eventRecorder) {
+    public JobAutoScaler create(EventRecorder eventRecorder) {
         return this;
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
@@ -27,15 +27,12 @@ import org.apache.flink.kubernetes.operator.reconciler.Reconciler;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
-
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** The factory to create reconciler based on app mode. */
 public class ReconcilerFactory {
 
-    private final KubernetesClient kubernetesClient;
     private final FlinkConfigManager configManager;
     private final EventRecorder eventRecorder;
     private final StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> deploymentStatusRecorder;
@@ -44,12 +41,10 @@ public class ReconcilerFactory {
             reconcilerMap;
 
     public ReconcilerFactory(
-            KubernetesClient kubernetesClient,
             FlinkConfigManager configManager,
             EventRecorder eventRecorder,
             StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> deploymentStatusRecorder,
             JobAutoScalerFactory autoscalerFactory) {
-        this.kubernetesClient = kubernetesClient;
         this.configManager = configManager;
         this.eventRecorder = eventRecorder;
         this.deploymentStatusRecorder = deploymentStatusRecorder;
@@ -65,14 +60,10 @@ public class ReconcilerFactory {
                 modes -> {
                     switch (modes.f0) {
                         case SESSION:
-                            return new SessionReconciler(
-                                    kubernetesClient, eventRecorder, deploymentStatusRecorder);
+                            return new SessionReconciler(eventRecorder, deploymentStatusRecorder);
                         case APPLICATION:
                             return new ApplicationReconciler(
-                                    kubernetesClient,
-                                    eventRecorder,
-                                    deploymentStatusRecorder,
-                                    autoscalerFactory);
+                                    eventRecorder, deploymentStatusRecorder, autoscalerFactory);
                         default:
                             throw new UnsupportedOperationException(
                                     String.format("Unsupported running mode: %s", modes.f0));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -33,7 +33,6 @@ import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
 import org.apache.flink.runtime.messages.FlinkJobTerminatedWithoutCancellationException;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,10 +47,9 @@ public class SessionJobReconciler
     private static final Logger LOG = LoggerFactory.getLogger(SessionJobReconciler.class);
 
     public SessionJobReconciler(
-            KubernetesClient kubernetesClient,
             EventRecorder eventRecorder,
             StatusRecorder<FlinkSessionJob, FlinkSessionJobStatus> statusRecorder) {
-        super(kubernetesClient, eventRecorder, statusRecorder, new NoopJobAutoscalerFactory());
+        super(eventRecorder, statusRecorder, new NoopJobAutoscalerFactory());
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
@@ -33,7 +33,6 @@ import org.apache.flink.kubernetes.operator.metrics.OperatorMetricUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import org.slf4j.Logger;
@@ -49,7 +48,6 @@ public class FlinkResourceContextFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlinkResourceContextFactory.class);
 
-    private final KubernetesClient kubernetesClient;
     private final FlinkConfigManager configManager;
     private final ArtifactManager artifactManager;
     private final ExecutorService clientExecutorService;
@@ -60,11 +58,9 @@ public class FlinkResourceContextFactory {
             resourceMetricGroups = new ConcurrentHashMap<>();
 
     public FlinkResourceContextFactory(
-            KubernetesClient kubernetesClient,
             FlinkConfigManager configManager,
             KubernetesOperatorMetricGroup operatorMetricGroup,
             EventRecorder eventRecorder) {
-        this.kubernetesClient = kubernetesClient;
         this.configManager = configManager;
         this.operatorMetricGroup = operatorMetricGroup;
         this.eventRecorder = eventRecorder;
@@ -109,14 +105,14 @@ public class FlinkResourceContextFactory {
         switch (deploymentMode) {
             case NATIVE:
                 return new NativeFlinkService(
-                        kubernetesClient,
+                        ctx.getKubernetesClient(),
                         artifactManager,
                         clientExecutorService,
                         ctx.getOperatorConfig(),
                         eventRecorder);
             case STANDALONE:
                 return new StandaloneFlinkService(
-                        kubernetesClient,
+                        ctx.getKubernetesClient(),
                         artifactManager,
                         clientExecutorService,
                         ctx.getOperatorConfig());

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -230,7 +230,8 @@ public class NativeFlinkService extends AbstractFlinkService {
                         EventRecorder.Type.Normal,
                         EventRecorder.Reason.Scaling,
                         EventRecorder.Component.Job,
-                        "In-place scaling triggered");
+                        "In-place scaling triggered",
+                        ctx.getKubernetesClient());
             }
             return result;
         } catch (Throwable t) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -34,12 +34,9 @@ import java.util.function.BiConsumer;
 /** Helper class for creating Kubernetes events for Flink resources. */
 public class EventRecorder {
 
-    private final KubernetesClient client;
     private final BiConsumer<AbstractFlinkResource<?, ?>, Event> eventListener;
 
-    public EventRecorder(
-            KubernetesClient client, BiConsumer<AbstractFlinkResource<?, ?>, Event> eventListener) {
-        this.client = client;
+    public EventRecorder(BiConsumer<AbstractFlinkResource<?, ?>, Event> eventListener) {
         this.eventListener = eventListener;
     }
 
@@ -48,8 +45,9 @@ public class EventRecorder {
             Type type,
             Reason reason,
             Component component,
-            String message) {
-        return triggerEvent(resource, type, reason, component, message, null);
+            String message,
+            KubernetesClient client) {
+        return triggerEvent(resource, type, reason, component, message, null, client);
     }
 
     public boolean triggerEventOnce(
@@ -58,8 +56,10 @@ public class EventRecorder {
             Reason reason,
             Component component,
             String message,
-            String messageKey) {
-        return triggerEventOnce(resource, type, reason.toString(), message, component, messageKey);
+            String messageKey,
+            KubernetesClient client) {
+        return triggerEventOnce(
+                resource, type, reason.toString(), message, component, messageKey, client);
     }
 
     public boolean triggerEvent(
@@ -68,8 +68,10 @@ public class EventRecorder {
             Reason reason,
             Component component,
             String message,
-            @Nullable String messageKey) {
-        return triggerEvent(resource, type, reason.toString(), message, component, messageKey);
+            @Nullable String messageKey,
+            KubernetesClient client) {
+        return triggerEvent(
+                resource, type, reason.toString(), message, component, messageKey, client);
     }
 
     public boolean triggerEvent(
@@ -78,7 +80,8 @@ public class EventRecorder {
             String reason,
             String message,
             Component component,
-            String messageKey) {
+            String messageKey,
+            KubernetesClient client) {
         return EventUtils.createOrUpdateEvent(
                 client,
                 resource,
@@ -96,7 +99,8 @@ public class EventRecorder {
             String reason,
             String message,
             Component component,
-            String messageKey) {
+            String messageKey,
+            KubernetesClient client) {
         return EventUtils.createIfNotExists(
                 client,
                 resource,
@@ -113,8 +117,9 @@ public class EventRecorder {
             Type type,
             String reason,
             String message,
-            Component component) {
-        return triggerEvent(resource, type, reason, message, component, null);
+            Component component,
+            KubernetesClient client) {
+        return triggerEvent(resource, type, reason, message, component, null, client);
     }
 
     public static EventRecorder create(
@@ -150,7 +155,7 @@ public class EventRecorder {
                     AuditUtils.logContext(ctx);
                 };
 
-        return new EventRecorder(client, biConsumer);
+        return new EventRecorder(biConsumer);
     }
 
     /** The type of the events. */

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtils.java
@@ -31,6 +31,7 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.SnapshotType;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.core.util.CronExpression;
 import org.slf4j.Logger;
@@ -363,7 +364,9 @@ public class SnapshotUtils {
     }
 
     public static void resetSnapshotTriggers(
-            AbstractFlinkResource<?, ?> resource, EventRecorder eventRecorder) {
+            AbstractFlinkResource<?, ?> resource,
+            EventRecorder eventRecorder,
+            KubernetesClient client) {
         var status = resource.getStatus();
         var jobStatus = status.getJobStatus();
 
@@ -380,7 +383,8 @@ public class SnapshotUtils {
                         EventRecorder.Reason.SavepointError,
                         EventRecorder.Component.Operator,
                         savepointInfo.formatErrorMessage(
-                                resource.getSpec().getJob().getSavepointTriggerNonce()));
+                                resource.getSpec().getJob().getSavepointTriggerNonce()),
+                        client);
             }
             if (SnapshotUtils.checkpointInProgress(jobStatus)) {
                 var checkpointInfo = jobStatus.getCheckpointInfo();
@@ -394,7 +398,8 @@ public class SnapshotUtils {
                         EventRecorder.Reason.CheckpointError,
                         EventRecorder.Component.Operator,
                         checkpointInfo.formatErrorMessage(
-                                resource.getSpec().getJob().getCheckpointTriggerNonce()));
+                                resource.getSpec().getJob().getCheckpointTriggerNonce()),
+                        client);
             }
         }
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/OperatorTestBase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/OperatorTestBase.java
@@ -48,7 +48,7 @@ public abstract class OperatorTestBase {
         getKubernetesClient().resource(TestUtils.buildSessionJob()).createOrReplace();
         flinkService = new TestingFlinkService(getKubernetesClient());
         context = flinkService.getContext();
-        eventRecorder = new EventRecorder(getKubernetesClient(), eventCollector);
+        eventRecorder = new EventRecorder(eventCollector);
         operatorMetricGroup = TestUtils.createTestMetricGroup(configManager.getDefaultConfig());
         setup();
     }
@@ -66,11 +66,7 @@ public abstract class OperatorTestBase {
             CR cr, Context josdkContext) {
         var ctxFactory =
                 new TestingFlinkResourceContextFactory(
-                        getKubernetesClient(),
-                        configManager,
-                        operatorMetricGroup,
-                        flinkService,
-                        eventRecorder);
+                        configManager, operatorMetricGroup, flinkService, eventRecorder);
         return ctxFactory.getResourceContext(cr, josdkContext);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -147,33 +147,55 @@ public class TestUtils extends BaseTestUtils {
     }
 
     public static <T extends HasMetadata> Context<T> createContextWithDeployment(
-            @Nullable Deployment deployment) {
+            @Nullable Deployment deployment, KubernetesClient client) {
         return new TestingContext<>() {
             @Override
             public Optional<T> getSecondaryResource(Class expectedType, String eventSourceName) {
                 return (Optional<T>) Optional.ofNullable(deployment);
             }
+
+            @Override
+            public KubernetesClient getClient() {
+                return client;
+            }
         };
     }
 
     public static <T extends HasMetadata> Context<T> createEmptyContext() {
-        return createContextWithDeployment(null);
+        return createContextWithDeployment(null, null);
     }
 
-    public static <T extends HasMetadata> Context<T> createContextWithReadyJobManagerDeployment() {
-        return createContextWithDeployment(createDeployment(true));
+    public static <T extends HasMetadata> Context<T> createEmptyContextWithClient(
+            KubernetesClient client) {
+        return createContextWithDeployment(null, client);
     }
 
-    public static <T extends HasMetadata> Context<T> createContextWithInProgressDeployment() {
-        return createContextWithDeployment(createDeployment(false));
+    public static <T extends HasMetadata> Context<T> createContextWithReadyJobManagerDeployment(
+            KubernetesClient client) {
+        return createContextWithDeployment(createDeployment(true), client);
+    }
+
+    public static <T extends HasMetadata> Context<T> createContextWithInProgressDeployment(
+            KubernetesClient client) {
+        return createContextWithDeployment(createDeployment(false), client);
     }
 
     public static <T extends HasMetadata> Context<T> createContextWithReadyFlinkDeployment() {
-        return createContextWithReadyFlinkDeployment(new HashMap<>());
+        return createContextWithReadyFlinkDeployment(new HashMap<>(), null);
+    }
+
+    public static <T extends HasMetadata> Context<T> createContextWithReadyFlinkDeployment(
+            KubernetesClient client) {
+        return createContextWithReadyFlinkDeployment(new HashMap<>(), client);
     }
 
     public static <T extends HasMetadata> Context<T> createContextWithReadyFlinkDeployment(
             Map<String, String> flinkDepConfig) {
+        return createContextWithReadyFlinkDeployment(flinkDepConfig, null);
+    }
+
+    public static <T extends HasMetadata> Context<T> createContextWithReadyFlinkDeployment(
+            Map<String, String> flinkDepConfig, KubernetesClient client) {
         return new TestingContext<>() {
             @Override
             public Optional<T> getSecondaryResource(Class expectedType, String eventSourceName) {
@@ -184,6 +206,11 @@ public class TestUtils extends BaseTestUtils {
                         .getReconciliationStatus()
                         .serializeAndSetLastReconciledSpec(session.getSpec(), session);
                 return (Optional<T>) Optional.of(session);
+            }
+
+            @Override
+            public KubernetesClient getClient() {
+                return client;
             }
         };
     }
@@ -202,7 +229,8 @@ public class TestUtils extends BaseTestUtils {
 
     public static final String DEPLOYMENT_ERROR = "test deployment error message";
 
-    public static <T extends HasMetadata> Context<T> createContextWithFailedJobManagerDeployment() {
+    public static <T extends HasMetadata> Context<T> createContextWithFailedJobManagerDeployment(
+            KubernetesClient client) {
         return new TestingContext<>() {
             @Override
             public Optional getSecondaryResource(Class expectedType, String eventSourceName) {
@@ -225,6 +253,11 @@ public class TestUtils extends BaseTestUtils {
                 deployment.setSpec(spec);
                 deployment.setStatus(status);
                 return Optional.of(deployment);
+            }
+
+            @Override
+            public KubernetesClient getClient() {
+                return client;
             }
         };
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkResourceContextFactory.java
@@ -26,7 +26,6 @@ import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 import java.util.Map;
@@ -36,12 +35,11 @@ public class TestingFlinkResourceContextFactory extends FlinkResourceContextFact
     private final FlinkService flinkService;
 
     public TestingFlinkResourceContextFactory(
-            KubernetesClient kubernetesClient,
             FlinkConfigManager configManager,
             KubernetesOperatorMetricGroup operatorMetricGroup,
             FlinkService flinkService,
             EventRecorder eventRecorder) {
-        super(kubernetesClient, configManager, operatorMetricGroup, eventRecorder);
+        super(configManager, operatorMetricGroup, eventRecorder);
         this.flinkService = flinkService;
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -171,6 +171,11 @@ public class TestingFlinkService extends AbstractFlinkService {
                 }
                 return (Optional<T>) Optional.of(TestUtils.createDeployment(jobManagerReady));
             }
+
+            @Override
+            public KubernetesClient getClient() {
+                return kubernetesClient;
+            }
         };
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingStatusRecorder.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 /** Testing statusRecorder. */
@@ -32,11 +33,11 @@ public class TestingStatusRecorder<
         extends StatusRecorder<CR, STATUS> {
 
     public TestingStatusRecorder() {
-        super(null, new MetricManager<>(), (r, s) -> {});
+        super(new MetricManager<>(), (r, s) -> {});
     }
 
     @Override
-    public void patchAndCacheStatus(CR resource) {
+    public void patchAndCacheStatus(CR resource, KubernetesClient client) {
         statusCache.put(
                 ResourceID.fromResource(resource),
                 objectMapper.convertValue(resource.getStatus(), ObjectNode.class));

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -54,8 +54,7 @@ public class DeploymentRecoveryTest {
     public void setup() {
         flinkService = new TestingFlinkService(kubernetesClient);
         context = flinkService.getContext();
-        testController =
-                new TestingFlinkDeploymentController(configManager, kubernetesClient, flinkService);
+        testController = new TestingFlinkDeploymentController(configManager, flinkService);
         kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
     }
 
@@ -80,9 +79,11 @@ public class DeploymentRecoveryTest {
 
         // Make sure we do not try to recover JM deployment errors (only missing)
         testController.reconcile(
-                appCluster, TestUtils.createContextWithFailedJobManagerDeployment());
+                appCluster,
+                TestUtils.createContextWithFailedJobManagerDeployment(kubernetesClient));
         testController.reconcile(
-                appCluster, TestUtils.createContextWithFailedJobManagerDeployment());
+                appCluster,
+                TestUtils.createContextWithFailedJobManagerDeployment(kubernetesClient));
         assertEquals(
                 JobManagerDeploymentStatus.ERROR,
                 appCluster.getStatus().getJobManagerDeploymentStatus());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
@@ -54,8 +54,7 @@ public class FailedDeploymentRestartTest {
         configManager = new FlinkConfigManager(configuration);
         flinkService = new TestingFlinkService(kubernetesClient);
         context = flinkService.getContext();
-        testController =
-                new TestingFlinkDeploymentController(configManager, kubernetesClient, flinkService);
+        testController = new TestingFlinkDeploymentController(configManager, flinkService);
         kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -100,8 +100,7 @@ public class FlinkDeploymentControllerTest {
     public void setup() {
         flinkService = new TestingFlinkService(kubernetesClient);
         context = flinkService.getContext();
-        testController =
-                new TestingFlinkDeploymentController(configManager, kubernetesClient, flinkService);
+        testController = new TestingFlinkDeploymentController(configManager, flinkService);
         kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
     }
 
@@ -250,7 +249,8 @@ public class FlinkDeploymentControllerTest {
         testController.reconcile(appCluster, context);
         updateControl =
                 testController.reconcile(
-                        appCluster, TestUtils.createContextWithFailedJobManagerDeployment());
+                        appCluster,
+                        TestUtils.createContextWithFailedJobManagerDeployment(kubernetesClient));
         submittedEventValidatingResponseProvider.assertValidated();
         assertFalse(updateControl.isUpdateStatus());
         assertEquals(
@@ -270,7 +270,8 @@ public class FlinkDeploymentControllerTest {
         // next cycle should not create another event
         updateControl =
                 testController.reconcile(
-                        appCluster, TestUtils.createContextWithFailedJobManagerDeployment());
+                        appCluster,
+                        TestUtils.createContextWithFailedJobManagerDeployment(kubernetesClient));
         assertEquals(
                 JobManagerDeploymentStatus.ERROR,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
@@ -334,7 +335,8 @@ public class FlinkDeploymentControllerTest {
         testController.reconcile(appCluster, context);
         updateControl =
                 testController.reconcile(
-                        appCluster, TestUtils.createContextWithInProgressDeployment());
+                        appCluster,
+                        TestUtils.createContextWithInProgressDeployment(kubernetesClient));
         submittedEventValidatingResponseProvider.assertValidated();
         assertFalse(updateControl.isUpdateStatus());
         assertEquals(
@@ -355,7 +357,8 @@ public class FlinkDeploymentControllerTest {
         // next cycle should not create another event
         updateControl =
                 testController.reconcile(
-                        appCluster, TestUtils.createContextWithFailedJobManagerDeployment());
+                        appCluster,
+                        TestUtils.createContextWithFailedJobManagerDeployment(kubernetesClient));
         assertEquals(
                 JobManagerDeploymentStatus.ERROR,
                 appCluster.getStatus().getJobManagerDeploymentStatus());
@@ -582,7 +585,8 @@ public class FlinkDeploymentControllerTest {
                         .getJob()
                         .getState());
         appCluster.getSpec().setLogConfiguration(Map.of("invalid", "conf"));
-        testController.reconcile(appCluster, TestUtils.createEmptyContext());
+        testController.reconcile(
+                appCluster, TestUtils.createEmptyContextWithClient(kubernetesClient));
         assertEquals(2, testController.events().size());
         testController.events().remove();
         assertEquals(
@@ -910,7 +914,8 @@ public class FlinkDeploymentControllerTest {
         FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
 
         testController.reconcile(appCluster, context);
-        testController.reconcile(appCluster, TestUtils.createContextWithInProgressDeployment());
+        testController.reconcile(
+                appCluster, TestUtils.createContextWithInProgressDeployment(kubernetesClient));
 
         assertNull(appCluster.getStatus().getReconciliationStatus().getLastStableSpec());
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
@@ -58,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 class FlinkSessionJobControllerTest {
     private KubernetesClient kubernetesClient;
     private final FlinkConfigManager configManager = new FlinkConfigManager(new Configuration());
-    private final Context context = TestUtils.createContextWithReadyFlinkDeployment();
+    private Context context;
 
     private TestingFlinkService flinkService = new TestingFlinkService();
     private TestingFlinkSessionJobController testController;
@@ -68,11 +68,11 @@ class FlinkSessionJobControllerTest {
     @BeforeEach
     public void before() {
         flinkService = new TestingFlinkService();
-        testController =
-                new TestingFlinkSessionJobController(configManager, kubernetesClient, flinkService);
+        testController = new TestingFlinkSessionJobController(configManager, flinkService);
         sessionJob = TestUtils.buildSessionJob();
         suspendedSessionJob = TestUtils.buildSessionJob(JobState.SUSPENDED);
         kubernetesClient.resource(sessionJob).createOrReplace();
+        context = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -70,9 +70,7 @@ public class RollbackTest {
         context = flinkService.getContext();
         testController =
                 new TestingFlinkDeploymentController(
-                        new FlinkConfigManager(new Configuration()),
-                        kubernetesClient,
-                        flinkService);
+                        new FlinkConfigManager(new Configuration()), flinkService);
         kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -38,7 +38,6 @@ import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 
 import io.fabric8.kubernetes.api.model.Event;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Cleaner;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
@@ -80,29 +79,24 @@ public class TestingFlinkDeploymentController
     private Map<ResourceID, Tuple2<FlinkDeploymentSpec, Long>> currentGenerations = new HashMap<>();
 
     public TestingFlinkDeploymentController(
-            FlinkConfigManager configManager,
-            KubernetesClient kubernetesClient,
-            TestingFlinkService flinkService) {
+            FlinkConfigManager configManager, TestingFlinkService flinkService) {
 
         contextFactory =
                 new TestingFlinkResourceContextFactory(
-                        kubernetesClient,
                         configManager,
                         TestUtils.createTestMetricGroup(new Configuration()),
                         flinkService,
                         eventRecorder);
 
-        eventRecorder = new EventRecorder(kubernetesClient, eventCollector);
-        statusRecorder =
-                new StatusRecorder<>(kubernetesClient, new MetricManager<>(), statusUpdateCounter);
+        eventRecorder = new EventRecorder(eventCollector);
+        statusRecorder = new StatusRecorder<>(new MetricManager<>(), statusUpdateCounter);
         reconcilerFactory =
                 new ReconcilerFactory(
-                        kubernetesClient,
                         configManager,
                         eventRecorder,
                         statusRecorder,
                         new NoopJobAutoscalerFactory());
-        canaryResourceManager = new CanaryResourceManager<>(configManager, kubernetesClient);
+        canaryResourceManager = new CanaryResourceManager<>(configManager);
         flinkDeploymentController =
                 new FlinkDeploymentController(
                         ValidatorUtils.discoverValidators(configManager),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
@@ -37,7 +37,6 @@ import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 
 import io.fabric8.kubernetes.api.model.Event;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Cleaner;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
@@ -73,29 +72,25 @@ public class TestingFlinkSessionJobController
     private Map<ResourceID, Tuple2<FlinkSessionJobSpec, Long>> currentGenerations = new HashMap<>();
 
     public TestingFlinkSessionJobController(
-            FlinkConfigManager configManager,
-            KubernetesClient kubernetesClient,
-            TestingFlinkService flinkService) {
+            FlinkConfigManager configManager, TestingFlinkService flinkService) {
         var ctxFactory =
                 new TestingFlinkResourceContextFactory(
-                        kubernetesClient,
                         configManager,
                         TestUtils.createTestMetricGroup(new Configuration()),
                         flinkService,
                         eventRecorder);
 
-        eventRecorder = new EventRecorder(kubernetesClient, eventCollector);
+        eventRecorder = new EventRecorder(eventCollector);
 
-        statusRecorder =
-                new StatusRecorder<>(kubernetesClient, new MetricManager<>(), statusUpdateCounter);
+        statusRecorder = new StatusRecorder<>(new MetricManager<>(), statusUpdateCounter);
 
-        canaryResourceManager = new CanaryResourceManager<>(configManager, kubernetesClient);
+        canaryResourceManager = new CanaryResourceManager<>(configManager);
 
         flinkSessionJobController =
                 new FlinkSessionJobController(
                         ValidatorUtils.discoverValidators(configManager),
                         ctxFactory,
-                        new SessionJobReconciler(kubernetesClient, eventRecorder, statusRecorder),
+                        new SessionJobReconciler(eventRecorder, statusRecorder),
                         new FlinkSessionJobObserver(eventRecorder),
                         statusRecorder,
                         eventRecorder,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/UnhealthyDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/UnhealthyDeploymentRestartTest.java
@@ -68,8 +68,7 @@ public class UnhealthyDeploymentRestartTest {
         configManager = new FlinkConfigManager(configuration);
         flinkService = new TestingFlinkService(kubernetesClient);
         context = flinkService.getContext();
-        testController =
-                new TestingFlinkDeploymentController(configManager, kubernetesClient, flinkService);
+        testController = new TestingFlinkDeploymentController(configManager, flinkService);
         kubernetesClient.resource(TestUtils.buildApplicationCluster()).createOrReplace();
 
         flinkService.setMetricValue(NUM_RESTARTS_METRIC_NAME, "0");

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/HealthProbeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/HealthProbeTest.java
@@ -182,31 +182,31 @@ public class HealthProbeTest {
 
         var canaryManager =
                 new CanaryResourceManager<FlinkDeployment>(
-                        new FlinkConfigManager(new Configuration()), client);
+                        new FlinkConfigManager(new Configuration()));
         HealthProbe.INSTANCE.registerCanaryResourceManager(canaryManager);
 
         // No canary resources
         assertTrue(HealthProbe.INSTANCE.isHealthy());
 
         var canary = TestUtils.createCanaryDeployment();
-        canaryManager.handleCanaryResourceReconciliation(ReconciliationUtils.clone(canary));
+        canaryManager.handleCanaryResourceReconciliation(ReconciliationUtils.clone(canary), client);
 
         // Canary resource healthy before health check
         assertTrue(HealthProbe.INSTANCE.isHealthy());
 
         // No reconciliation before health check
-        canaryManager.checkHealth(ResourceID.fromResource(canary));
+        canaryManager.checkHealth(ResourceID.fromResource(canary), client);
         assertFalse(HealthProbe.INSTANCE.isHealthy());
 
         // Healthy again
         canary.getMetadata().setGeneration(2L);
-        canaryManager.handleCanaryResourceReconciliation(ReconciliationUtils.clone(canary));
-        canaryManager.checkHealth(ResourceID.fromResource(canary));
+        canaryManager.handleCanaryResourceReconciliation(ReconciliationUtils.clone(canary), client);
+        canaryManager.checkHealth(ResourceID.fromResource(canary), client);
         assertTrue(HealthProbe.INSTANCE.isHealthy());
 
         canary.getMetadata().setGeneration(3L);
-        canaryManager.handleCanaryResourceReconciliation(ReconciliationUtils.clone(canary));
-        canaryManager.checkHealth(ResourceID.fromResource(canary));
+        canaryManager.handleCanaryResourceReconciliation(ReconciliationUtils.clone(canary), client);
+        canaryManager.checkHealth(ResourceID.fromResource(canary), client);
         assertTrue(HealthProbe.INSTANCE.isHealthy());
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/FlinkResourceListenerTest.java
@@ -72,12 +72,12 @@ public class FlinkResourceListenerTest {
         assertEquals(deployment, listener1.updates.get(0).getFlinkResource());
 
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.ERROR);
-        statusRecorder.patchAndCacheStatus(deployment);
+        statusRecorder.patchAndCacheStatus(deployment, kubernetesClient);
         assertEquals(2, listener1.updates.size());
         assertEquals(deployment, listener1.updates.get(1).getFlinkResource());
 
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
-        statusRecorder.patchAndCacheStatus(deployment);
+        statusRecorder.patchAndCacheStatus(deployment, kubernetesClient);
         assertEquals(3, listener1.updates.size());
         assertEquals(deployment, listener1.updates.get(2).getFlinkResource());
 
@@ -105,14 +105,16 @@ public class FlinkResourceListenerTest {
                 EventRecorder.Type.Warning,
                 EventRecorder.Reason.SavepointError,
                 EventRecorder.Component.Operator,
-                "err");
+                "err",
+                kubernetesClient);
         assertEquals(1, listener1.events.size());
         eventRecorder.triggerEvent(
                 deployment,
                 EventRecorder.Type.Warning,
                 EventRecorder.Reason.SavepointError,
                 EventRecorder.Component.Operator,
-                "err");
+                "err",
+                kubernetesClient);
         assertEquals(2, listener1.events.size());
 
         for (int i = 0; i < listener1.events.size(); i++) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -72,13 +72,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ApplicationObserverTest extends OperatorTestBase {
     @Getter private KubernetesClient kubernetesClient;
 
-    private final Context<FlinkDeployment> readyContext =
-            TestUtils.createContextWithReadyJobManagerDeployment();
+    private Context<FlinkDeployment> readyContext;
     private TestObserverAdapter<FlinkDeployment> observer;
 
     @Override
     public void setup() {
         observer = new TestObserverAdapter<>(this, new ApplicationObserver(eventRecorder));
+        readyContext = TestUtils.createContextWithReadyJobManagerDeployment(kubernetesClient);
     }
 
     @Test
@@ -769,7 +769,8 @@ public class ApplicationObserverTest extends OperatorTestBase {
                         () ->
                                 observer.observe(
                                         deployment,
-                                        TestUtils.createContextWithInProgressDeployment()));
+                                        TestUtils.createContextWithInProgressDeployment(
+                                                kubernetesClient)));
         assertEquals(podFailedMessage, exception.getMessage());
     }
 
@@ -778,7 +779,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
         var kubernetesDeployment = TestUtils.createDeployment(true);
         kubernetesDeployment.getMetadata().setAnnotations(new HashMap<>());
 
-        var context = TestUtils.createContextWithDeployment(kubernetesDeployment);
+        var context = TestUtils.createContextWithDeployment(kubernetesDeployment, kubernetesClient);
 
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         deployment.getMetadata().setGeneration(123L);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -46,7 +46,7 @@ public class SessionObserverTest extends OperatorTestBase {
     @Getter private KubernetesClient kubernetesClient;
 
     private final Context<FlinkDeployment> readyContext =
-            TestUtils.createContextWithReadyJobManagerDeployment();
+            TestUtils.createContextWithReadyJobManagerDeployment(kubernetesClient);
     private TestObserverAdapter<FlinkDeployment> observer;
 
     @Override
@@ -106,7 +106,7 @@ public class SessionObserverTest extends OperatorTestBase {
         var kubernetesDeployment = TestUtils.createDeployment(true);
         kubernetesDeployment.getMetadata().setAnnotations(new HashMap<>());
 
-        var context = TestUtils.createContextWithDeployment(kubernetesDeployment);
+        var context = TestUtils.createContextWithDeployment(kubernetesDeployment, kubernetesClient);
 
         FlinkDeployment deployment = TestUtils.buildSessionCluster();
         deployment.getMetadata().setGeneration(123L);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
@@ -78,10 +78,7 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                 new TestReconcilerAdapter<>(
                         this,
                         new ApplicationReconciler(
-                                kubernetesClient,
-                                eventRecorder,
-                                statusRecorder,
-                                new NoopJobAutoscalerFactory()));
+                                eventRecorder, statusRecorder, new NoopJobAutoscalerFactory()));
     }
 
     @ParameterizedTest

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -60,8 +60,7 @@ public class SessionReconcilerTest extends OperatorTestBase {
     public void setup() {
         reconciler =
                 new TestReconcilerAdapter<>(
-                        this,
-                        new SessionReconciler(kubernetesClient, eventRecorder, statusRecorder));
+                        this, new SessionReconciler(eventRecorder, statusRecorder));
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
@@ -92,8 +92,7 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         configManager = new FlinkConfigManager(configuration);
         reconciler =
                 new TestReconcilerAdapter<>(
-                        this,
-                        new SessionJobReconciler(kubernetesClient, eventRecorder, statusRecorder));
+                        this, new SessionJobReconciler(eventRecorder, statusRecorder));
     }
 
     @Test
@@ -105,13 +104,15 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
         // session ready
-        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(1, flinkService.listJobs().size());
         verifyAndSetRunningJobsToStatus(
                 sessionJob, JobState.RUNNING, RECONCILING.name(), null, flinkService.listJobs());
 
         // clean up
-        reconciler.cleanup(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.cleanup(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(
                 "savepoint_0",
                 sessionJob
@@ -131,13 +132,15 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
                 .put(KubernetesOperatorConfigOptions.SAVEPOINT_ON_DELETION.key(), "true");
 
         // session ready
-        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(1, flinkService.listJobs().size());
         verifyAndSetRunningJobsToStatus(
                 sessionJob, JobState.RUNNING, RECONCILING.name(), null, flinkService.listJobs());
 
         // clean up
-        reconciler.cleanup(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.cleanup(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(
                 "savepoint_0",
                 sessionJob
@@ -161,12 +164,14 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         assertEquals(0, flinkService.listJobs().size());
 
         // session ready
-        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(1, flinkService.listJobs().size());
         verifyAndSetRunningJobsToStatus(
                 sessionJob, JobState.RUNNING, RECONCILING.name(), null, flinkService.listJobs());
         // clean up
-        reconciler.cleanup(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.cleanup(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(FINISHED, flinkService.listJobs().get(0).f1.getJobState());
     }
 
@@ -175,20 +180,25 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
         // session ready
-        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(1, flinkService.listJobs().size());
         verifyAndSetRunningJobsToStatus(
                 sessionJob, JobState.RUNNING, RECONCILING.name(), null, flinkService.listJobs());
         // clean up
         flinkService.setPortReady(false);
         var deleteControl =
-                reconciler.cleanup(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+                reconciler.cleanup(
+                        sessionJob,
+                        TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(10_000, deleteControl.getScheduleDelay().get());
         assertEquals(RUNNING, flinkService.listJobs().get(0).f1.getJobState());
 
         flinkService.setPortReady(true);
         deleteControl =
-                reconciler.cleanup(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+                reconciler.cleanup(
+                        sessionJob,
+                        TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(true, deleteControl.isRemoveFinalizer());
         assertEquals(FINISHED, flinkService.listJobs().get(0).f1.getJobState());
     }
@@ -198,17 +208,22 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
         // session ready
-        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(1, flinkService.listJobs().size());
         verifyAndSetRunningJobsToStatus(
                 sessionJob, JobState.RUNNING, RECONCILING.name(), null, flinkService.listJobs());
         // clean up
         flinkService.setFlinkJobNotFound(true);
         var deleteControl =
-                reconciler.cleanup(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+                reconciler.cleanup(
+                        sessionJob,
+                        TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
 
         deleteControl =
-                reconciler.cleanup(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+                reconciler.cleanup(
+                        sessionJob,
+                        TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(true, deleteControl.isRemoveFinalizer());
     }
 
@@ -217,17 +232,22 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
         // session ready
-        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(1, flinkService.listJobs().size());
         verifyAndSetRunningJobsToStatus(
                 sessionJob, JobState.RUNNING, RECONCILING.name(), null, flinkService.listJobs());
         // clean up
         flinkService.setFlinkJobTerminatedWithoutCancellation(true);
         var deleteControl =
-                reconciler.cleanup(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+                reconciler.cleanup(
+                        sessionJob,
+                        TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
 
         deleteControl =
-                reconciler.cleanup(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+                reconciler.cleanup(
+                        sessionJob,
+                        TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(true, deleteControl.isRemoveFinalizer());
     }
 
@@ -236,14 +256,17 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
         // session ready
-        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(1, flinkService.listJobs().size());
         verifyAndSetRunningJobsToStatus(
                 sessionJob, JobState.RUNNING, RECONCILING.name(), null, flinkService.listJobs());
         sessionJob.getSpec().setRestartNonce(2L);
-        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         assertEquals(FINISHED, flinkService.listJobs().get(0).f1.getJobState());
-        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         verifyAndSetRunningJobsToStatus(
                 sessionJob, JobState.RUNNING, RECONCILING.name(), null, flinkService.listJobs());
     }
@@ -251,7 +274,7 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
     @Test
     public void testRestartWhenFailed() throws Exception {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
-        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
 
         // session ready
         reconciler.reconcile(sessionJob, readyContext);
@@ -271,7 +294,8 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
 
         var initSavepointPath = "file:///init-sp";
         sessionJob.getSpec().getJob().setInitialSavepointPath(initSavepointPath);
-        reconciler.reconcile(sessionJob, TestUtils.createContextWithReadyFlinkDeployment());
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
         verifyAndSetRunningJobsToStatus(
                 sessionJob,
                 JobState.RUNNING,
@@ -284,7 +308,7 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
     public void testStatelessUpgrade() throws Exception {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
-        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
         reconciler.reconcile(sessionJob, readyContext);
         assertEquals(1, flinkService.listJobs().size());
         verifyAndSetRunningJobsToStatus(
@@ -313,7 +337,7 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
     public void testSavepointUpgrade() throws Exception {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
-        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
         reconciler.reconcile(sessionJob, readyContext);
         // start the job
         assertEquals(1, flinkService.listJobs().size());
@@ -376,7 +400,7 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
         assertFalse(SnapshotUtils.savepointInProgress(sessionJob.getStatus().getJobStatus()));
 
-        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
         reconciler.reconcile(sessionJob, readyContext);
         verifyAndSetRunningJobsToStatus(
                 sessionJob, JobState.RUNNING, RECONCILING.name(), null, flinkService.listJobs());
@@ -497,7 +521,7 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
         assertFalse(SnapshotUtils.checkpointInProgress(getJobStatus(sessionJob)));
 
-        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
         reconciler.reconcile(sessionJob, readyContext);
         verifyAndSetRunningJobsToStatus(
                 sessionJob, JobState.RUNNING, RECONCILING.name(), null, flinkService.listJobs());
@@ -574,7 +598,7 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
             throws Exception {
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
-        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
 
         reconciler.reconcile(sessionJob, readyContext);
         assertEquals(1, flinkService.listJobs().size());
@@ -644,7 +668,7 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
 
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
 
-        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
 
         reconciler.reconcile(sessionJob, readyContext);
         assertEquals(1, flinkService.listJobs().size());
@@ -735,7 +759,7 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
 
     @Test
     public void testJobUpgradeIgnorePendingSavepoint() throws Exception {
-        var readyContext = TestUtils.createContextWithReadyFlinkDeployment();
+        var readyContext = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
         FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
         reconciler.reconcile(sessionJob, readyContext);
         verifyAndSetRunningJobsToStatus(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -97,7 +97,7 @@ public class NativeFlinkServiceTest {
         configuration.set(KubernetesConfigOptions.CLUSTER_ID, TestUtils.TEST_DEPLOYMENT_NAME);
         configuration.set(KubernetesConfigOptions.NAMESPACE, TestUtils.TEST_NAMESPACE);
         configuration.set(FLINK_VERSION, FlinkVersion.v1_15);
-        eventRecorder = new EventRecorder(client, eventCollector);
+        eventRecorder = new EventRecorder(eventCollector);
         operatorConfig = FlinkOperatorConfiguration.fromConfiguration(configuration);
         executorService = Executors.newDirectExecutorService();
     }
@@ -247,7 +247,7 @@ public class NativeFlinkServiceTest {
                 service.scale(
                         new FlinkDeploymentContext(
                                 flinkDep,
-                                TestUtils.createEmptyContext(),
+                                TestUtils.createEmptyContextWithClient(client),
                                 null,
                                 configManager,
                                 ctx -> service),
@@ -445,7 +445,7 @@ public class NativeFlinkServiceTest {
                 service.scale(
                         new FlinkDeploymentContext(
                                 depCopy,
-                                TestUtils.createEmptyContext(),
+                                TestUtils.createEmptyContextWithClient(client),
                                 null,
                                 configManager,
                                 c -> service),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -147,7 +147,6 @@ public class StandaloneFlinkServiceTest {
         flinkDeployment.getSpec().getTaskManager().setReplicas(5);
         var ctx =
                 new FlinkResourceContextFactory(
-                                kubernetesClient,
                                 configManager,
                                 TestUtils.createTestMetricGroup(new Configuration()),
                                 null)
@@ -176,7 +175,6 @@ public class StandaloneFlinkServiceTest {
                 .serializeAndSetLastReconciledSpec(flinkDeployment.getSpec(), flinkDeployment);
         ctx =
                 new FlinkResourceContextFactory(
-                                kubernetesClient,
                                 configManager,
                                 TestUtils.createTestMetricGroup(new Configuration()),
                                 null)
@@ -209,7 +207,6 @@ public class StandaloneFlinkServiceTest {
 
         var ctx =
                 new FlinkResourceContextFactory(
-                                kubernetesClient,
                                 configManager,
                                 TestUtils.createTestMetricGroup(new Configuration()),
                                 null)

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
@@ -41,23 +41,23 @@ public class StatusRecorderTest {
     public void testPatchOnlyWhenChanged() throws InterruptedException {
         var helper =
                 new StatusRecorder<FlinkDeployment, FlinkDeploymentStatus>(
-                        kubernetesClient, new MetricManager<>(), (e, s) -> {});
+                        new MetricManager<>(), (e, s) -> {});
         var deployment = TestUtils.buildApplicationCluster();
         kubernetesClient.resource(deployment).createOrReplace();
         var lastRequest = mockServer.getLastRequest();
 
-        helper.patchAndCacheStatus(deployment);
+        helper.patchAndCacheStatus(deployment, kubernetesClient);
         assertTrue(mockServer.getLastRequest() != lastRequest);
         lastRequest = mockServer.getLastRequest();
         deployment.getStatus().getReconciliationStatus().setState(ReconciliationState.ROLLING_BACK);
-        helper.patchAndCacheStatus(deployment);
+        helper.patchAndCacheStatus(deployment, kubernetesClient);
 
         // We intentionally compare references
         assertTrue(mockServer.getLastRequest() != lastRequest);
         lastRequest = mockServer.getLastRequest();
 
         // No update
-        helper.patchAndCacheStatus(deployment);
+        helper.patchAndCacheStatus(deployment, kubernetesClient);
         assertTrue(mockServer.getLastRequest() == lastRequest);
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Refactor code to use KubernetesClient from JOSDK Context


## Brief change log

KubernetesClient is passed from josdkContext to flinkResourceContext. The rest of the code get client from either context.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
