### PR TITLE
[FLINK-33107] Use correct upgrade mode when executing rollback, simpl…

### DIFF
--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/JobAutoScalerImpl.java
@@ -171,7 +171,7 @@ public class JobAutoScalerImpl implements JobAutoScaler {
         var status = resource.getStatus();
         if (status.getLifecycleState() != ResourceLifecycleState.STABLE
                 || !status.getJobStatus().getState().equals(JobStatus.RUNNING.name())) {
-            LOG.info("Autoscaler is waiting for RUNNING job state");
+            LOG.info("Autoscaler is waiting for stable, running state");
             lastEvaluatedMetrics.remove(resourceId);
             return;
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -85,13 +85,12 @@ public abstract class AbstractJobReconciler<
     }
 
     @Override
-    protected boolean reconcileSpecChange(FlinkResourceContext<CR> ctx, Configuration deployConfig)
+    protected boolean reconcileSpecChange(
+            FlinkResourceContext<CR> ctx, Configuration deployConfig, SPEC lastReconciledSpec)
             throws Exception {
 
         var resource = ctx.getResource();
         STATUS status = resource.getStatus();
-        var reconciliationStatus = status.getReconciliationStatus();
-        SPEC lastReconciledSpec = reconciliationStatus.deserializeLastReconciledSpec();
         SPEC currentDeploySpec = resource.getSpec();
 
         JobState currentJobState = lastReconciledSpec.getJob().getState();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -85,9 +85,13 @@ public class ApplicationReconciler
         }
         var flinkService = ctx.getFlinkService();
 
-        if (deployConfig.getBoolean(
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_JOB_UPGRADE_LAST_STATE_FALLBACK_ENABLED)
+        boolean lastStateAllowed =
+                deployment.getSpec().getJob().getUpgradeMode() == UpgradeMode.LAST_STATE
+                        || deployConfig.getBoolean(
+                                KubernetesOperatorConfigOptions
+                                        .OPERATOR_JOB_UPGRADE_LAST_STATE_FALLBACK_ENABLED);
+
+        if (lastStateAllowed
                 && HighAvailabilityMode.isHighAvailabilityModeActivated(deployConfig)
                 && HighAvailabilityMode.isHighAvailabilityModeActivated(ctx.getObserveConfig())
                 && !flinkVersionChanged(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -60,7 +60,9 @@ public class SessionReconciler
 
     @Override
     protected boolean reconcileSpecChange(
-            FlinkResourceContext<FlinkDeployment> ctx, Configuration deployConfig)
+            FlinkResourceContext<FlinkDeployment> ctx,
+            Configuration deployConfig,
+            FlinkDeploymentSpec lastReconciledSpec)
             throws Exception {
         var deployment = ctx.getResource();
         deleteSessionCluster(ctx);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -374,11 +374,10 @@ public class RollbackTest {
 
         assertFalse(deployment.getStatus().getReconciliationStatus().isLastReconciledSpecStable());
         assertEquals(
-                ReconciliationState.ROLLING_BACK,
+                deployment.getSpec().getJob() != null
+                        ? ReconciliationState.ROLLING_BACK
+                        : ReconciliationState.ROLLED_BACK,
                 deployment.getStatus().getReconciliationStatus().getState());
-        assertEquals(
-                "Deployment is not ready within the configured timeout, rolling back.",
-                deployment.getStatus().getError());
 
         if (injectValidationError) {
             deployment.getSpec().setLogConfiguration(Map.of("invalid", "entry"));


### PR DESCRIPTION
## What is the purpose of the change

Rollbacks have recently been improved to use the same `upgrade` mechanism that we use during user spec changes to cover more cases.

However the previous implementation has a few shortcomings / bugs:
 - The code is a bit scattered around in the reconciler, making it difficult to understand
 - The upgradeMode was picked up from the last-stable spec, which in many cases can cause unintentional state loss. It should be picked up from the lastReconciledSpec
 - During upgrade the shutdown upgrade mode is not recorded correctly anywhere which may cause state loss or unrecoverable situations

This PR aims at improving the rollback flow and solve the current issues highlighted previously.

## Brief change log

  - *Refactor upgrade flow and remove extra reconcile cycle previously added when rollback was initiated*
  - *Use upgradeMode from lastReconciledSpec instead of lastStableSpec when rolling back*
  - *Record upgradeMode in lastReconciledSpec correctly when suspend was performed in ROLLING_BACK state*

## Verifying this change

 - Existing unit tests have been extended + new unit tests added to cover the previously not working corner cases.
 - Manual verification on local k8s

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
