### PR TITLE
[FLINK-33306] Use observed source throughput as true processing rate

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -57,6 +57,24 @@
             <td>Scaling metrics aggregation window size.</td>
         </tr>
         <tr>
+            <td><h5>job.autoscaler.observed-tpr.lag-threshold</h5></td>
+            <td style="word-wrap: break-word;">30 s</td>
+            <td>Duration</td>
+            <td>Lag threshold for enabling observed tpr measurements.</td>
+        </tr>
+        <tr>
+            <td><h5>job.autoscaler.observed-tpr.min-observations</h5></td>
+            <td style="word-wrap: break-word;">2</td>
+            <td>Integer</td>
+            <td>Minimum nr of observations used when estimating / switching to observed tpr</td>
+        </tr>
+        <tr>
+            <td><h5>job.autoscaler.observed-tpr.switch-threshold</h5></td>
+            <td style="word-wrap: break-word;">0.15</td>
+            <td>Double</td>
+            <td>Percentage threshold for switching to observed from busy time based true processing rate  if the measurement is off by at least the configured fraction. For example 0.15 means we switch to observed TPR if the busy time based one is at least 15% higher during catchup.</td>
+        </tr>
+        <tr>
             <td><h5>job.autoscaler.restart.time</h5></td>
             <td style="word-wrap: break-word;">3 min</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -57,22 +57,22 @@
             <td>Scaling metrics aggregation window size.</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.observed-tpr.lag-threshold</h5></td>
+            <td><h5>job.autoscaler.observed-true-processing-rate.lag-threshold</h5></td>
             <td style="word-wrap: break-word;">30 s</td>
             <td>Duration</td>
-            <td>Lag threshold for enabling observed tpr measurements.</td>
+            <td>Lag threshold for enabling observed true processing rate measurements.</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.observed-tpr.min-observations</h5></td>
+            <td><h5>job.autoscaler.observed-true-processing-rate.min-observations</h5></td>
             <td style="word-wrap: break-word;">2</td>
             <td>Integer</td>
-            <td>Minimum nr of observations used when estimating / switching to observed tpr</td>
+            <td>Minimum nr of observations used when estimating / switching to observed true processing rate.</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.observed-tpr.switch-threshold</h5></td>
+            <td><h5>job.autoscaler.observed-true-processing-rate.switch-threshold</h5></td>
             <td style="word-wrap: break-word;">0.15</td>
             <td>Double</td>
-            <td>Percentage threshold for switching to observed from busy time based true processing rate  if the measurement is off by at least the configured fraction. For example 0.15 means we switch to observed TPR if the busy time based one is at least 15% higher during catchup.</td>
+            <td>Percentage threshold for switching to observed from busy time based true processing rate if the measurement is off by at least the configured fraction. For example 0.15 means we switch to observed if the busy time based computation is at least 15% higher during catchup.</td>
         </tr>
         <tr>
             <td><h5>job.autoscaler.restart.time</h5></td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -163,7 +163,6 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
 
         for (Map.Entry<JobVertexID, ScalingSummary> entry : scalingSummaries.entrySet()) {
             var vertex = entry.getKey();
-            var scalingSummary = entry.getValue();
             var metrics = evaluatedMetrics.get(vertex);
 
             double processingRate = metrics.get(TRUE_PROCESSING_RATE).getAverage();

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
@@ -363,25 +363,13 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                                         queryFilteredMetricNames(
                                                 ctx,
                                                 topology,
-                                                vertices.stream()
-                                                        .filter(topology::isSource)
-                                                        .filter(
-                                                                v ->
-                                                                        !topology.getFinishedVertices()
-                                                                                .contains(v)));
+                                                vertices.stream().filter(topology::isSource));
                                 newMetricNames.putAll(sourceMetricNames);
                                 return newMetricNames;
                             }
 
                             // Query all metric names
-                            return queryFilteredMetricNames(
-                                    ctx,
-                                    topology,
-                                    vertices.stream()
-                                            .filter(
-                                                    v ->
-                                                            !topology.getFinishedVertices()
-                                                                    .contains(v)));
+                            return queryFilteredMetricNames(ctx, topology, vertices.stream());
                         });
         names.keySet().removeAll(topology.getFinishedVertices());
         return names;

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
@@ -59,8 +59,10 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.updateVertexList;
 import static org.apache.flink.autoscaler.utils.AutoScalerUtils.excludeVerticesFromScaling;
@@ -97,32 +99,30 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                             }
                         });
 
-        // The timestamp of the first metric observation marks the start
-        // If we haven't collected any metrics, we are starting now
-        var metricCollectionStartTs = metricHistory.isEmpty() ? now : metricHistory.firstKey();
-
         var jobDetailsInfo =
                 getJobDetailsInfo(ctx, conf.get(AutoScalerOptions.FLINK_CLIENT_TIMEOUT));
         var jobUpdateTs = getJobUpdateTs(jobDetailsInfo);
