### PR TITLE
[FLINK-33522] Use created savepoint even if job cancellation fails

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -80,6 +80,7 @@ import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagerInfo;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersHeaders;
 import org.apache.flink.runtime.rest.messages.taskmanager.TaskManagersInfo;
 import org.apache.flink.runtime.rest.util.RestMapperUtils;
+import org.apache.flink.runtime.scheduler.stopwithsavepoint.StopWithSavepointStoppingException;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.runtime.webmonitor.handlers.JarDeleteHeaders;
 import org.apache.flink.runtime.webmonitor.handlers.JarRunRequestBody;
@@ -116,6 +117,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -611,8 +613,19 @@ public class AbstractFlinkServiceTest {
 
     @Test
     public void nativeSavepointFormatTest() throws Exception {
+        runNativeSavepointFormatTest(false);
+    }
+
+    @Test
+    public void testSavepointCompletesButJobFailsAfterwards() throws Exception {
+        runNativeSavepointFormatTest(true);
+    }
+
+    private void runNativeSavepointFormatTest(boolean failAfterSavepointCompletes)
+            throws Exception {
         final TestingClusterClient<String> testingClusterClient =
                 new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
+        final JobID jobID = JobID.generate();
         final String savepointPath = "file:///path/of/svp";
         final CompletableFuture<Tuple4<JobID, String, Boolean, SavepointFormatType>>
                 triggerSavepointFuture = new CompletableFuture<>();
@@ -634,13 +647,20 @@ public class AbstractFlinkServiceTest {
                 stopWithSavepointFuture = new CompletableFuture<>();
         testingClusterClient.setStopWithSavepointFormat(
                 (id, formatType, savepointDir) -> {
-                    stopWithSavepointFuture.complete(new Tuple3<>(id, formatType, savepointDir));
+                    if (failAfterSavepointCompletes) {
+                        stopWithSavepointFuture.completeExceptionally(
+                                new CompletionException(
+                                        new StopWithSavepointStoppingException(
+                                                savepointPath, jobID)));
+                    } else {
+                        stopWithSavepointFuture.complete(
+                                new Tuple3<>(id, formatType, savepointDir));
+                    }
                     return CompletableFuture.completedFuture(savepointPath);
                 });
 
         var flinkService = new TestingService(testingClusterClient);
 
-        final JobID jobID = JobID.generate();
         final FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         deployment
                 .getSpec()
@@ -673,9 +693,11 @@ public class AbstractFlinkServiceTest {
                         .set(OPERATOR_SAVEPOINT_FORMAT_TYPE, SavepointFormatType.NATIVE),
                 false);
         assertTrue(stopWithSavepointFuture.isDone());
-        assertEquals(jobID, stopWithSavepointFuture.get().f0);
-        assertEquals(SavepointFormatType.NATIVE, stopWithSavepointFuture.get().f1);
-        assertEquals(savepointPath, stopWithSavepointFuture.get().f2);
+        if (!failAfterSavepointCompletes) {
+            assertEquals(jobID, stopWithSavepointFuture.get().f0);
+            assertEquals(SavepointFormatType.NATIVE, stopWithSavepointFuture.get().f1);
+            assertEquals(savepointPath, stopWithSavepointFuture.get().f2);
+        }
     }
 
     @Test


### PR DESCRIPTION

Under certain circumstances, savepoint creation can succeed but the job fails afterwards. One example is when there are messages being distributed by the source coordinator to finished tasks. This is possibly a Flink bug although it's not clear yet how to resolve the issue.

After the savepoint succeeded Flink fails the job like this:

```
Source (1/2) (cd4d56ddb71c0e763cc400bcfe2fd8ac_4081cf0163fcce7fe6af0cf07ad2d43c_0_0) switched from RUNNING to FAILED on host-taskmanager-1-1 @ ip(dataPort=36519). 
```

```
An OperatorEvent from an OperatorCoordinator to a task was lost. Triggering task failover to ensure consistency. Event: 'AddSplitEvents[[[B@722a23fa]]', targetTask: Source (1/2) - execution #0
Caused by:
org.apache.flink.runtime.operators.coordination.TaskNotRunningException: Task is not running, but in state FINISHED
   at org.apache.flink.runtime.taskmanager.Task.deliverOperatorEvent(Task.java:1502)
   at org.apache.flink.runtime.taskexecutor.TaskExecutor.sendOperatorEventToTask
```

Inside the operator this is processed as:

```
java.util.concurrent.CompletionException: org.apache.flink.runtime.scheduler.stopwithsavepoint.StopWithSavepointStoppingException: A savepoint has been created at: s3://..., but the corresponding job 1b1a3061194c62ded6e2fe823b61b2ea failed during stopping. The savepoint is consistent, but might have uncommitted transactions. If you want to commit the transaction please restart a job from this savepoint. 

          java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:395) 
          java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2022) 
          org.apache.flink.kubernetes.operator.service.AbstractFlinkService.cancelJob(AbstractFlinkService.java:319) 
          org.apache.flink.kubernetes.operator.service.NativeFlinkService.cancelJob(NativeFlinkService.java:121) 
          org.apache.flink.kubernetes.operator.reconciler.deployment.ApplicationReconciler.cancelJob(ApplicationReconciler.java:223) 
          org.apache.flink.kubernetes.operator.reconciler.deployment.AbstractJobReconciler.reconcileSpecChange(AbstractJobReconciler.java:122) 
         org.apache.flink.kubernetes.operator.reconciler.deployment.AbstractFlinkResourceReconciler.reconcile(AbstractFlinkResourceReconciler.java:163)
          org.apache.flink.kubernetes.operator.controller.FlinkDeploymentController.reconcile(FlinkDeploymentController.java:136) 
          org.apache.flink.kubernetes.operator.controller.FlinkDeploymentController.reconcile(FlinkDeploymentController.java:56) 
          io.javaoperatorsdk.operator.processing.Controller$1.execute(Controller.java:138) 
          io.javaoperatorsdk.operator.processing.Controller$1.execute(Controller.java:96) 
          org.apache.flink.kubernetes.operator.metrics.OperatorJosdkMetrics.timeControllerExecution(OperatorJosdkMetrics.java:80) 
          io.javaoperatorsdk.operator.processing.Controller.reconcile(Controller.java:95) 
          io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.reconcileExecution(ReconciliationDispatcher.java:139) 
          io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleReconcile(ReconciliationDispatcher.java:119) 
          io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleDispatch(ReconciliationDispatcher.java:89) 
          io.javaoperatorsdk.operator.processing.event.ReconciliationDispatcher.handleExecution(ReconciliationDispatcher.java:62) 
          io.javaoperatorsdk.operator.processing.event.EventProcessor$ReconcilerExecutor.run(EventProcessor.java:414) 
          java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) 
          java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) 
          java.lang.Thread.run(Thread.java:829) 
```

Subsequently we get the following because HA metadata is not available anymore. It has been cleared up after the terminal job failure:

```
org.apache.flink.kubernetes.operator.exception.RecoveryFailureException","message":"HA metadata not available to restore from last state. It is possible that the job has finished or terminally failed, or the configmaps have been deleted. 
```

The deployment needs to be manually restored from a savepoint. This PR allows the cluster upgrade to succeed by recovering the savepoint location info and preventing the upgrade process to be disrupted.
