### PR TITLE
[FLINK-33097] Cleanup use of Optional for new interfaces

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
@@ -58,7 +58,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -94,7 +93,7 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                         jobKey,
                         (k) -> {
                             try {
-                                return stateStore.getCollectedMetrics(ctx).orElse(new TreeMap<>());
+                                return stateStore.getCollectedMetrics(ctx);
                             } catch (Exception exception) {
                                 throw new RuntimeException(
                                         "Get evaluated metrics failed.", exception);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingHistoryUtils.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingHistoryUtils.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import javax.annotation.Nonnull;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -86,10 +85,7 @@ public class ScalingHistoryUtils {
                     Instant now)
                     throws Exception {
         var conf = context.getConfiguration();
-        return autoScalerStateStore
-                .getScalingHistory(context)
-                .map(scalingHistory -> trimScalingHistory(now, conf, scalingHistory))
-                .orElse(new HashMap<>());
+        return trimScalingHistory(now, conf, autoScalerStateStore.getScalingHistory(context));
     }
 
     public static Map<JobVertexID, SortedMap<Instant, ScalingSummary>> trimScalingHistory(

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
@@ -23,6 +23,8 @@ import org.apache.flink.autoscaler.ScalingSummary;
 import org.apache.flink.autoscaler.metrics.CollectedMetrics;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import javax.annotation.Nonnull;
+
 import java.time.Instant;
 import java.util.Map;
 import java.util.SortedMap;
@@ -40,6 +42,7 @@ public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
             Context jobContext, Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory)
             throws Exception;
 
+    @Nonnull
     Map<JobVertexID, SortedMap<Instant, ScalingSummary>> getScalingHistory(Context jobContext)
             throws Exception;
 
@@ -48,6 +51,7 @@ public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
     void storeCollectedMetrics(Context jobContext, SortedMap<Instant, CollectedMetrics> metrics)
             throws Exception;
 
+    @Nonnull
     SortedMap<Instant, CollectedMetrics> getCollectedMetrics(Context jobContext) throws Exception;
 
     void removeCollectedMetrics(Context jobContext) throws Exception;
@@ -55,6 +59,7 @@ public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
     void storeParallelismOverrides(Context jobContext, Map<String, String> parallelismOverrides)
             throws Exception;
 
+    @Nonnull
     Map<String, String> getParallelismOverrides(Context jobContext) throws Exception;
 
     void removeParallelismOverrides(Context jobContext) throws Exception;

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import java.time.Instant;
 import java.util.Map;
-import java.util.Optional;
 import java.util.SortedMap;
 
 /**
@@ -41,23 +40,22 @@ public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
             Context jobContext, Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory)
             throws Exception;
 
-    Optional<Map<JobVertexID, SortedMap<Instant, ScalingSummary>>> getScalingHistory(
-            Context jobContext) throws Exception;
+    Map<JobVertexID, SortedMap<Instant, ScalingSummary>> getScalingHistory(Context jobContext)
+            throws Exception;
 
     void removeScalingHistory(Context jobContext) throws Exception;
 
     void storeCollectedMetrics(Context jobContext, SortedMap<Instant, CollectedMetrics> metrics)
             throws Exception;
 
-    Optional<SortedMap<Instant, CollectedMetrics>> getCollectedMetrics(Context jobContext)
-            throws Exception;
+    SortedMap<Instant, CollectedMetrics> getCollectedMetrics(Context jobContext) throws Exception;
 
     void removeCollectedMetrics(Context jobContext) throws Exception;
 
     void storeParallelismOverrides(Context jobContext, Map<String, String> parallelismOverrides)
             throws Exception;
 
-    Optional<Map<String, String>> getParallelismOverrides(Context jobContext) throws Exception;
+    Map<String, String> getParallelismOverrides(Context jobContext) throws Exception;
 
     void removeParallelismOverrides(Context jobContext) throws Exception;
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
@@ -23,9 +23,11 @@ import org.apache.flink.autoscaler.metrics.CollectedMetrics;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -58,9 +60,10 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
     }
 
     @Override
-    public Optional<Map<JobVertexID, SortedMap<Instant, ScalingSummary>>> getScalingHistory(
+    public Map<JobVertexID, SortedMap<Instant, ScalingSummary>> getScalingHistory(
             Context jobContext) {
-        return Optional.ofNullable(scalingHistoryStore.get(jobContext.getJobKey()));
+        return Optional.ofNullable(scalingHistoryStore.get(jobContext.getJobKey()))
+                .orElse(new HashMap<>());
     }
 
     @Override
@@ -75,8 +78,9 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
     }
 
     @Override
-    public Optional<SortedMap<Instant, CollectedMetrics>> getCollectedMetrics(Context jobContext) {
-        return Optional.ofNullable(collectedMetricsStore.get(jobContext.getJobKey()));
+    public SortedMap<Instant, CollectedMetrics> getCollectedMetrics(Context jobContext) {
+        return Optional.ofNullable(collectedMetricsStore.get(jobContext.getJobKey()))
+                .orElse(new TreeMap<>());
     }
 
     @Override
@@ -91,8 +95,9 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
     }
 
     @Override
-    public Optional<Map<String, String>> getParallelismOverrides(Context jobContext) {
-        return Optional.ofNullable(parallelismOverridesStore.get(jobContext.getJobKey()));
+    public Map<String, String> getParallelismOverrides(Context jobContext) {
+        return Optional.ofNullable(parallelismOverridesStore.get(jobContext.getJobKey()))
+                .orElse(new HashMap<>());
     }
 
     @Override

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
@@ -39,7 +39,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 
@@ -368,7 +367,7 @@ public class BacklogBasedScalingTest {
                                         "", Double.NaN, Double.NaN, Double.NaN, 500.))));
 
         autoscaler.scale(context);
-        assertFalse(stateStore.getCollectedMetrics(context).get().isEmpty());
+        assertFalse(stateStore.getCollectedMetrics(context).isEmpty());
     }
 
     @Test
@@ -397,10 +396,9 @@ public class BacklogBasedScalingTest {
     }
 
     private void assertEvaluatedMetricsSize(int expectedSize) {
-        Optional<SortedMap<Instant, CollectedMetrics>> evaluatedMetricsOpt =
+        SortedMap<Instant, CollectedMetrics> evaluatedMetrics =
                 stateStore.getCollectedMetrics(context);
-        assertThat(evaluatedMetricsOpt).isPresent();
-        assertThat(evaluatedMetricsOpt.get()).hasSize(expectedSize);
+        assertThat(evaluatedMetrics).hasSize(expectedSize);
     }
 
     private void setClocksTo(Instant time) {

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -568,11 +568,11 @@ public class MetricsCollectionAndEvaluationTest {
         metricsCollector.setClock(Clock.fixed(Instant.ofEpochMilli(50), ZoneId.systemDefault()));
         assertTrue(
                 metricsCollector.updateMetrics(context, stateStore).getMetricHistory().isEmpty());
-        assertEquals(1, stateStore.getCollectedMetrics(context).get().size());
+        assertEquals(1, stateStore.getCollectedMetrics(context).size());
         metricsCollector.setClock(Clock.fixed(Instant.ofEpochMilli(60), ZoneId.systemDefault()));
         assertTrue(
                 metricsCollector.updateMetrics(context, stateStore).getMetricHistory().isEmpty());
-        assertEquals(2, stateStore.getCollectedMetrics(context).get().size());
+        assertEquals(2, stateStore.getCollectedMetrics(context).size());
 
         testTolerateMetricsMissingDuringStabilizationPhase(topology);
 
@@ -580,18 +580,18 @@ public class MetricsCollectionAndEvaluationTest {
         metricsCollector.setClock(Clock.fixed(Instant.ofEpochMilli(150), ZoneId.systemDefault()));
         assertEquals(
                 3, metricsCollector.updateMetrics(context, stateStore).getMetricHistory().size());
-        assertEquals(3, stateStore.getCollectedMetrics(context).get().size());
+        assertEquals(3, stateStore.getCollectedMetrics(context).size());
 
         metricsCollector.setClock(Clock.fixed(Instant.ofEpochMilli(180), ZoneId.systemDefault()));
         assertEquals(
                 4, metricsCollector.updateMetrics(context, stateStore).getMetricHistory().size());
-        assertEquals(4, stateStore.getCollectedMetrics(context).get().size());
+        assertEquals(4, stateStore.getCollectedMetrics(context).size());
 
         // Once we reach full time we trim the stabilization metrics
         metricsCollector.setClock(Clock.fixed(Instant.ofEpochMilli(260), ZoneId.systemDefault()));
         assertEquals(
                 2, metricsCollector.updateMetrics(context, stateStore).getMetricHistory().size());
-        assertEquals(2, stateStore.getCollectedMetrics(context).get().size());
+        assertEquals(2, stateStore.getCollectedMetrics(context).size());
     }
 
     private void testTolerateMetricsMissingDuringStabilizationPhase(JobTopology topology) {
@@ -610,7 +610,7 @@ public class MetricsCollectionAndEvaluationTest {
         collectorWithMissingMetrics.setJobUpdateTs(startTime);
 
         Supplier<Integer> numCollectedMetricsSupplier =
-                () -> stateStore.getCollectedMetrics(context).get().size();
+                () -> stateStore.getCollectedMetrics(context).size();
 
         int numCollectedMetricsBeforeTest = numCollectedMetricsSupplier.get();
         assertThrows(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
@@ -39,7 +39,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 
@@ -205,7 +204,7 @@ public class RecommendedParallelismTest {
 
         // after restart while the job is not running the evaluated metrics are gone
         autoscaler.scale(context);
-        assertEquals(3, stateStore.getCollectedMetrics(context).get().size());
+        assertEquals(3, stateStore.getCollectedMetrics(context).size());
         assertNull(autoscaler.lastEvaluatedMetrics.get(context.getJobKey()));
         scaledParallelism = ScalingExecutorTest.getScaledParallelism(stateStore, context);
         assertEquals(4, scaledParallelism.get(source));
@@ -229,10 +228,9 @@ public class RecommendedParallelismTest {
     }
 
     private void assertEvaluatedMetricsSize(int expectedSize) {
-        Optional<SortedMap<Instant, CollectedMetrics>> evaluatedMetricsOpt =
+        SortedMap<Instant, CollectedMetrics> evaluatedMetrics =
                 stateStore.getCollectedMetrics(context);
-        assertThat(evaluatedMetricsOpt).isPresent();
-        assertThat(evaluatedMetricsOpt.get()).hasSize(expectedSize);
+        assertThat(evaluatedMetrics).hasSize(expectedSize);
     }
 
     private Double getCurrentMetricValue(JobVertexID jobVertexID, ScalingMetric scalingMetric) {

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -247,15 +247,10 @@ public class ScalingExecutorTest {
             Map<JobVertexID, Integer> getScaledParallelism(
                     AutoScalerStateStore<KEY, Context> stateStore, Context context)
                     throws Exception {
-        return stateStore
-                .getParallelismOverrides(context)
-                .map(
-                        overrides ->
-                                overrides.entrySet().stream()
-                                        .collect(
-                                                Collectors.toMap(
-                                                        e -> JobVertexID.fromHexString(e.getKey()),
-                                                        e -> Integer.valueOf(e.getValue()))))
-                .orElse(Map.of());
+        return stateStore.getParallelismOverrides(context).entrySet().stream()
+                .collect(
+                        Collectors.toMap(
+                                e -> JobVertexID.fromHexString(e.getKey()),
+                                e -> Integer.valueOf(e.getValue())));
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerStateStoreTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerStateStoreTest.java
@@ -218,7 +218,7 @@ public class KubernetesAutoScalerStateStoreTest {
         var now = Instant.now();
 
         Assertions.assertEquals(scalingHistory, getTrimmedScalingHistory(stateStore, ctx, now));
-        assertThat(stateStore.getCollectedMetrics(ctx)).hasValue(metricHistory);
+        assertThat(stateStore.getCollectedMetrics(ctx)).isEqualTo(metricHistory);
 
         // Override with compressed data
         var newTs = Instant.now();
@@ -228,7 +228,7 @@ public class KubernetesAutoScalerStateStoreTest {
 
         // Make sure we can still access everything
         Assertions.assertEquals(scalingHistory, getTrimmedScalingHistory(stateStore, ctx, newTs));
-        assertThat(stateStore.getCollectedMetrics(ctx)).hasValue(metricHistory);
+        assertThat(stateStore.getCollectedMetrics(ctx)).isEqualTo(metricHistory);
     }
 
     @Test


### PR DESCRIPTION
The new interfaces make use of Optional in many places where returning the object directly would result in less and more readable code.
