### PR TITLE
[FLINK-33187] Don't record duplicate event if no change

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -93,6 +93,12 @@
             <td>Enable vertex scaling execution by the autoscaler. If disabled, the autoscaler will only collect metrics and evaluate the suggested parallelism for each vertex but will not upgrade the jobs.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.autoscaler.scaling.report.interval</h5></td>
+            <td style="word-wrap: break-word;">1800</td>
+            <td>Long</td>
+            <td>Time interval to resend the identical event</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.autoscaler.stabilization.interval</h5></td>
             <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -94,8 +94,8 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.autoscaler.scaling.report.interval</h5></td>
-            <td style="word-wrap: break-word;">1800</td>
-            <td>Long</td>
+            <td style="word-wrap: break-word;">30 min</td>
+            <td>Duration</td>
             <td>Time interval to resend the identical event</td>
         </tr>
         <tr>

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
@@ -94,14 +94,15 @@ public class ScalingExecutor {
         var scalingEnabled = conf.get(SCALING_ENABLED);
 
         var scalingReport = scalingReport(scalingSummaries, scalingEnabled);
-        eventRecorder.triggerEvent(
+        eventRecorder.triggerEventByInterval(
                 resource,
                 EventRecorder.Type.Normal,
                 EventRecorder.Reason.ScalingReport,
                 EventRecorder.Component.Operator,
                 scalingReport,
                 "ScalingExecutor",
-                client);
+                client,
+                conf.get(AutoScalerOptions.SCALING_REPORT_INTERVAL));
 
         if (!scalingEnabled) {
             return false;

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ScalingExecutor.java
@@ -94,18 +94,27 @@ public class ScalingExecutor {
         var scalingEnabled = conf.get(SCALING_ENABLED);
 
         var scalingReport = scalingReport(scalingSummaries, scalingEnabled);
-        eventRecorder.triggerEventByInterval(
-                resource,
-                EventRecorder.Type.Normal,
-                EventRecorder.Reason.ScalingReport,
-                EventRecorder.Component.Operator,
-                scalingReport,
-                "ScalingExecutor",
-                client,
-                conf.get(AutoScalerOptions.SCALING_REPORT_INTERVAL));
 
         if (!scalingEnabled) {
+            eventRecorder.triggerEventByInterval(
+                    resource,
+                    EventRecorder.Type.Normal,
+                    EventRecorder.Reason.ScalingReport,
+                    EventRecorder.Component.Operator,
+                    scalingReport,
+                    "ScalingExecutor",
+                    client,
+                    conf.get(AutoScalerOptions.SCALING_REPORT_INTERVAL));
             return false;
+        } else {
+            eventRecorder.triggerEvent(
+                    resource,
+                    EventRecorder.Type.Normal,
+                    EventRecorder.Reason.ScalingReport,
+                    EventRecorder.Component.Operator,
+                    scalingReport,
+                    "ScalingExecutor",
+                    client);
         }
 
         scalingInformation.addToScalingHistory(clock.instant(), scalingSummaries, conf);

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -169,9 +169,9 @@ public class AutoScalerOptions {
                     .withDescription(
                             "A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling. Caution: For non-sink vertices this will still scale their downstream operators until https://issues.apache.org/jira/browse/FLINK-31215 is implemented.");
 
-    public static final ConfigOption<Long> SCALING_REPORT_INTERVAL =
+    public static final ConfigOption<Duration> SCALING_REPORT_INTERVAL =
             autoScalerConfig("scaling.report.interval")
-                    .longType()
-                    .defaultValue(Long.valueOf(1800))
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1800))
                     .withDescription("Time interval to resend the identical event");
 }

--- a/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
+++ b/flink-kubernetes-operator-autoscaler/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/config/AutoScalerOptions.java
@@ -168,4 +168,10 @@ public class AutoScalerOptions {
                     .defaultValues()
                     .withDescription(
                             "A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling. Caution: For non-sink vertices this will still scale their downstream operators until https://issues.apache.org/jira/browse/FLINK-31215 is implemented.");
+
+    public static final ConfigOption<Long> SCALING_REPORT_INTERVAL =
+            autoScalerConfig("scaling.report.interval")
+                    .longType()
+                    .defaultValue(Long.valueOf(1800))
+                    .withDescription("Time interval to resend the identical event");
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -112,6 +112,27 @@ public class EventRecorder {
                 messageKey);
     }
 
+    public boolean triggerEventByInterval(
+            AbstractFlinkResource<?, ?> resource,
+            Type type,
+            Reason reason,
+            Component component,
+            String message,
+            @Nullable String messageKey,
+            KubernetesClient client,
+            long interval) {
+        return EventUtils.createByInterval(
+                client,
+                resource,
+                type,
+                reason.toString(),
+                message,
+                component,
+                e -> eventListener.accept(resource, e),
+                messageKey,
+                interval);
+    }
+
     public boolean triggerEvent(
             AbstractFlinkResource<?, ?> resource,
             Type type,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 
 import javax.annotation.Nullable;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.function.BiConsumer;
 
@@ -120,7 +121,7 @@ public class EventRecorder {
             String message,
             @Nullable String messageKey,
             KubernetesClient client,
-            long interval) {
+            Duration interval) {
         return EventUtils.createByInterval(
                 client,
                 resource,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 
 import javax.annotation.Nullable;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -63,7 +64,15 @@ public class EventUtils {
             Consumer<Event> eventListener,
             @Nullable String messageKey) {
         return createByInterval(
-                client, target, type, reason, message, component, eventListener, messageKey, 0);
+                client,
+                target,
+                type,
+                reason,
+                message,
+                component,
+                eventListener,
+                messageKey,
+                Duration.ofSeconds(0));
     }
 
     private static Event findExistingEvent(
@@ -108,7 +117,7 @@ public class EventUtils {
             EventRecorder.Component component,
             Consumer<Event> eventListener,
             @Nullable String messageKey,
-            long interval) {
+            Duration interval) {
 
         String eventName =
                 generateEventName(
@@ -120,7 +129,7 @@ public class EventUtils {
                     && Instant.now()
                             .isBefore(
                                     Instant.parse(existing.getLastTimestamp())
-                                            .plusSeconds(interval))) {
+                                            .plusMillis(interval.toMillis()))) {
                 return false;
             } else {
                 createUpdatedEvent(existing, client, message, eventListener);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import javax.annotation.Nullable;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -61,24 +62,8 @@ public class EventUtils {
             EventRecorder.Component component,
             Consumer<Event> eventListener,
             @Nullable String messageKey) {
-
-        String eventName =
-                generateEventName(
-                        target, type, reason, messageKey != null ? messageKey : message, component);
-        Event existing = findExistingEvent(client, target, eventName);
-
-        if (existing != null) {
-            // update
-            existing.setLastTimestamp(Instant.now().toString());
-            existing.setCount(existing.getCount() + 1);
-            existing.setMessage(message);
-            eventListener.accept(client.resource(existing).createOrReplace());
-            return false;
-        } else {
-            Event event = buildEvent(target, type, reason, message, component, eventName);
-            eventListener.accept(client.resource(event).createOrReplace());
-            return true;
-        }
+        return createByInterval(
+                client, target, type, reason, message, component, eventListener, messageKey, 0);
     }
 
     private static Event findExistingEvent(
@@ -108,10 +93,68 @@ public class EventUtils {
         if (existing != null) {
             return false;
         } else {
-            Event event = buildEvent(target, type, reason, message, component, eventName);
-            eventListener.accept(client.resource(event).createOrReplace());
+            createNewEvent(
+                    client, target, type, reason, message, component, eventListener, eventName);
             return true;
         }
+    }
+
+    public static boolean createByInterval(
+            KubernetesClient client,
+            HasMetadata target,
+            EventRecorder.Type type,
+            String reason,
+            String message,
+            EventRecorder.Component component,
+            Consumer<Event> eventListener,
+            @Nullable String messageKey,
+            long interval) {
+
+        String eventName =
+                generateEventName(
+                        target, type, reason, messageKey != null ? messageKey : message, component);
+        Event existing = findExistingEvent(client, target, eventName);
+
+        if (existing != null) {
+            if (Objects.equals(existing.getMessage(), message)
+                    && Instant.now()
+                            .isBefore(
+                                    Instant.parse(existing.getLastTimestamp())
+                                            .plusSeconds(interval))) {
+                return false;
+            } else {
+                createUpdatedEvent(existing, client, message, eventListener);
+                return false;
+            }
+        } else {
+            createNewEvent(
+                    client, target, type, reason, message, component, eventListener, eventName);
+            return true;
+        }
+    }
+
+    private static void createUpdatedEvent(
+            Event existing,
+            KubernetesClient client,
+            String message,
+            Consumer<Event> eventListener) {
+        existing.setLastTimestamp(Instant.now().toString());
+        existing.setCount(existing.getCount() + 1);
+        existing.setMessage(message);
+        eventListener.accept(client.resource(existing).createOrReplace());
+    }
+
+    private static void createNewEvent(
+            KubernetesClient client,
+            HasMetadata target,
+            EventRecorder.Type type,
+            String reason,
+            String message,
+            EventRecorder.Component component,
+            Consumer<Event> eventListener,
+            String eventName) {
+        Event event = buildEvent(target, type, reason, message, component, eventName);
+        eventListener.accept(client.resource(event).createOrReplace());
     }
 
     private static Event buildEvent(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.function.Consumer;
 
 /** Test for {@link EventUtils}. */
@@ -140,7 +141,7 @@ public class EventUtilsTest {
                         EventRecorder.Component.Operator,
                         consumer,
                         null,
-                        1800));
+                        Duration.ofSeconds(1800)));
         var event =
                 kubernetesClient
                         .v1()
@@ -164,7 +165,7 @@ public class EventUtilsTest {
                         EventRecorder.Component.Operator,
                         consumer,
                         null,
-                        1800));
+                        Duration.ofSeconds(1800)));
         event =
                 kubernetesClient
                         .v1()
@@ -186,7 +187,7 @@ public class EventUtilsTest {
                         EventRecorder.Component.Operator,
                         consumer,
                         null,
-                        1800));
+                        Duration.ofSeconds(1800)));
     }
 
     @Test
