### PR TITLE
[FLINK-33526] Autoscaler config improvement + cleanup

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -16,7 +16,7 @@
         </tr>
         <tr>
             <td><h5>job.autoscaler.catch-up.duration</h5></td>
-            <td style="word-wrap: break-word;">15 min</td>
+            <td style="word-wrap: break-word;">30 min</td>
             <td>Duration</td>
             <td>The target duration for fully processing any backlog after a scaling operation. Set to 0 to disable backlog based scaling.</td>
         </tr>
@@ -52,7 +52,7 @@
         </tr>
         <tr>
             <td><h5>job.autoscaler.metrics.window</h5></td>
-            <td style="word-wrap: break-word;">10 min</td>
+            <td style="word-wrap: break-word;">15 min</td>
             <td>Duration</td>
             <td>Scaling metrics aggregation window size.</td>
         </tr>
@@ -76,7 +76,7 @@
         </tr>
         <tr>
             <td><h5>job.autoscaler.restart.time</h5></td>
-            <td style="word-wrap: break-word;">3 min</td>
+            <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>
             <td>Expected restart time to be used until the operator can determine it reliably from history.</td>
         </tr>
@@ -136,7 +136,7 @@
         </tr>
         <tr>
             <td><h5>job.autoscaler.target.utilization.boundary</h5></td>
-            <td style="word-wrap: break-word;">0.4</td>
+            <td style="word-wrap: break-word;">0.3</td>
             <td>Double</td>
             <td>Target vertex utilization boundary. Scaling won't be performed if the current processing rate is within [target_rate / (target_utilization - boundary), (target_rate / (target_utilization + boundary)]</td>
         </tr>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScaler.java
@@ -20,16 +20,26 @@ package org.apache.flink.autoscaler;
 import org.apache.flink.annotation.Internal;
 
 /**
- * The generic Autoscaler.
+ * Flink Job AutoScaler.
  *
  * @param <KEY> The job key.
+ * @param <Context> Instance of {@link JobAutoScalerContext}.
  */
 @Internal
 public interface JobAutoScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
 
-    /** Called as part of the reconciliation loop. */
+    /**
+     * Compute and apply new parallelism overrides for the provided job context.
+     *
+     * @param context Job context.
+     * @throws Exception
+     */
     void scale(Context context) throws Exception;
 
