### PR TITLE
[FLINK-29436][FLINK-33359] Upgrade spotless to 2.27.1 to support jdk17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ under the License.
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
 
-        <spotless.version>2.4.2</spotless.version>
+        <spotless.version>2.27.1</spotless.version>
         <it.skip>true</it.skip>
 
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION

## What is the purpose of the change

the blockers for using it with jdk17 are fixed at  https://github.com/diffplug/spotless/pull/1224 and https://github.com/diffplug/spotless/pull/1228.

This allows to run `spotless` for kubernetes operator


## Brief change log

pom.xml

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: ( no)
  - Core observer or reconciler logic that is regularly executed: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