-        if (jobUpdateTs.isAfter(metricCollectionStartTs)) {
+        // We detect job change compared to our collected metrics by checking against the earliest
+        // metric timestamp
+        if (!metricHistory.isEmpty() && jobUpdateTs.isAfter(metricHistory.firstKey())) {
             LOG.info("Job updated at {}. Clearing metrics.", jobUpdateTs);
             stateStore.removeEvaluatedMetrics(ctx);
             cleanup(ctx.getJobKey());
             metricHistory.clear();
-            metricCollectionStartTs = now;
         }
         var topology = getJobTopology(ctx, stateStore, jobDetailsInfo);
+        var stableTime = jobUpdateTs.plus(conf.get(AutoScalerOptions.STABILIZATION_INTERVAL));
+
+        // Calculate timestamp when the metric windows is full
+        var metricWindowSize = getMetricWindowSize(conf);
+        var metricsAfterStable = metricHistory.tailMap(stableTime);
+        var windowFullTime =
+                metricsAfterStable.isEmpty()
+                        ? now.plus(metricWindowSize)
+                        : metricsAfterStable.firstKey().plus(metricWindowSize);
 
         // Trim metrics outside the metric window from metrics history
-        var metricWindowSize = getMetricWindowSize(conf);
         metricHistory.headMap(now.minus(metricWindowSize)).clear();
-
-        var stableTime = jobUpdateTs.plus(conf.get(AutoScalerOptions.STABILIZATION_INTERVAL));
-        if (now.isBefore(stableTime)) {
-            // As long as we are stabilizing, collect no metrics at all
-            LOG.info("Skipping metric collection during stabilization period until {}", stableTime);
-            return new CollectedMetricHistory(topology, Collections.emptySortedMap());
-        }
 
         // The filtered list of metrics we want to query for each vertex
         var filteredVertexMetricNames = queryFilteredMetricNames(ctx, topology);
@@ -138,15 +138,19 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
         metricHistory.put(now, scalingMetrics);
         stateStore.storeEvaluatedMetrics(ctx, metricHistory);
 
-        var collectedMetrics = new CollectedMetricHistory(topology, metricHistory);
-
-        var windowFullTime = metricCollectionStartTs.plus(metricWindowSize);
-        collectedMetrics.setFullyCollected(!now.isBefore(windowFullTime));
-
-        if (!collectedMetrics.isFullyCollected()) {
-            LOG.info("Metric window not full until {}", windowFullTime);
+        if (now.isBefore(stableTime)) {
+            LOG.info("Stabilizing until {}", stableTime);
+            return new CollectedMetricHistory(topology, Collections.emptySortedMap());
         }
 
+        var collectedMetrics = new CollectedMetricHistory(topology, metricHistory);
+        if (now.isBefore(windowFullTime)) {
+            LOG.info("Metric window not full until {}", windowFullTime);
+        } else {
+            // We clear any metrics from the stabilization interval once the metric window is full
+            metricHistory.headMap(stableTime).clear();
+            collectedMetrics.setFullyCollected(true);
+        }
         return collectedMetrics;
     }
 
@@ -265,9 +269,11 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                     ScalingMetrics.computeLoadMetrics(
                             jobVertexID, vertexFlinkMetrics, vertexScalingMetrics, conf);
 
+                    var metricHistory =
+                            histories.getOrDefault(jobKey, Collections.emptySortedMap());
                     double lagGrowthRate =
                             computeLagGrowthRate(
-                                    jobKey,
+                                    metricHistory,
                                     jobVertexID,
                                     vertexScalingMetrics.get(ScalingMetric.LAG));
 
@@ -277,8 +283,11 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                             vertexScalingMetrics,
                             jobTopology,
                             lagGrowthRate,
-                            conf);
-
+                            conf,
+                            observedTprAvg(
+                                    jobVertexID,
+                                    metricHistory,
+                                    conf.get(AutoScalerOptions.OBSERVED_TPR_MIN_OBSERVATIONS)));
                     vertexScalingMetrics
                             .entrySet()
                             .forEach(e -> e.setValue(ScalingMetrics.roundMetric(e.getValue())));
@@ -292,10 +301,21 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
         return new CollectedMetrics(out, outputRatios);
     }
 
-    private double computeLagGrowthRate(KEY jobKey, JobVertexID jobVertexID, Double currentLag) {
-        var metricHistory = histories.get(jobKey);
+    private static Supplier<Double> observedTprAvg(
+            JobVertexID jobVertexID,
+            SortedMap<Instant, CollectedMetrics> metricHistory,
+            int minObservations) {
+        return () ->
+                ScalingMetricEvaluator.getAverage(
+                        ScalingMetric.OBSERVED_TPR, jobVertexID, metricHistory, minObservations);
+    }
 
-        if (metricHistory == null || metricHistory.isEmpty()) {
+    private double computeLagGrowthRate(
+            SortedMap<Instant, CollectedMetrics> metricHistory,
+            JobVertexID jobVertexID,
+            Double currentLag) {
+
+        if (metricHistory.isEmpty()) {
             return Double.NaN;
         }
 
@@ -332,28 +352,49 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                                     && previousMetricNames
                                             .keySet()
                                             .equals(topology.getParallelisms().keySet())) {
-                                // We have already gathered the metric names for this topology
-                                return previousMetricNames;
+                                var newMetricNames = new HashMap<>(previousMetricNames);
+                                var sourceMetricNames =
+                                        queryFilteredMetricNames(
+                                                ctx,
+                                                topology,
+                                                vertices.stream()
+                                                        .filter(topology::isSource)
+                                                        .filter(
+                                                                v ->
+                                                                        !topology.getFinishedVertices()
+                                                                                .contains(v)));
+                                newMetricNames.putAll(sourceMetricNames);
+                                return newMetricNames;
                             }
 
-                            try (var restClient = ctx.getRestClusterClient()) {
-                                return vertices.stream()
-                                        .filter(v -> !topology.getFinishedVertices().contains(v))
-                                        .collect(
-                                                Collectors.toMap(
-                                                        v -> v,
-                                                        v ->
-                                                                getFilteredVertexMetricNames(
-                                                                        restClient,
-                                                                        ctx.getJobID(),
-                                                                        v,
-                                                                        topology)));
-                            } catch (Exception e) {
-                                throw new RuntimeException(e);
-                            }
+                            // Query all metric names
+                            return queryFilteredMetricNames(
+                                    ctx,
+                                    topology,
+                                    vertices.stream()
+                                            .filter(
+                                                    v ->
+                                                            !topology.getFinishedVertices()
+                                                                    .contains(v)));
                         });
         names.keySet().removeAll(topology.getFinishedVertices());
         return names;
