### PR TITLE
[hotfix] Fix the checkstyle after supporting jdk21

### DIFF
--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/flinkcluster/FlinkClusterJobListFetcher.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/flinkcluster/FlinkClusterJobListFetcher.java
@@ -53,7 +53,9 @@ public class FlinkClusterJobListFetcher
     @Override
     public List<JobAutoScalerContext<JobID>> fetch() throws Exception {
         try (var restClusterClient = restClientGetter.apply(new Configuration())) {
-            return restClusterClient.listJobs().get(restClientTimeout.toSeconds(), TimeUnit.SECONDS)
+            return restClusterClient
+                    .listJobs()
+                    .get(restClientTimeout.toSeconds(), TimeUnit.SECONDS)
                     .stream()
                     .map(
                             jobStatusMessage -> {


### PR DESCRIPTION
[hotfix] Fix the checkstyle after supporting jdk21

## Why:

https://github.com/apache/flink-kubernetes-operator/pull/701 didn't rebase master branch after FLINK-33099 is merged, and checkstyle is changed in https://github.com/apache/flink-kubernetes-operator/pull/701 , so the checkstyle are broken.

https://github.com/apache/flink-kubernetes-operator/actions/runs/6822258542/job/18554006329#step:5:22559  showed the checkstyle is failed.

