### PR TITLE
[FLINK-32777] add config for opt out okhttp hostname verification

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -213,6 +213,12 @@
             <td>Max allowed checkpoint age for initiating last-state upgrades on running jobs. If a checkpoint is not available within the desired age (and nothing in progress) a savepoint will be triggered.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.kubernetes.client.verify.hostname.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Verify host name of Okhttp in Kubernetes client.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.label.selector</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/system_section.html
+++ b/docs/layouts/shortcodes/generated/system_section.html
@@ -51,6 +51,12 @@
             <td>The timeout for the observer to wait the flink rest client to return.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.kubernetes.client.verify.hostname.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Verify host name of Okhttp in Kubernetes client.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.leader-election.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -57,6 +57,7 @@ public class FlinkOperatorConfiguration {
     int metricsHistogramSampleSize;
     boolean kubernetesClientMetricsEnabled;
     boolean kubernetesClientMetricsHttpResponseCodeGroupsEnabled;
+    boolean kubernetesClientVerifyHostnameEnabled;
     Duration flinkCancelJobTimeout;
     Duration flinkShutdownClusterTimeout;
     String artifactsBaseDir;
@@ -169,6 +170,10 @@ public class FlinkOperatorConfiguration {
                         KubernetesOperatorMetricOptions
                                 .OPERATOR_KUBERNETES_CLIENT_METRICS_HTTP_RESPONSE_CODE_GROUPS_ENABLED);
 
+        boolean kubernetesClientVerifyHostnameEnabled =
+                operatorConfig.get(
+                        KubernetesOperatorConfigOptions.KUBERNETES_CLIENT_VERIFY_HOSTNAME_ENABLED);
+
         int metricsHistogramSampleSize =
                 operatorConfig.get(
                         KubernetesOperatorMetricOptions.OPERATOR_METRICS_HISTOGRAM_SAMPLE_SIZE);
@@ -194,6 +199,7 @@ public class FlinkOperatorConfiguration {
                 metricsHistogramSampleSize,
                 kubernetesClientMetricsEnabled,
                 kubernetesClientMetricsHttpResponseCodeGroupsEnabled,
+                kubernetesClientVerifyHostnameEnabled,
                 flinkCancelJobTimeout,
                 flinkShutdownClusterTimeout,
                 artifactsBaseDir,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -341,6 +341,13 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Comma separated list of namespaces the operator monitors for custom resources.");
 
+    @Documentation.Section(SECTION_SYSTEM)
+    public static final ConfigOption<Boolean> KUBERNETES_CLIENT_VERIFY_HOSTNAME_ENABLED =
+            operatorConfig("kubernetes.client.verify.hostname.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Verify host name of Okhttp in Kubernetes client.");
+
     @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<String> OPERATOR_LABEL_SELECTOR =
             operatorConfig("label.selector")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/KubernetesClientUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/KubernetesClientUtils.java
@@ -61,6 +61,10 @@ public class KubernetesClientUtils {
                                     builder.addInterceptor(
                                             new KubernetesClientMetrics(
                                                     metricGroup, operatorConfig));
+
+                                    if (!operatorConfig.isKubernetesClientVerifyHostnameEnabled()) {
+                                        builder.hostnameVerifier((hostname, session) -> true);
+                                    }
                                 }
                             });
         }


### PR DESCRIPTION
## What is the purpose of the change
Currently, Flink operator can't run in IPV6 environment due to a OKhttp host name verification bug. To mitigate the issue reported by users, this change enable a config for user to choose disable host name verification in http client

## Brief change log
- add a configuration to disble okhttp host name verification for IPV6 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
