### PR TITLE
[FLINK-33007] Integrate autoscaler config validation into the general validator flow

### DIFF
--- a/e2e-tests/data/autoscaler.yaml
+++ b/e2e-tests/data/autoscaler.yaml
@@ -41,6 +41,12 @@ spec:
     job.autoscaler.stabilization.interval: "5s"
     job.autoscaler.metrics.window: "1m"
 
+#    Invalid Validations for testing autoscaler configurations
+#    kubernetes.operator.job.autoscaler.scale-down.max-factor: "-0.6"
+#    kubernetes.operator.job.autoscaler.scale-up.max-factor: "-1.0"
+#    kubernetes.operator.job.autoscaler.target.utilization: "-10.7"
+#    kubernetes.operator.job.autoscaler.target.utilization.boundary: "-Hundred"
+
     jobmanager.scheduler: adaptive
   serviceAccount: flink
   podTemplate:

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -17,7 +17,9 @@
 
 package org.apache.flink.kubernetes.operator.validation;
 
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.configuration.CheckpointingOptions;
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -60,6 +62,7 @@ import java.util.regex.Pattern;
 
 /** Default validator implementation for {@link FlinkDeployment}. */
 public class DefaultValidator implements FlinkResourceValidator {
+
     private static final Pattern DEPLOYMENT_NAME_PATTERN =
             Pattern.compile("[a-z]([-a-z\\d]{0,43}[a-z\\d])?");
     private static final String[] FORBIDDEN_CONF_KEYS =
@@ -102,7 +105,8 @@ public class DefaultValidator implements FlinkResourceValidator {
                 validateJmSpec(spec.getJobManager(), effectiveConfig),
                 validateTmSpec(spec.getTaskManager(), effectiveConfig),
                 validateSpecChange(deployment, effectiveConfig),
-                validateServiceAccount(spec.getServiceAccount()));
+                validateServiceAccount(spec.getServiceAccount()),
+                validateAutoScalerFlinkConfiguration(effectiveConfig));
     }
 
     @SafeVarargs
@@ -487,7 +491,8 @@ public class DefaultValidator implements FlinkResourceValidator {
         return firstPresent(
                 validateNotApplicationCluster(sessionCluster),
                 validateSessionClusterId(sessionJob, sessionCluster),
-                validateJobSpec(sessionJob.getSpec().getJob(), null, effectiveConfig));
+                validateJobSpec(sessionJob.getSpec().getJob(), null, effectiveConfig),
+                validateAutoScalerFlinkConfiguration(effectiveConfig));
     }
 
     private Optional<String> validateJobNotEmpty(FlinkSessionJob sessionJob) {
@@ -553,5 +558,53 @@ public class DefaultValidator implements FlinkResourceValidator {
                     "spec.serviceAccount must be defined. If you use helm, its value should be the same with the name of jobServiceAccount.");
         }
         return Optional.empty();
+    }
+
+    public static Optional<String> validateAutoScalerFlinkConfiguration(
+            Map<String, String> effectiveConfig) {
+        if (effectiveConfig == null) {
+            return Optional.empty();
+        }
+        Configuration flinkConfiguration = Configuration.fromMap(effectiveConfig);
+        if (!flinkConfiguration.getBoolean(AutoScalerOptions.AUTOSCALER_ENABLED)) {
+            return Optional.empty();
+        }
+        return firstPresent(
+                validateNumber(flinkConfiguration, AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.0d),
+                validateNumber(flinkConfiguration, AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.0d),
+                validateNumber(flinkConfiguration, AutoScalerOptions.TARGET_UTILIZATION, 0.0d),
+                validateNumber(
+                        flinkConfiguration, AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.0d));
+    }
+
+    private static <T extends Number> Optional<String> validateNumber(
+            Configuration flinkConfiguration,
+            ConfigOption<T> autoScalerConfig,
+            Double min,
+            Double max) {
+        try {
+            var configValue = flinkConfiguration.get(autoScalerConfig);
+            if (configValue != null) {
+                double value = configValue.doubleValue();
+                if ((min != null && value < min) || (max != null && value > max)) {
+                    return Optional.of(
+                            String.format(
+                                    "The AutoScalerOption %s is invalid, it should be a value within the range [%s, %s]",
+                                    autoScalerConfig.key(),
+                                    min != null ? min.toString() : "-Infinity",
+                                    max != null ? max.toString() : "+Infinity"));
+                }
+            }
+            return Optional.empty();
+        } catch (IllegalArgumentException e) {
+            return Optional.of(
+                    String.format(
+                            "Invalid value in the autoscaler config %s", autoScalerConfig.key()));
+        }
+    }
+
+    private static <T extends Number> Optional<String> validateNumber(
+            Configuration flinkConfiguration, ConfigOption<T> autoScalerConfig, Double min) {
+        return validateNumber(flinkConfiguration, autoScalerConfig, min, null);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*Currently the AutoScaler configurations are not validated, hence they fail at runtime. This change intends to introduce a validator plugin for validating AutoScaler configuration*


## Brief change log

  - *AutoScaler Validator implemented using FlinkResourceValidator plugin*
  - *Unit tests added for the same, please find below details of all the rules being validated*
  - *Added the META-INF/services file for the validator to pick the right autoscaler plugin while available in classpath*

## Verifying this change
This change added tests and can be verified as follows:

  - *Added Unit tests to cover all the rules validated on the autoscaler configuration.*
  - *Extended e2e-tests to make sure the AutoScaler validator plugin is picked and validated on the tests*
  - *Manually verified the change by running a test on the operator with a flinkdeployment with the CR voilating the validation rules.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

## Properties and Rules validated by the AutoScaler Configuration


|| Rule      | Affecting Property | MinValue | MaxValue | 
|-| ----------- | ----------- | ----------- | ----------- | 
|1| validateMaxScaleDownFactor | kubernetes.operator.job.autoscaler.scale-down.max-factor | 0.0d | 1.0d |
|2| validateMaxScaleUpFactor   | kubernetes.operator.job.autoscaler.scale-up.max-factor | 1.0d | 100000.0d |
|3| validateTargetUtilization   | kubernetes.operator.job.autoscaler.target.utilization | 0.0d | 1.0d | 
|4| validateTargetUtilizationBoundary   | kubernetes.operator.job.autoscaler.target.utilization.boundary | 0.0d | 1.0d | 


