### PR TITLE
[Flink 31966] Flink Kubernetes operator lacks TLS support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -100,6 +100,17 @@ To try out this run the following command:
 kubectl apply -f basic-session-deployment-and-job.yaml
 ```
 
+#### Basic secured application
+
+This sample uses cert-manager to create a self-signed Issuer and jks certificate to secure the internal and rest 
+communication between pods. N.b. you may see RuntimeExceptions in the operator logs whilst the cert-manger creates the
+ssl certificate secret
+
+To try out this run the following command:
+```bash
+kubectl apply -f basic-secure.yaml
+```
+
 ### SQL runner
 
 For running Flink SQL scripts check this [example](flink-sql-runner-example/README.md).

--- a/examples/basic-secure.yaml
+++ b/examples/basic-secure.yaml
@@ -1,0 +1,84 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-secure-cert-secret-creds
+type: Opaque
+data:
+  password: cGFzc3dvcmQxMjM0
+---
+# Source: flink-kubernetes-operator/templates/webhook.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: basic-secure-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: basic-secure-cert
+spec:
+  dnsNames:
+    - '*.flink.svc'
+    - '*.svc.cluster.local'
+  keystores:
+    jks:
+      create: true
+      passwordSecretRef:
+        name: basic-secure-cert-secret-creds
+        key: password
+  issuerRef:
+    kind: Issuer
+    name: basic-secure-selfsigned-issuer
+  commonName: FlinkDeployment
+  secretName: basic-secure-cert
+---
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: basic-secure
+spec:
+  image: flink:1.17
+  flinkVersion: v1_17
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "2"
+    security.ssl.enabled: 'true'
+    security.ssl.truststore: /etc/tls/truststore.jks
+    security.ssl.truststore-password: password1234
+    security.ssl.keystore: /etc/tls/keystore.jks
+    security.ssl.keystore-password: password1234
+    security.ssl.key-password: password1234
+    kubernetes.secrets: 'basic-secure-cert:/etc/tls'
+  serviceAccount: flink
+  jobManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  taskManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+    parallelism: 2
+    upgradeMode: stateless
+---

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/OperatorKubernetesClusterDescriptor.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/OperatorKubernetesClusterDescriptor.java
@@ -46,7 +46,6 @@ import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerSpecification;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
 import org.apache.flink.kubernetes.kubeclient.factory.KubernetesJobManagerFactory;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
-import org.apache.flink.kubernetes.operator.standalone.KubernetesStandaloneClusterDescriptor;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
@@ -69,7 +68,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class OperatorKubernetesClusterDescriptor extends KubernetesClusterDescriptor {
 
     private static final Logger LOG =
-            LoggerFactory.getLogger(KubernetesStandaloneClusterDescriptor.class);
+            LoggerFactory.getLogger(OperatorKubernetesClusterDescriptor.class);
 
     private final Configuration flinkConfig;
     private final FlinkKubeClient client;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -240,7 +240,7 @@ public class TestingFlinkService extends AbstractFlinkService {
     }
 
     @Override
-    public void submitSessionCluster(Configuration conf) throws Exception {
+    public void deploySessionCluster(Configuration conf) throws Exception {
         if (deployFailure) {
             throw new Exception("Deployment failure");
         }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -1043,7 +1043,7 @@ public class AbstractFlinkServiceTest {
         }
 
         @Override
-        public void submitSessionCluster(Configuration conf) {
+        public void deploySessionCluster(Configuration conf) {
             throw new UnsupportedOperationException();
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/OperatorKubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/OperatorKubernetesClusterDescriptorTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.service;
+
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.client.deployment.application.ApplicationConfiguration;
+import org.apache.flink.configuration.BlobServerOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.DeploymentOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.RestOptions;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesDeploymentTarget;
+import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
+import org.apache.flink.kubernetes.operator.kubeclient.Fabric8FlinkStandaloneKubeClient;
+import org.apache.flink.kubernetes.operator.kubeclient.FlinkStandaloneKubeClient;
+import org.apache.flink.kubernetes.shaded.io.fabric8.kubernetes.api.model.apps.Deployment;
+import org.apache.flink.kubernetes.shaded.io.fabric8.kubernetes.client.Config;
+import org.apache.flink.kubernetes.shaded.io.fabric8.kubernetes.client.ConfigBuilder;
+import org.apache.flink.kubernetes.shaded.io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import org.apache.flink.kubernetes.shaded.io.fabric8.kubernetes.client.NamespacedKubernetesClient;
+import org.apache.flink.kubernetes.utils.Constants;
+import org.apache.flink.util.concurrent.Executors;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils.TEST_DEPLOYMENT_NAME;
+import static org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils.TEST_NAMESPACE;
+import static org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder.FLINK_VERSION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** @link KubernetesStandaloneClusterDescriptor unit tests */
+@EnableKubernetesMockClient(crud = true, https = false)
+public class OperatorKubernetesClusterDescriptorTest {
+    KubernetesMockServer mockWebServer;
+    private OperatorKubernetesClusterDescriptor clusterDescriptor;
+    private FlinkStandaloneKubeClient flinkKubeClient;
+
+    KubernetesClient client;
+    private Configuration flinkConfig = new Configuration();
+
+    @BeforeEach
+    public void setup() {
+        flinkConfig = createTestFlinkConfig();
+        flinkKubeClient =
+                new Fabric8FlinkStandaloneKubeClient(
+                        flinkConfig, getClient(), Executors.newDirectExecutorService());
+        clusterDescriptor =
+                new OperatorKubernetesClusterDescriptor(flinkConfig, flinkKubeClient, null);
+    }
+
+    @Test
+    public void testDeploySessionCluster() throws Exception {
+        var cluster = TestUtils.buildSessionCluster();
+
+        flinkConfig.setString(BlobServerOptions.PORT, String.valueOf(0));
+        flinkConfig.setString(TaskManagerOptions.RPC_PORT, String.valueOf(0));
+        flinkConfig.setString(RestOptions.BIND_PORT, String.valueOf(0));
+        flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.SESSION.getName());
+        var clusterSpecification =
+                new KubernetesClusterClientFactory().getClusterSpecification(flinkConfig);
+
+        var clusterClientProvider = clusterDescriptor.deploySessionCluster(clusterSpecification);
+
+        List<Deployment> deployments =
+                getClient().apps().deployments().inNamespace(TEST_NAMESPACE).list().getItems();
+        String expectedJMDeploymentName = TEST_DEPLOYMENT_NAME;
+
+        assertEquals(1, deployments.size());
+        assertThat(
+                deployments.stream()
+                        .map(d -> d.getMetadata().getName())
+                        .collect(Collectors.toList()),
+                containsInAnyOrder(expectedJMDeploymentName));
+        assertEquals(
+                flinkConfig.get(BlobServerOptions.PORT),
+                String.valueOf(Constants.BLOB_SERVER_PORT));
+        assertEquals(
+                flinkConfig.get(TaskManagerOptions.RPC_PORT),
+                String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
+        assertEquals(flinkConfig.get(RestOptions.BIND_PORT), String.valueOf(Constants.REST_PORT));
+
+        Deployment jmDeployment =
+                deployments.stream()
+                        .filter(d -> d.getMetadata().getName().equals(expectedJMDeploymentName))
+                        .findFirst()
+                        .orElse(null);
+        assertTrue(
+                jmDeployment.getSpec().getTemplate().getSpec().getContainers().stream()
+                        .anyMatch(
+                                c ->
+                                        c.getArgs()
+                                                .contains(
+                                                        "kubernetes-jobmanager.sh kubernetes-session ")));
+
+        var clusterClient = clusterClientProvider.getClusterClient();
+
+        String expectedWebUrl =
+                String.format(
+                        "http://%s:%d",
+                        ExternalServiceDecorator.getNamespacedExternalServiceName(
+                                TEST_DEPLOYMENT_NAME, TEST_NAMESPACE),
+                        Constants.REST_PORT);
+        assertEquals(expectedWebUrl, clusterClient.getWebInterfaceURL());
+    }
+
+    @Test
+    public void testDeployApplicationCluster() throws Exception {
+        ClusterSpecification clusterSpecification =
+                new ClusterSpecification.ClusterSpecificationBuilder()
+                        .setMasterMemoryMB(2048)
+                        .setTaskManagerMemoryMB(1024)
+                        .setSlotsPerTaskManager(2)
+                        .createClusterSpecification();
+
+        flinkConfig.setString(BlobServerOptions.PORT, String.valueOf(0));
+        flinkConfig.setString(TaskManagerOptions.RPC_PORT, String.valueOf(0));
+        flinkConfig.setString(RestOptions.BIND_PORT, String.valueOf(0));
+        flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.APPLICATION.getName());
+        flinkConfig.set(
+                PipelineOptions.JARS, Collections.singletonList("local:///path/of/user.jar"));
+
+        var clusterClientProvider =
+                clusterDescriptor.deployApplicationCluster(
+                        clusterSpecification,
+                        ApplicationConfiguration.fromConfiguration(flinkConfig));
+
+        List<Deployment> deployments =
+                getClient().apps().deployments().inNamespace(TEST_NAMESPACE).list().getItems();
+        String expectedJMDeploymentName = TEST_DEPLOYMENT_NAME;
+
+        assertEquals(1, deployments.size());
+        assertThat(
+                deployments.stream()
+                        .map(d -> d.getMetadata().getName())
+                        .collect(Collectors.toList()),
+                containsInAnyOrder(expectedJMDeploymentName));
+        assertEquals(
+                flinkConfig.get(BlobServerOptions.PORT),
+                String.valueOf(Constants.BLOB_SERVER_PORT));
+        assertEquals(
+                flinkConfig.get(TaskManagerOptions.RPC_PORT),
+                String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
+        assertEquals(flinkConfig.get(RestOptions.BIND_PORT), String.valueOf(Constants.REST_PORT));
+
+        Deployment jmDeployment =
+                deployments.stream()
+                        .filter(d -> d.getMetadata().getName().equals(expectedJMDeploymentName))
+                        .findFirst()
+                        .orElse(null);
+
+        assertTrue(
+                jmDeployment.getSpec().getTemplate().getSpec().getContainers().stream()
+                        .anyMatch(
+                                c ->
+                                        c.getArgs()
+                                                .contains(
+                                                        "kubernetes-jobmanager.sh kubernetes-application ")));
+
+        var clusterClient = clusterClientProvider.getClusterClient();
+
+        String expectedWebUrl =
+                String.format(
+                        "http://%s:%d",
+                        ExternalServiceDecorator.getNamespacedExternalServiceName(
+                                TEST_DEPLOYMENT_NAME, TEST_NAMESPACE),
+                        Constants.REST_PORT);
+        assertEquals(expectedWebUrl, clusterClient.getWebInterfaceURL());
+    }
+
+    private NamespacedKubernetesClient getClient() {
+        var config =
+                new ConfigBuilder(Config.empty())
+                        .withMasterUrl(mockWebServer.url("/").toString())
+                        .withHttp2Disable(true)
+                        .build();
+        return new DefaultKubernetesClient(config).inNamespace(TEST_NAMESPACE);
+    }
+
+    public static Configuration createTestFlinkConfig() {
+        Configuration configuration = new Configuration();
+        configuration.set(KubernetesConfigOptions.CLUSTER_ID, TEST_DEPLOYMENT_NAME);
+        configuration.set(KubernetesConfigOptions.NAMESPACE, TestUtils.TEST_NAMESPACE);
+        configuration.set(FLINK_VERSION, FlinkVersion.v1_18);
+        configuration.set(KubernetesConfigOptions.JOB_MANAGER_CPU, 2.0);
+        configuration.set(KubernetesConfigOptions.TASK_MANAGER_CPU, 4.0);
+        configuration.set(JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(1000));
+        configuration.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(1000));
+        return configuration;
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/SecureFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/SecureFlinkServiceTest.java
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.service;
+
+import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.SecurityOptions;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.TestingClusterClient;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
+import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
+import org.apache.flink.kubernetes.operator.utils.EventCollector;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+import org.apache.flink.util.ConfigurationException;
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.concurrent.Executors;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder.FLINK_VERSION;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_HEALTH_PROBE_PORT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** @link FlinkService unit tests */
+@EnableKubernetesMockClient(crud = true)
+public class SecureFlinkServiceTest {
+    public static final String DUMMY_KEYSTORE_CONTENTS = "Dummy Keystore Contents";
+    public static final String DUMMY_TRUSTSTORE_CONTENTS = "Dummy Truststore Contents";
+    KubernetesClient client;
+    private final Configuration configuration = new Configuration();
+    private final FlinkConfigManager configManager = new FlinkConfigManager(configuration);
+
+    private final EventCollector eventCollector = new EventCollector();
+
+    private EventRecorder eventRecorder;
+    private FlinkOperatorConfiguration operatorConfig;
+    private ExecutorService executorService;
+    private Path certLocation;
+    private Path keyStoreFile;
+    private Path trustStoreFile;
+    private String certificateSecret = "certsecret";
+    private Base64.Encoder encoder = Base64.getEncoder();
+
+    @BeforeEach
+    public void setup() {
+        configuration.set(KubernetesConfigOptions.CLUSTER_ID, TestUtils.TEST_DEPLOYMENT_NAME);
+        configuration.set(KubernetesConfigOptions.NAMESPACE, TestUtils.TEST_NAMESPACE);
+        configuration.set(FLINK_VERSION, FlinkVersion.v1_15);
+        eventRecorder = new EventRecorder(eventCollector);
+        operatorConfig = FlinkOperatorConfiguration.fromConfiguration(configuration);
+        executorService = Executors.newDirectExecutorService();
+        certLocation = Paths.get(System.getProperty("user.dir"), "temp");
+        keyStoreFile = Paths.get(certLocation.toString(), "keystore.jks");
+        trustStoreFile = Paths.get(certLocation.toString(), "truststore.jks");
+        createCertSecret();
+    }
+
+    @Test
+    public void testDeleteSecureClusterDeployment() throws IOException {
+        var deployment = TestUtils.buildApplicationCluster();
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
+        var flinkService = createFlinkService(null);
+        Files.createDirectories(certLocation);
+        Files.createFile(keyStoreFile);
+        Files.createFile(trustStoreFile);
+        var conf = createOperatorConfig();
+
+        var dep =
+                new DeploymentBuilder()
+                        .withNewMetadata()
+                        .withName(TestUtils.TEST_DEPLOYMENT_NAME)
+                        .withNamespace(TestUtils.TEST_NAMESPACE)
+                        .endMetadata()
+                        .withNewSpec()
+                        .endSpec()
+                        .build();
+        client.resource(dep).create();
+
+        assertTrue(Files.exists(keyStoreFile));
+        assertTrue(Files.exists(trustStoreFile));
+
+        assertNotNull(
+                client.apps()
+                        .deployments()
+                        .inNamespace(TestUtils.TEST_NAMESPACE)
+                        .withName(TestUtils.TEST_DEPLOYMENT_NAME)
+                        .get());
+
+        flinkService.deleteClusterDeployment(
+                deployment.getMetadata(), deployment.getStatus(), conf, false);
+        assertNull(
+                client.apps()
+                        .deployments()
+                        .inNamespace(TestUtils.TEST_NAMESPACE)
+                        .withName(TestUtils.TEST_DEPLOYMENT_NAME)
+                        .get());
+        assertFalse(Files.exists(keyStoreFile));
+        assertFalse(Files.exists(trustStoreFile));
+        Files.deleteIfExists(trustStoreFile.getParent());
+    }
+
+    // @Test
+    public void testSubmitSecureApplicationCluster() throws Exception {
+        var testingClusterClient =
+                new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
+        Configuration deployConfig = createOperatorConfig();
+        Secret secret =
+                client.secrets()
+                        .inNamespace(TestUtils.TEST_NAMESPACE)
+                        .withName(certificateSecret)
+                        .get();
+        assertNotNull(secret);
+        final FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+
+        var flinkService = (NativeFlinkService) createFlinkService(testingClusterClient);
+        var testingService = new SecureFlinkService(flinkService);
+        testingService.submitApplicationCluster(deployment.getSpec().getJob(), deployConfig, false);
+        assertTrue(Files.exists(keyStoreFile));
+        assertEquals(DUMMY_KEYSTORE_CONTENTS, Files.readString(keyStoreFile));
+        assertTrue(Files.exists(trustStoreFile));
+        assertEquals(DUMMY_TRUSTSTORE_CONTENTS, Files.readString(trustStoreFile));
+        FileUtils.deleteDirectory(certLocation.toFile());
+    }
+
+    // @Test
+    public void testSubmitSecureSessionCluster() throws Exception {
+        var testingClusterClient =
+                new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
+        Configuration deployConfig = createOperatorConfig();
+        var flinkService = (NativeFlinkService) createFlinkService(testingClusterClient);
+        var testingService = new SecureFlinkService(flinkService);
+        testingService.submitSessionCluster(deployConfig);
+        assertTrue(Files.exists(keyStoreFile));
+        assertEquals(DUMMY_KEYSTORE_CONTENTS, Files.readString(keyStoreFile));
+        assertTrue(Files.exists(trustStoreFile));
+        assertEquals(DUMMY_TRUSTSTORE_CONTENTS, Files.readString(trustStoreFile));
+        FileUtils.deleteDirectory(certLocation.toFile());
+    }
+
+    // @Test
+    public void testGetSecureClusterClient() throws Exception {
+        var testingClusterClient =
+                new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
+        Configuration deployConfig = createOperatorConfig();
+        var flinkService = (NativeFlinkService) createFlinkService(testingClusterClient);
+        var testingService = new SecureFlinkService(flinkService);
+        try {
+            testingService.getClusterClient(deployConfig);
+        } catch (ConfigurationException e) {
+            System.out.println(e.getMessage());
+            assertEquals("Failed to initialize SSLContext for the REST client", e.getMessage());
+        }
+        assertTrue(Files.exists(keyStoreFile));
+        assertEquals(DUMMY_KEYSTORE_CONTENTS, Files.readString(keyStoreFile));
+        assertTrue(Files.exists(trustStoreFile));
+        assertEquals(DUMMY_TRUSTSTORE_CONTENTS, Files.readString(trustStoreFile));
+        FileUtils.deleteDirectory(certLocation.toFile());
+    }
+
+    class SecureFlinkService extends NativeFlinkService {
+        private Configuration runtimeConfig;
+
+        public SecureFlinkService(NativeFlinkService nativeFlinkService) {
+            super(
+                    nativeFlinkService.kubernetesClient,
+                    nativeFlinkService.artifactManager,
+                    nativeFlinkService.executorService,
+                    SecureFlinkServiceTest.this.operatorConfig,
+                    eventRecorder);
+        }
+
+        @Override
+        protected void deployApplicationCluster(JobSpec jobSpec, Configuration conf) {
+            this.runtimeConfig = conf;
+        }
+
+        @Override
+        protected void submitClusterInternal(Configuration conf) throws Exception {
+            this.runtimeConfig = conf;
+        }
+
+        public Configuration getRuntimeConfig() {
+            return runtimeConfig;
+        }
+    }
+
+    private AbstractFlinkService createFlinkService(RestClusterClient<String> clusterClient) {
+        return new NativeFlinkService(
+                client, null, executorService, operatorConfig, eventRecorder) {
+            @Override
+            public RestClusterClient<String> getClusterClient(Configuration config) {
+                return clusterClient;
+            }
+        };
+    }
+
+    private Configuration createOperatorConfig() {
+        Configuration deployConfig = new Configuration(configuration);
+        deployConfig.setString(OPERATOR_HEALTH_PROBE_PORT.key(), "80");
+        deployConfig.setBoolean(SecurityOptions.SSL_REST_ENABLED, true);
+        deployConfig.setString(SecurityOptions.SSL_REST_KEYSTORE, keyStoreFile.toString());
+        deployConfig.setString(SecurityOptions.SSL_REST_TRUSTSTORE, trustStoreFile.toString());
+        deployConfig.setString(
+                KubernetesConfigOptions.KUBERNETES_SECRETS.key(),
+                certificateSecret + ":" + certLocation.toString());
+        return deployConfig;
+    }
+
+    private void createCertSecret() {
+        Secret certsecret =
+                new SecretBuilder()
+                        .withNewMetadata()
+                        .withName(certificateSecret)
+                        .endMetadata()
+                        .addToData(
+                                "keystore.jks",
+                                encoder.encodeToString(DUMMY_KEYSTORE_CONTENTS.getBytes()))
+                        .addToData(
+                                "truststore.jks",
+                                encoder.encodeToString(DUMMY_TRUSTSTORE_CONTENTS.getBytes()))
+                        .build();
+        client.secrets().inNamespace(TestUtils.TEST_NAMESPACE).resource(certsecret).create();
+    }
+}

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/standalone/KubernetesStandaloneClusterDescriptorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/standalone/KubernetesStandaloneClusterDescriptorTest.java
@@ -64,7 +64,8 @@ public class KubernetesStandaloneClusterDescriptorTest {
                 new Fabric8FlinkStandaloneKubeClient(
                         flinkConfig, getClient(), Executors.newDirectExecutorService());
 
-        clusterDescriptor = new KubernetesStandaloneClusterDescriptor(flinkConfig, flinkKubeClient);
+        clusterDescriptor =
+                new KubernetesStandaloneClusterDescriptor(flinkConfig, flinkKubeClient, null);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change
If the FlinkDeployment CR is configured to use ssl, the operator is unable to properly reconcile the deployment as the underlying RestClient the operator uses tries to load the certificates defined in the config.

## Brief change log
  - When rest cluster client is created (in AbstractFlinkService) the config is checked to see if rest ssl is configured. If it is, find the relevant secret defined in the kubernetes.secret config and copy the secret to a local directory in the location of /tmp/operator/certs/{namespace}/{instanceName}. Copied config is then modified to point to the new ssl cert location before the rest client is created.
  - Creation of a new OperatorKubernetesClusterDescriptor so that a restclient created in the operator can be passed to it and prevent the creation of a restclient within the private createClusterClientProvider method
  - Modify the KubernetesStandaloneClusterDescriptor to be able to pass in a RestClient in same way as the above class

## Verifying this change

This change added tests and can be verified as follows:
  - Added new tests for the new OperatorKubernetesClusterDescriptor class
  - Added a SecureFlinkServiceTest that checks that the copied certs are deleted when the cluster is deleted, that data in the secrets are copied into the relevant directory of the operator and additional test when relevant file does not exist or secret does not exist
  - Added new basic-secure.yaml example that provides a secured flink application and updated relevant README 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no) N.b. this only modifies the Flink service used by the observers and reconcilers

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