+    }
+
+    private Map<JobVertexID, Map<String, FlinkMetric>> queryFilteredMetricNames(
+            Context ctx, JobTopology topology, Stream<JobVertexID> vertexStream) {
+        try (var restClient = ctx.getRestClusterClient()) {
+            return vertexStream
+                    .filter(v -> !topology.getFinishedVertices().contains(v))
+                    .collect(
+                            Collectors.toMap(
+                                    v -> v,
+                                    v ->
+                                            getFilteredVertexMetricNames(
+                                                    restClient, ctx.getJobID(), v, topology)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
@@ -378,6 +419,7 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
         requiredMetrics.add(FlinkMetric.BUSY_TIME_PER_SEC);
 
         if (topology.isSource(jobVertexID)) {
+            requiredMetrics.add(FlinkMetric.BACKPRESSURE_TIME_PER_SEC);
             requiredMetrics.add(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC);
             // Pending records metric won't be available for some sources.
             // The Kafka source, for instance, lazily initializes this metric on receiving

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -165,7 +165,7 @@ public class ScalingMetricEvaluator {
                         OBSERVED_TPR,
                         vertex,
                         metricsHistory,
-                        conf.get(AutoScalerOptions.OBSERVED_TPR_MIN_OBSERVATIONS));
+                        conf.get(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_MIN_OBSERVATIONS));
 
         var tprMetric = selectTprMetric(vertex, conf, busyTimeTprAvg, observedTprAvg);
         return new EvaluatedScalingMetric(
@@ -187,7 +187,8 @@ public class ScalingMetricEvaluator {
             return TRUE_PROCESSING_RATE;
         }
 
-        double switchThreshold = conf.get(AutoScalerOptions.OBSERVED_TPR_SWITCH_THRESHOLD);
+        double switchThreshold =
+                conf.get(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_SWITCH_THRESHOLD);
         // If we could measure the observed tpr we decide whether to switch to using it
         // instead of busy time based on the error / difference between the two
         if (busyTimeTprAvg > observedTprAvg * (1 + switchThreshold)) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -151,6 +151,31 @@ public class AutoScalerOptions {
                     .withDescription(
                             "Lag threshold which will prevent unnecessary scalings while removing the pending messages responsible for the lag.");
 
+    public static final ConfigOption<Duration> OBSERVE_TPR_LAG_THRESHOLD =
+            autoScalerConfig("observed-tpr.lag-threshold")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    .withDeprecatedKeys(deprecatedOperatorConfigKey("observed-tpr.lag-threshold"))
+                    .withDescription("Lag threshold for enabling observed tpr measurements.");
+
+    public static final ConfigOption<Double> OBSERVED_TPR_SWITCH_THRESHOLD =
+            autoScalerConfig("observed-tpr.switch-threshold")
+                    .doubleType()
+                    .defaultValue(0.15)
+                    .withDeprecatedKeys(
+                            deprecatedOperatorConfigKey("observed-tpr.switch-threshold"))
+                    .withDescription(
+                            "Percentage threshold for switching to observed from busy time based true processing rate  if the measurement is off by at least the configured fraction. For example 0.15 means we switch to observed TPR if the busy time based one is at least 15% higher during catchup.");
+
+    public static final ConfigOption<Integer> OBSERVED_TPR_MIN_OBSERVATIONS =
+            autoScalerConfig("observed-tpr.min-observations")
+                    .intType()
+                    .defaultValue(2)
+                    .withDeprecatedKeys(
+                            deprecatedOperatorConfigKey("observed-tpr.min-observations"))
+                    .withDescription(
+                            "Minimum nr of observations used when estimating / switching to observed tpr");
+
     public static final ConfigOption<Boolean> SCALING_EFFECTIVENESS_DETECTION_ENABLED =
             autoScalerConfig("scaling.effectiveness.detection.enabled")
                     .booleanType()

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -151,30 +151,35 @@ public class AutoScalerOptions {
                     .withDescription(
                             "Lag threshold which will prevent unnecessary scalings while removing the pending messages responsible for the lag.");
 
-    public static final ConfigOption<Duration> OBSERVE_TPR_LAG_THRESHOLD =
-            autoScalerConfig("observed-tpr.lag-threshold")
+    public static final ConfigOption<Duration> OBSERVE_TRUE_PROCESSING_RATE_LAG_THRESHOLD =
+            autoScalerConfig("observed-true-processing-rate.lag-threshold")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(30))
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("observed-tpr.lag-threshold"))
-                    .withDescription("Lag threshold for enabling observed tpr measurements.");
+                    .withDeprecatedKeys(
+                            deprecatedOperatorConfigKey(
+                                    "observed-true-processing-rate.lag-threshold"))
+                    .withDescription(
+                            "Lag threshold for enabling observed true processing rate measurements.");
 
-    public static final ConfigOption<Double> OBSERVED_TPR_SWITCH_THRESHOLD =
-            autoScalerConfig("observed-tpr.switch-threshold")
+    public static final ConfigOption<Double> OBSERVED_TRUE_PROCESSING_RATE_SWITCH_THRESHOLD =
+            autoScalerConfig("observed-true-processing-rate.switch-threshold")
                     .doubleType()
                     .defaultValue(0.15)
                     .withDeprecatedKeys(
-                            deprecatedOperatorConfigKey("observed-tpr.switch-threshold"))
+                            deprecatedOperatorConfigKey(
+                                    "observed-true-processing-rate.switch-threshold"))
                     .withDescription(
-                            "Percentage threshold for switching to observed from busy time based true processing rate  if the measurement is off by at least the configured fraction. For example 0.15 means we switch to observed TPR if the busy time based one is at least 15% higher during catchup.");
+                            "Percentage threshold for switching to observed from busy time based true processing rate if the measurement is off by at least the configured fraction. For example 0.15 means we switch to observed if the busy time based computation is at least 15% higher during catchup.");
 
-    public static final ConfigOption<Integer> OBSERVED_TPR_MIN_OBSERVATIONS =
-            autoScalerConfig("observed-tpr.min-observations")
+    public static final ConfigOption<Integer> OBSERVED_TRUE_PROCESSING_RATE_MIN_OBSERVATIONS =
+            autoScalerConfig("observed-true-processing-rate.min-observations")
                     .intType()
                     .defaultValue(2)
                     .withDeprecatedKeys(
-                            deprecatedOperatorConfigKey("observed-tpr.min-observations"))
+                            deprecatedOperatorConfigKey(
+                                    "observed-true-processing-rate.min-observations"))
                     .withDescription(
-                            "Minimum nr of observations used when estimating / switching to observed tpr");
+                            "Minimum nr of observations used when estimating / switching to observed true processing rate.");
 
     public static final ConfigOption<Boolean> SCALING_EFFECTIVENESS_DETECTION_ENABLED =
             autoScalerConfig("scaling.effectiveness.detection.enabled")

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoScalerEventHandler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoScalerEventHandler.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 
 /**
- * Handler all loggable events during scaling.
+ * Handler for autoscaler events.
  *
  * @param <KEY> The job key.
  * @param <Context> Instance of JobAutoScalerContext.

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
@@ -38,7 +38,8 @@ public enum FlinkMetric {
             s -> s.startsWith("Source__") && s.endsWith(".numRecordsOutPerSecond")),
     SOURCE_TASK_NUM_RECORDS_IN_PER_SEC(
             s -> s.startsWith("Source__") && s.endsWith(".numRecordsInPerSecond")),
-    PENDING_RECORDS(s -> s.endsWith(".pendingRecords"));
+    PENDING_RECORDS(s -> s.endsWith(".pendingRecords")),
+    BACKPRESSURE_TIME_PER_SEC(s -> s.equals("backPressuredTimeMsPerSecond"));
 
     public static final Map<FlinkMetric, AggregatedMetric> FINISHED_METRICS =
             Map.of(

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
@@ -29,6 +29,9 @@ public enum ScalingMetric {
     /** Processing rate at full capacity (records/sec). */
     TRUE_PROCESSING_RATE(true),
 
+    /** Observed true processing rate for sources. */
+    OBSERVED_TPR(true),
+
     /** Current processing rate. */
     CURRENT_PROCESSING_RATE(true),
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -103,7 +103,8 @@ public class ScalingMetrics {
         // configured observe threshold
         boolean catchingUp =
                 scalingMetrics.getOrDefault(ScalingMetric.LAG, 0.)
-                        >= conf.get(AutoScalerOptions.OBSERVE_TPR_LAG_THRESHOLD).toSeconds()
+                        >= conf.get(AutoScalerOptions.OBSERVE_TRUE_PROCESSING_RATE_LAG_THRESHOLD)
+                                        .toSeconds()
                                 * numRecordsInPerSecond;
         if (!catchingUp) {
             return Optional.empty();

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -30,6 +30,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 /** Utilities for computing scaling metrics based on Flink metrics. */
 public class ScalingMetrics {
@@ -52,11 +54,11 @@ public class ScalingMetrics {
             Map<ScalingMetric, Double> scalingMetrics,
             JobTopology topology,
             double lagGrowthRate,
-            Configuration conf) {
+            Configuration conf,
+            Supplier<Double> observedTprAvg) {
 
         var isSource = topology.isSource(jobVertexID);
 
-        double busyTimeMsPerSecond = getBusyTimeMsPerSecond(flinkMetrics, conf, jobVertexID);
         double numRecordsInPerSecond =
                 getNumRecordsInPerSecond(flinkMetrics, jobVertexID, isSource);
 
@@ -68,7 +70,15 @@ public class ScalingMetrics {
         }
 
         if (!Double.isNaN(numRecordsInPerSecond)) {
-            double trueProcessingRate = computeTrueRate(numRecordsInPerSecond, busyTimeMsPerSecond);
+            double busyTimeMsPerSecond = getBusyTimeMsPerSecond(flinkMetrics, conf, jobVertexID);
+            double trueProcessingRate =
+                    computeTprFromBusyTime(conf, numRecordsInPerSecond, busyTimeMsPerSecond);
+            if (isSource) {
+                var observedTprOpt =
+                        getObservedTpr(flinkMetrics, scalingMetrics, numRecordsInPerSecond, conf)
+                                .orElseGet(observedTprAvg);
+                scalingMetrics.put(ScalingMetric.OBSERVED_TPR, observedTprOpt);
+            }
             scalingMetrics.put(ScalingMetric.TRUE_PROCESSING_RATE, trueProcessingRate);
             scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, numRecordsInPerSecond);
         } else {
@@ -76,6 +86,44 @@ public class ScalingMetrics {
             scalingMetrics.put(ScalingMetric.TRUE_PROCESSING_RATE, Double.NaN);
             scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, Double.NaN);
         }
+    }
+
+    private static Optional<Double> getObservedTpr(
+            Map<FlinkMetric, AggregatedMetric> flinkMetrics,
+            Map<ScalingMetric, Double> scalingMetrics,
+            double numRecordsInPerSecond,
+            Configuration conf) {
+
+        // If there are no incoming records we return infinity to allow scale down
+        if (numRecordsInPerSecond == 0) {
+            return Optional.of(Double.POSITIVE_INFINITY);
+        }
+
+        // We only measure observed tpr when we are catching up, that is when the lag is beyond the
+        // configured observe threshold
+        boolean catchingUp =
+                scalingMetrics.getOrDefault(ScalingMetric.LAG, 0.)
+                        >= conf.get(AutoScalerOptions.OBSERVE_TPR_LAG_THRESHOLD).toSeconds()
+                                * numRecordsInPerSecond;
+        if (!catchingUp) {
+            return Optional.empty();
+        }
+
+        double observedTpr =
+                computeObservedTprWithBackpressure(
+                        numRecordsInPerSecond,
+                        flinkMetrics.get(FlinkMetric.BACKPRESSURE_TIME_PER_SEC).getAvg());
+
+        return Double.isNaN(observedTpr) ? Optional.empty() : Optional.of(observedTpr);
+    }
+
+    public static double computeObservedTprWithBackpressure(
+            double numRecordsInPerSecond, double backpressureMsPerSeconds) {
+        if (backpressureMsPerSeconds >= 1000) {
+            return Double.NaN;
+        }
+        double nonBackpressuredRate = (1 - (backpressureMsPerSeconds / 1000));
+        return numRecordsInPerSecond / nonBackpressuredRate;
     }
 
     public static Map<Edge, Double> computeOutputRatios(
@@ -136,10 +184,9 @@ public class ScalingMetrics {
                         "No busyTimeMsPerSecond metric available for {}. No scaling will be performed for this vertex.",
                         jobVertexId);
             }
-            // Pretend that the load is balanced because we don't know any better
-            busyTimeMsPerSecond = conf.get(AutoScalerOptions.TARGET_UTILIZATION) * 1000;
+            return Double.NaN;
         }
-        return busyTimeMsPerSecond;
+        return Math.max(0, busyTimeMsPerSecond);
     }
 
     private static double getNumRecordsInPerSecond(
@@ -159,7 +206,7 @@ public class ScalingMetrics {
             LOG.warn("Received null input rate for {}. Returning NaN.", jobVertexID);
             return Double.NaN;
         }
-        return numRecordsInPerSecond.getSum();
+        return Math.max(0, numRecordsInPerSecond.getSum());
     }
 
     private static double getNumRecordsOutPerSecond(
@@ -225,11 +272,16 @@ public class ScalingMetrics {
         return getNumRecordsOutPerSecond(fromMetrics, from);
     }
 
-    private static double computeTrueRate(double rate, double busyTimeMsPerSecond) {
-        if (rate <= 0 || busyTimeMsPerSecond <= 0) {
+    private static double computeTprFromBusyTime(
+            Configuration conf, double rate, double busyTimeMsPerSecond) {
+        if (rate == 0) {
             // Nothing is coming in, we assume infinite processing power
             // until we can sample the true processing rate (i.e. data flows).
             return Double.POSITIVE_INFINITY;
+        }
+        // Pretend that the load is balanced because we don't know any better
+        if (Double.isNaN(busyTimeMsPerSecond)) {
+            busyTimeMsPerSecond = conf.get(AutoScalerOptions.TARGET_UTILIZATION) * 1000;
         }
         return rate / (busyTimeMsPerSecond / 1000);
     }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/realizer/ScalingRealizer.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/realizer/ScalingRealizer.java
@@ -23,7 +23,8 @@ import org.apache.flink.autoscaler.JobAutoScalerContext;
 import java.util.Map;
 
 /**
- * The Scaling Realizer is responsible for managing scaling actions.
+ * The Scaling Realizer is responsible for applying scaling actions, i.e. actually rescaling the
+ * jobs.
  *
  * @param <KEY> The job key.
  * @param <Context> Instance of JobAutoScalerContext.

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
@@ -46,14 +46,13 @@ public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
 
     void removeScalingHistory(Context jobContext) throws Exception;
 
-    void storeEvaluatedMetrics(
-            Context jobContext, SortedMap<Instant, CollectedMetrics> evaluatedMetrics)
+    void storeCollectedMetrics(Context jobContext, SortedMap<Instant, CollectedMetrics> metrics)
             throws Exception;
 
-    Optional<SortedMap<Instant, CollectedMetrics>> getEvaluatedMetrics(Context jobContext)
+    Optional<SortedMap<Instant, CollectedMetrics>> getCollectedMetrics(Context jobContext)
             throws Exception;
 
-    void removeEvaluatedMetrics(Context jobContext) throws Exception;
+    void removeCollectedMetrics(Context jobContext) throws Exception;
 
     void storeParallelismOverrides(Context jobContext, Map<String, String> parallelismOverrides)
             throws Exception;

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
@@ -29,7 +29,7 @@ import java.util.SortedMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * The state store based on the Java Heap, the state will be discarded after process restarts.
+ * State store based on the Java Heap, the state will be discarded after process restarts.
  *
  * @param <KEY> The job key.
  * @param <Context> The job autoscaler context.

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
@@ -40,13 +40,13 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
     private final Map<KEY, Map<JobVertexID, SortedMap<Instant, ScalingSummary>>>
             scalingHistoryStore;
 
-    private final Map<KEY, SortedMap<Instant, CollectedMetrics>> evaluatedMetricsStore;
+    private final Map<KEY, SortedMap<Instant, CollectedMetrics>> collectedMetricsStore;
 
     private final Map<KEY, Map<String, String>> parallelismOverridesStore;
 
     public InMemoryAutoScalerStateStore() {
         scalingHistoryStore = new ConcurrentHashMap<>();
-        evaluatedMetricsStore = new ConcurrentHashMap<>();
+        collectedMetricsStore = new ConcurrentHashMap<>();
         parallelismOverridesStore = new ConcurrentHashMap<>();
     }
 
@@ -69,19 +69,19 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
     }
 
     @Override
-    public void storeEvaluatedMetrics(
-            Context jobContext, SortedMap<Instant, CollectedMetrics> evaluatedMetrics) {
-        evaluatedMetricsStore.put(jobContext.getJobKey(), evaluatedMetrics);
+    public void storeCollectedMetrics(
+            Context jobContext, SortedMap<Instant, CollectedMetrics> metrics) {
+        collectedMetricsStore.put(jobContext.getJobKey(), metrics);
     }
 
     @Override
-    public Optional<SortedMap<Instant, CollectedMetrics>> getEvaluatedMetrics(Context jobContext) {
-        return Optional.ofNullable(evaluatedMetricsStore.get(jobContext.getJobKey()));
+    public Optional<SortedMap<Instant, CollectedMetrics>> getCollectedMetrics(Context jobContext) {
+        return Optional.ofNullable(collectedMetricsStore.get(jobContext.getJobKey()));
     }
 
     @Override
-    public void removeEvaluatedMetrics(Context jobContext) {
-        evaluatedMetricsStore.remove(jobContext.getJobKey());
+    public void removeCollectedMetrics(Context jobContext) {
+        collectedMetricsStore.remove(jobContext.getJobKey());
     }
 
     @Override
@@ -108,7 +108,7 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
     @Override
     public void removeInfoFromCache(KEY jobKey) {
         scalingHistoryStore.remove(jobKey);
-        evaluatedMetricsStore.remove(jobKey);
+        collectedMetricsStore.remove(jobKey);
         parallelismOverridesStore.remove(jobKey);
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
@@ -392,7 +392,7 @@ public class BacklogBasedScalingTest {
         setClocksTo(now);
         metricsCollector.setJobUpdateTs(now);
         autoscaler.scale(context);
-        assertTrue(stateStore.getEvaluatedMetrics(context).isEmpty());
+        assertTrue(autoscaler.lastEvaluatedMetrics.isEmpty());
         assertTrue(eventCollector.events.isEmpty());
     }
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
@@ -368,7 +368,7 @@ public class BacklogBasedScalingTest {
                                         "", Double.NaN, Double.NaN, Double.NaN, 500.))));
 
         autoscaler.scale(context);
-        assertFalse(stateStore.getEvaluatedMetrics(context).get().isEmpty());
+        assertFalse(stateStore.getCollectedMetrics(context).get().isEmpty());
     }
 
     @Test
@@ -398,7 +398,7 @@ public class BacklogBasedScalingTest {
 
     private void assertEvaluatedMetricsSize(int expectedSize) {
         Optional<SortedMap<Instant, CollectedMetrics>> evaluatedMetricsOpt =
-                stateStore.getEvaluatedMetrics(context);
+                stateStore.getCollectedMetrics(context);
         assertThat(evaluatedMetricsOpt).isPresent();
         assertThat(evaluatedMetricsOpt.get()).hasSize(expectedSize);
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -75,6 +75,7 @@ public class JobVertexScalerTest {
 
     @Test
     public void testParallelismScaling() {
+        System.out.println("" + (-2 & 0x7FFFFFFF));
         var op = new JobVertexID();
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         assertEquals(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -75,7 +75,6 @@ public class JobVertexScalerTest {
 
     @Test
     public void testParallelismScaling() {
-        System.out.println("" + (-2 & 0x7FFFFFFF));
         var op = new JobVertexID();
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         assertEquals(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.event.TestingEventCollector;
 import org.apache.flink.autoscaler.metrics.CollectedMetricHistory;
+import org.apache.flink.autoscaler.metrics.CollectedMetrics;
 import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.autoscaler.metrics.FlinkMetric;
 import org.apache.flink.autoscaler.metrics.ScalingMetric;
@@ -41,6 +42,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -121,7 +123,7 @@ public class MetricsCollectionAndEvaluationTest {
         clock = Clock.offset(clock, conf.get(AutoScalerOptions.STABILIZATION_INTERVAL));
         metricsCollector.setClock(clock);
         collectedMetrics = metricsCollector.updateMetrics(context, stateStore);
-        assertEquals(1, collectedMetrics.getMetricHistory().size());
+        assertEquals(2, collectedMetrics.getMetricHistory().size());
         assertFalse(collectedMetrics.isFullyCollected());
 
         // We haven't collected a full window yet
@@ -129,7 +131,7 @@ public class MetricsCollectionAndEvaluationTest {
         clock = Clock.offset(clock, Duration.ofSeconds(1));
         metricsCollector.setClock(clock);
         collectedMetrics = metricsCollector.updateMetrics(context, stateStore);
-        assertEquals(2, collectedMetrics.getMetricHistory().size());
+        assertEquals(3, collectedMetrics.getMetricHistory().size());
         assertFalse(collectedMetrics.isFullyCollected());
 
         // Advance time to stabilization period + full window => metrics should be present
@@ -294,13 +296,13 @@ public class MetricsCollectionAndEvaluationTest {
         // This call will lead to metric collection but we haven't reached the window size yet
         // which will hold back metrics
         metricsHistory = metricsCollector.updateMetrics(context, stateStore);
-        assertEquals(1, metricsHistory.getMetricHistory().size());
+        assertEquals(3, metricsHistory.getMetricHistory().size());
         assertFalse(metricsHistory.isFullyCollected());
 
         // Collect more values in window
         metricsCollector.setClock(Clock.offset(clock, Duration.ofSeconds(1)));
         metricsHistory = metricsCollector.updateMetrics(context, stateStore);
-        assertEquals(2, metricsHistory.getMetricHistory().size());
+        assertEquals(4, metricsHistory.getMetricHistory().size());
         assertFalse(metricsHistory.isFullyCollected());
 
         // Window size reached
@@ -418,14 +420,116 @@ public class MetricsCollectionAndEvaluationTest {
                         0.,
                         ScalingMetric.TRUE_PROCESSING_RATE,
                         Double.POSITIVE_INFINITY,
+                        ScalingMetric.OBSERVED_TPR,
+                        Double.POSITIVE_INFINITY,
                         ScalingMetric.LOAD,
                         0.),
                 finishedMetrics);
     }
 
     @Test
+    public void testObservedTprCollection() throws Exception {
+        var source = new JobVertexID();
+        var topology = new JobTopology(new VertexInfo(source, Set.of(), 10, 720));
+        Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>> metrics =
+                Map.of(
+                        source,
+                        new HashMap<>(
+                                Map.of(
+                                        FlinkMetric.PENDING_RECORDS,
+                                        new AggregatedMetric(
+                                                "", Double.NaN, Double.NaN, Double.NaN, 1000000.),
+                                        FlinkMetric.BACKPRESSURE_TIME_PER_SEC,
+                                        new AggregatedMetric(
+                                                "", Double.NaN, Double.NaN, 600., Double.NaN),
+                                        FlinkMetric.BUSY_TIME_PER_SEC,
+                                        new AggregatedMetric(
+                                                "", Double.NaN, 200., Double.NaN, Double.NaN),
+                                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
+                                        new AggregatedMetric(
+                                                "", Double.NaN, Double.NaN, Double.NaN, 1000.),
+                                        FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC,
+                                        new AggregatedMetric(
+                                                "", Double.NaN, Double.NaN, Double.NaN, 500.))));
+
+        metricsCollector = new TestingMetricsCollector(topology);
+        metricsCollector.setJobUpdateTs(startTime);
+        metricsCollector.setCurrentMetrics(metrics);
+
+        context.getConfiguration().set(AutoScalerOptions.STABILIZATION_INTERVAL, Duration.ZERO);
+        metricsCollector.setClock(Clock.fixed(Instant.ofEpochMilli(100), ZoneId.systemDefault()));
+        var collectedMetrics =
+                metricsCollector
+                        .updateMetrics(context, stateStore)
+                        .getMetricHistory()
+                        .get(Instant.ofEpochMilli(100))
+                        .getVertexMetrics()
+                        .get(source);
+
+        // Make sure both busy time and observed tpr is collected
+        assertEquals(2500., collectedMetrics.get(ScalingMetric.TRUE_PROCESSING_RATE));
+        assertEquals(500. / 0.4, collectedMetrics.get(ScalingMetric.OBSERVED_TPR));
+
+        // Make sure that average observed tpr is picked up only if 2 valid observations
+        // We set no lag so observed cannot be computed and expect nan
+        metrics.get(source)
+                .put(
+                        FlinkMetric.PENDING_RECORDS,
+                        new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 0.));
+        metricsCollector.setClock(Clock.fixed(Instant.ofEpochMilli(200), ZoneId.systemDefault()));
+        collectedMetrics =
+                metricsCollector
+                        .updateMetrics(context, stateStore)
+                        .getMetricHistory()
+                        .get(Instant.ofEpochMilli(200))
+                        .getVertexMetrics()
+                        .get(source);
+
+        // Make sure observed busy time is empty but still using observed
+        assertEquals(Double.NaN, collectedMetrics.get(ScalingMetric.OBSERVED_TPR));
+
+        // Add another valid observed computation
+        metrics.get(source)
+                .put(
+                        FlinkMetric.PENDING_RECORDS,
+                        new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 100000.));
+        metrics.get(source)
+                .put(
+                        FlinkMetric.BACKPRESSURE_TIME_PER_SEC,
+                        new AggregatedMetric("", Double.NaN, Double.NaN, 500., Double.NaN));
+        metricsCollector.setClock(Clock.fixed(Instant.ofEpochMilli(300), ZoneId.systemDefault()));
+        collectedMetrics =
+                metricsCollector
+                        .updateMetrics(context, stateStore)
+                        .getMetricHistory()
+                        .get(Instant.ofEpochMilli(300))
+                        .getVertexMetrics()
+                        .get(source);
+
+        assertEquals(500. / 0.5, collectedMetrics.get(ScalingMetric.OBSERVED_TPR));
+        // Make sure avg is picked correctly another valid observed computation
+        metrics.get(source)
+                .put(
+                        FlinkMetric.PENDING_RECORDS,
+                        new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, 0.));
+
+        metricsCollector.setClock(Clock.fixed(Instant.ofEpochMilli(400), ZoneId.systemDefault()));
+        collectedMetrics =
+                metricsCollector
+                        .updateMetrics(context, stateStore)
+                        .getMetricHistory()
+                        .get(Instant.ofEpochMilli(400))
+                        .getVertexMetrics()
+                        .get(source);
+
+        assertEquals(
+                ((500. / 0.5) + (500. / 0.4)) / 2,
+                collectedMetrics.get(ScalingMetric.OBSERVED_TPR));
+    }
+
+    @Test
     public void testScaleDownWithZeroProcessingRate() throws Exception {
-        var topology = new JobTopology(new VertexInfo(source1, Set.of(), 10, 720));
+        var topology = new JobTopology(new VertexInfo(source1, Set.of(), 2, 720));
 
         metricsCollector = new TestingMetricsCollector<>(topology);
         metricsCollector.setJobUpdateTs(startTime);
@@ -448,7 +552,7 @@ public class MetricsCollectionAndEvaluationTest {
         assertEquals(0, evaluation.get(source1).get(ScalingMetric.TARGET_DATA_RATE).getCurrent());
         assertEquals(
                 Double.POSITIVE_INFINITY,
-                evaluation.get(source1).get(ScalingMetric.TRUE_PROCESSING_RATE).getCurrent());
+                evaluation.get(source1).get(ScalingMetric.TRUE_PROCESSING_RATE).getAverage());
         assertEquals(
                 0.,
                 evaluation.get(source1).get(ScalingMetric.SCALE_DOWN_RATE_THRESHOLD).getCurrent());
@@ -459,6 +563,23 @@ public class MetricsCollectionAndEvaluationTest {
         scalingExecutor.scaleResource(context, evaluation);
         var scaledParallelism = ScalingExecutorTest.getScaledParallelism(stateStore, context);
         assertEquals(1, scaledParallelism.get(source1));
+
+        // Make sure if there are measurements with non-infinite TPR, we don't evaluate infinite
+        var lastCollected = collectedMetrics.getMetricHistory().values().iterator().next();
+        var newMetrics = new HashMap<>(lastCollected.getVertexMetrics());
+        newMetrics.get(source1).put(ScalingMetric.TRUE_PROCESSING_RATE, 3.);
+        newMetrics.get(source1).put(ScalingMetric.OBSERVED_TPR, 3.);
+        newMetrics.get(source1).put(ScalingMetric.SOURCE_DATA_RATE, 2.);
+
+        collectedMetrics
+                .getMetricHistory()
+                .put(
+                        Instant.ofEpochSecond(1234),
+                        new CollectedMetrics(newMetrics, lastCollected.getOutputRatios()));
+
+        evaluation = evaluator.evaluate(context.getConfiguration(), collectedMetrics);
+        assertEquals(
+                3., evaluation.get(source1).get(ScalingMetric.TRUE_PROCESSING_RATE).getAverage());
     }
 
     private CollectedMetricHistory collectMetrics() throws Exception {

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
@@ -205,7 +205,7 @@ public class RecommendedParallelismTest {
 
         // after restart while the job is not running the evaluated metrics are gone
         autoscaler.scale(context);
-        assertEquals(3, stateStore.getEvaluatedMetrics(context).get().size());
+        assertEquals(3, stateStore.getCollectedMetrics(context).get().size());
         assertNull(autoscaler.lastEvaluatedMetrics.get(context.getJobKey()));
         scaledParallelism = ScalingExecutorTest.getScaledParallelism(stateStore, context);
         assertEquals(4, scaledParallelism.get(source));
@@ -230,7 +230,7 @@ public class RecommendedParallelismTest {
 
     private void assertEvaluatedMetricsSize(int expectedSize) {
         Optional<SortedMap<Instant, CollectedMetrics>> evaluatedMetricsOpt =
-                stateStore.getEvaluatedMetrics(context);
+                stateStore.getCollectedMetrics(context);
         assertThat(evaluatedMetricsOpt).isPresent();
         assertThat(evaluatedMetricsOpt.get()).hasSize(expectedSize);
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
@@ -46,17 +46,16 @@ public class RestApiMetricsCollectorTest {
 
     @Test
     public void testAggregateMultiplePendingRecordsMetricsPerSource() throws Exception {
-        RestApiMetricsCollector<JobID, JobAutoScalerContext<JobID>> collector =
-                new RestApiMetricsCollector<>();
+        var collector = new RestApiMetricsCollector<JobID, JobAutoScalerContext<JobID>>();
 
         JobVertexID jobVertexID = new JobVertexID();
-        Map<String, FlinkMetric> flinkMetrics =
+        var flinkMetrics =
                 Map.of(
                         "a.pendingRecords", FlinkMetric.PENDING_RECORDS,
                         "b.pendingRecords", FlinkMetric.PENDING_RECORDS);
-        Map<JobVertexID, Map<String, FlinkMetric>> metrics = Map.of(jobVertexID, flinkMetrics);
+        var metrics = Map.of(jobVertexID, flinkMetrics);
 
-        List<AggregatedMetric> aggregatedMetricsResponse =
+        var aggregatedMetricsResponse =
                 List.of(
                         new AggregatedMetric(
                                 "a.pendingRecords", Double.NaN, Double.NaN, Double.NaN, 100.),
@@ -65,8 +64,8 @@ public class RestApiMetricsCollectorTest {
                         new AggregatedMetric(
                                 "c.unrelated", Double.NaN, Double.NaN, Double.NaN, 100.));
 
-        Configuration conf = new Configuration();
-        RestClusterClient<String> restClusterClient =
+        var conf = new Configuration();
+        var restClusterClient =
                 new RestClusterClient<>(
                         conf,
                         "test-cluster",
@@ -91,7 +90,7 @@ public class RestApiMetricsCollectorTest {
                 };
 
         JobID jobID = new JobID();
-        JobAutoScalerContext<JobID> context =
+        var context =
                 new JobAutoScalerContext<>(
                         jobID,
                         jobID,
@@ -100,8 +99,7 @@ public class RestApiMetricsCollectorTest {
                         new UnregisteredMetricsGroup(),
                         () -> restClusterClient);
 
-        Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>> jobVertexIDMapMap =
-                collector.queryAllAggregatedMetrics(context, metrics);
+        var jobVertexIDMapMap = collector.queryAllAggregatedMetrics(context, metrics);
 
         Assertions.assertEquals(1, jobVertexIDMapMap.size());
         Map<FlinkMetric, AggregatedMetric> vertexMetrics = jobVertexIDMapMap.get(jobVertexID);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -368,7 +368,7 @@ public class ScalingMetricEvaluatorTest {
         // Bust Time TPR average: 350
 
         // Set diff threshold to 20% -> within threshold
-        conf.set(AutoScalerOptions.OBSERVED_TPR_SWITCH_THRESHOLD, 0.2);
+        conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_SWITCH_THRESHOLD, 0.2);
 
         // Test that we used busy time based TPR
         assertEquals(
@@ -379,7 +379,7 @@ public class ScalingMetricEvaluatorTest {
                         .get(ScalingMetric.TRUE_PROCESSING_RATE));
 
         // Set diff threshold to 10% -> outside threshold
-        conf.set(AutoScalerOptions.OBSERVED_TPR_SWITCH_THRESHOLD, 0.1);
+        conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_SWITCH_THRESHOLD, 0.1);
 
         // Test that we used the observed TPR
         assertEquals(
@@ -390,7 +390,7 @@ public class ScalingMetricEvaluatorTest {
                         .get(ScalingMetric.TRUE_PROCESSING_RATE));
 
         // Test that observed tpr min observations are respected. If less, use busy time
-        conf.set(AutoScalerOptions.OBSERVED_TPR_MIN_OBSERVATIONS, 3);
+        conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_MIN_OBSERVATIONS, 3);
         assertEquals(
                 new EvaluatedScalingMetric(400., 350.),
                 evaluator

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoscalerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/AutoscalerFactory.java
@@ -33,10 +33,8 @@ public class AutoscalerFactory {
     public static JobAutoScaler<ResourceID, KubernetesJobAutoScalerContext> create(
             KubernetesClient client, EventRecorder eventRecorder) {
 
-        KubernetesAutoScalerStateStore stateStore =
-                new KubernetesAutoScalerStateStore(new ConfigMapStore(client));
-        KubernetesAutoScalerEventHandler eventHandler =
-                new KubernetesAutoScalerEventHandler(eventRecorder);
+        var stateStore = new KubernetesAutoScalerStateStore(new ConfigMapStore(client));
+        var eventHandler = new KubernetesAutoScalerEventHandler(eventRecorder);
 
         return new JobAutoScalerImpl<>(
                 new RestApiMetricsCollector<>(),

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ConfigMapStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/ConfigMapStore.java
@@ -44,12 +44,11 @@ public class ConfigMapStore {
 
     private final KubernetesClient kubernetesClient;
 
-    // The cache for each resourceId may be in three situations:
-    // 1. The resourceId isn't exist : ConfigMap isn't loaded from kubernetes, or it's removed.
-    // 2. The resourceId is exist, and value is the Optional.empty() : We have loaded the ConfigMap
-    // from kubernetes, but the ConfigMap isn't created at kubernetes side.
-    // 3. The resourceId is exist, and the Optional isn't empty : We have loaded the ConfigMap from
-    // kubernetes, it may be not same with kubernetes side due to it's not flushed after updating.
+    // The cache for each resourceId may be in three states:
+    // 1. The resourceId doesn't exist : ConfigMap isn't loaded from kubernetes, or it's deleted
+    // 2  Exists, Optional.empty() : The ConfigMap doesn't exist in Kubernetes
+    // 3. Exists, Not Empty : We have loaded the ConfigMap from kubernetes, it may not be the same
+    // if not flushed already
     private final ConcurrentHashMap<ResourceID, Optional<ConfigMap>> cache =
             new ConcurrentHashMap<>();
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerStateStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerStateStore.java
@@ -108,15 +108,15 @@ public class KubernetesAutoScalerStateStore
     }
 
     @Override
-    public void storeEvaluatedMetrics(
+    public void storeCollectedMetrics(
             KubernetesJobAutoScalerContext jobContext,
-            SortedMap<Instant, CollectedMetrics> evaluatedMetrics) {
+            SortedMap<Instant, CollectedMetrics> metrics) {
         configMapStore.putSerializedState(
-                jobContext, COLLECTED_METRICS_KEY, serializeEvaluatedMetrics(evaluatedMetrics));
+                jobContext, COLLECTED_METRICS_KEY, serializeEvaluatedMetrics(metrics));
     }
 
     @Override
-    public Optional<SortedMap<Instant, CollectedMetrics>> getEvaluatedMetrics(
+    public Optional<SortedMap<Instant, CollectedMetrics>> getCollectedMetrics(
             KubernetesJobAutoScalerContext jobContext) {
         Optional<String> serializedEvaluatedMetricsOpt =
                 configMapStore.getSerializedState(jobContext, COLLECTED_METRICS_KEY);
@@ -135,7 +135,7 @@ public class KubernetesAutoScalerStateStore
     }
 
     @Override
-    public void removeEvaluatedMetrics(KubernetesJobAutoScalerContext jobContext) {
+    public void removeCollectedMetrics(KubernetesJobAutoScalerContext jobContext) {
         configMapStore.removeSerializedState(jobContext, COLLECTED_METRICS_KEY);
     }
 
@@ -217,7 +217,7 @@ public class KubernetesAutoScalerStateStore
                         .orElse(0);
 
         Optional<SortedMap<Instant, CollectedMetrics>> evaluatedMetricsOpt =
-                getEvaluatedMetrics(context);
+                getCollectedMetrics(context);
         if (evaluatedMetricsOpt.isEmpty()) {
             return;
         }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerStateStoreTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerStateStoreTest.java
@@ -218,17 +218,17 @@ public class KubernetesAutoScalerStateStoreTest {
         var now = Instant.now();
 
         Assertions.assertEquals(scalingHistory, getTrimmedScalingHistory(stateStore, ctx, now));
-        assertThat(stateStore.getEvaluatedMetrics(ctx)).hasValue(metricHistory);
+        assertThat(stateStore.getCollectedMetrics(ctx)).hasValue(metricHistory);
 
         // Override with compressed data
         var newTs = Instant.now();
 
         addToScalingHistoryAndStore(stateStore, ctx, newTs, Map.of());
-        stateStore.storeEvaluatedMetrics(ctx, metricHistory);
+        stateStore.storeCollectedMetrics(ctx, metricHistory);
 
         // Make sure we can still access everything
         Assertions.assertEquals(scalingHistory, getTrimmedScalingHistory(stateStore, ctx, newTs));
-        assertThat(stateStore.getEvaluatedMetrics(ctx)).hasValue(metricHistory);
+        assertThat(stateStore.getCollectedMetrics(ctx)).hasValue(metricHistory);
     }
 
     @Test
@@ -265,7 +265,7 @@ public class KubernetesAutoScalerStateStoreTest {
                         new ScalingSummary(
                                 1, 2, Map.of(ScalingMetric.LAG, EvaluatedScalingMetric.of(2.)))));
 
-        stateStore.storeEvaluatedMetrics(ctx, metricHistory);
+        stateStore.storeCollectedMetrics(ctx, metricHistory);
 
         assertFalse(
                 configMapStore
@@ -314,7 +314,7 @@ public class KubernetesAutoScalerStateStoreTest {
                         configMapStore.getSerializedState(
                                 ctx, KubernetesAutoScalerStateStore.COLLECTED_METRICS_KEY))
                 .isPresent();
-        assertThat(stateStore.getEvaluatedMetrics(ctx)).isEmpty();
+        assertThat(stateStore.getCollectedMetrics(ctx)).isEmpty();
         assertThat(
                         configMapStore.getSerializedState(
                                 ctx, KubernetesAutoScalerStateStore.COLLECTED_METRICS_KEY))


### PR DESCRIPTION
## What is the purpose of the change

The aim of this PR is to address the cases when operator incorrectly reports low busy time (high idleness) for sources that are in fact cannot keep up due to the slowness of the reader/fetchers. As the metrics cannot be generally fixed on the Flink - connector side we have to detect this and handle it when collecting the metrics.

The main symptom of this problem is overestimation of the true processing rate and not triggering scaling even if lag is building up as the autoscaler thinks it will be able to keep up.

To tackle this we differentiate two different methods of TPR measurement:
 1. **Busy-time based TPR** (this is the current approach in the autoscaler) : computed from incoming records and busy time 
 2. **Observed TPR** : computed from incoming records and back pressure, measurable only when we assume full processing throughput (i.e during catch-up)

### Current behaviour

The operator currently always uses a busy-time based TPR calculation which is very flexible and allows for scaling up / down but is susceptible to overestimation due to the broken metrics. 

### Suggested new behaviour

Instead of using the busy-time based TPR we detect when TPR is overestimated (busy-time too low) and switch to observed TPR. 

To do this, whenever we there is lag for a source (during catchup, or lag-buildup) we measure both busy-time and observed TPR.

If the avg busy-time based TPR is off by a configured amount we switch to observed TPR for this source during metric evaluation. 

**Why not use observed TPR all the time?**
Observed TPR can only be measured when we are catching up (during stabilization) or when cannot keep up. This makes it harder to scale down or to detect changes in source throughput over time (before lag starts to build up). Instead of using observed TPR we switch to it only when we detect a problem with the busy-time (this is a rare case overall), to hopefully get the best of both worlds.

### Other related fixes

#### Fix metric name querying for sources

Metric names were only previously queried in topology change, however this is not good for sources where new metrics are dynamically added/removed. Now source metric names are always queried.

#### Fix infinity handling in average

Previously avg logic returned infinity on any infinite value in the array. This causes invalid scale downs when new records are indeed coming in. The logic has been fixed to only return infinity when all of them are infinity.

## Brief change log

  - *Fix source metric name querying (always refresh for sources to detect new partition metrics)*
  - *Collect metrics also during stabilization (but do not evaluate) to allow measuring observed TPR*
  - *Add new TPR measurement logic for sources*
  - *Change TPR evaluation logic to switch between observed vs busy time based true processing rate*
  - *Fix infinity handling for average (only return infinity if all infinite otherwise ignore)*

## Verifying this change

Unit tests + manual verification

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no