### PR TITLE
[FLINK-33089] Drop support for Flink 1.13 and 1.14 and clean up related codepaths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: ["v1_18","v1_17","v1_16","v1_15","v1_14","v1_13"]
+        version: ["v1_18","v1_17","v1_16","v1_15"]
         namespace: ["default","flink"]
         mode: ["native", "standalone"]
         test:
@@ -82,17 +82,13 @@ jobs:
           - namespace: flink
             extraArgs: '--create-namespace --set "watchNamespaces={default,flink}"'
           - version: v1_18
-            image: ghcr.io\/apache\/flink-docker:1.18-SNAPSHOT-scala_2.12-java11-debian
+            image: flink:1.18
           - version: v1_17
             image: flink:1.17
           - version: v1_16
             image: flink:1.16
           - version: v1_15
             image: flink:1.15
-          - version: v1_14
-            image: flink:1.14
-          - version: v1_13
-            image: flink:1.13
         exclude:
           - namespace: default
             test: test_multi_sessionjob.sh
@@ -103,14 +99,6 @@ jobs:
           - mode: standalone
             test: test_autoscaler.sh
           - mode: standalone
-            test: test_dynamic_config.sh
-          - version: v1_13
-            test: test_autoscaler.sh
-          - version: v1_13
-            test: test_dynamic_config.sh
-          - version: v1_14
-            test: test_autoscaler.sh
-          - version: v1_14
             test: test_dynamic_config.sh
           - version: v1_15
             test: test_autoscaler.sh

--- a/docs/content/docs/concepts/overview.md
+++ b/docs/content/docs/concepts/overview.md
@@ -36,7 +36,7 @@ Flink Kubernetes Operator aims to capture the responsibilities of a human operat
   - Stateful and stateless application upgrades
   - Triggering and managing savepoints
   - Handling errors, rolling-back broken upgrades
-- Multiple Flink version support: v1.13, v1.14, v1.15, v1.16, v1.17
+- Multiple Flink version support: v1.15, v1.16, v1.17, v1.18
 - [Deployment Modes]({{< ref "docs/custom-resource/overview#application-deployments" >}}):
   - Application cluster
   - Session cluster

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -84,6 +84,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | v1_16 |  |
 | v1_17 |  |
 | v1_18 |  |
+| v1_19 |  |
 
 ### IngressSpec
 **Class**: org.apache.flink.kubernetes.operator.api.spec.IngressSpec

--- a/examples/autoscaling/Dockerfile
+++ b/examples/autoscaling/Dockerfile
@@ -16,5 +16,5 @@
 # limitations under the License.
 ################################################################################
 
-FROM ghcr.io/apache/flink-docker:1.18-SNAPSHOT-scala_2.12-java11-debian
+FROM flink:1.18
 COPY ./target/autoscaling*.jar /opt/flink/usrlib/autoscaling.jar

--- a/examples/basic-checkpoint-ha.yaml
+++ b/examples/basic-checkpoint-ha.yaml
@@ -27,7 +27,7 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
     state.savepoints.dir: file:///flink-data/savepoints
     state.checkpoints.dir: file:///flink-data/checkpoints
-    high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
+    high-availability.type: kubernetes
     high-availability.storageDir: file:///flink-data/ha
   serviceAccount: flink
   jobManager:

--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -225,7 +225,7 @@ under the License.
                                       fork="true" failonerror="true">
                                     <classpath refid="maven.compile.classpath"/>
                                     <arg value="file://${rootDir}/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
-                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.4.0/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
+                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.6.0/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml"/>
                                 </java>
                             </target>
                         </configuration>
@@ -242,7 +242,7 @@ under the License.
                                       fork="true" failonerror="true">
                                     <classpath refid="maven.compile.classpath"/>
                                     <arg value="file://${rootDir}/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
