### PR TITLE
[FLINK-33011] Never accidentally delete HA metadata for last state de…

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -165,7 +165,7 @@ public class ApplicationReconciler
             Preconditions.checkArgument(ReconciliationUtils.isJobInTerminalState(status));
             LOG.info("Deleting deployment with terminated application before new deployment");
             flinkService.deleteClusterDeployment(
-                    relatedResource.getMetadata(), status, deployConfig, true);
+                    relatedResource.getMetadata(), status, deployConfig, !requireHaMetadata);
             flinkService.waitForClusterShutdown(deployConfig);
             statusRecorder.patchAndCacheStatus(relatedResource, ctx.getKubernetesClient());
         }


### PR DESCRIPTION
## What is the purpose of the change

Fix a bug where HA metadata may get accidentally deleted right before deployment, due to incorrectly observing the JobManager deployment in a DEPLOYING state.

Not sure if this is a bug in the JOSDK but it leads to a previously unexpected state. Some users encountered this.

## Brief change log

- Fix deletion logic to never delete HA metadata when it's needed
- Add unit tests

## Verifying this change

Unit test and manual verification

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
