### PR TITLE
[FLINK-33427] Handle new autoscaler config keys like operator configs

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
@@ -48,6 +48,7 @@ public abstract class AbstractFlinkSpec implements Diffable<AbstractFlinkSpec> {
 
     /** Flink configuration overrides for the Flink deployment or Flink session job. */
     @SpecDiff.Config({
+        @SpecDiff.Entry(prefix = "job.autoscaler", type = DiffType.IGNORE),
         @SpecDiff.Entry(prefix = "parallelism.default", type = DiffType.IGNORE),
         @SpecDiff.Entry(prefix = "kubernetes.operator", type = DiffType.IGNORE),
         @SpecDiff.Entry(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.kubernetes.operator.config;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.GlobalConfiguration;
@@ -245,7 +246,8 @@ public class FlinkConfigManager {
             spec.getFlinkConfiguration()
                     .forEach(
                             (k, v) -> {
-                                if (k.startsWith(K8S_OP_CONF_PREFIX)) {
+                                if (k.startsWith(K8S_OP_CONF_PREFIX)
+                                        || k.startsWith(AutoScalerOptions.AUTOSCALER_CONF_PREFIX)) {
                                     conf.setString(k, v);
                                 }
                             });

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.config;
 
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
@@ -80,6 +81,10 @@ public class FlinkConfigManagerTest {
 
         deployment.getSpec().getFlinkConfiguration().put(testConf.key(), "latest");
         deployment.getSpec().getFlinkConfiguration().put(opTestConf.key(), "latest");
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(AutoScalerOptions.METRICS_WINDOW.key(), "1234m");
 
         assertEquals(
                 "latest",
@@ -93,6 +98,9 @@ public class FlinkConfigManagerTest {
                         .get(opTestConf));
         assertEquals("reconciled", configManager.getObserveConfig(deployment).get(testConf));
         assertEquals("latest", configManager.getObserveConfig(deployment).get(opTestConf));
+        assertEquals(
+                Duration.ofMinutes(1234),
+                configManager.getObserveConfig(deployment).get(AutoScalerOptions.METRICS_WINDOW));
 
         deployment.getSpec().getFlinkConfiguration().put(testConf.key(), "stable");
         reconciliationStatus.serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/diff/SpecDiffTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/diff/SpecDiffTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.reconciler.diff;
 
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.kubernetes.operator.TestUtils;
@@ -80,12 +81,14 @@ public class SpecDiffTest {
         right.getFlinkConfiguration().put(OPERATOR_RECONCILE_INTERVAL.key(), "100 SECONDS");
         right.getFlinkConfiguration().put(SCOPE_NAMING_KUBERNETES_OPERATOR.key(), "foo.bar");
         right.getFlinkConfiguration().put(CoreOptions.DEFAULT_PARALLELISM.key(), "100");
+        right.getFlinkConfiguration().put(AutoScalerOptions.METRICS_WINDOW.key(), "1234m");
 
         diff = new ReflectiveDiffBuilder<>(KubernetesDeploymentMode.NATIVE, left, right).build();
         assertEquals(DiffType.IGNORE, diff.getType());
-        assertEquals(7, diff.getNumDiffs());
+        assertEquals(8, diff.getNumDiffs());
 
         right.getFlinkConfiguration().remove(SCOPE_NAMING_KUBERNETES_OPERATOR.key());
+        right.getFlinkConfiguration().remove(AutoScalerOptions.METRICS_WINDOW.key());
 
         diff = new ReflectiveDiffBuilder<>(KubernetesDeploymentMode.NATIVE, left, right).build();
         assertEquals(DiffType.IGNORE, diff.getType());


### PR DESCRIPTION
## What is the purpose of the change

An important logic in the operator is to "ignore" config changes that only affect operator behaviour and do not perform application upgrades when only those change. This is currently done based on the `kubernetes.operator` config prefix.

As we have renamed the autoscaler configs and removed the prefix, we need to adapt the operator side as well.


## Brief change log

 - Add `job.autoscaler` prefix to ignored list

## Verifying this change

Unit tests extended

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