-                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.4.0/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
+                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.6.0/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml"/>
                                 </java>
                             </target>
                         </configuration>

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkVersion.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkVersion.java
@@ -28,7 +28,8 @@ public enum FlinkVersion {
     v1_15,
     v1_16,
     v1_17,
-    v1_18;
+    v1_18,
+    v1_19;
 
     public boolean isNewerVersionThan(FlinkVersion otherVersion) {
         return this.ordinal() > otherVersion.ordinal();
@@ -41,5 +42,9 @@ public enum FlinkVersion {
      */
     public static FlinkVersion current() {
         return values()[values().length - 1];
+    }
+
+    public static boolean isSupported(FlinkVersion version) {
+        return version != null && version.isNewerVersionThan(FlinkVersion.v1_14);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -162,9 +162,7 @@ public class FlinkConfigBuilder {
             }
 
             // We need to keep the application clusters around for proper operator behaviour
-            if (spec.getFlinkVersion().isNewerVersionThan(FlinkVersion.v1_14)) {
-                effectiveConfig.set(SHUTDOWN_ON_APPLICATION_FINISH, false);
-            }
+            effectiveConfig.set(SHUTDOWN_ON_APPLICATION_FINISH, false);
             if (HighAvailabilityMode.isHighAvailabilityModeActivated(effectiveConfig)) {
                 setDefaultConf(SUBMIT_FAILED_JOB_ON_APPLICATION_ERROR, true);
             }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -67,6 +67,14 @@ public class SessionJobReconciler
             Optional<String> savepoint,
             boolean requireHaMetadata)
             throws Exception {
+
+        eventRecorder.triggerEvent(
+                ctx.getResource(),
+                EventRecorder.Type.Normal,
+                EventRecorder.Reason.Submit,
+                EventRecorder.Component.Job,
+                MSG_SUBMIT,
+                ctx.getKubernetesClient());
         var jobID =
                 ctx.getFlinkService()
                         .submitJobToSessionCluster(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -114,11 +114,7 @@ public class NativeFlinkService extends AbstractFlinkService {
     public void cancelJob(
             FlinkDeployment deployment, UpgradeMode upgradeMode, Configuration configuration)
             throws Exception {
-        // prior to Flink 1.15, ensure removal of orphaned config maps
-        // https://issues.apache.org/jira/browse/FLINK-30004
-        boolean deleteClusterAfterSavepoint =
-                !deployment.getSpec().getFlinkVersion().isNewerVersionThan(FlinkVersion.v1_14);
-        cancelJob(deployment, upgradeMode, configuration, deleteClusterAfterSavepoint);
+        cancelJob(deployment, upgradeMode, configuration, false);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -249,6 +249,7 @@ public class EventRecorder {
         ScalingReport,
         IneffectiveScaling,
         AutoscalerError,
-        Scaling
+        Scaling,
+        UnsupportedFlinkVersion
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -26,8 +26,6 @@ import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
-import org.apache.flink.kubernetes.operator.api.spec.FlinkDeploymentSpec;
-import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
@@ -338,10 +336,6 @@ public class FlinkUtils {
         return haMode.equalsIgnoreCase(KubernetesHaServicesFactory.class.getCanonicalName())
                 // Hardcoded config value should be removed when upgrading Flink dependency to 1.16
                 || haMode.equalsIgnoreCase("kubernetes");
-    }
-
-    public static boolean clusterShutdownDisabled(FlinkDeploymentSpec spec) {
-        return spec.getFlinkVersion().isNewerVersionThan(FlinkVersion.v1_14);
     }
 
     public static int getNumTaskManagers(Configuration conf) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtils.java
@@ -20,7 +20,6 @@ package org.apache.flink.kubernetes.operator.utils;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
-import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.status.JobStatus;
@@ -402,16 +401,5 @@ public class SnapshotUtils {
                         client);
             }
         }
-    }
-
-    public static SavepointFormatType getSavepointFormatType(Configuration configuration) {
-        var savepointFormatType = org.apache.flink.core.execution.SavepointFormatType.CANONICAL;
-        if (configuration.get(FLINK_VERSION) != null
-                && configuration.get(FLINK_VERSION).isNewerVersionThan(FlinkVersion.v1_14)) {
-            savepointFormatType =
-                    configuration.get(
-                            KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_FORMAT_TYPE);
-        }
-        return savepointFormatType;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
@@ -19,7 +19,9 @@ package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.validation.DefaultValidator;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
 
@@ -55,5 +57,21 @@ public final class ValidatorUtils {
                             resourceValidators.add(validator);
                         });
         return resourceValidators;
+    }
+
+    public static boolean validateSupportedVersion(
+            FlinkResourceContext<?> ctx, EventRecorder eventRecorder) {
+        var version = ctx.getFlinkVersion();
+        if (!FlinkVersion.isSupported(version)) {
+            eventRecorder.triggerEvent(
+                    ctx.getResource(),
+                    EventRecorder.Type.Warning,
+                    EventRecorder.Reason.UnsupportedFlinkVersion,
+                    EventRecorder.Component.Operator,
+                    "Flink version " + version + " is not supported by this operator version",
+                    ctx.getJosdkContext().getClient());
+            return false;
+        }
+        return true;
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -191,16 +191,16 @@ public class TestUtils extends BaseTestUtils {
     }
 
     public static <T extends HasMetadata> Context<T> createContextWithReadyFlinkDeployment(
-            Map<String, String> flinkDepConfig) {
-        return createContextWithReadyFlinkDeployment(flinkDepConfig, null);
+            Map<String, String> flinkDepConfig, KubernetesClient client) {
+        return createContextWithReadyFlinkDeployment(flinkDepConfig, client, FlinkVersion.v1_18);
     }
 
     public static <T extends HasMetadata> Context<T> createContextWithReadyFlinkDeployment(
-            Map<String, String> flinkDepConfig, KubernetesClient client) {
+            Map<String, String> flinkDepConfig, KubernetesClient client, FlinkVersion version) {
         return new TestingContext<>() {
             @Override
             public Optional<T> getSecondaryResource(Class expectedType, String eventSourceName) {
-                var session = buildSessionCluster();
+                var session = buildSessionCluster(version);
                 session.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
                 session.getSpec().getFlinkConfiguration().putAll(flinkDepConfig);
                 session.getStatus()
@@ -324,7 +324,7 @@ public class TestUtils extends BaseTestUtils {
 
     public static Stream<Arguments> flinkVersionsAndUpgradeModes() {
         List<Arguments> args = new ArrayList<>();
-        for (FlinkVersion version : Set.of(FlinkVersion.v1_14, FlinkVersion.v1_15)) {
+        for (FlinkVersion version : Set.of(FlinkVersion.v1_15, FlinkVersion.v1_18)) {
             for (UpgradeMode upgradeMode : UpgradeMode.values()) {
                 args.add(arguments(version, upgradeMode));
             }
@@ -333,10 +333,7 @@ public class TestUtils extends BaseTestUtils {
     }
 
     public static Stream<Arguments> flinkVersions() {
-        return Stream.of(
-                arguments(FlinkVersion.v1_14),
-                arguments(FlinkVersion.v1_15),
-                arguments(FlinkVersion.v1_17));
+        return Stream.of(arguments(FlinkVersion.v1_15), arguments(FlinkVersion.v1_18));
     }
 
     public static FlinkDeployment createCanaryDeployment() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -177,11 +177,7 @@ public class FlinkConfigBuilderTest {
                 new FlinkConfigBuilder(flinkDeployment, new Configuration())
                         .applyFlinkConfiguration()
                         .build();
-        if (flinkVersion.isNewerVersionThan(FlinkVersion.v1_14)) {
-            Assertions.assertFalse(configuration.getBoolean(SHUTDOWN_ON_APPLICATION_FINISH));
-        } else {
-            Assertions.assertTrue(configuration.getBoolean(SHUTDOWN_ON_APPLICATION_FINISH));
-        }
+        Assertions.assertFalse(configuration.getBoolean(SHUTDOWN_ON_APPLICATION_FINISH));
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -24,7 +24,6 @@ import org.apache.flink.kubernetes.operator.OperatorTestBase;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
-import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobStatus;
@@ -694,43 +693,6 @@ public class ApplicationObserverTest extends OperatorTestBase {
                         .getTriggerNonce());
         assertEquals(
                 SavepointFormatType.NATIVE,
-                deployment
-                        .getStatus()
-                        .getJobStatus()
-                        .getSavepointInfo()
-                        .getLastSavepoint()
-                        .getFormatType());
-
-        // canonical for flink savepoint
-        Long thirdNonce = 789L;
-        deployment.getSpec().getJob().setSavepointTriggerNonce(thirdNonce);
-        deployment.getSpec().setFlinkVersion(FlinkVersion.v1_14);
-        deployment
-                .getSpec()
-                .setFlinkConfiguration(
-                        Map.of(
-                                OPERATOR_SAVEPOINT_FORMAT_TYPE.key(),
-                                org.apache.flink.core.execution.SavepointFormatType.NATIVE.name()));
-        conf = configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
-        flinkService.triggerSavepoint(
-                deployment.getStatus().getJobStatus().getJobId(),
-                SnapshotTriggerType.MANUAL,
-                deployment.getStatus().getJobStatus().getSavepointInfo(),
-                conf);
-
-        observer.observe(deployment, readyContext);
-        observer.observe(deployment, readyContext);
-        assertFalse(SnapshotUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
-        assertEquals(
-                thirdNonce,
-                deployment
-                        .getStatus()
-                        .getJobStatus()
-                        .getSavepointInfo()
-                        .getLastSavepoint()
-                        .getTriggerNonce());
-        assertEquals(
-                SavepointFormatType.CANONICAL,
                 deployment
                         .getStatus()
                         .getJobStatus()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -152,9 +152,7 @@ public class NativeFlinkServiceTest {
                             UpgradeMode upgradeMode,
                             Configuration conf,
                             boolean deleteClusterAfterSavepoint) {
-                        assertEquals(
-                                flinkVersion.isNewerVersionThan(FlinkVersion.v1_14) ? false : true,
-                                deleteClusterAfterSavepoint);
+                        assertEquals(false, deleteClusterAfterSavepoint);
                         tested.set(true);
                     }
                 };

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -45,6 +45,7 @@ spec:
                 - v1_16
                 - v1_17
                 - v1_18
+                - v1_19
                 type: string
               ingress:
                 properties:


### PR DESCRIPTION
## What is the purpose of the change

Based on community agreement we drop support for 1.13/1.14 to allow the removal of specific (deprecated) codepaths and reduce CI time overall.

With this we introduce an explicit check and short-circuit exit on unsupported versions.

## Brief change log

  - *Remove 1.13/1.14 specific codepaths and tests*
  - *Short-circuit the controller loop on unsupported versions and trigger user event*
  - *New unit test*

## Verifying this change

New unit tests added, manual verification

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? [TODO]
