### PR TITLE
[FLINK-33102][autoscaler] Document the autoscaler standalone and Extensibility of Autoscaler

### DIFF
--- a/flink-autoscaler/README.md
+++ b/flink-autoscaler/README.md
@@ -27,7 +27,7 @@ designed to be as generic as possible. The following are the introduction of the
 generic interfaces:
 
 - **AutoScalerEventHandler** : Handling autoscaler events, such as: ScalingReport,
-  AutoscalerError, etc. `LoggableEventHandler` is the default implementation, it logs events.
+  AutoscalerError, etc. `LoggingEventHandler` is the default implementation, it logs events.
 - **AutoScalerStateStore** : Storing all state during scaling. `InMemoryAutoScalerStateStore`
   is the default implementation, it's based on the Java Heap, so the state will be discarded
   after process restarts. We will implement persistent State Store in the future, such as


### PR DESCRIPTION
## Brief change log

[FLINK-33102][autoscaler] Document the autoscaler standalone and Extensibility of Autoscaler

The following is the documentation on My Mac.

![image](https://github.com/apache/flink-kubernetes-operator/assets/38427477/8e9520a5-d9f6-422d-962a-f09f89b5ea62)

