### PR TITLE
[FLINK-33187] using hashcode for parallelism map comparison

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -117,7 +117,7 @@
             <td>Enable vertex scaling execution by the autoscaler. If disabled, the autoscaler will only collect metrics and evaluate the suggested parallelism for each vertex but will not upgrade the jobs.</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.scaling.report.interval</h5></td>
+            <td><h5>job.autoscaler.event.report.interval</h5></td>
             <td style="word-wrap: break-word;">30 min</td>
             <td>Duration</td>
             <td>Time interval to resend the identical event</td>

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -117,7 +117,7 @@
             <td>Enable vertex scaling execution by the autoscaler. If disabled, the autoscaler will only collect metrics and evaluate the suggested parallelism for each vertex but will not upgrade the jobs.</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.event.report.interval</h5></td>
+            <td><h5>job.autoscaler.scaling.event.interval</h5></td>
             <td style="word-wrap: break-word;">30 min</td>
             <td>Duration</td>
             <td>Time interval to resend the identical event</td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -194,12 +194,7 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
         LOG.error("Error while scaling job", e);
         autoscalerMetrics.incrementError();
         eventHandler.handleEvent(
-                ctx,
-                AutoScalerEventHandler.Type.Warning,
-                AUTOSCALER_ERROR,
-                e.getMessage(),
-                null,
-                null);
+                ctx, AutoScalerEventHandler.Type.Warning, AUTOSCALER_ERROR, e.getMessage(), null);
     }
 
     private AutoscalerFlinkMetrics getOrInitAutoscalerFlinkMetrics(Context ctx) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -194,7 +194,12 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
         LOG.error("Error while scaling job", e);
         autoscalerMetrics.incrementError();
         eventHandler.handleEvent(
-                ctx, AutoScalerEventHandler.Type.Warning, AUTOSCALER_ERROR, e.getMessage(), null);
+                ctx,
+                AutoScalerEventHandler.Type.Warning,
+                AUTOSCALER_ERROR,
+                e.getMessage(),
+                null,
+                null);
     }
 
     private AutoscalerFlinkMetrics getOrInitAutoscalerFlinkMetrics(Context ctx) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -39,6 +39,7 @@ import java.util.SortedMap;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.MAX_SCALE_DOWN_FACTOR;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.MAX_SCALE_UP_FACTOR;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALE_UP_GRACE_PERIOD;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_EVENT_INTERVAL;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.VERTEX_MAX_PARALLELISM;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.VERTEX_MIN_PARALLELISM;
