### PR TITLE
[FLINK-32777] add doc for supporting IPV6 env

### DIFF
--- a/docs/content/docs/operations/configuration.md
+++ b/docs/content/docs/operations/configuration.md
@@ -143,3 +143,11 @@ Operator system metrics configuration. Cannot be overridden on a per-resource ba
 Advanced operator system configuration. Cannot be overridden on a per-resource basis.
 
 {{< generated/system_advanced_section >}}
+
+### IPV6 Configuration
+
+If you run Flink Operator in IPV6 environment, the [host name verification error](https://issues.apache.org/jira/browse/FLINK-32777) will be triggered
+due to a known bug in Okhttp client. As a workaround before new Okhttp 5.0.0 release, the environment variable below needs to be set 
+for both Flink Operator and Flink Deployment Configuration.
+
+KUBERNETES_DISABLE_HOSTNAME_VERIFICATION=true


### PR DESCRIPTION
## What is the purpose of the change

Add doc for run Flink Operator in IPV6 env

## Brief change log

Add config needed as a workaround for supporting IPV6 env

## Verifying this change
Only documentation change. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (docs)
