### PR TITLE
[FLINK-33027] Allow users to override parallelism of excluded vertices

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/JobAutoScaler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/JobAutoScaler.java
@@ -19,8 +19,6 @@ package org.apache.flink.kubernetes.operator.reconciler.deployment;
 
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 
-import java.util.Map;
-
 /** Per-job Autoscaler instance. */
 public interface JobAutoScaler {
 
@@ -30,6 +28,6 @@ public interface JobAutoScaler {
     /** Called when the custom resource is deleted. */
     void cleanup(FlinkResourceContext<?> ctx);
 
-    /** Get the current parallelism overrides for the job. */
-    Map<String, String> getParallelismOverrides(FlinkResourceContext<?> ctx);
+    /** Apply current parallelism overrides. */
+    void applyParallelismOverrides(FlinkResourceContext<?> ctx);
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/NoopJobAutoscalerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/NoopJobAutoscalerFactory.java
@@ -20,8 +20,6 @@ package org.apache.flink.kubernetes.operator.reconciler.deployment;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 
-import java.util.Map;
-
 /** An autoscaler implementation which does nothing. */
 public class NoopJobAutoscalerFactory implements JobAutoScalerFactory, JobAutoScaler {
 
@@ -39,7 +37,5 @@ public class NoopJobAutoscalerFactory implements JobAutoScalerFactory, JobAutoSc
     public void cleanup(FlinkResourceContext<?> ctx) {}
 
     @Override
-    public Map<String, String> getParallelismOverrides(FlinkResourceContext<?> ctx) {
-        return Map.of();
-    }
+    public void applyParallelismOverrides(FlinkResourceContext<?> ctx) {}
 }


### PR DESCRIPTION
## What is the purpose of the change

1. Move parallelism override application to JobAutoscaler instead of reconciler to not leak autoscaler logic
2. Allow users to override excluded vertex parallelisms to avoid the corner case where excluded vertex parallelisms are stuck

## Verifying this change

Improved and extended unit test coverage

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