@@ -214,7 +215,12 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
         var message = String.format(INEFFECTIVE_MESSAGE_FORMAT, vertex);
 
         autoScalerEventHandler.handleEvent(
-                context, AutoScalerEventHandler.Type.Normal, INEFFECTIVE_SCALING, message, null);
+                context,
+                AutoScalerEventHandler.Type.Normal,
+                INEFFECTIVE_SCALING,
+                message,
+                null,
+                conf.get(SCALING_EVENT_INTERVAL));
 
         if (conf.get(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED)) {
             LOG.warn(

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -214,12 +214,7 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
         var message = String.format(INEFFECTIVE_MESSAGE_FORMAT, vertex);
 
         autoScalerEventHandler.handleEvent(
-                context,
-                AutoScalerEventHandler.Type.Normal,
-                INEFFECTIVE_SCALING,
-                message,
-                null,
-                null);
+                context, AutoScalerEventHandler.Type.Normal, INEFFECTIVE_SCALING, message, null);
 
         if (conf.get(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED)) {
             LOG.warn(

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -40,21 +40,12 @@ import java.util.SortedMap;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_ENABLED;
 import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.addToScalingHistoryAndStore;
 import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.getTrimmedScalingHistory;
-import static org.apache.flink.autoscaler.metrics.ScalingMetric.EXPECTED_PROCESSING_RATE;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.SCALE_DOWN_RATE_THRESHOLD;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.SCALE_UP_RATE_THRESHOLD;
-import static org.apache.flink.autoscaler.metrics.ScalingMetric.TARGET_DATA_RATE;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_RATE;
 
 /** Class responsible for executing scaling decisions. */
 public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
-    public static final String SCALING_SUMMARY_ENTRY =
-            " Vertex ID %s | Parallelism %d -> %d | Processing capacity %.2f -> %.2f | Target data rate %.2f";
-    public static final String SCALING_SUMMARY_HEADER_SCALING_DISABLED =
-            "Recommended parallelism change:";
-    public static final String SCALING_SUMMARY_HEADER_SCALING_ENABLED = "Scaling vertices:";
-    @VisibleForTesting static final String SCALING_REPORT_REASON = "ScalingReport";
-
     private static final Logger LOG = LoggerFactory.getLogger(ScalingExecutor.class);
 
     private final JobVertexScaler<KEY, Context> jobVertexScaler;
@@ -100,18 +91,9 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
 
         updateRecommendedParallelism(evaluatedMetrics, scalingSummaries);
 
-        var scalingEnabled = conf.get(SCALING_ENABLED);
+        autoScalerEventHandler.handleScalingEvent(context, scalingSummaries);
 
-        var scalingReport = scalingReport(scalingSummaries, scalingEnabled);
-        autoScalerEventHandler.handleEvent(
-                context,
-                AutoScalerEventHandler.Type.Normal,
-                SCALING_REPORT_REASON,
-                scalingReport,
-                "ScalingExecutor",
-                scalingEnabled ? null : conf.get(AutoScalerOptions.SCALING_REPORT_INTERVAL));
-
-        if (!scalingEnabled) {
+        if (!conf.get(SCALING_ENABLED)) {
             return false;
         }
 
@@ -134,27 +116,6 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                                         ScalingMetric.RECOMMENDED_PARALLELISM,
                                         EvaluatedScalingMetric.of(
                                                 scalingSummary.getNewParallelism())));
-    }
-
-    private static String scalingReport(
-            Map<JobVertexID, ScalingSummary> scalingSummaries, boolean scalingEnabled) {
-        StringBuilder sb =
-                new StringBuilder(
-                        scalingEnabled
-                                ? SCALING_SUMMARY_HEADER_SCALING_ENABLED
-                                : SCALING_SUMMARY_HEADER_SCALING_DISABLED);
-        scalingSummaries.forEach(
-                (v, s) ->
-                        sb.append(
-                                String.format(
-                                        SCALING_SUMMARY_ENTRY,
-                                        v,
-                                        s.getCurrentParallelism(),
-                                        s.getNewParallelism(),
-                                        s.getMetrics().get(TRUE_PROCESSING_RATE).getAverage(),
-                                        s.getMetrics().get(EXPECTED_PROCESSING_RATE).getCurrent(),
-                                        s.getMetrics().get(TARGET_DATA_RATE).getAverage())));
-        return sb.toString();
     }
 
     protected static boolean allVerticesWithinUtilizationTarget(
@@ -190,7 +151,8 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
         return true;
     }
 
-    private Map<JobVertexID, ScalingSummary> computeScalingSummary(
+    @VisibleForTesting
+    Map<JobVertexID, ScalingSummary> computeScalingSummary(
             Context context,
             Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluatedMetrics,
             Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.SortedMap;
 
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_ENABLED;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_EVENT_INTERVAL;
 import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.addToScalingHistoryAndStore;
 import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.getTrimmedScalingHistory;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.SCALE_DOWN_RATE_THRESHOLD;
@@ -91,9 +92,11 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
 
         updateRecommendedParallelism(evaluatedMetrics, scalingSummaries);
 
-        autoScalerEventHandler.handleScalingEvent(context, scalingSummaries);
+        var scaleEnabled = conf.get(SCALING_ENABLED);
+        autoScalerEventHandler.handleScalingEvent(
+                context, scalingSummaries, scaleEnabled, conf.get(SCALING_EVENT_INTERVAL));
 
-        if (!conf.get(SCALING_ENABLED)) {
+        if (!scaleEnabled) {
             return false;
         }
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -235,6 +235,7 @@ public class AutoScalerOptions {
             autoScalerConfig("scaling.event.interval")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(1800))
+                    .withDeprecatedKeys(deprecatedOperatorConfigKey("scaling.event.interval"))
                     .withDescription("Time interval to resend the identical event");
 
     public static final ConfigOption<Duration> FLINK_CLIENT_TIMEOUT =

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -231,8 +231,8 @@ public class AutoScalerOptions {
                     .withDescription(
                             "A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling. Caution: For non-sink vertices this will still scale their downstream operators until https://issues.apache.org/jira/browse/FLINK-31215 is implemented.");
 
-    public static final ConfigOption<Duration> SCALING_REPORT_INTERVAL =
-            autoScalerConfig("scaling.report.interval")
+    public static final ConfigOption<Duration> SCALING_EVENT_INTERVAL =
+            autoScalerConfig("scaling.event.interval")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(1800))
                     .withDescription("Time interval to resend the identical event");

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -37,8 +37,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.autoscaler.ScalingExecutor.SCALING_SUMMARY_ENTRY;
 import static org.apache.flink.autoscaler.TestingAutoscalerUtils.createDefaultJobAutoScalerContext;
+import static org.apache.flink.autoscaler.event.AutoScalerEventHandler.SCALING_REPORT_REASON;
+import static org.apache.flink.autoscaler.event.AutoScalerEventHandler.SCALING_SUMMARY_ENTRY;
+import static org.apache.flink.autoscaler.event.AutoScalerEventHandler.SCALING_SUMMARY_HEADER_SCALING_DISABLED;
+import static org.apache.flink.autoscaler.event.AutoScalerEventHandler.SCALING_SUMMARY_HEADER_SCALING_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -208,9 +211,9 @@ public class ScalingExecutorTest {
                 event.getMessage()
                         .contains(
                                 scalingEnabled
-                                        ? ScalingExecutor.SCALING_SUMMARY_HEADER_SCALING_ENABLED
-                                        : ScalingExecutor.SCALING_SUMMARY_HEADER_SCALING_DISABLED));
-        assertEquals(ScalingExecutor.SCALING_REPORT_REASON, event.getReason());
+                                        ? SCALING_SUMMARY_HEADER_SCALING_ENABLED
+                                        : SCALING_SUMMARY_HEADER_SCALING_DISABLED));
+        assertEquals(SCALING_REPORT_REASON, event.getReason());
 
         metrics = Map.of(jobVertexID, evaluated(1, 110, 101));
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -154,19 +154,20 @@ public class ScalingExecutorTest {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testScalingEventsWith0Interval(boolean scalingEnabled) throws Exception {
+    public void testScalingEventsWith0IntervalConfig(boolean scalingEnabled) throws Exception {
         testScalingEvents(scalingEnabled, Duration.ofSeconds(0));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testScalingEventsWithInterval(boolean scalingEnabled) throws Exception {
+    public void testScalingEventsWithIntervalConfig(boolean scalingEnabled) throws Exception {
         testScalingEvents(scalingEnabled, Duration.ofSeconds(1800));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    public void testScalingEventsWithDefaultInterval(boolean scalingEnabled) throws Exception {
+    public void testScalingEventsWithDefaultIntervalConfig(boolean scalingEnabled)
+            throws Exception {
         testScalingEvents(scalingEnabled, null);
     }
 
@@ -178,17 +179,13 @@ public class ScalingExecutorTest {
         var metrics = Map.of(jobVertexID, evaluated(1, 110, 100));
 
         if (interval != null) {
-            conf.set(AutoScalerOptions.SCALING_REPORT_INTERVAL, interval);
+            conf.set(AutoScalerOptions.SCALING_EVENT_INTERVAL, interval);
         }
 
         assertEquals(scalingEnabled, scalingDecisionExecutor.scaleResource(context, metrics));
         assertEquals(scalingEnabled, scalingDecisionExecutor.scaleResource(context, metrics));
 
-        int expectedSize =
-                (interval == null || (!interval.isNegative() && !interval.isZero()))
-                                && !scalingEnabled
-                        ? 1
-                        : 2;
+        int expectedSize = (interval == null || interval.toMillis() > 0) && !scalingEnabled ? 1 : 2;
         assertEquals(expectedSize, eventCollector.events.size());
 
         TestingEventCollector.Event<JobID, JobAutoScalerContext<JobID>> event;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerEventHandler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerEventHandler.java
@@ -17,19 +17,29 @@
 
 package org.apache.flink.kubernetes.operator.autoscaler;
 
+import org.apache.flink.autoscaler.ScalingSummary;
 import org.apache.flink.autoscaler.event.AutoScalerEventHandler;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 import javax.annotation.Nullable;
 
-import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiPredicate;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_ENABLED;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_REPORT_INTERVAL;
 
 /** An event handler which posts events to the Kubernetes events API. */
 public class KubernetesAutoScalerEventHandler
         implements AutoScalerEventHandler<ResourceID, KubernetesJobAutoScalerContext> {
 
+    public static final String PARALLELISM_MAP_KEY = "parallelismMap";
     private final EventRecorder eventRecorder;
 
     public KubernetesAutoScalerEventHandler(EventRecorder eventRecorder) {
@@ -42,27 +52,71 @@ public class KubernetesAutoScalerEventHandler
             Type type,
             String reason,
             String message,
-            @Nullable String messageKey,
-            @Nullable Duration interval) {
-        if (interval == null) {
-            eventRecorder.triggerEvent(
-                    context.getResource(),
-                    EventRecorder.Type.valueOf(type.name()),
-                    reason,
-                    message,
-                    EventRecorder.Component.Operator,
-                    messageKey,
-                    context.getKubernetesClient());
+            @Nullable String messageKey) {
+        eventRecorder.triggerEvent(
+                context.getResource(),
+                EventRecorder.Type.valueOf(type.name()),
+                reason,
+                message,
+                EventRecorder.Component.Operator,
+                messageKey,
+                context.getKubernetesClient());
+    }
+
+    @Override
+    public void handleScalingEvent(
+            KubernetesJobAutoScalerContext context,
+            Map<JobVertexID, ScalingSummary> scalingSummaries) {
+        var scalingEnabled = context.getConfiguration().get(SCALING_ENABLED);
+        if (scalingEnabled) {
+            AutoScalerEventHandler.super.handleScalingEvent(context, scalingSummaries);
         } else {
-            eventRecorder.triggerEventByInterval(
+            var conf = context.getConfiguration();
+            var scalingReport =
+                    AutoScalerEventHandler.scalingReport(scalingSummaries, scalingEnabled);
+            var labels = Map.of(PARALLELISM_MAP_KEY, getParallelismHashCode(scalingSummaries));
+            var interval = context.getConfiguration().get(SCALING_REPORT_INTERVAL);
+
+            @Nullable
+            BiPredicate<Map<String, String>, Instant> suppressionPredicate =
+                    new BiPredicate<Map<String, String>, Instant>() {
+                        @Override
+                        public boolean test(Map<String, String> stringStringMap, Instant instant) {
+                            return Instant.now().isBefore(instant.plusMillis(interval.toMillis()))
+                                    && stringStringMap != null
+                                    && Objects.equals(
+                                            stringStringMap.get(PARALLELISM_MAP_KEY),
+                                            getParallelismHashCode(scalingSummaries));
+                        }
+                    };
+
+            eventRecorder.triggerEventWithLabels(
                     context.getResource(),
-                    EventRecorder.Type.valueOf(type.name()),
-                    reason,
+                    EventRecorder.Type.Normal,
+                    AutoScalerEventHandler.SCALING_REPORT_REASON,
+                    scalingReport,
                     EventRecorder.Component.Operator,
-                    message,
-                    messageKey,
+                    AutoScalerEventHandler.EVENT_MESSAGE_KEY,
                     context.getKubernetesClient(),
-                    interval);
+                    suppressionPredicate,
+                    labels);
         }
+    }
+
+    private static String getParallelismHashCode(
+            Map<JobVertexID, ScalingSummary> scalingSummaryHashMap) {
+        return Integer.toString(
+                scalingSummaryHashMap.entrySet().stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                e -> e.getKey().toString(),
+                                                e ->
+                                                        String.format(
+                                                                "Parallelism %d -> %d",
+                                                                e.getValue()
+                                                                        .getCurrentParallelism(),
+                                                                e.getValue().getNewParallelism())))
+                                .hashCode()
+                        & 0x7FFFFFFF);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -203,8 +203,8 @@ public abstract class AbstractFlinkResourceReconciler<
                 cr,
                 EventRecorder.Type.Normal,
                 EventRecorder.Reason.SpecChanged,
-                EventRecorder.Component.JobManagerDeployment,
                 String.format(MSG_SPEC_CHANGED, specDiff.getType(), specDiff),
+                EventRecorder.Component.JobManagerDeployment,
                 "SpecChange: " + cr.getMetadata().getGeneration(),
                 client);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -20,14 +20,15 @@ package org.apache.flink.kubernetes.operator.utils;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
 import javax.annotation.Nullable;
 
-import java.time.Duration;
 import java.time.Instant;
-import java.util.Objects;
+import java.util.Map;
+import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 
 /**
@@ -63,7 +64,7 @@ public class EventUtils {
             EventRecorder.Component component,
             Consumer<Event> eventListener,
             @Nullable String messageKey) {
-        return createByInterval(
+        return createOrUpdateEventWithLabels(
                 client,
                 target,
                 type,
@@ -72,10 +73,11 @@ public class EventUtils {
                 component,
                 eventListener,
                 messageKey,
-                Duration.ofSeconds(0));
+                null,
+                Map.of());
     }
 
-    private static Event findExistingEvent(
+    public static Event findExistingEvent(
             KubernetesClient client, HasMetadata target, String eventName) {
         return client.v1()
                 .events()
@@ -102,13 +104,13 @@ public class EventUtils {
         if (existing != null) {
             return false;
         } else {
-            createNewEvent(
-                    client, target, type, reason, message, component, eventListener, eventName);
+            Event event = buildEvent(target, type, reason, message, component, eventName);
+            eventListener.accept(client.resource(event).createOrReplace());
             return true;
         }
     }
 
-    public static boolean createByInterval(
+    public static boolean createOrUpdateEventWithLabels(
             KubernetesClient client,
             HasMetadata target,
             EventRecorder.Type type,
@@ -117,53 +119,53 @@ public class EventUtils {
             EventRecorder.Component component,
             Consumer<Event> eventListener,
             @Nullable String messageKey,
-            Duration interval) {
-
+            @Nullable BiPredicate<Map<String, String>, Instant> suppressionPredicate,
+            @Nullable Map<String, String> labels) {
         String eventName =
                 generateEventName(
                         target, type, reason, messageKey != null ? messageKey : message, component);
         Event existing = findExistingEvent(client, target, eventName);
 
         if (existing != null) {
-            if (Objects.equals(existing.getMessage(), message)
-                    && Instant.now()
-                            .isBefore(
-                                    Instant.parse(existing.getLastTimestamp())
-                                            .plusMillis(interval.toMillis()))) {
-                return false;
-            } else {
-                createUpdatedEvent(existing, client, message, eventListener);
+            if (suppressionPredicate != null
+                    && existing.getMetadata() != null
+                    && suppressionPredicate.test(
+                            existing.getMetadata().getLabels(),
+                            Instant.parse(existing.getLastTimestamp()))) {
                 return false;
             }
+            updatedEventWithLabels(existing, client, message, eventListener, labels);
+            return false;
         } else {
-            createNewEvent(
-                    client, target, type, reason, message, component, eventListener, eventName);
+            Event event = buildEvent(target, type, reason, message, component, eventName);
+            setLabels(event, labels);
+            eventListener.accept(client.resource(event).createOrReplace());
             return true;
         }
     }
 
-    private static void createUpdatedEvent(
+    private static void updatedEventWithLabels(
             Event existing,
             KubernetesClient client,
             String message,
-            Consumer<Event> eventListener) {
+            Consumer<Event> eventListener,
+            @Nullable Map<String, String> labels) {
         existing.setLastTimestamp(Instant.now().toString());
         existing.setCount(existing.getCount() + 1);
         existing.setMessage(message);
+        setLabels(existing, labels);
         eventListener.accept(client.resource(existing).createOrReplace());
     }
 
-    private static void createNewEvent(
-            KubernetesClient client,
-            HasMetadata target,
-            EventRecorder.Type type,
-            String reason,
-            String message,
-            EventRecorder.Component component,
-            Consumer<Event> eventListener,
-            String eventName) {
-        Event event = buildEvent(target, type, reason, message, component, eventName);
-        eventListener.accept(client.resource(event).createOrReplace());
+    private static void setLabels(Event existing, @Nullable Map<String, String> labels) {
+        if (existing.getMetadata() == null) {
+            var metaData = new ObjectMeta();
+            metaData.setLabels(labels);
+        } else if (existing.getMetadata().getLabels() == null) {
+            existing.getMetadata().setLabels(labels);
+        } else {
+            existing.getMetadata().setLabels(labels);
+        }
     }
 
     private static Event buildEvent(


### PR DESCRIPTION
## What is the purpose of the change

This is to implement the scaling report comparison algorithm for event suppression by using hashcodes of the parallelism maps. Originally I used the full string of report message which contains the metrics fluctuating with current load. As long as parallelism map doesn't change, we don't need to generate new events within the defined interval.


## Brief change log
  - Save hashcode of the parallelism map to metadata labels
  - Use the hashcode to compare two scaling report for advice

## Verifying this change
  - Updated and added unit tests.
  - Verified in integration test env.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: No
  - Core observer or reconciler logic that is regularly executed: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? N/A
