### PR TITLE
[FLINK-33306] Always use busy tpr when observed is nan

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -179,12 +179,12 @@ public class ScalingMetricEvaluator {
             double busyTimeTprAvg,
             double observedTprAvg) {
 
-        if (Double.isInfinite(busyTimeTprAvg) || Double.isNaN(busyTimeTprAvg)) {
-            return OBSERVED_TPR;
-        }
-
         if (Double.isNaN(observedTprAvg)) {
             return TRUE_PROCESSING_RATE;
+        }
+
+        if (Double.isInfinite(busyTimeTprAvg) || Double.isNaN(busyTimeTprAvg)) {
+            return OBSERVED_TPR;
         }
 
         double switchThreshold =

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -433,6 +433,32 @@ public class ScalingMetricEvaluatorTest {
                         .evaluate(conf, new CollectedMetricHistory(topology, metricHistory))
                         .get(source)
                         .get(ScalingMetric.TRUE_PROCESSING_RATE));
+
+        metricHistory.put(
+                Instant.ofEpochMilli(100),
+                new CollectedMetrics(
+                        Map.of(
+                                source,
+                                Map.of(
+                                        ScalingMetric.LAG,
+                                        0.,
+                                        ScalingMetric.TRUE_PROCESSING_RATE,
+                                        Double.POSITIVE_INFINITY,
+                                        ScalingMetric.CURRENT_PROCESSING_RATE,
+                                        100.,
+                                        ScalingMetric.SOURCE_DATA_RATE,
+                                        50.,
+                                        ScalingMetric.LOAD,
+                                        10.)),
+                        Map.of()));
+
+        // Test that we used busy time based TPR even when infinity
+        assertEquals(
+                new EvaluatedScalingMetric(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY),
+                evaluator
+                        .evaluate(conf, new CollectedMetricHistory(topology, metricHistory))
+                        .get(source)
+                        .get(ScalingMetric.TRUE_PROCESSING_RATE));
     }
 
     private Tuple2<Double, Double> getThresholds(


### PR DESCRIPTION
## What is the purpose of the change

Fixes a bug where vertices with 0 busy time and low incoming records wouldn't be scaled down due to TPR computed as NAN instead of Infinity.


## Verifying this change

Unit test added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
