### PR TITLE
[FLINK-33081] Apply parallelism overrides in scale

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-kubernetes-operator-autoscaler/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/BacklogBasedScalingTest.java
@@ -412,7 +412,7 @@ public class BacklogBasedScalingTest extends OperatorTestBase {
         var now = Instant.ofEpochMilli(0);
         setClocksTo(now);
         metricsCollector.setJobUpdateTs(now);
-        assertFalse(autoscaler.scale(getResourceContext(app, ctx)));
+        autoscaler.scale(getResourceContext(app, ctx));
         assertTrue(getOrCreateInfo(app, kubernetesClient).getMetricHistory().isEmpty());
         assertTrue(eventCollector.events.isEmpty());
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -132,7 +132,7 @@ public abstract class AbstractFlinkResourceReconciler<
         SPEC lastReconciledSpec =
                 cr.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
         SPEC currentDeploySpec = cr.getSpec();
-        resourceScaler.applyParallelismOverrides(ctx);
+        resourceScaler.scale(ctx);
 
         var specDiff =
                 new ReflectiveDiffBuilder<>(
@@ -183,13 +183,7 @@ public abstract class AbstractFlinkResourceReconciler<
                     MSG_ROLLBACK,
                     ctx.getKubernetesClient());
         } else if (!reconcileOtherChanges(ctx)) {
-            if (resourceScaler.scale(ctx)) {
-                LOG.info(
-                        "Rescheduling new reconciliation immediately to execute scaling operation.");
-                status.setImmediateReconciliationNeeded(true);
-            } else {
-                LOG.info("Resource fully reconciled, nothing to do...");
-            }
+            LOG.info("Resource fully reconciled, nothing to do...");
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/JobAutoScaler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/JobAutoScaler.java
@@ -23,11 +23,8 @@ import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 public interface JobAutoScaler {
 
     /** Called as part of the reconciliation loop. Returns true if this call led to scaling. */
-    boolean scale(FlinkResourceContext<?> ctx);
+    void scale(FlinkResourceContext<?> ctx) throws Exception;
 
     /** Called when the custom resource is deleted. */
     void cleanup(FlinkResourceContext<?> ctx);
-
-    /** Apply current parallelism overrides. */
-    void applyParallelismOverrides(FlinkResourceContext<?> ctx);
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/NoopJobAutoscalerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/NoopJobAutoscalerFactory.java
@@ -29,13 +29,8 @@ public class NoopJobAutoscalerFactory implements JobAutoScalerFactory, JobAutoSc
     }
 
     @Override
-    public boolean scale(FlinkResourceContext<?> ctx) {
-        return false;
-    }
+    public void scale(FlinkResourceContext<?> ctx) {}
 
     @Override
     public void cleanup(FlinkResourceContext<?> ctx) {}
-
-    @Override
-    public void applyParallelismOverrides(FlinkResourceContext<?> ctx) {}
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -884,7 +884,7 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
                 (r) ->
                         new NoopJobAutoscalerFactory() {
                             @Override
-                            public void applyParallelismOverrides(FlinkResourceContext<?> ctx) {
+                            public void scale(FlinkResourceContext<?> ctx) {
                                 overrideFunction.get().accept(ctx.getResource().getSpec());
                             }
                         };


### PR DESCRIPTION
## What is the purpose of the change

Simplify the scale / parallelism override flow based on previous feedback. This change is a refactor and does not introduce new behaviour.

## Brief change log

  - *Unify scale / applyParallelismOverride methods*
  - *Move scaling before reconciling spec diffs*
  - *Refactor JobAutoscalerImpl and extract some methods to simplify the core flow*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
