### PR TITLE
[FLINK-33359][FLINK-25002] add-opens jvm args to support jdk17 for kubernetes operator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         version: ["v1_18","v1_17","v1_16","v1_15","v1_14","v1_13"]
         namespace: ["default","flink"]
         mode: ["native", "standalone"]
+        java-version: [ 11, 17 ]
         test:
           - test_application_kubernetes_ha.sh
           - test_application_operations.sh
@@ -128,10 +129,10 @@ jobs:
     name: e2e_ci
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
       - name: Cache local Maven repository
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,15 @@ jobs:
   test_ci:
     runs-on: ubuntu-latest
     name: test_ci
+    strategy:
+      matrix:
+        java-version: [ 11, 17 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
       - name: Cache local Maven repository
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,16 @@ jobs:
             test: test_dynamic_config.sh
           - version: v1_17
             test: test_dynamic_config.sh
+          - version: v1_13
+            java-version: 17
+          - version: v1_14
+            java-version: 17
+          - version: v1_15
+            java-version: 17
+          - version: v1_16
+            java-version: 17
+          - version: v1_17
+            java-version: 17
     name: e2e_ci
     steps:
       - uses: actions/checkout@v2

--- a/flink-autoscaler/pom.xml
+++ b/flink-autoscaler/pom.xml
@@ -31,6 +31,13 @@ under the License.
     <name>Flink Autoscaler</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <surefire.module.config> <!-- required by
+            JobTopologyTest
+			-->--add-opens=java.base/java.lang=ALL-UNNAMED
+        </surefire.module.config>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-autoscaler/pom.xml
+++ b/flink-autoscaler/pom.xml
@@ -32,9 +32,9 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <surefire.module.config> <!-- required by
-        JobTopologyTest
-        -->--add-opens=java.base/java.lang=ALL-UNNAMED
+        <surefire.module.config>
+            <!-- required by JobTopologyTest -->
+            --add-opens=java.base/java.lang=ALL-UNNAMED
         </surefire.module.config>
     </properties>
 

--- a/flink-autoscaler/pom.xml
+++ b/flink-autoscaler/pom.xml
@@ -33,8 +33,8 @@ under the License.
 
     <properties>
         <surefire.module.config> <!-- required by
-            JobTopologyTest
-			-->--add-opens=java.base/java.lang=ALL-UNNAMED
+        JobTopologyTest
+        -->--add-opens=java.base/java.lang=ALL-UNNAMED
         </surefire.module.config>
     </properties>
 

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -34,6 +34,10 @@ under the License.
     <properties>
         <awaitility.version>4.1.0</awaitility.version>
         <plugins.tmp.dir>${project.build.directory}/plugins</plugins.tmp.dir>
+        <surefire.module.config> <!-- required by
+        FlinkConfigManagerTest
+        -->--add-opens=java.base/java.util=ALL-UNNAMED
+        </surefire.module.config>
     </properties>
 
     <dependencies>

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -34,9 +34,9 @@ under the License.
     <properties>
         <awaitility.version>4.1.0</awaitility.version>
         <plugins.tmp.dir>${project.build.directory}/plugins</plugins.tmp.dir>
-        <surefire.module.config> <!-- required by
-        FlinkConfigManagerTest
-        -->--add-opens=java.base/java.util=ALL-UNNAMED
+        <surefire.module.config>
+            <!-- required by FlinkConfigManagerTest -->
+            --add-opens=java.base/java.util=ALL-UNNAMED
         </surefire.module.config>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,14 @@ under the License.
         <curator-test.version>5.2.0</curator-test.version>
 
         <assertj.version>3.21.0</assertj.version>
+
+        <flink-kubernetes-operator.surefire.baseArgLine>-XX:+IgnoreUnrecognizedVMOptions ${surefire.module.config}</flink-kubernetes-operator.surefire.baseArgLine>
+
+        <!-- This property should contain the add-opens/add-exports commands required for the tests
+		     in the given module to pass.
+		     It MUST be a space-separated list not containing any newlines,
+		     of entries in the form '[-]{2}add-[opens|exports]=<module>/<package>=ALL-UNNAMED'.-->
+        <surefire.module.config/>
     </properties>
 
     <dependencyManagement>
@@ -181,6 +189,17 @@ under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <!-- This is picked up by IntelliJ -->
+                    <argLine>${flink-kubernetes-operator.surefire.baseArgLine}</argLine>
+                </configuration>
+                <executions>
+                    <execution>
+                        <configuration>
+                            <argLine>${flink-kubernetes-operator.surefire.baseArgLine}</argLine>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -435,7 +435,7 @@ under the License.
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.7.3</version>
+                <version>2.7.9</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
The PR applies similar logic as done for FLINK-25002 by introducing `surefire.module.config` to set module related `add-opens`/`add-exports` properties required by jdk17+

## What is the purpose of the change

to support jdk17


## Brief change log

pom files

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.




## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: ( no)
  - Core observer or reconciler logic that is regularly executed: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
