### PR TITLE
[FLINK-33067] Expose rate limiter config and enable by default

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -279,6 +279,18 @@
             <td>Configure the array merge behaviour during pod merging. Arrays can be either merged by position or name matching.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.rate-limiter.limit</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>Max number of reconcile loops triggered within the rate limiter refresh period for each resource. Setting the limit &lt;= 0 disables the limiter.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.rate-limiter.refresh-period</h5></td>
+            <td style="word-wrap: break-word;">15 s</td>
+            <td>Duration</td>
+            <td>Operator rate limiter refresh period for each resource.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.reconcile.interval</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
@@ -306,19 +318,25 @@
             <td><h5>kubernetes.operator.retry.initial.interval</h5></td>
             <td style="word-wrap: break-word;">5 s</td>
             <td>Duration</td>
-            <td>Initial interval of automatic reconcile retries on recoverable errors.</td>
+            <td>Initial interval of retries on unhandled controller errors.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.retry.interval.multiplier</h5></td>
-            <td style="word-wrap: break-word;">2.0</td>
+            <td style="word-wrap: break-word;">1.5</td>
             <td>Double</td>
-            <td>Interval multiplier of automatic reconcile retries on recoverable errors.</td>
+            <td>Interval multiplier of retries on unhandled controller errors.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.retry.max.attempts</h5></td>
-            <td style="word-wrap: break-word;">10</td>
+            <td style="word-wrap: break-word;">15</td>
             <td>Integer</td>
-            <td>Max attempts of automatic reconcile retries on recoverable errors.</td>
+            <td>Max attempts of retries on unhandled controller errors.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.retry.max.interval</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Max interval of retries on unhandled controller errors.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.cleanup.enabled</h5></td>

--- a/docs/layouts/shortcodes/generated/system_section.html
+++ b/docs/layouts/shortcodes/generated/system_section.html
@@ -81,6 +81,18 @@
             <td>Leader election retry period.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.rate-limiter.limit</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Integer</td>
+            <td>Max number of reconcile loops triggered within the rate limiter refresh period for each resource. Setting the limit &lt;= 0 disables the limiter.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.rate-limiter.refresh-period</h5></td>
+            <td style="word-wrap: break-word;">15 s</td>
+            <td>Duration</td>
+            <td>Operator rate limiter refresh period for each resource.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.reconcile.interval</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
@@ -102,19 +114,25 @@
             <td><h5>kubernetes.operator.retry.initial.interval</h5></td>
             <td style="word-wrap: break-word;">5 s</td>
             <td>Duration</td>
-            <td>Initial interval of automatic reconcile retries on recoverable errors.</td>
+            <td>Initial interval of retries on unhandled controller errors.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.retry.interval.multiplier</h5></td>
-            <td style="word-wrap: break-word;">2.0</td>
+            <td style="word-wrap: break-word;">1.5</td>
             <td>Double</td>
-            <td>Interval multiplier of automatic reconcile retries on recoverable errors.</td>
+            <td>Interval multiplier of retries on unhandled controller errors.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.retry.max.attempts</h5></td>
-            <td style="word-wrap: break-word;">10</td>
+            <td style="word-wrap: break-word;">15</td>
             <td>Integer</td>
-            <td>Max attempts of automatic reconcile retries on recoverable errors.</td>
+            <td>Max attempts of retries on unhandled controller errors.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.retry.max.interval</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Max interval of retries on unhandled controller errors.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.user.artifacts.base.dir</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -215,6 +215,7 @@ public class FlinkOperator {
         overrider.settingNamespaces(operatorConf.getWatchedNamespaces());
 
         overrider.withRetry(operatorConf.getRetryConfiguration());
+        overrider.withRateLimiter(operatorConf.getRateLimiter());
 
         var labelSelector = operatorConf.getLabelSelector();
         LOG.info(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -362,24 +362,44 @@ public class KubernetesOperatorConfigOptions {
             operatorConfig("retry.initial.interval")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(5))
-                    .withDescription(
-                            "Initial interval of automatic reconcile retries on recoverable errors.");
+                    .withDescription("Initial interval of retries on unhandled controller errors.");
+
+    @Documentation.Section(SECTION_SYSTEM)
+    public static final ConfigOption<Duration> OPERATOR_RETRY_MAX_INTERVAL =
+            operatorConfig("retry.max.interval")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription("Max interval of retries on unhandled controller errors.");
 
     @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Double> OPERATOR_RETRY_INTERVAL_MULTIPLIER =
             operatorConfig("retry.interval.multiplier")
                     .doubleType()
-                    .defaultValue(2.0)
+                    .defaultValue(1.5)
                     .withDescription(
-                            "Interval multiplier of automatic reconcile retries on recoverable errors.");
+                            "Interval multiplier of retries on unhandled controller errors.");
 
     @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Integer> OPERATOR_RETRY_MAX_ATTEMPTS =
             operatorConfig("retry.max.attempts")
                     .intType()
-                    .defaultValue(10)
+                    .defaultValue(15)
+                    .withDescription("Max attempts of retries on unhandled controller errors.");
+
+    @Documentation.Section(SECTION_SYSTEM)
+    public static final ConfigOption<Duration> OPERATOR_RATE_LIMITER_PERIOD =
+            operatorConfig("rate-limiter.refresh-period")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(15))
+                    .withDescription("Operator rate limiter refresh period for each resource.");
+
+    @Documentation.Section(SECTION_SYSTEM)
+    public static final ConfigOption<Integer> OPERATOR_RATE_LIMITER_LIMIT =
+            operatorConfig("rate-limiter.limit")
+                    .intType()
+                    .defaultValue(5)
                     .withDescription(
-                            "Max attempts of automatic reconcile retries on recoverable errors.");
+                            "Max number of reconcile loops triggered within the rate limiter refresh period for each resource. Setting the limit <= 0 disables the limiter.");
 
     @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> OPERATOR_JOB_UPGRADE_LAST_STATE_FALLBACK_ENABLED =

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptio
 import io.fabric8.kubernetes.client.Config;
 import io.javaoperatorsdk.operator.RegisteredController;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.processing.event.rate.LinearRateLimiter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -84,6 +85,11 @@ public class FlinkOperatorTest {
 
         labelSelectors.forEach(selector -> Assertions.assertEquals(testSelector, selector));
         Assertions.assertFalse(configService.stopOnInformerErrorDuringStartup());
+
+        testOperator.registeredControllers.stream()
+                .map(RegisteredController::getConfiguration)
+                .map(ControllerConfiguration::getRateLimiter)
+                .forEach(rl -> Assertions.assertTrue(((LinearRateLimiter) rl).isActivated()));
 
         var leaderElectionConfiguration = configService.getLeaderElectionConfiguration().get();
 


### PR DESCRIPTION
## What is the purpose of the change

There are certain cases currently when the operator can stuck in an infinite no wait retry loop under certain circumstances (see https://github.com/operator-framework/java-operator-sdk/issues/2046 for details).

As a solution we introduce rate limiter configuration with a default that should already safeguard against prod problems that may arise without it.

The PR also fixes and improves the default retry configuration and fixes a bug with exponential backoff.

## Brief change log

  - *Expose rate limiter config and enable by default*
  - *Update default retry config*
  - *Unit Tests*

## Verifying this change

Unit tests, manual verification

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
