### PR TITLE
[hotfix] Removing the obsolete comment of JobAutoScaler#scale

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/JobAutoScaler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/JobAutoScaler.java
@@ -22,7 +22,7 @@ import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 /** Per-job Autoscaler instance. */
 public interface JobAutoScaler {
 
-    /** Called as part of the reconciliation loop. Returns true if this call led to scaling. */
+    /** Called as part of the reconciliation loop. */
     void scale(FlinkResourceContext<?> ctx) throws Exception;
 
     /** Called when the custom resource is deleted. */


### PR DESCRIPTION
## What is the purpose of the change

After FLINK-33081, the `JobAutoScaler#scale` doesn't return value anymore, so the comment can be updated.


## Brief change log

[hotfix] Removing the obsolete comment of `JobAutoScaler#scale`