### PR TITLE
[FLINK-33105] Log ClusterInfo fetch error as warning

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -86,7 +86,7 @@ public abstract class AbstractFlinkDeploymentObserver
             flinkApp.getStatus().getClusterInfo().putAll(clusterInfo);
             logger.debug("ClusterInfo: {}", flinkApp.getStatus().getClusterInfo());
         } catch (Exception e) {
-            logger.error("Exception while fetching cluster info", e);
+            logger.warn("Exception while fetching cluster info", e);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

`ClusterInfo` fetch error can happen in normal situation which can show temporary issues so I've lowered the log level from error to warning.

## Brief change log

`ClusterInfo` fetch error level to warning

## Verifying this change

Trivial change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
