### PR TITLE
[FLINK-31871] Interpret Flink MemoryUnits according to the actual user input

### DIFF
--- a/e2e-tests/data/flinkdep-cr.yaml
+++ b/e2e-tests/data/flinkdep-cr.yaml
@@ -72,7 +72,7 @@ spec:
       cpu: 0.5
   taskManager:
     resource:
-      memory: "1024m"
+      memory: "1Gi"
       cpu: 0.5
   job:
     jarURI: local:///opt/flink/usrlib/myjob.jar

--- a/e2e-tests/data/sessionjob-cr.yaml
+++ b/e2e-tests/data/sessionjob-cr.yaml
@@ -55,7 +55,7 @@ spec:
             claimName: session-cluster-1-pvc
   jobManager:
     resource:
-      memory: "1024m"
+      memory: "1Gi"
       cpu: 0.5
   taskManager:
     resource:

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -36,6 +36,7 @@ import org.apache.flink.kubernetes.operator.api.spec.Resource;
 import org.apache.flink.kubernetes.operator.api.spec.TaskManagerSpec;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
@@ -367,7 +368,8 @@ public class DefaultValidator implements FlinkResourceValidator {
 
         if (memory != null) {
             try {
-                MemorySize.parse(memory);
+                MemorySize.parse(
+                        FlinkConfigBuilder.parseResourceMemoryString(resource.getMemory()));
             } catch (IllegalArgumentException iae) {
                 builder.append(component + " resource memory parse error: " + iae.getMessage());
             }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -429,7 +429,7 @@ public class FlinkConfigBuilderTest {
                         .build();
 
         assertEquals(
-                MemorySize.parse("2048m"),
+                MemorySize.parse("2 gb"),
                 configuration.get(JobManagerOptions.TOTAL_PROCESS_MEMORY));
         assertEquals(Double.valueOf(1), configuration.get(KubernetesConfigOptions.JOB_MANAGER_CPU));
         assertEquals(
@@ -472,10 +472,228 @@ public class FlinkConfigBuilderTest {
                         .build();
 
         assertEquals(
-                MemorySize.parse("2048m"),
+                MemorySize.parse("2 gb"),
                 configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
         assertEquals(
                 Double.valueOf(1), configuration.get(KubernetesConfigOptions.TASK_MANAGER_CPU));
+    }
+
+    @Test
+    public void testApplyJobManagerSpecWithBiByteMemorySetting() {
+        var resource = new Resource(1.0, "1Gi", "20Gi");
+        flinkDeployment.getSpec().getJobManager().setResource(resource);
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyJobManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("1 gb"),
+                configuration.get(JobManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith2048MiSetting() {
+        var resource = new Resource(1.0, "2048Mi", "20Gi");
+        flinkDeployment.getSpec().getTaskManager().setResource(resource);
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("2147483648 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith2gSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("2g");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("2147483648 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith2giSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("2gi");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("2147483648 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith2gbSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("2gb");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("2 gb"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith2gibSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("2gib");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("2 gb"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith2GSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("2G");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("2 gb"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith2GiSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("2Gi");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("2147483648 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith2_gSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("2 g");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("2 gb"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith2_GiSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("2 Gi");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("2147483648 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith512mSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("512m");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("512 mb"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith512miSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("512mi");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("536870912 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith1024mSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("1024m");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("1 gb"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith1024miSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("1024mi");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("1073741824 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith1000000bSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("1000000b");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("1000000 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith1000000_bSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("1000000 b");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("1000000 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith1e6Setting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("1e6");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("1000000 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
+    }
+
+    @Test
+    public void testTaskManagerSpecWith1e6_bSetting() {
+        flinkDeployment.getSpec().getTaskManager().getResource().setMemory("1e6 b");
+        Configuration configuration =
+                new FlinkConfigBuilder(flinkDeployment, new Configuration())
+                        .applyTaskManagerSpec()
+                        .build();
+        assertEquals(
+                MemorySize.parse("1000000 b"),
+                configuration.get(TaskManagerOptions.TOTAL_PROCESS_MEMORY));
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -283,6 +283,10 @@ public class DefaultValidatorTest {
         testSuccess(dep -> dep.getSpec().getTaskManager().getResource().setMemory("1G"));
         testSuccess(dep -> dep.getSpec().getTaskManager().getResource().setMemory("100"));
 
+        // Test resource validation with k8s specification
+        testSuccess(dep -> dep.getSpec().getJobManager().getResource().setMemory("1Gi"));
+        testSuccess(dep -> dep.getSpec().getTaskManager().getResource().setMemory("1Gi"));
+
         testError(
                 dep -> dep.getSpec().getTaskManager().getResource().setMemory("invalid"),
                 "TaskManager resource memory parse error");


### PR DESCRIPTION
## What is the purpose of the change
JM and TM memory settings is only supported in bibytes format. This change will help interpreting the flink memory according to the actual user input.

## Brief change log

- Added the implementation 
- Added tests

## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no


Example values for the change

The below table property applies for the 

- jobManager.resource.memory
- taskManager.resource.memory

| Configuration | Previous InterpretedValue 			| New InterpretedValue 	|
|---------------|---------------------------------------|-----------------------|
| 2g            | 2147483648 b              			| 2000000000 b          |
| 2gb           | 2147483648 b              			| 2000000000 b          |
| 2G            | 2147483648 b              			| 2000000000 b          |
| 2 g           | 2147483648 b              			| 2000000000 b 			|
| 512m          | 536870912 b							| 512000000 b           |
| 2gi           | Fail (Could not parse value '2gi') 	| 2147483648 b 			|
| 2Gi           | Fail (Could not parse value '2Gi')	| 2147483648 b          |
| 2gib          | Fail (Could not parse value '2gi') 	| 2147483648 b 			|
| 2 Gi          | Fail (Could not parse value '2 Gi')	| 2147483648 b 			|
| 512mi         | Fail (Could not parse value '512mi')	| 536870912 b 			|
| 1000000b      | 1000000b								| 1000000b b 			|
| 1000000 b     | 1000000b								| 1000000b b 			|
| 1e6 b     	| Fail (Could not parse value '1e6 b')  | 1000000b b 			|
| 1e6 		    | Fail (Could not parse value '1e6')    | 1000000b b 			|


All these cases are covered with tests.