@@ -282,7 +283,7 @@ public class EventUtilsTest {
                         EventRecorder.Component.Operator,
                         consumer,
                         "mk",
-                        1800));
+                        Duration.ofSeconds(1800)));
         var event =
                 kubernetesClient
                         .v1()
@@ -306,7 +307,7 @@ public class EventUtilsTest {
                         EventRecorder.Component.Operator,
                         consumer,
                         "mk",
-                        1800));
+                        Duration.ofSeconds(1800)));
 
         event =
                 kubernetesClient
@@ -331,7 +332,7 @@ public class EventUtilsTest {
                         EventRecorder.Component.Operator,
                         consumer,
                         "mk",
-                        1800));
+                        Duration.ofSeconds(1800)));
 
         event =
                 kubernetesClient
@@ -354,7 +355,7 @@ public class EventUtilsTest {
                         EventRecorder.Component.Operator,
                         consumer,
                         "mk2",
-                        1800));
+                        Duration.ofSeconds(1800)));
         eventName =
                 EventUtils.generateEventName(
                         flinkApp,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
@@ -112,6 +112,84 @@ public class EventUtilsTest {
     }
 
     @Test
+    public void testCreateUpdatedEvent() {
+        var consumer =
+                new Consumer<Event>() {
+                    @Override
+                    public void accept(Event event) {
+                        eventConsumed = event;
+                    }
+                };
+        var flinkApp = TestUtils.buildApplicationCluster();
+        var reason = "Cleanup";
+        var message = "message";
+        var eventName =
+                EventUtils.generateEventName(
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        message,
+                        EventRecorder.Component.Operator);
+        Assertions.assertTrue(
+                EventUtils.createByInterval(
+                        kubernetesClient,
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        message,
+                        EventRecorder.Component.Operator,
+                        consumer,
+                        null,
+                        1800));
+        var event =
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(flinkApp.getMetadata().getNamespace())
+                        .withName(eventName)
+                        .get();
+        Assertions.assertNotNull(event);
+        Assertions.assertEquals(eventConsumed, event);
+        Assertions.assertEquals(1, event.getCount());
+        Assertions.assertEquals(reason, event.getReason());
+
+        eventConsumed = null;
+        Assertions.assertFalse(
+                EventUtils.createByInterval(
+                        kubernetesClient,
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        message,
+                        EventRecorder.Component.Operator,
+                        consumer,
+                        null,
+                        1800));
+        event =
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(flinkApp.getMetadata().getNamespace())
+                        .withName(eventName)
+                        .get();
+        Assertions.assertNotNull(event);
+        Assertions.assertNull(eventConsumed);
+        Assertions.assertEquals(1, event.getCount());
+
+        Assertions.assertTrue(
+                EventUtils.createByInterval(
+                        kubernetesClient,
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        null,
+                        EventRecorder.Component.Operator,
+                        consumer,
+                        null,
+                        1800));
+    }
+
+    @Test
     public void testCreateWithMessageKey() {
         var consumer =
                 new Consumer<Event>() {
@@ -172,6 +250,129 @@ public class EventUtilsTest {
         Assertions.assertNotNull(event);
         Assertions.assertEquals("message2", event.getMessage());
         Assertions.assertEquals(2, event.getCount());
+    }
+
+    @Test
+    public void testCreateByIntervalWithMessageKey() {
+        var consumer =
+                new Consumer<Event>() {
+                    @Override
+                    public void accept(Event event) {
+                        eventConsumed = event;
+                    }
+                };
+        var flinkApp = TestUtils.buildApplicationCluster();
+        var reason = "Cleanup";
+        var eventName =
+                EventUtils.generateEventName(
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        "mk",
+                        EventRecorder.Component.Operator);
+
+        eventConsumed = null;
+        Assertions.assertTrue(
+                EventUtils.createByInterval(
+                        kubernetesClient,
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        "message1",
+                        EventRecorder.Component.Operator,
+                        consumer,
+                        "mk",
+                        1800));
+        var event =
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(flinkApp.getMetadata().getNamespace())
+                        .withName(eventName)
+                        .get();
+        Assertions.assertNotNull(event);
+        Assertions.assertEquals(eventConsumed, event);
+        Assertions.assertEquals("message1", event.getMessage());
+        Assertions.assertEquals(1, event.getCount());
+
+        eventConsumed = null;
+        Assertions.assertFalse(
+                EventUtils.createByInterval(
+                        kubernetesClient,
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        "message2",
+                        EventRecorder.Component.Operator,
+                        consumer,
+                        "mk",
+                        1800));
+
+        event =
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(flinkApp.getMetadata().getNamespace())
+                        .withName(eventName)
+                        .get();
+        Assertions.assertNotNull(event);
+        Assertions.assertEquals(eventConsumed, event);
+        Assertions.assertEquals("message2", event.getMessage());
+        Assertions.assertEquals(2, event.getCount());
+
+        eventConsumed = null;
+        Assertions.assertFalse(
+                EventUtils.createByInterval(
+                        kubernetesClient,
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        "message2",
+                        EventRecorder.Component.Operator,
+                        consumer,
+                        "mk",
+                        1800));
+
+        event =
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(flinkApp.getMetadata().getNamespace())
+                        .withName(eventName)
+                        .get();
+        Assertions.assertNotNull(event);
+        Assertions.assertNull(eventConsumed);
+
+        eventConsumed = null;
+        Assertions.assertTrue(
+                EventUtils.createByInterval(
+                        kubernetesClient,
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        "message2",
+                        EventRecorder.Component.Operator,
+                        consumer,
+                        "mk2",
+                        1800));
+        eventName =
+                EventUtils.generateEventName(
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        reason,
+                        "mk2",
+                        EventRecorder.Component.Operator);
+        event =
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(flinkApp.getMetadata().getNamespace())
+                        .withName(eventName)
+                        .get();
+        Assertions.assertNotNull(event);
+        Assertions.assertEquals(eventConsumed, event);
+        Assertions.assertEquals("message2", event.getMessage());
+        Assertions.assertEquals(1, event.getCount());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

https://issues.apache.org/jira/browse/FLINK-33187
Suppress duplicate event for scaling report within the interval defined by a new operator config "scaling.report.interval" in second, defaulted to 1800.

## Brief change log

  - Add a new method in EventUtil to suppress duplicate event within an interval.
  - Suppress duplicate event for scaling report within the interval defined by a new operator config "scaling.report.interval" in second, defaulted to 1800.

## Verifying this change
This change added tests and can be verified as follows:

  - manually verify by reading records

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: No
  - Core observer or reconciler logic that is regularly executed: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? docs
