### PR TITLE
[FLINK-33471] Make flink kubernetes operator compilable with jdk21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     name: test_ci
     strategy:
       matrix:
-        java-version: [ 11, 17 ]
+        java-version: [ 11, 17, 21 ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         version: ["v1_18","v1_17","v1_16","v1_15"]
         namespace: ["default","flink"]
         mode: ["native", "standalone"]
-        java-version: [ 11, 17 ]
+        java-version: [ 11, 17, 21 ]
         test:
           - test_application_kubernetes_ha.sh
           - test_application_operations.sh
@@ -114,16 +114,18 @@ jobs:
             test: test_dynamic_config.sh
           - version: v1_17
             test: test_dynamic_config.sh
-          - version: v1_13
-            java-version: 17
-          - version: v1_14
-            java-version: 17
           - version: v1_15
             java-version: 17
           - version: v1_16
             java-version: 17
           - version: v1_17
             java-version: 17
+          - version: v1_15
+            java-version: 21
+          - version: v1_16
+            java-version: 21
+          - version: v1_17
+            java-version: 21
     name: e2e_ci
     steps:
       - uses: actions/checkout@v2

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
@@ -143,13 +143,19 @@ public abstract class FlinkResourceContext<CR extends AbstractFlinkResource<?, ?
      */
     protected abstract Configuration createObserveConfig();
 
-    /** @return Cluster deployment mode. */
+    /**
+     * @return Cluster deployment mode.
+     */
     public abstract KubernetesDeploymentMode getDeploymentMode();
 
-    /** @return Cluster Flink Version. */
+    /**
+     * @return Cluster Flink Version.
+     */
     public abstract FlinkVersion getFlinkVersion();
 
-    /** @return Operator configuration for this resource. */
+    /**
+     * @return Operator configuration for this resource.
+     */
     public FlinkOperatorConfiguration getOperatorConfig() {
         if (operatorConfig != null) {
             return operatorConfig;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
@@ -46,7 +46,8 @@ public class EventSourceUtils {
             EventSourceContext<FlinkDeployment> context) {
         final String labelSelector =
                 Map.of(Constants.LABEL_COMPONENT_KEY, Constants.LABEL_COMPONENT_JOB_MANAGER)
-                        .entrySet().stream()
+                        .entrySet()
+                        .stream()
                         .map(Object::toString)
                         .collect(Collectors.joining(","));
 
@@ -77,7 +78,8 @@ public class EventSourceUtils {
                 InformerConfiguration.from(FlinkSessionJob.class, context)
                         .withSecondaryToPrimaryMapper(
                                 sessionJob ->
-                                        context.getPrimaryCache()
+                                        context
+                                                .getPrimaryCache()
                                                 .byIndex(
                                                         FLINK_DEPLOYMENT_IDX,
                                                         indexKey(
@@ -112,7 +114,8 @@ public class EventSourceUtils {
                 InformerConfiguration.from(FlinkDeployment.class, context)
                         .withSecondaryToPrimaryMapper(
                                 flinkDeployment ->
-                                        context.getPrimaryCache()
+                                        context
+                                                .getPrimaryCache()
                                                 .byIndex(
                                                         FLINK_SESSIONJOB_IDX,
                                                         indexKey(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/OperatorTestBase.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/OperatorTestBase.java
@@ -29,7 +29,9 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import org.junit.jupiter.api.BeforeEach;
 
-/** @link JobStatusObserver unit tests */
+/**
+ * @link JobStatusObserver unit tests
+ */
 public abstract class OperatorTestBase {
 
     protected Configuration conf = new Configuration();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -38,7 +38,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** @link Missing deployment recovery tests */
+/**
+ * @link Missing deployment recovery tests
+ */
 @EnableKubernetesMockClient(crud = true)
 public class DeploymentRecoveryTest {
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FailedDeploymentRestartTest.java
@@ -36,7 +36,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_JOB_RESTART_FAILED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** @link Unhealthy deployment restart tests */
+/**
+ * @link Unhealthy deployment restart tests
+ */
 @EnableKubernetesMockClient(crud = true)
 public class FailedDeploymentRestartTest {
     private FlinkConfigManager configManager;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -51,7 +51,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** @link RollBack logic tests */
+/**
+ * @link RollBack logic tests
+ */
 @EnableKubernetesMockClient(crud = true)
 public class RollbackTest {
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/UnhealthyDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/UnhealthyDeploymentRestartTest.java
@@ -41,7 +41,9 @@ import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConf
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CLUSTER_HEALTH_CHECK_RESTARTS_THRESHOLD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** @link Unhealthy deployment restart tests */
+/**
+ * @link Unhealthy deployment restart tests
+ */
 @EnableKubernetesMockClient(crud = true)
 public class UnhealthyDeploymentRestartTest {
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/HealthProbeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/HealthProbeTest.java
@@ -51,7 +51,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** @link Health probe unit tests */
+/**
+ * @link Health probe unit tests
+ */
 @EnableKubernetesMockClient(crud = true)
 public class HealthProbeTest {
     KubernetesClient client;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetricsTest.java
@@ -43,7 +43,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** @link FlinkDeploymentMetrics tests. */
+/**
+ * @link FlinkDeploymentMetrics tests.
+ */
 public class FlinkDeploymentMetricsTest {
 
     private final Configuration configuration = new Configuration();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/FlinkSessionJobMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/FlinkSessionJobMetricsTest.java
@@ -29,7 +29,9 @@ import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMet
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** @link FlinkSessionJobMetrics tests. */
+/**
+ * @link FlinkSessionJobMetrics tests.
+ */
 public class FlinkSessionJobMetricsTest {
 
     private final Configuration configuration = new Configuration();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricGroupTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricGroupTest.java
@@ -30,7 +30,9 @@ import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMet
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** @link KubernetesOperatorMetricGroup tests. */
+/**
+ * @link KubernetesOperatorMetricGroup tests.
+ */
 public class KubernetesOperatorMetricGroupTest {
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -259,17 +259,26 @@ public class ApplicationObserverTest extends OperatorTestBase {
         assertEquals(
                 0,
                 (int)
-                        kubernetesClient.v1().events()
-                                .inNamespace(deployment.getMetadata().getNamespace()).list()
-                                .getItems().stream()
+                        kubernetesClient
+                                .v1()
+                                .events()
+                                .inNamespace(deployment.getMetadata().getNamespace())
+                                .list()
+                                .getItems()
+                                .stream()
                                 .filter(e -> e.getReason().contains("SavepointError"))
                                 .count());
         observer.observe(deployment, readyContext);
         assertFalse(SnapshotUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
         assertEquals(
                 1,
-                kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
-                        .list().getItems().stream()
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(deployment.getMetadata().getNamespace())
+                        .list()
+                        .getItems()
+                        .stream()
                         .filter(e -> e.getReason().contains("SavepointError"))
                         .count());
 
@@ -289,8 +298,13 @@ public class ApplicationObserverTest extends OperatorTestBase {
         assertFalse(SnapshotUtils.savepointInProgress(deployment.getStatus().getJobStatus()));
         assertEquals(
                 1,
-                kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
-                        .list().getItems().stream()
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(deployment.getMetadata().getNamespace())
+                        .list()
+                        .getItems()
+                        .stream()
                         .filter(e -> e.getReason().contains("SavepointError"))
                         .filter(
                                 e ->
@@ -301,8 +315,13 @@ public class ApplicationObserverTest extends OperatorTestBase {
                         .count());
         assertEquals(
                 2,
-                kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
-                        .list().getItems().stream()
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(deployment.getMetadata().getNamespace())
+                        .list()
+                        .getItems()
+                        .stream()
                         .filter(e -> e.getReason().contains("SavepointError"))
                         .filter(
                                 e ->
@@ -414,8 +433,13 @@ public class ApplicationObserverTest extends OperatorTestBase {
 
         assertEquals(
                 1,
-                kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
-                        .list().getItems().stream()
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(deployment.getMetadata().getNamespace())
+                        .list()
+                        .getItems()
+                        .stream()
                         .filter(e -> e.getReason().contains("SavepointError"))
                         .filter(
                                 e ->
@@ -426,8 +450,13 @@ public class ApplicationObserverTest extends OperatorTestBase {
                         .count());
         assertEquals(
                 1,
-                kubernetesClient.v1().events().inNamespace(deployment.getMetadata().getNamespace())
-                        .list().getItems().stream()
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(deployment.getMetadata().getNamespace())
+                        .list()
+                        .getItems()
+                        .stream()
                         .filter(e -> e.getReason().contains("SavepointError"))
                         .filter(
                                 e ->

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -126,7 +126,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-/** @link JobStatusObserver unit tests */
+/**
+ * @link JobStatusObserver unit tests
+ */
 @EnableKubernetesMockClient(crud = true)
 public class ApplicationReconcilerTest extends OperatorTestBase {
 
@@ -619,11 +621,11 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
                 .setJobStatus(
                         new JobStatus()
                                 .toBuilder()
-                                .jobId(runningJobs.get(0).f1.getJobId().toHexString())
-                                .jobName(runningJobs.get(0).f1.getJobName())
-                                .updateTime(Long.toString(System.currentTimeMillis()))
-                                .state("RUNNING")
-                                .build());
+                                        .jobId(runningJobs.get(0).f1.getJobId().toHexString())
+                                        .jobName(runningJobs.get(0).f1.getJobName())
+                                        .updateTime(Long.toString(System.currentTimeMillis()))
+                                        .state("RUNNING")
+                                        .build());
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
@@ -65,7 +65,9 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-/** @link JobStatusObserver unit tests */
+/**
+ * @link JobStatusObserver unit tests
+ */
 @EnableKubernetesMockClient(crud = true)
 public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
 
@@ -723,11 +725,11 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                 .setJobStatus(
                         new JobStatus()
                                 .toBuilder()
-                                .jobId(runningJobs.get(0).f1.getJobId().toHexString())
-                                .jobName(runningJobs.get(0).f1.getJobName())
-                                .startTime(Long.toString(System.currentTimeMillis()))
-                                .state("RUNNING")
-                                .build());
+                                        .jobId(runningJobs.get(0).f1.getJobId().toHexString())
+                                        .jobName(runningJobs.get(0).f1.getJobName())
+                                        .startTime(Long.toString(System.currentTimeMillis()))
+                                        .state("RUNNING")
+                                        .build());
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -130,7 +130,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-/** @link FlinkService unit tests */
+/**
+ * @link FlinkService unit tests
+ */
 @EnableKubernetesMockClient(crud = true)
 public class AbstractFlinkServiceTest {
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -79,7 +79,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-/** @link FlinkService unit tests */
+/**
+ * @link FlinkService unit tests
+ */
 @EnableKubernetesMockClient(crud = true)
 public class NativeFlinkServiceTest {
     KubernetesClient client;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -50,7 +50,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** @link StandaloneFlinkService unit tests */
+/**
+ * @link StandaloneFlinkService unit tests
+ */
 @EnableKubernetesMockClient(crud = true)
 public class StandaloneFlinkServiceTest {
     KubernetesMockServer mockServer;

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/Fabric8FlinkStandaloneKubeClientTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/Fabric8FlinkStandaloneKubeClientTest.java
@@ -43,7 +43,9 @@ import java.util.List;
 import static org.apache.flink.kubernetes.operator.kubeclient.utils.TestUtils.TEST_NAMESPACE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** @link Fabric8FlinkStandaloneKubeClient unit tests */
+/**
+ * @link Fabric8FlinkStandaloneKubeClient unit tests
+ */
 @EnableKubernetesMockClient(crud = true, https = false)
 public class Fabric8FlinkStandaloneKubeClientTest {
     KubernetesMockServer mockWebServer;

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
@@ -36,7 +36,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-/** @link CmdStandaloneJobManagerDecorator unit tests */
+/**
+ * @link CmdStandaloneJobManagerDecorator unit tests
+ */
 public class CmdStandaloneJobManagerDecoratorTest {
 
     private static final String MOCK_ENTRYPATH = "./docker-entrypath";

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneTaskManagerDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneTaskManagerDecoratorTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
-/** @link CmdStandaloneTaskManagerDecorator unit tests */
+/**
+ * @link CmdStandaloneTaskManagerDecorator unit tests
+ */
 public class CmdStandaloneTaskManagerDecoratorTest {
 
     private static final String MOCK_ENTRYPATH = "./docker-entrypath";

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/InitStandaloneTaskManagerDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/InitStandaloneTaskManagerDecoratorTest.java
@@ -47,7 +47,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** @link InitStandaloneTaskManagerDecorator unit tests */
+/**
+ * @link InitStandaloneTaskManagerDecorator unit tests
+ */
 public class InitStandaloneTaskManagerDecoratorTest extends ParametersTestBase {
 
     private Pod resultPod;

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/UserLibMountDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/UserLibMountDecoratorTest.java
@@ -36,7 +36,9 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** @link UserLibMountDecorator unit tests */
+/**
+ * @link UserLibMountDecorator unit tests
+ */
 public class UserLibMountDecoratorTest {
 
     @Test

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesJobManagerFactoryTest.java
@@ -62,7 +62,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-/** @link StandaloneKubernetesJobManagerFactory unit tests */
+/**
+ * @link StandaloneKubernetesJobManagerFactory unit tests
+ */
 public class StandaloneKubernetesJobManagerFactoryTest extends ParametersTestBase {
 
     KubernetesJobManagerSpecification jmSpec;

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/factory/StandaloneKubernetesTaskManagerFactoryTest.java
@@ -46,7 +46,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** @link StandaloneKubernetesJobManagerFactory unit tests */
+/**
+ * @link StandaloneKubernetesJobManagerFactory unit tests
+ */
 public class StandaloneKubernetesTaskManagerFactoryTest extends ParametersTestBase {
 
     private Deployment deployment;

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParametersTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesJobManagerParametersTest.java
@@ -34,7 +34,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** @link StandaloneKubernetesJobManagerParameters unit tests */
+/**
+ * @link StandaloneKubernetesJobManagerParameters unit tests
+ */
 public class StandaloneKubernetesJobManagerParametersTest extends ParametersTestBase {
     private StandaloneKubernetesJobManagerParameters kubernetesJobManagerParameters;
 

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesTaskManagerParametersTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesTaskManagerParametersTest.java
@@ -37,7 +37,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** @link StandaloneKubernetesTaskManagerParameters unit tests */
+/**
+ * @link StandaloneKubernetesTaskManagerParameters unit tests
+ */
 public class StandaloneKubernetesTaskManagerParametersTest extends ParametersTestBase {
 
     private StandaloneKubernetesTaskManagerParameters kubernetesTaskManagerParameters;

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/standalone/KubernetesStandaloneClusterDescriptorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/standalone/KubernetesStandaloneClusterDescriptorTest.java
@@ -49,7 +49,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** @link KubernetesStandaloneClusterDescriptor unit tests */
+/**
+ * @link KubernetesStandaloneClusterDescriptor unit tests
+ */
 @EnableKubernetesMockClient(crud = true, https = false)
 public class KubernetesStandaloneClusterDescriptorTest {
     KubernetesMockServer mockWebServer;

--- a/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
+++ b/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
@@ -57,7 +57,9 @@ import static org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpVer
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/** @link AdmissionHandler unit tests */
+/**
+ * @link AdmissionHandler unit tests
+ */
 public class AdmissionHandlerTest {
 
     private final AdmissionHandler admissionHandler =

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@ under the License.
 
         <fabric8.version>6.8.1</fabric8.version>
 
-        <lombok.version>1.18.22</lombok.version>
+        <lombok.version>1.18.30</lombok.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-io.version>2.11.0</commons-io.version>
         <flink.version>1.17.1</flink.version>
@@ -86,7 +86,7 @@ under the License.
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
 
-        <spotless.version>2.27.1</spotless.version>
+        <spotless.version>2.40.0</spotless.version>
         <it.skip>true</it.skip>
 
         <hamcrest.version>1.3</hamcrest.version>
@@ -259,7 +259,7 @@ under the License.
                 <configuration>
                     <java>
                         <googleJavaFormat>
-                            <version>1.7</version>
+                            <version>1.17.0</version>
                             <style>AOSP</style>
                         </googleJavaFormat>
 


### PR DESCRIPTION
## What is the purpose of the change

The PR is aiming to support compilation with java 21

Since spotless and google java format needs to be updated to work with java 21
new spotless/google-java-format rules are applied as well

Also lombok dependency is bump to the version which supports  java 21

## Brief change log


## Verifying this change
This change is a trivial rework


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