-    /** Called when the job is deleted. */
-    void cleanup(KEY key);
+    /**
+     * Called when the job is deleted.
+     *
+     * @param jobKey Job key.
+     */
+    void cleanup(KEY jobKey);
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -91,6 +91,7 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
             }
 
             if (ctx.getJobStatus() != JobStatus.RUNNING) {
+                LOG.debug("Autoscaler is waiting for stable, running state");
                 lastEvaluatedMetrics.remove(ctx.getJobKey());
                 return;
             }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -60,7 +60,7 @@ public class AutoScalerOptions {
     public static final ConfigOption<Duration> METRICS_WINDOW =
             autoScalerConfig("metrics.window")
                     .durationType()
-                    .defaultValue(Duration.ofMinutes(10))
+                    .defaultValue(Duration.ofMinutes(15))
                     .withDeprecatedKeys(deprecatedOperatorConfigKey("metrics.window"))
                     .withDescription("Scaling metrics aggregation window size.");
 
@@ -82,7 +82,7 @@ public class AutoScalerOptions {
     public static final ConfigOption<Double> TARGET_UTILIZATION_BOUNDARY =
             autoScalerConfig("target.utilization.boundary")
                     .doubleType()
-                    .defaultValue(0.4)
+                    .defaultValue(0.3)
                     .withDeprecatedKeys(deprecatedOperatorConfigKey("target.utilization.boundary"))
                     .withDescription(
                             "Target vertex utilization boundary. Scaling won't be performed if the current processing rate is within [target_rate / (target_utilization - boundary), (target_rate / (target_utilization + boundary)]");
@@ -129,7 +129,7 @@ public class AutoScalerOptions {
     public static final ConfigOption<Duration> CATCH_UP_DURATION =
             autoScalerConfig("catch-up.duration")
                     .durationType()
-                    .defaultValue(Duration.ofMinutes(15))
+                    .defaultValue(Duration.ofMinutes(30))
                     .withDeprecatedKeys(deprecatedOperatorConfigKey("catch-up.duration"))
                     .withDescription(
                             "The target duration for fully processing any backlog after a scaling operation. Set to 0 to disable backlog based scaling.");
@@ -137,7 +137,7 @@ public class AutoScalerOptions {
     public static final ConfigOption<Duration> RESTART_TIME =
             autoScalerConfig("restart.time")
                     .durationType()
-                    .defaultValue(Duration.ofMinutes(3))
+                    .defaultValue(Duration.ofMinutes(5))
                     .withDeprecatedKeys(deprecatedOperatorConfigKey("restart.time"))
                     .withDescription(
                             "Expected restart time to be used until the operator can determine it reliably from history.");
@@ -234,7 +234,7 @@ public class AutoScalerOptions {
     public static final ConfigOption<Duration> SCALING_EVENT_INTERVAL =
             autoScalerConfig("scaling.event.interval")
                     .durationType()
-                    .defaultValue(Duration.ofSeconds(1800))
+                    .defaultValue(Duration.ofMinutes(30))
                     .withDeprecatedKeys(deprecatedOperatorConfigKey("scaling.event.interval"))
                     .withDescription("Time interval to resend the identical event");
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -376,7 +376,7 @@ public class MetricsCollectionAndEvaluationTest {
                 5000.,
                 evaluation.get(source1).get(ScalingMetric.TRUE_PROCESSING_RATE).getCurrent());
         assertEquals(
-                1667.,
+                1250.,
                 evaluation.get(source1).get(ScalingMetric.SCALE_DOWN_RATE_THRESHOLD).getCurrent());
         assertEquals(
                 500.,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -166,8 +166,7 @@ public class FlinkOperator {
                 MetricManager.createFlinkDeploymentMetricManager(baseConfig, metricGroup);
         var statusRecorder = StatusRecorder.create(client, metricManager, listeners);
         var autoscaler = AutoscalerFactory.create(client, eventRecorder);
-        var reconcilerFactory =
-                new ReconcilerFactory(configManager, eventRecorder, statusRecorder, autoscaler);
+        var reconcilerFactory = new ReconcilerFactory(eventRecorder, statusRecorder, autoscaler);
         var observerFactory = new FlinkDeploymentObserverFactory(eventRecorder);
         var canaryResourceManager = new CanaryResourceManager<FlinkDeployment>(configManager);
         HealthProbe.INSTANCE.registerCanaryResourceManager(canaryResourceManager);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ReconcilerFactory.java
@@ -23,7 +23,6 @@ import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.autoscaler.KubernetesJobAutoScalerContext;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.Mode;
 import org.apache.flink.kubernetes.operator.reconciler.Reconciler;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
@@ -37,7 +36,6 @@ import java.util.concurrent.ConcurrentHashMap;
 /** The factory to create reconciler based on app mode. */
 public class ReconcilerFactory {
 
-    private final FlinkConfigManager configManager;
     private final EventRecorder eventRecorder;
     private final StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> deploymentStatusRecorder;
     private final JobAutoScaler<ResourceID, KubernetesJobAutoScalerContext> autoscaler;
@@ -45,11 +43,9 @@ public class ReconcilerFactory {
             reconcilerMap;
 
     public ReconcilerFactory(
-            FlinkConfigManager configManager,
             EventRecorder eventRecorder,
             StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> deploymentStatusRecorder,
             JobAutoScaler<ResourceID, KubernetesJobAutoScalerContext> autoscaler) {
-        this.configManager = configManager;
         this.eventRecorder = eventRecorder;
         this.deploymentStatusRecorder = deploymentStatusRecorder;
         this.autoscaler = autoscaler;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -92,7 +92,6 @@ public class TestingFlinkDeploymentController
         statusRecorder = new StatusRecorder<>(new MetricManager<>(), statusUpdateCounter);
         reconcilerFactory =
                 new ReconcilerFactory(
-                        configManager,
                         eventRecorder,
                         statusRecorder,
                         AutoscalerFactory.create(


### PR DESCRIPTION
## What is the purpose of the change

There are a few config defaults that should be improved based on prod usage:
 - Metric window : 10 -> 15m
 - Catch up duration: 15 -> 30m
 - Restart time: 3 -> 5m
 - Utilisation boundary: 0.4 -> 0.3

These configs help make the default autoscaler behaviour smoother and less aggressive.

## Brief change log

  - *Config improvements*
  - *Javadoc method naming cleanup*
  - *Support autoscaler for session jobs*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
