### PR TITLE
Give cluster/job role access to k8s services API

### DIFF
--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -90,6 +90,7 @@ rules:
     resources:
       - pods
       - configmaps
+      - services
     verbs:
       - '*'
   - apiGroups:


### PR DESCRIPTION
The current RBAC configuration does not give the cluster/job role (i.e. `flink`) access to the `services` API. This means that if you connect to a Flink Session Cluster and run `flink list`, you get the error

```
io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: https://10.100.0.1/api/v1/namespaces/default/services/flink-session-cluster-rest. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. services "flink-session-cluster-rest" is forbidden: User "system:serviceaccount:default:flink" cannot get resource "services" in API group "" in the namespace "default".
```

This one-line change adds the `services` API to the job/cluster role RBAC configuration, allowing users to run `flink list`.