### PR TITLE
[FLINK-30593][autoscaler] Determine restart time on the fly fo Autoscaler

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -81,16 +81,16 @@
             <td>Expected restart time to be used until the operator can determine it reliably from history.</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.restart.time.tracked.enabled</h5></td>
+            <td><h5>job.autoscaler.restart.time-tracking.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Whether to use the actually observed rescaling restart times instead of the fixed 'job.autoscaler.restart.time' configuration. If set to true, the maximum restart duration over a number of samples will be used. The value of 'job.autoscaler.restart.time' will act as an upper bound.</td>
+            <td>Whether to use the actual observed rescaling restart times instead of the fixed 'job.autoscaler.restart.time' configuration. If set to true, the maximum restart duration over a number of samples will be used. The value of 'job.autoscaler.restart.time' will act as an upper bound.</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.restart.time.tracked.limit</h5></td>
+            <td><h5>job.autoscaler.restart.time-tracking.limit</h5></td>
             <td style="word-wrap: break-word;">15 min</td>
             <td>Duration</td>
-            <td>Maximum cap for the calculated restart time when 'job.autoscaler.restart.time.tracked.enabled' is set to true.</td>
+            <td>Maximum cap for the observed restart time when 'job.autoscaler.restart.time-tracking.enabled' is set to true.</td>
         </tr>
         <tr>
             <td><h5>job.autoscaler.scale-down.max-factor</h5></td>

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -81,6 +81,18 @@
             <td>Expected restart time to be used until the operator can determine it reliably from history.</td>
         </tr>
         <tr>
+            <td><h5>job.autoscaler.restart.time.tracked.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to use the actually observed rescaling restart times instead of the fixed 'job.autoscaler.restart.time' configuration. If set to true, the maximum restart duration over a number of samples will be used. The value of 'job.autoscaler.restart.time' will act as an upper bound.</td>
+        </tr>
+        <tr>
+            <td><h5>job.autoscaler.restart.time.tracked.limit</h5></td>
+            <td style="word-wrap: break-word;">15 min</td>
+            <td>Duration</td>
+            <td>Maximum cap for the calculated restart time when 'job.autoscaler.restart.time.tracked.enabled' is set to true.</td>
+        </tr>
+        <tr>
             <td><h5>job.autoscaler.scale-down.max-factor</h5></td>
             <td style="word-wrap: break-word;">0.6</td>
             <td>Double</td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerContext.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerContext.java
@@ -26,6 +26,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.util.function.SupplierWithException;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -39,6 +40,7 @@ import javax.annotation.Nullable;
 @Experimental
 @AllArgsConstructor
 @ToString
+@Builder(toBuilder = true)
 public class JobAutoScalerContext<KEY> {
 
     /** The identifier of each flink job. */

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -171,7 +171,7 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
         var now = clock.instant();
         // Scaling tracking data contains previous restart times that are taken into account
         var scalingTracking = getTrimmedScalingTracking(stateStore, ctx, now);
-        var restartTime = scalingTracking.getMaxRestartTimeSecondsOrDefault(ctx.getConfiguration());
+        var restartTime = scalingTracking.getMaxRestartTimeOrDefault(ctx.getConfiguration());
         var evaluatedMetrics =
                 evaluator.evaluate(ctx.getConfiguration(), collectedMetrics, restartTime);
         LOG.debug("Evaluated metrics: {}", evaluatedMetrics);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -171,10 +171,9 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
         var now = clock.instant();
         // Scaling tracking data contains previous restart times that are taken into account
         var scalingTracking = getTrimmedScalingTracking(stateStore, ctx, now);
-        var restartTimeSec =
-                scalingTracking.getMaxRestartTimeSecondsOrDefault(ctx.getConfiguration());
+        var restartTime = scalingTracking.getMaxRestartTimeSecondsOrDefault(ctx.getConfiguration());
         var evaluatedMetrics =
-                evaluator.evaluate(ctx.getConfiguration(), collectedMetrics, restartTimeSec);
+                evaluator.evaluate(ctx.getConfiguration(), collectedMetrics, restartTime);
         LOG.debug("Evaluated metrics: {}", evaluatedMetrics);
         lastEvaluatedMetrics.put(ctx.getJobKey(), evaluatedMetrics);
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -42,6 +42,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.AUTOSCALER_ENABLED;
 import static org.apache.flink.autoscaler.metrics.AutoscalerFlinkMetrics.initRecommendedParallelism;
 import static org.apache.flink.autoscaler.metrics.AutoscalerFlinkMetrics.resetRecommendedParallelism;
+import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.getTrimmedScalingHistory;
+import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.getTrimmedScalingTracking;
 
 /** The default implementation of {@link JobAutoScaler}. */
 public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
@@ -159,19 +161,26 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
             throws Exception {
 
         var collectedMetrics = metricsCollector.updateMetrics(ctx, stateStore);
+        var jobTopology = collectedMetrics.getJobTopology();
 
         if (collectedMetrics.getMetricHistory().isEmpty()) {
             return;
         }
         LOG.debug("Collected metrics: {}", collectedMetrics);
 
-        var evaluatedMetrics = evaluator.evaluate(ctx.getConfiguration(), collectedMetrics);
+        var now = clock.instant();
+        // Scaling tracking data contains previous restart times that are taken into account
+        var scalingTracking = getTrimmedScalingTracking(stateStore, ctx, now);
+        var restartTimeSec =
+                scalingTracking.getMaxRestartTimeSecondsOrDefault(ctx.getConfiguration());
+        var evaluatedMetrics =
+                evaluator.evaluate(ctx.getConfiguration(), collectedMetrics, restartTimeSec);
         LOG.debug("Evaluated metrics: {}", evaluatedMetrics);
         lastEvaluatedMetrics.put(ctx.getJobKey(), evaluatedMetrics);
 
         initRecommendedParallelism(evaluatedMetrics);
         autoscalerMetrics.registerScalingMetrics(
-                collectedMetrics.getJobTopology().getVerticesInTopologicalOrder(),
+                jobTopology.getVerticesInTopologicalOrder(),
                 () -> lastEvaluatedMetrics.get(ctx.getJobKey()));
 
         if (!collectedMetrics.isFullyCollected()) {
@@ -180,7 +189,19 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
             return;
         }
 
-        var parallelismChanged = scalingExecutor.scaleResource(ctx, evaluatedMetrics);
+        var scalingHistory = getTrimmedScalingHistory(stateStore, ctx, now);
+        // A scaling tracking without an end time gets created whenever a scaling decision is
+        // applied. Here, when the job transitions to RUNNING, we record the time for it.
+        if (ctx.getJobStatus() == JobStatus.RUNNING) {
+            if (scalingTracking.setEndTimeIfTrackedAndParallelismMatches(
+                    now, jobTopology, scalingHistory)) {
+                stateStore.storeScalingTracking(ctx, scalingTracking);
+            }
+        }
+
+        var parallelismChanged =
+                scalingExecutor.scaleResource(
+                        ctx, evaluatedMetrics, scalingHistory, scalingTracking, now);
 
         if (parallelismChanged) {
             autoscalerMetrics.incrementScaling();

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Map;
@@ -72,7 +73,7 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
             JobVertexID vertex,
             Map<ScalingMetric, EvaluatedScalingMetric> evaluatedMetrics,
             SortedMap<Instant, ScalingSummary> history,
-            double restartTimeSec) {
+            Duration restartTime) {
         var conf = context.getConfiguration();
         var currentParallelism = (int) evaluatedMetrics.get(PARALLELISM).getCurrent();
         double averageTrueProcessingRate = evaluatedMetrics.get(TRUE_PROCESSING_RATE).getAverage();
@@ -85,7 +86,7 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
 
         double targetCapacity =
                 AutoScalerUtils.getTargetProcessingCapacity(
-                        evaluatedMetrics, conf, conf.get(TARGET_UTILIZATION), true, restartTimeSec);
+                        evaluatedMetrics, conf, conf.get(TARGET_UTILIZATION), true, restartTime);
         if (Double.isNaN(targetCapacity)) {
             LOG.warn(
                     "Target data rate is not available for {}, cannot compute new parallelism",

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -71,7 +71,8 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
             Context context,
             JobVertexID vertex,
             Map<ScalingMetric, EvaluatedScalingMetric> evaluatedMetrics,
-            SortedMap<Instant, ScalingSummary> history) {
+            SortedMap<Instant, ScalingSummary> history,
+            double restartTimeSec) {
         var conf = context.getConfiguration();
         var currentParallelism = (int) evaluatedMetrics.get(PARALLELISM).getCurrent();
         double averageTrueProcessingRate = evaluatedMetrics.get(TRUE_PROCESSING_RATE).getAverage();
@@ -84,7 +85,7 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
 
         double targetCapacity =
                 AutoScalerUtils.getTargetProcessingCapacity(
-                        evaluatedMetrics, conf, conf.get(TARGET_UTILIZATION), true);
+                        evaluatedMetrics, conf, conf.get(TARGET_UTILIZATION), true, restartTimeSec);
         if (Double.isNaN(targetCapacity)) {
             LOG.warn(
                     "Target data rate is not available for {}, cannot compute new parallelism",

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -77,7 +77,7 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
             throws Exception {
 
         var conf = context.getConfiguration();
-        var restartTime = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+        var restartTime = scalingTracking.getMaxRestartTimeOrDefault(conf);
 
         var scalingSummaries =
                 computeScalingSummary(context, evaluatedMetrics, scalingHistory, restartTime);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -24,14 +24,11 @@ import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.autoscaler.metrics.ScalingMetric;
 import org.apache.flink.autoscaler.state.AutoScalerStateStore;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
-import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Clock;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +37,6 @@ import java.util.SortedMap;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_ENABLED;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_EVENT_INTERVAL;
 import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.addToScalingHistoryAndStore;
-import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.getTrimmedScalingHistory;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.SCALE_DOWN_RATE_THRESHOLD;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.SCALE_UP_RATE_THRESHOLD;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_RATE;
@@ -52,7 +48,6 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
     private final JobVertexScaler<KEY, Context> jobVertexScaler;
     private final AutoScalerEventHandler<KEY, Context> autoScalerEventHandler;
     private final AutoScalerStateStore<KEY, Context> autoScalerStateStore;
-    private Clock clock = Clock.system(ZoneId.systemDefault());
 
     public ScalingExecutor(
             AutoScalerEventHandler<KEY, Context> autoScalerEventHandler,
@@ -74,12 +69,17 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
 
     public boolean scaleResource(
             Context context,
-            Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluatedMetrics)
+            Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluatedMetrics,
+            Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory,
+            ScalingTracking scalingTracking,
+            Instant now)
             throws Exception {
 
         var conf = context.getConfiguration();
-        var scalingHistory = getTrimmedScalingHistory(autoScalerStateStore, context, Instant.now());
-        var scalingSummaries = computeScalingSummary(context, evaluatedMetrics, scalingHistory);
+        var restartTimeSec = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+
+        var scalingSummaries =
+                computeScalingSummary(context, evaluatedMetrics, scalingHistory, restartTimeSec);
 
         if (scalingSummaries.isEmpty()) {
             LOG.info("All job vertices are currently running at their target parallelism.");
@@ -101,7 +101,11 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
         }
 
         addToScalingHistoryAndStore(
-                autoScalerStateStore, context, scalingHistory, clock.instant(), scalingSummaries);
+                autoScalerStateStore, context, scalingHistory, now, scalingSummaries);
+
+        scalingTracking.addScalingRecord(now, new ScalingRecord());
+        autoScalerStateStore.storeScalingTracking(context, scalingTracking);
+
         autoScalerStateStore.storeParallelismOverrides(
                 context, getVertexParallelismOverrides(evaluatedMetrics, scalingSummaries));
 
@@ -158,7 +162,8 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
     Map<JobVertexID, ScalingSummary> computeScalingSummary(
             Context context,
             Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluatedMetrics,
-            Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory) {
+            Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory,
+            double restartTimeSec) {
 
         var out = new HashMap<JobVertexID, ScalingSummary>();
         var excludeVertexIdList =
@@ -178,7 +183,8 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                                         v,
                                         metrics,
                                         scalingHistory.getOrDefault(
-                                                v, Collections.emptySortedMap()));
+                                                v, Collections.emptySortedMap()),
+                                        restartTimeSec);
                         if (currentParallelism != newParallelism) {
                             out.put(
                                     v,
@@ -209,11 +215,5 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                     }
                 });
         return overrides;
-    }
-
-    @VisibleForTesting
-    protected void setClock(Clock clock) {
-        this.clock = Preconditions.checkNotNull(clock);
-        jobVertexScaler.setClock(clock);
     }
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -76,10 +77,10 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
             throws Exception {
 
         var conf = context.getConfiguration();
-        var restartTimeSec = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+        var restartTime = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
 
         var scalingSummaries =
-                computeScalingSummary(context, evaluatedMetrics, scalingHistory, restartTimeSec);
+                computeScalingSummary(context, evaluatedMetrics, scalingHistory, restartTime);
 
         if (scalingSummaries.isEmpty()) {
             LOG.info("All job vertices are currently running at their target parallelism.");
@@ -163,7 +164,7 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
             Context context,
             Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluatedMetrics,
             Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory,
-            double restartTimeSec) {
+            Duration restartTime) {
 
         var out = new HashMap<JobVertexID, ScalingSummary>();
         var excludeVertexIdList =
@@ -184,7 +185,7 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                                         metrics,
                                         scalingHistory.getOrDefault(
                                                 v, Collections.emptySortedMap()),
-                                        restartTimeSec);
+                                        restartTime);
                         if (currentParallelism != newParallelism) {
                             out.put(
                                     v,

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -62,7 +63,7 @@ public class ScalingMetricEvaluator {
     private static final Logger LOG = LoggerFactory.getLogger(ScalingMetricEvaluator.class);
 
     public Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluate(
-            Configuration conf, CollectedMetricHistory collectedMetrics, double restartTimeSec) {
+            Configuration conf, CollectedMetricHistory collectedMetrics, Duration restartTime) {
 
         var scalingOutput = new HashMap<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>();
         var metricsHistory = collectedMetrics.getMetricHistory();
@@ -80,7 +81,7 @@ public class ScalingMetricEvaluator {
                             topology,
                             vertex,
                             processingBacklog,
-                            restartTimeSec));
+                            restartTime));
         }
 
         return scalingOutput;
@@ -121,7 +122,7 @@ public class ScalingMetricEvaluator {
             JobTopology topology,
             JobVertexID vertex,
             boolean processingBacklog,
-            double restartTime) {
+            Duration restartTime) {
 
         var latestVertexMetrics =
                 metricsHistory.get(metricsHistory.lastKey()).getVertexMetrics().get(vertex);
@@ -211,7 +212,7 @@ public class ScalingMetricEvaluator {
             Map<ScalingMetric, EvaluatedScalingMetric> metrics,
             Configuration conf,
             boolean processingBacklog,
-            double restartTimeSec) {
+            Duration restartTime) {
 
         double utilizationBoundary = conf.getDouble(TARGET_UTILIZATION_BOUNDARY);
         double targetUtilization = conf.get(TARGET_UTILIZATION);
@@ -231,11 +232,11 @@ public class ScalingMetricEvaluator {
 
         double scaleUpThreshold =
                 AutoScalerUtils.getTargetProcessingCapacity(
-                        metrics, conf, upperUtilization, false, restartTimeSec);
+                        metrics, conf, upperUtilization, false, restartTime);
 
         double scaleDownThreshold =
                 AutoScalerUtils.getTargetProcessingCapacity(
-                        metrics, conf, lowerUtilization, true, restartTimeSec);
+                        metrics, conf, lowerUtilization, true, restartTime);
 
         metrics.put(SCALE_UP_RATE_THRESHOLD, EvaluatedScalingMetric.of(scaleUpThreshold));
         metrics.put(SCALE_DOWN_RATE_THRESHOLD, EvaluatedScalingMetric.of(scaleDownThreshold));

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingRecord.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingRecord.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * Class for tracking scaling details, including time it took for the job to transition to the
+ * target parallelism.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScalingRecord {
+    private Instant endTime;
+}

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingTracking.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingTracking.java
@@ -27,6 +27,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -43,6 +45,8 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @Builder
 public class ScalingTracking {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ScalingTracking.class);
 
     /** Details related to recent rescaling operations. */
     private final TreeMap<Instant, ScalingRecord> scalingRecords = new TreeMap<>();
@@ -89,6 +93,11 @@ public class ScalingTracking {
                                 if (targetParallelismMatchesActual(
                                         targetParallelism, actualParallelism)) {
                                     value.setEndTime(now);
+                                    LOG.debug(
+                                            "Recorded restart duration of {} seconds (from {} till {})",
+                                            Duration.between(scalingTimestamp, now).getSeconds(),
+                                            scalingTimestamp,
+                                            now);
                                     return true;
                                 }
                             }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingTracking.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingTracking.java
@@ -130,7 +130,7 @@ public class ScalingTracking {
      * option is set to false, or if there are no tracking records available. Otherwise, the maximum
      * observed restart time is capped by the MAX_RESTART_TIME.
      */
-    public double getMaxRestartTimeSecondsOrDefault(Configuration conf) {
+    public Duration getMaxRestartTimeSecondsOrDefault(Configuration conf) {
         long maxRestartTime = -1;
         if (conf.get(AutoScalerOptions.PREFER_TRACKED_RESTART_TIME)) {
             for (Map.Entry<Instant, ScalingRecord> entry : scalingRecords.entrySet()) {
@@ -142,12 +142,12 @@ public class ScalingTracking {
                 }
             }
         }
-        long restartTimeFromConfig = conf.get(AutoScalerOptions.RESTART_TIME).toSeconds();
+        var restartTimeFromConfig = conf.get(AutoScalerOptions.RESTART_TIME);
         long maxRestartTimeFromConfig =
                 conf.get(AutoScalerOptions.TRACKED_RESTART_TIME_LIMIT).toSeconds();
         return maxRestartTime == -1
                 ? restartTimeFromConfig
-                : Math.min(maxRestartTime, maxRestartTimeFromConfig);
+                : Duration.ofSeconds(Math.min(maxRestartTime, maxRestartTimeFromConfig));
     }
 
     /**

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingTracking.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingTracking.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.autoscaler.topology.JobTopology;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+/** Stores rescaling related information for the job. */
+@Experimental
+@Data
+@NoArgsConstructor
+@Builder
+public class ScalingTracking {
+
+    /** Details related to recent rescaling operations. */
+    private final TreeMap<Instant, ScalingRecord> scalingRecords = new TreeMap<>();
+
+    public void addScalingRecord(Instant startTimestamp, ScalingRecord scalingRecord) {
+        scalingRecords.put(startTimestamp, scalingRecord);
+    }
+
+    @JsonIgnore
+    public Optional<Entry<Instant, ScalingRecord>> getLatestScalingRecordEntry() {
+        if (!scalingRecords.isEmpty()) {
+            return Optional.of(scalingRecords.lastEntry());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Sets the end time for the latest scaling record if its parallelism matches the current job
+     * parallelism.
+     *
+     * @param now The current instant to be set as the end time of the scaling record.
+     * @param jobTopology The current job topology containing details of the job's parallelism.
+     * @param scalingHistory The scaling history.
+     * @return true if the end time is successfully set, false if the end time is already set, the
+     *     latest scaling record cannot be found, or the target parallelism does not match the
+     *     actual parallelism.
+     */
+    public boolean setEndTimeIfTrackedAndParallelismMatches(
+            Instant now,
+            JobTopology jobTopology,
+            Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory) {
+        return getLatestScalingRecordEntry()
+                .map(
+                        entry -> {
+                            var value = entry.getValue();
+                            var scalingTimestamp = entry.getKey();
+                            if (value.getEndTime() == null) {
+                                var targetParallelism =
+                                        getTargetParallelismOfScaledVertices(
+                                                scalingTimestamp, scalingHistory);
+                                var actualParallelism = jobTopology.getParallelisms();
+
+                                if (targetParallelismMatchesActual(
+                                        targetParallelism, actualParallelism)) {
+                                    value.setEndTime(now);
+                                    return true;
+                                }
+                            }
+                            return false;
+                        })
+                .orElse(false);
+    }
+
+    private static Map<JobVertexID, Integer> getTargetParallelismOfScaledVertices(
+            Instant scalingTimestamp,
+            Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory) {
+        return scalingHistory.entrySet().stream()
+                .filter(entry -> entry.getValue().containsKey(scalingTimestamp))
+                .collect(
+                        Collectors.toMap(
+                                Map.Entry::getKey,
+                                entry ->
+                                        entry.getValue()
+                                                .get(scalingTimestamp)
+                                                .getNewParallelism()));
+    }
+
+    private static boolean targetParallelismMatchesActual(
+            Map<JobVertexID, Integer> targetParallelisms,
+            Map<JobVertexID, Integer> actualParallelisms) {
+        return targetParallelisms.entrySet().stream()
+                .allMatch(
+                        entry -> {
+                            var vertexID = entry.getKey();
+                            var targetParallelism = entry.getValue();
+                            var actualParallelism = actualParallelisms.getOrDefault(vertexID, -1);
+                            return actualParallelism.equals(targetParallelism);
+                        });
+    }
+
+    /**
+     * Retrieves the maximum restart time in seconds based on the provided configuration and scaling
+     * records. Defaults to the RESTART_TIME from configuration if the PREFER_TRACKED_RESTART_TIME
+     * option is set to false, or if there are no tracking records available. Otherwise, the maximum
+     * observed restart time is capped by the MAX_RESTART_TIME.
+     */
+    public double getMaxRestartTimeSecondsOrDefault(Configuration conf) {
+        long maxRestartTime = -1;
+        if (conf.get(AutoScalerOptions.PREFER_TRACKED_RESTART_TIME)) {
+            for (Map.Entry<Instant, ScalingRecord> entry : scalingRecords.entrySet()) {
+                var startTime = entry.getKey();
+                var endTime = entry.getValue().getEndTime();
+                if (endTime != null) {
+                    var restartTime = Duration.between(startTime, endTime).toSeconds();
+                    maxRestartTime = Math.max(restartTime, maxRestartTime);
+                }
+            }
+        }
+        long restartTimeFromConfig = conf.get(AutoScalerOptions.RESTART_TIME).toSeconds();
+        long maxRestartTimeFromConfig =
+                conf.get(AutoScalerOptions.TRACKED_RESTART_TIME_LIMIT).toSeconds();
+        return maxRestartTime == -1
+                ? restartTimeFromConfig
+                : Math.min(maxRestartTime, maxRestartTimeFromConfig);
+    }
+
+    /**
+     * Removes records from the internal map that are older than the specified time span and trims
+     * the number of records to the specified maximum count.
+     *
+     * @param keptTimeSpan Duration for how long recent records are to be kept.
+     * @param keptNumRecords The maximum number of recent records to keep.
+     */
+    public void removeOldRecords(Instant now, Duration keptTimeSpan, int keptNumRecords) {
+        var cutoffTime = now.minus(keptTimeSpan);
+
+        // Remove records older than the cutoff time
+        scalingRecords.headMap(cutoffTime).clear();
+
+        // If the map size is still larger than keptNumRecords, trim further
+        while (scalingRecords.size() > keptNumRecords) {
+            scalingRecords.pollFirstEntry();
+        }
+    }
+}

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -143,7 +143,7 @@ public class AutoScalerOptions {
                             "Expected restart time to be used until the operator can determine it reliably from history.");
 
     public static final ConfigOption<Boolean> PREFER_TRACKED_RESTART_TIME =
-            autoScalerConfig("restart.time.tracked.enabled")
+            autoScalerConfig("restart.time-tracking.enabled")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
@@ -155,7 +155,7 @@ public class AutoScalerOptions {
                                     + "' will act as an upper bound.");
 
     public static final ConfigOption<Duration> TRACKED_RESTART_TIME_LIMIT =
-            autoScalerConfig("restart.time.tracked.limit")
+            autoScalerConfig("restart.time-tracking.limit")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(15))
                     .withDescription(

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -142,6 +142,27 @@ public class AutoScalerOptions {
                     .withDescription(
                             "Expected restart time to be used until the operator can determine it reliably from history.");
 
+    public static final ConfigOption<Boolean> PREFER_TRACKED_RESTART_TIME =
+            autoScalerConfig("restart.time.tracked.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to use the actual observed rescaling restart times instead of the fixed '"
+                                    + RESTART_TIME.key()
+                                    + "' configuration. If set to true, the maximum restart duration over a number of "
+                                    + "samples will be used. The value of '"
+                                    + RESTART_TIME.key()
+                                    + "' will act as an upper bound.");
+
+    public static final ConfigOption<Duration> TRACKED_RESTART_TIME_LIMIT =
+            autoScalerConfig("restart.time.tracked.limit")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(15))
+                    .withDescription(
+                            "Maximum cap for the observed restart time when '"
+                                    + PREFER_TRACKED_RESTART_TIME.key()
+                                    + "' is set to true.");
+
     public static final ConfigOption<Duration> BACKLOG_PROCESSING_LAG_THRESHOLD =
             autoScalerConfig("backlog-processing.lag-threshold")
                     .durationType()

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingHistoryUtils.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingHistoryUtils.java
@@ -19,6 +19,7 @@ package org.apache.flink.autoscaler.metrics;
 
 import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.ScalingSummary;
+import org.apache.flink.autoscaler.ScalingTracking;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.state.AutoScalerStateStore;
 import org.apache.flink.configuration.Configuration;
@@ -110,5 +111,22 @@ public class ScalingHistoryUtils {
             }
         }
         return result;
+    }
+
+    @Nonnull
+    public static <KEY, Context extends JobAutoScalerContext<KEY>>
+            ScalingTracking getTrimmedScalingTracking(
+                    AutoScalerStateStore<KEY, Context> autoScalerStateStore,
+                    Context context,
+                    Instant now)
+                    throws Exception {
+        var conf = context.getConfiguration();
+        var scalingTracking = autoScalerStateStore.getScalingTracking(context);
+        // Reusing settings used for scaling history
+        scalingTracking.removeOldRecords(
+                now,
+                conf.get(AutoScalerOptions.VERTEX_SCALING_HISTORY_AGE),
+                conf.get(AutoScalerOptions.VERTEX_SCALING_HISTORY_COUNT));
+        return scalingTracking;
     }
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
@@ -20,6 +20,7 @@ package org.apache.flink.autoscaler.state;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.ScalingSummary;
+import org.apache.flink.autoscaler.ScalingTracking;
 import org.apache.flink.autoscaler.metrics.CollectedMetrics;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
@@ -45,6 +46,10 @@ public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
     @Nonnull
     Map<JobVertexID, SortedMap<Instant, ScalingSummary>> getScalingHistory(Context jobContext)
             throws Exception;
+
+    void storeScalingTracking(Context jobContext, ScalingTracking scalingTrack) throws Exception;
+
+    ScalingTracking getScalingTracking(Context jobContext) throws Exception;
 
     void removeScalingHistory(Context jobContext) throws Exception;
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
@@ -19,6 +19,7 @@ package org.apache.flink.autoscaler.state;
 
 import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.ScalingSummary;
+import org.apache.flink.autoscaler.ScalingTracking;
 import org.apache.flink.autoscaler.metrics.CollectedMetrics;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
@@ -46,10 +47,13 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
 
     private final Map<KEY, Map<String, String>> parallelismOverridesStore;
 
+    private final Map<KEY, ScalingTracking> scalingTrackingStore;
+
     public InMemoryAutoScalerStateStore() {
         scalingHistoryStore = new ConcurrentHashMap<>();
         collectedMetricsStore = new ConcurrentHashMap<>();
         parallelismOverridesStore = new ConcurrentHashMap<>();
+        scalingTrackingStore = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -64,6 +68,17 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
             Context jobContext) {
         return Optional.ofNullable(scalingHistoryStore.get(jobContext.getJobKey()))
                 .orElse(new HashMap<>());
+    }
+
+    @Override
+    public void storeScalingTracking(Context jobContext, ScalingTracking scalingTracking) {
+        scalingTrackingStore.put(jobContext.getJobKey(), scalingTracking);
+    }
+
+    @Override
+    public ScalingTracking getScalingTracking(Context jobContext) {
+        return Optional.ofNullable(scalingTrackingStore.get(jobContext.getJobKey()))
+                .orElse(new ScalingTracking());
     }
 
     @Override

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/AutoScalerUtils.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/AutoScalerUtils.java
@@ -40,7 +40,8 @@ public class AutoScalerUtils {
             Map<ScalingMetric, EvaluatedScalingMetric> evaluatedMetrics,
             Configuration conf,
             double targetUtilization,
-            boolean withRestart) {
+            boolean withRestart,
+            double restartTimeSec) {
 
         // Target = Lag Catchup Rate + Restart Catchup Rate + Processing at utilization
         // Target = LAG/CATCH_UP + INPUT_RATE*RESTART/CATCH_UP + INPUT_RATE/TARGET_UTIL
@@ -51,7 +52,6 @@ public class AutoScalerUtils {
         }
 
         double catchUpTargetSec = conf.get(AutoScalerOptions.CATCH_UP_DURATION).toSeconds();
-        double restartTimeSec = conf.get(AutoScalerOptions.RESTART_TIME).toSeconds();
 
         targetUtilization = Math.max(0., targetUtilization);
         targetUtilization = Math.min(1., targetUtilization);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/AutoScalerUtils.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/AutoScalerUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.autoscaler.metrics.ScalingMetric;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -41,7 +42,7 @@ public class AutoScalerUtils {
             Configuration conf,
             double targetUtilization,
             boolean withRestart,
-            double restartTimeSec) {
+            Duration restartTime) {
 
         // Target = Lag Catchup Rate + Restart Catchup Rate + Processing at utilization
         // Target = LAG/CATCH_UP + INPUT_RATE*RESTART/CATCH_UP + INPUT_RATE/TARGET_UTIL
@@ -68,7 +69,7 @@ public class AutoScalerUtils {
         double restartCatchupRate =
                 !withRestart || catchUpTargetSec == 0
                         ? 0
-                        : (avgInputTargetRate * restartTimeSec) / catchUpTargetSec;
+                        : (avgInputTargetRate * restartTime.toSeconds()) / catchUpTargetSec;
         double inputTargetAtUtilization = avgInputTargetRate / targetUtilization;
 
         return Math.round(lagCatchupTargetRate + restartCatchupRate + inputTargetAtUtilization);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -53,6 +53,7 @@ public class JobVertexScalerTest {
     private JobVertexScaler<JobID, JobAutoScalerContext<JobID>> vertexScaler;
     private JobAutoScalerContext<JobID> context;
     private Configuration conf;
+    private long restartTimeSec;
 
     @BeforeEach
     public void setup() {
@@ -71,77 +72,123 @@ public class JobVertexScalerTest {
                         conf,
                         new UnregisteredMetricsGroup(),
                         null);
+        restartTimeSec = conf.get(AutoScalerOptions.RESTART_TIME).toSeconds();
     }
 
     @Test
     public void testParallelismScaling() {
         var op = new JobVertexID();
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+
         assertEquals(
                 5,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(10, 50, 100), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(10, 50, 100),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
                 8,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(10, 50, 100), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(10, 50, 100),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(10, 80, 100), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(10, 80, 100),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
                 8,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(10, 60, 100), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(10, 60, 100),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         assertEquals(
                 8,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(10, 59, 100), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(10, 59, 100),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.5);
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(2, 100, 40), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(2, 100, 40),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
         assertEquals(
                 4,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(2, 100, 100), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(2, 100, 100),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.5);
         assertEquals(
                 5,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(10, 10, 100), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(10, 10, 100),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.6);
         assertEquals(
                 4,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(10, 10, 100), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(10, 10, 100),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.5);
         assertEquals(
                 15,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(10, 200, 10), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(10, 200, 10),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.6);
         assertEquals(
                 16,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated(10, 200, 10), Collections.emptySortedMap()));
+                        context,
+                        op,
+                        evaluated(10, 200, 10),
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
     }
 
     @Test
@@ -190,7 +237,8 @@ public class JobVertexScalerTest {
                         context,
                         new JobVertexID(),
                         evaluated(10, 100, 500),
-                        Collections.emptySortedMap()));
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         // Make sure we respect current parallelism in case it's lower
         assertEquals(
@@ -199,7 +247,8 @@ public class JobVertexScalerTest {
                         context,
                         new JobVertexID(),
                         evaluated(4, 100, 500),
-                        Collections.emptySortedMap()));
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
     }
 
     @Test
@@ -212,7 +261,8 @@ public class JobVertexScalerTest {
                         context,
                         new JobVertexID(),
                         evaluated(10, 500, 100),
-                        Collections.emptySortedMap()));
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
 
         // Make sure we respect current parallelism in case it's higher
         assertEquals(
@@ -221,7 +271,8 @@ public class JobVertexScalerTest {
                         context,
                         new JobVertexID(),
                         evaluated(12, 500, 100),
-                        Collections.emptySortedMap()));
+                        Collections.emptySortedMap(),
+                        restartTimeSec));
     }
 
     @Test
@@ -235,27 +286,35 @@ public class JobVertexScalerTest {
         var evaluated = evaluated(5, 100, 50);
         var history = new TreeMap<Instant, ScalingSummary>();
         assertEquals(
-                10, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                10,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
 
         history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
 
         // Should not allow scale back down immediately
         evaluated = evaluated(10, 50, 100);
         assertEquals(
-                10, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                10,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
 
         // Pass some time...
         clock = Clock.offset(Clock.systemDefaultZone(), Duration.ofSeconds(61));
         vertexScaler.setClock(clock);
 
         assertEquals(
-                5, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                5,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
         history.put(clock.instant(), new ScalingSummary(10, 5, evaluated));
 
         // Allow immediate scale up
         evaluated = evaluated(5, 100, 50);
         assertEquals(
-                10, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                10,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
         history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
     }
 
@@ -269,14 +328,18 @@ public class JobVertexScalerTest {
         var evaluated = evaluated(5, 100, 50);
         var history = new TreeMap<Instant, ScalingSummary>();
         assertEquals(
-                10, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                10,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
         // Allow to scale higher if scaling was effective (80%)
         evaluated = evaluated(10, 180, 90);
         assertEquals(
-                20, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                20,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
 
@@ -284,38 +347,50 @@ public class JobVertexScalerTest {
         // 90 -> 94. Do not try to scale above 20
         evaluated = evaluated(20, 180, 94);
         assertEquals(
-                20, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                20,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Still considered ineffective (less than <10%)
         evaluated = evaluated(20, 180, 98);
         assertEquals(
-                20, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                20,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Allow scale up if current parallelism doesnt match last (user rescaled manually)
         evaluated = evaluated(10, 180, 90);
         assertEquals(
-                20, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                20,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
 
         // Over 10%, effective
         evaluated = evaluated(20, 180, 100);
         assertEquals(
-                36, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                36,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Ineffective but detection is turned off
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, false);
         evaluated = evaluated(20, 180, 90);
         assertEquals(
-                40, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                40,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
 
         // Allow scale down even if ineffective
         evaluated = evaluated(20, 45, 90);
         assertEquals(
-                10, vertexScaler.computeScaleTargetParallelism(context, op, evaluated, history));
+                10,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, op, evaluated, history, restartTimeSec));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
     }
 
@@ -331,7 +406,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history));
+                        context, jobVertexID, evaluated, history, restartTimeSec));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
@@ -340,7 +415,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history));
+                        context, jobVertexID, evaluated, history, restartTimeSec));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
         assertEquals(0, eventCollector.events.size());
@@ -350,7 +425,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history));
+                        context, jobVertexID, evaluated, history, restartTimeSec));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(1, eventCollector.events.size());
         var event = eventCollector.events.poll();
@@ -364,7 +439,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history));
+                        context, jobVertexID, evaluated, history, restartTimeSec));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(0, eventCollector.events.size());
 
@@ -373,7 +448,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history));
+                        context, jobVertexID, evaluated, history, restartTimeSec));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(0, eventCollector.events.size());
 
@@ -382,7 +457,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history));
+                        context, jobVertexID, evaluated, history, restartTimeSec));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(1, eventCollector.events.size());
         event = eventCollector.events.poll();
@@ -405,7 +480,8 @@ public class JobVertexScalerTest {
         metrics.put(
                 ScalingMetric.TRUE_PROCESSING_RATE,
                 new EvaluatedScalingMetric(trueProcessingRate, trueProcessingRate));
-        ScalingMetricEvaluator.computeProcessingRateThresholds(metrics, conf, false);
+        ScalingMetricEvaluator.computeProcessingRateThresholds(
+                metrics, conf, false, restartTimeSec);
         return metrics;
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -53,7 +53,7 @@ public class JobVertexScalerTest {
     private JobVertexScaler<JobID, JobAutoScalerContext<JobID>> vertexScaler;
     private JobAutoScalerContext<JobID> context;
     private Configuration conf;
-    private long restartTimeSec;
+    private Duration restartTime;
 
     @BeforeEach
     public void setup() {
@@ -72,7 +72,7 @@ public class JobVertexScalerTest {
                         conf,
                         new UnregisteredMetricsGroup(),
                         null);
-        restartTimeSec = conf.get(AutoScalerOptions.RESTART_TIME).toSeconds();
+        restartTime = conf.get(AutoScalerOptions.RESTART_TIME);
     }
 
     @Test
@@ -87,7 +87,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(10, 50, 100),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
@@ -97,7 +97,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(10, 50, 100),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
@@ -107,7 +107,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(10, 80, 100),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
@@ -117,7 +117,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(10, 60, 100),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         assertEquals(
                 8,
@@ -126,7 +126,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(10, 59, 100),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.5);
         assertEquals(
@@ -136,7 +136,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(2, 100, 40),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
         assertEquals(
@@ -146,7 +146,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(2, 100, 100),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.5);
@@ -157,7 +157,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(10, 10, 100),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.6);
         assertEquals(
@@ -167,7 +167,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(10, 10, 100),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.5);
@@ -178,7 +178,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(10, 200, 10),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.6);
         assertEquals(
@@ -188,7 +188,7 @@ public class JobVertexScalerTest {
                         op,
                         evaluated(10, 200, 10),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
     }
 
     @Test
@@ -238,7 +238,7 @@ public class JobVertexScalerTest {
                         new JobVertexID(),
                         evaluated(10, 100, 500),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         // Make sure we respect current parallelism in case it's lower
         assertEquals(
@@ -248,7 +248,7 @@ public class JobVertexScalerTest {
                         new JobVertexID(),
                         evaluated(4, 100, 500),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
     }
 
     @Test
@@ -262,7 +262,7 @@ public class JobVertexScalerTest {
                         new JobVertexID(),
                         evaluated(10, 500, 100),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
 
         // Make sure we respect current parallelism in case it's higher
         assertEquals(
@@ -272,7 +272,7 @@ public class JobVertexScalerTest {
                         new JobVertexID(),
                         evaluated(12, 500, 100),
                         Collections.emptySortedMap(),
-                        restartTimeSec));
+                        restartTime));
     }
 
     @Test
@@ -288,7 +288,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
 
         history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
 
@@ -297,7 +297,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
 
         // Pass some time...
         clock = Clock.offset(Clock.systemDefaultZone(), Duration.ofSeconds(61));
@@ -306,7 +306,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 5,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
         history.put(clock.instant(), new ScalingSummary(10, 5, evaluated));
 
         // Allow immediate scale up
@@ -314,7 +314,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
         history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
     }
 
@@ -330,7 +330,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
@@ -339,7 +339,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
 
@@ -349,7 +349,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Still considered ineffective (less than <10%)
@@ -357,7 +357,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Allow scale up if current parallelism doesnt match last (user rescaled manually)
@@ -365,14 +365,14 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
 
         // Over 10%, effective
         evaluated = evaluated(20, 180, 100);
         assertEquals(
                 36,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Ineffective but detection is turned off
@@ -381,7 +381,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 40,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
 
@@ -390,7 +390,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTimeSec));
+                        context, op, evaluated, history, restartTime));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
     }
 
@@ -406,7 +406,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTimeSec));
+                        context, jobVertexID, evaluated, history, restartTime));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
@@ -415,7 +415,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTimeSec));
+                        context, jobVertexID, evaluated, history, restartTime));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
         assertEquals(0, eventCollector.events.size());
@@ -425,7 +425,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTimeSec));
+                        context, jobVertexID, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(1, eventCollector.events.size());
         var event = eventCollector.events.poll();
@@ -439,7 +439,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTimeSec));
+                        context, jobVertexID, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(0, eventCollector.events.size());
 
@@ -448,7 +448,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTimeSec));
+                        context, jobVertexID, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(0, eventCollector.events.size());
 
@@ -457,7 +457,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTimeSec));
+                        context, jobVertexID, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(1, eventCollector.events.size());
         event = eventCollector.events.poll();
@@ -480,8 +480,7 @@ public class JobVertexScalerTest {
         metrics.put(
                 ScalingMetric.TRUE_PROCESSING_RATE,
                 new EvaluatedScalingMetric(trueProcessingRate, trueProcessingRate));
-        ScalingMetricEvaluator.computeProcessingRateThresholds(
-                metrics, conf, false, restartTimeSec);
+        ScalingMetricEvaluator.computeProcessingRateThresholds(metrics, conf, false, restartTime);
         return metrics;
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -73,7 +73,7 @@ public class MetricsCollectionAndEvaluationTest {
     private Clock clock;
 
     private Instant startTime;
-    private long restartTimeSec;
+    private Duration restartTime;
 
     @BeforeEach
     public void setup() {
@@ -108,7 +108,7 @@ public class MetricsCollectionAndEvaluationTest {
         metricsCollector.setClock(clock);
         startTime = clock.instant();
         metricsCollector.setJobUpdateTs(startTime);
-        restartTimeSec = conf.get(AutoScalerOptions.RESTART_TIME).toSeconds();
+        restartTime = conf.get(AutoScalerOptions.RESTART_TIME);
     }
 
     @Test
@@ -161,7 +161,7 @@ public class MetricsCollectionAndEvaluationTest {
         assertEquals(3, collectedMetrics.getMetricHistory().size());
         assertTrue(collectedMetrics.isFullyCollected());
 
-        var evaluation = evaluator.evaluate(conf, collectedMetrics, restartTimeSec);
+        var evaluation = evaluator.evaluate(conf, collectedMetrics, restartTime);
         scalingExecutor.scaleResource(
                 context, evaluation, new HashMap<>(), new ScalingTracking(), clock.instant());
 
@@ -176,7 +176,7 @@ public class MetricsCollectionAndEvaluationTest {
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.5);
         conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.);
 
-        evaluation = evaluator.evaluate(conf, collectedMetrics, restartTimeSec);
+        evaluation = evaluator.evaluate(conf, collectedMetrics, restartTime);
         scalingExecutor.scaleResource(
                 context, evaluation, new HashMap<>(), new ScalingTracking(), clock.instant());
 
@@ -373,7 +373,7 @@ public class MetricsCollectionAndEvaluationTest {
         var collectedMetrics = collectMetrics();
 
         Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluation =
-                evaluator.evaluate(context.getConfiguration(), collectedMetrics, restartTimeSec);
+                evaluator.evaluate(context.getConfiguration(), collectedMetrics, restartTime);
         assertEquals(
                 500., evaluation.get(source1).get(ScalingMetric.TARGET_DATA_RATE).getCurrent());
         assertEquals(
@@ -645,7 +645,7 @@ public class MetricsCollectionAndEvaluationTest {
         var collectedMetrics = collectMetrics();
 
         Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluation =
-                evaluator.evaluate(context.getConfiguration(), collectedMetrics, restartTimeSec);
+                evaluator.evaluate(context.getConfiguration(), collectedMetrics, restartTime);
         assertEquals(0, evaluation.get(source1).get(ScalingMetric.TARGET_DATA_RATE).getCurrent());
         assertEquals(
                 Double.POSITIVE_INFINITY,
@@ -675,8 +675,7 @@ public class MetricsCollectionAndEvaluationTest {
                         Instant.ofEpochSecond(1234),
                         new CollectedMetrics(newMetrics, lastCollected.getOutputRatios()));
 
-        evaluation =
-                evaluator.evaluate(context.getConfiguration(), collectedMetrics, restartTimeSec);
+        evaluation = evaluator.evaluate(context.getConfiguration(), collectedMetrics, restartTime);
         assertEquals(
                 3., evaluation.get(source1).get(ScalingMetric.TRUE_PROCESSING_RATE).getAverage());
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
@@ -271,6 +271,6 @@ public class RecommendedParallelismTest {
     private void setClocksTo(Instant time) {
         var clock = Clock.fixed(time, ZoneId.systemDefault());
         metricsCollector.setClock(clock);
-        scalingExecutor.setClock(clock);
+        autoscaler.setClock(clock);
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -250,8 +250,7 @@ public class ScalingExecutorTest {
         metrics.put(
                 ScalingMetric.TRUE_PROCESSING_RATE, new EvaluatedScalingMetric(procRate, procRate));
 
-        var restartTime =
-                context.getConfiguration().get(AutoScalerOptions.RESTART_TIME).toSeconds();
+        var restartTime = context.getConfiguration().get(AutoScalerOptions.RESTART_TIME);
         ScalingMetricEvaluator.computeProcessingRateThresholds(
                 metrics, context.getConfiguration(), false, restartTime);
         return metrics;

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,10 +147,15 @@ public class ScalingExecutorTest {
                         evaluated(10, 80, 100));
         // filter operator should not scale
         conf.set(AutoScalerOptions.VERTEX_EXCLUDE_IDS, List.of(filterOperatorHexString));
-        assertFalse(scalingDecisionExecutor.scaleResource(context, metrics));
+        var now = Instant.now();
+        assertFalse(
+                scalingDecisionExecutor.scaleResource(
+                        context, metrics, new HashMap<>(), new ScalingTracking(), now));
         // filter operator should scale
         conf.set(AutoScalerOptions.VERTEX_EXCLUDE_IDS, List.of());
-        assertTrue(scalingDecisionExecutor.scaleResource(context, metrics));
+        assertTrue(
+                scalingDecisionExecutor.scaleResource(
+                        context, metrics, new HashMap<>(), new ScalingTracking(), now));
     }
 
     @ParameterizedTest
@@ -182,8 +188,15 @@ public class ScalingExecutorTest {
             conf.set(AutoScalerOptions.SCALING_EVENT_INTERVAL, interval);
         }
 
-        assertEquals(scalingEnabled, scalingDecisionExecutor.scaleResource(context, metrics));
-        assertEquals(scalingEnabled, scalingDecisionExecutor.scaleResource(context, metrics));
+        var now = Instant.now();
+        assertEquals(
+                scalingEnabled,
+                scalingDecisionExecutor.scaleResource(
+                        context, metrics, new HashMap<>(), new ScalingTracking(), now));
+        assertEquals(
+                scalingEnabled,
+                scalingDecisionExecutor.scaleResource(
+                        context, metrics, new HashMap<>(), new ScalingTracking(), now));
 
         int expectedSize = (interval == null || interval.toMillis() > 0) && !scalingEnabled ? 1 : 2;
         assertEquals(expectedSize, eventCollector.events.size());
@@ -216,7 +229,10 @@ public class ScalingExecutorTest {
 
         assertEquals(expectedSize, event.getCount());
 
-        assertEquals(scalingEnabled, scalingDecisionExecutor.scaleResource(context, metrics));
+        assertEquals(
+                scalingEnabled,
+                scalingDecisionExecutor.scaleResource(
+                        context, metrics, new HashMap<>(), new ScalingTracking(), now));
         var event2 = eventCollector.events.poll();
         assertThat(event2).isNotNull();
         assertThat(event2.getContext()).isSameAs(event.getContext());
@@ -233,8 +249,11 @@ public class ScalingExecutorTest {
         metrics.put(ScalingMetric.CATCH_UP_DATA_RATE, EvaluatedScalingMetric.of(catchupRate));
         metrics.put(
                 ScalingMetric.TRUE_PROCESSING_RATE, new EvaluatedScalingMetric(procRate, procRate));
+
+        var restartTime =
+                context.getConfiguration().get(AutoScalerOptions.RESTART_TIME).toSeconds();
         ScalingMetricEvaluator.computeProcessingRateThresholds(
-                metrics, context.getConfiguration(), false);
+                metrics, context.getConfiguration(), false, restartTime);
         return metrics;
     }
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -258,7 +258,7 @@ public class ScalingMetricEvaluatorTest {
                 Instant.parse("2023-11-15T16:20:00.00Z"),
                 new ScalingRecord(Instant.parse("2023-11-15T16:25:00.00Z")));
 
-        var restartTimeSec = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+        var restartTimeSec = scalingTracking.getMaxRestartTimeOrDefault(conf);
         // Restart time does not factor in
         assertEquals(Tuple2.of(778.0, 1000.0), getThresholds(700, 0, restartTimeSec, conf));
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -114,7 +114,8 @@ public class ScalingMetricEvaluatorTest {
 
         conf.set(CATCH_UP_DURATION, Duration.ofSeconds(2));
         var evaluatedMetrics =
-                evaluator.evaluate(conf, new CollectedMetricHistory(topology, metricHistory), 0);
+                evaluator.evaluate(
+                        conf, new CollectedMetricHistory(topology, metricHistory), Duration.ZERO);
 
         assertEquals(new EvaluatedScalingMetric(.6, .7), evaluatedMetrics.get(source).get(LOAD));
 
@@ -135,7 +136,8 @@ public class ScalingMetricEvaluatorTest {
 
         conf.set(CATCH_UP_DURATION, Duration.ofSeconds(1));
         evaluatedMetrics =
-                evaluator.evaluate(conf, new CollectedMetricHistory(topology, metricHistory), 0);
+                evaluator.evaluate(
+                        conf, new CollectedMetricHistory(topology, metricHistory), Duration.ZERO);
         assertEquals(
                 new EvaluatedScalingMetric(200, 150),
                 evaluatedMetrics.get(source).get(TARGET_DATA_RATE));
@@ -153,7 +155,8 @@ public class ScalingMetricEvaluatorTest {
         conf.set(RESTART_TIME, Duration.ofSeconds(2));
 
         evaluatedMetrics =
-                evaluator.evaluate(conf, new CollectedMetricHistory(topology, metricHistory), 0);
+                evaluator.evaluate(
+                        conf, new CollectedMetricHistory(topology, metricHistory), Duration.ZERO);
         assertEquals(
                 new EvaluatedScalingMetric(200, 150),
                 evaluatedMetrics.get(source).get(TARGET_DATA_RATE));
@@ -170,7 +173,8 @@ public class ScalingMetricEvaluatorTest {
         // Turn off lag based scaling
         conf.set(CATCH_UP_DURATION, Duration.ZERO);
         evaluatedMetrics =
-                evaluator.evaluate(conf, new CollectedMetricHistory(topology, metricHistory), 0);
+                evaluator.evaluate(
+                        conf, new CollectedMetricHistory(topology, metricHistory), Duration.ZERO);
         assertEquals(
                 new EvaluatedScalingMetric(200, 150),
                 evaluatedMetrics.get(source).get(TARGET_DATA_RATE));
@@ -204,7 +208,8 @@ public class ScalingMetricEvaluatorTest {
 
         conf.set(CATCH_UP_DURATION, Duration.ofMinutes(1));
         evaluatedMetrics =
-                evaluator.evaluate(conf, new CollectedMetricHistory(topology, metricHistory), 0);
+                evaluator.evaluate(
+                        conf, new CollectedMetricHistory(topology, metricHistory), Duration.ZERO);
         assertEquals(
                 new EvaluatedScalingMetric(100, 100),
                 evaluatedMetrics.get(source).get(TARGET_DATA_RATE));
@@ -355,7 +360,7 @@ public class ScalingMetricEvaluatorTest {
     public void testObservedTprEvaluation() {
         var source = new JobVertexID();
         var conf = new Configuration();
-        var restartTimeSec = conf.get(AutoScalerOptions.RESTART_TIME).toSeconds();
+        var restartTime = conf.get(AutoScalerOptions.RESTART_TIME);
 
         var topology = new JobTopology(new VertexInfo(source, Collections.emptySet(), 1, 1));
         var evaluator = new ScalingMetricEvaluator();
@@ -413,7 +418,7 @@ public class ScalingMetricEvaluatorTest {
                         .evaluate(
                                 conf,
                                 new CollectedMetricHistory(topology, metricHistory),
-                                restartTimeSec)
+                                restartTime)
                         .get(source)
                         .get(ScalingMetric.TRUE_PROCESSING_RATE));
 
@@ -427,7 +432,7 @@ public class ScalingMetricEvaluatorTest {
                         .evaluate(
                                 conf,
                                 new CollectedMetricHistory(topology, metricHistory),
-                                restartTimeSec)
+                                restartTime)
                         .get(source)
                         .get(ScalingMetric.TRUE_PROCESSING_RATE));
 
@@ -439,7 +444,7 @@ public class ScalingMetricEvaluatorTest {
                         .evaluate(
                                 conf,
                                 new CollectedMetricHistory(topology, metricHistory),
-                                restartTimeSec)
+                                restartTime)
                         .get(source)
                         .get(ScalingMetric.TRUE_PROCESSING_RATE));
     }
@@ -448,7 +453,7 @@ public class ScalingMetricEvaluatorTest {
     public void testMissingObservedTpr() {
         var source = new JobVertexID();
         var conf = new Configuration();
-        var restartTimeSec = conf.get(AutoScalerOptions.RESTART_TIME).toSeconds();
+        var restartTime = conf.get(AutoScalerOptions.RESTART_TIME);
 
         var topology = new JobTopology(new VertexInfo(source, Collections.emptySet(), 1, 1));
         var evaluator = new ScalingMetricEvaluator();
@@ -479,7 +484,7 @@ public class ScalingMetricEvaluatorTest {
                         .evaluate(
                                 conf,
                                 new CollectedMetricHistory(topology, metricHistory),
-                                restartTimeSec)
+                                restartTime)
                         .get(source)
                         .get(ScalingMetric.TRUE_PROCESSING_RATE));
 
@@ -508,7 +513,7 @@ public class ScalingMetricEvaluatorTest {
                         .evaluate(
                                 conf,
                                 new CollectedMetricHistory(topology, metricHistory),
-                                restartTimeSec)
+                                restartTime)
                         .get(source)
                         .get(ScalingMetric.TRUE_PROCESSING_RATE));
     }
@@ -519,20 +524,20 @@ public class ScalingMetricEvaluatorTest {
     }
 
     private Tuple2<Double, Double> getThresholds(
-            double inputTargetRate, double catchUpRate, double restartTimeSec, Configuration conf) {
-        return getThresholds(inputTargetRate, catchUpRate, restartTimeSec, conf, false);
+            double inputTargetRate, double catchUpRate, Duration restartTime, Configuration conf) {
+        return getThresholds(inputTargetRate, catchUpRate, restartTime, conf, false);
     }
 
     private Tuple2<Double, Double> getThresholds(
             double inputTargetRate, double catchUpRate, Configuration conf, boolean catchingUp) {
-        var restartTimeSec = conf.get(AutoScalerOptions.RESTART_TIME).toSeconds();
-        return getThresholds(inputTargetRate, catchUpRate, restartTimeSec, conf, catchingUp);
+        var restartTime = conf.get(AutoScalerOptions.RESTART_TIME);
+        return getThresholds(inputTargetRate, catchUpRate, restartTime, conf, catchingUp);
     }
 
     private Tuple2<Double, Double> getThresholds(
             double inputTargetRate,
             double catchUpRate,
-            double restartTimeSec,
+            Duration restartTime,
             Configuration conf,
             boolean catchingUp) {
         var map = new HashMap<ScalingMetric, EvaluatedScalingMetric>();
@@ -540,8 +545,7 @@ public class ScalingMetricEvaluatorTest {
         map.put(TARGET_DATA_RATE, new EvaluatedScalingMetric(Double.NaN, inputTargetRate));
         map.put(CATCH_UP_DATA_RATE, EvaluatedScalingMetric.of(catchUpRate));
 
-        ScalingMetricEvaluator.computeProcessingRateThresholds(
-                map, conf, catchingUp, restartTimeSec);
+        ScalingMetricEvaluator.computeProcessingRateThresholds(map, conf, catchingUp, restartTime);
         return Tuple2.of(
                 map.get(SCALE_UP_RATE_THRESHOLD).getCurrent(),
                 map.get(SCALE_DOWN_RATE_THRESHOLD).getCurrent());

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingTrackingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingTrackingTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler;
+
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.autoscaler.topology.JobTopology;
+import org.apache.flink.autoscaler.topology.VertexInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScalingTrackingTest {
+
+    long configuredRestartTimeSeconds = 300;
+    long configuredMaxRestartTimeSeconds = 900;
+    private ScalingTracking scalingTracking;
+    private Configuration conf;
+
+    @BeforeEach
+    void setUp() {
+        scalingTracking = new ScalingTracking();
+        conf = new Configuration();
+        conf.set(AutoScalerOptions.RESTART_TIME, Duration.ofSeconds(configuredRestartTimeSeconds));
+        conf.set(AutoScalerOptions.PREFER_TRACKED_RESTART_TIME, true);
+    }
+
+    @Test
+    void shouldReturnConfiguredRestartTime_WhenNoScalingRecords() {
+        // Empty scalingTracking
+        double result = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+
+        assertThat(result).isEqualTo(configuredRestartTimeSeconds);
+    }
+
+    @Test
+    void shouldReturnConfiguredRestartTime_WhenPreferTrackedRestartTimeIsFalse() {
+        conf.set(AutoScalerOptions.PREFER_TRACKED_RESTART_TIME, false);
+        setUpScalingRecords(Duration.ofSeconds(configuredRestartTimeSeconds - 1));
+
+        double result = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+
+        assertThat(result).isEqualTo(configuredRestartTimeSeconds);
+    }
+
+    @Test
+    void maxRestartTimeShouldNotCapConfiguredRestartTime_WhenPreferTrackedRestartTimeIsFalse() {
+        conf.set(AutoScalerOptions.PREFER_TRACKED_RESTART_TIME, false);
+        var restartTime =
+                configuredMaxRestartTimeSeconds
+                        + 1; // exceeds max configured, but should not be capped
+        conf.set(AutoScalerOptions.RESTART_TIME, Duration.ofSeconds(restartTime));
+        setUpScalingRecords(
+                Duration.ofSeconds(
+                        configuredRestartTimeSeconds - 1)); // should not be taken into account
+
+        double result = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+
+        assertThat(result).isEqualTo(restartTime);
+    }
+
+    @Test
+    void shouldReturnMaxTrackedRestartTime_WhenNotCapped() {
+        long duration = configuredMaxRestartTimeSeconds - 1;
+        setUpScalingRecords(Duration.ofSeconds(duration));
+
+        double result = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+
+        assertThat(result).isEqualTo(duration);
+    }
+
+    @Test
+    void shouldReturnConfiguredRestartTime_WhenCapped() {
+        long duration = configuredMaxRestartTimeSeconds + 1;
+        setUpScalingRecords(Duration.ofSeconds(duration));
+
+        double result = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+
+        assertThat(result).isEqualTo(configuredMaxRestartTimeSeconds);
+    }
+
+    private void setUpScalingRecords(Duration secondRescaleDuration) {
+        scalingTracking.addScalingRecord(
+                Instant.parse("2023-11-15T16:00:00.00Z"),
+                new ScalingRecord(Instant.parse("2023-11-15T16:03:00.00Z")));
+        var secondRecordStart = Instant.parse("2023-11-15T16:20:00.00Z");
+        scalingTracking.addScalingRecord(
+                secondRecordStart,
+                new ScalingRecord(secondRecordStart.plus(secondRescaleDuration)));
+    }
+
+    @Test
+    void shouldSetEndTime_WhenParallelismMatches() {
+        var now = Instant.now();
+        var lastScaling = now.minusSeconds(60);
+        addScalingRecordWithoutEndTime(lastScaling);
+        var actualParallelisms = initActualParallelisms();
+        var jobTopology = new JobTopology(createVertexInfoSet(actualParallelisms));
+        var scalingHistory =
+                initScalingHistoryWithTargetParallelism(lastScaling, actualParallelisms);
+
+        boolean result =
+                scalingTracking.setEndTimeIfTrackedAndParallelismMatches(
+                        now, jobTopology, scalingHistory);
+
+        assertThat(result).isTrue();
+        assertThat(scalingTracking.getLatestScalingRecordEntry().get().getValue().getEndTime())
+                .isEqualTo(now);
+    }
+
+    @Test
+    void shouldNotSetEndTime_WhenParallelismDoesNotMatch() {
+        var now = Instant.now();
+        var lastScaling = now.minusSeconds(60);
+        addScalingRecordWithoutEndTime(lastScaling);
+        var actualParallelisms = initActualParallelisms();
+        var jobTopology = new JobTopology(createVertexInfoSet(actualParallelisms));
+        var mismatchedParallelisms = new HashMap<>(actualParallelisms);
+        mismatchedParallelisms.replaceAll((key, value) -> value + 1);
+        var scalingHistory =
+                initScalingHistoryWithTargetParallelism(lastScaling, mismatchedParallelisms);
+
+        boolean result =
+                scalingTracking.setEndTimeIfTrackedAndParallelismMatches(
+                        now, jobTopology, scalingHistory);
+
+        assertThat(result).isFalse();
+        assertThat(scalingTracking.getLatestScalingRecordEntry().get().getValue().getEndTime())
+                .isNull();
+    }
+
+    private void addScalingRecordWithoutEndTime(Instant startTime) {
+        ScalingRecord record = new ScalingRecord();
+        scalingTracking.addScalingRecord(startTime, record);
+    }
+
+    private Set<VertexInfo> createVertexInfoSet(Map<JobVertexID, Integer> parallelisms) {
+        Set<VertexInfo> vertexInfos = new HashSet<>();
+        for (Map.Entry<JobVertexID, Integer> entry : parallelisms.entrySet()) {
+            vertexInfos.add(
+                    new VertexInfo(
+                            entry.getKey(), new HashSet<>(), entry.getValue(), entry.getValue()));
+        }
+        return vertexInfos;
+    }
+
+    private Map<JobVertexID, Integer> initActualParallelisms() {
+        var parallelisms = new HashMap<JobVertexID, Integer>();
+        parallelisms.put(new JobVertexID(), 2);
+        parallelisms.put(new JobVertexID(), 3);
+        return parallelisms;
+    }
+
+    private Map<JobVertexID, SortedMap<Instant, ScalingSummary>>
+            initScalingHistoryWithTargetParallelism(
+                    Instant scalingTimestamp, Map<JobVertexID, Integer> targetParallelisms) {
+        var history = new HashMap<JobVertexID, SortedMap<Instant, ScalingSummary>>();
+        targetParallelisms.forEach(
+                (id, parallelism) -> {
+                    var vertexHistory = new TreeMap<Instant, ScalingSummary>();
+                    vertexHistory.put(
+                            scalingTimestamp,
+                            new ScalingSummary(parallelism - 1, parallelism, null));
+                    history.put(id, vertexHistory);
+                });
+        return history;
+    }
+}

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingTrackingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingTrackingTest.java
@@ -55,7 +55,7 @@ class ScalingTrackingTest {
     @Test
     void shouldReturnConfiguredRestartTime_WhenNoScalingRecords() {
         // Empty scalingTracking
-        var result = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+        var result = scalingTracking.getMaxRestartTimeOrDefault(conf);
 
         assertThat(result).isEqualTo(configuredRestartTime);
     }
@@ -65,7 +65,7 @@ class ScalingTrackingTest {
         conf.set(AutoScalerOptions.PREFER_TRACKED_RESTART_TIME, false);
         setUpScalingRecords(configuredRestartTime.minusSeconds(1));
 
-        var result = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+        var result = scalingTracking.getMaxRestartTimeOrDefault(conf);
 
         assertThat(result).isEqualTo(configuredRestartTime);
     }
@@ -80,7 +80,7 @@ class ScalingTrackingTest {
         setUpScalingRecords(
                 configuredRestartTime.minusSeconds(1)); // should not be taken into account
 
-        var result = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+        var result = scalingTracking.getMaxRestartTimeOrDefault(conf);
 
         assertThat(result).isEqualTo(restartTime);
     }
@@ -90,7 +90,7 @@ class ScalingTrackingTest {
         var duration = configuredMaxRestartTime.minusSeconds(1);
         setUpScalingRecords(duration);
 
-        var result = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+        var result = scalingTracking.getMaxRestartTimeOrDefault(conf);
 
         assertThat(result).isEqualTo(duration);
     }
@@ -100,7 +100,7 @@ class ScalingTrackingTest {
         var duration = configuredMaxRestartTime.plusSeconds(1);
         setUpScalingRecords(duration);
 
-        var result = scalingTracking.getMaxRestartTimeSecondsOrDefault(conf);
+        var result = scalingTracking.getMaxRestartTimeOrDefault(conf);
 
         assertThat(result).isEqualTo(configuredMaxRestartTime);
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/TestingAutoscalerUtils.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/TestingAutoscalerUtils.java
@@ -49,6 +49,19 @@ public class TestingAutoscalerUtils {
                 getRestClusterClientSupplier());
     }
 
+    public static JobAutoScalerContext<JobID> createJobAutoScalerContext(JobStatus jobStatus) {
+        MetricRegistry registry = NoOpMetricRegistry.INSTANCE;
+        GenericMetricGroup metricGroup = new GenericMetricGroup(registry, null, "test");
+        final JobID jobID = new JobID();
+        return new JobAutoScalerContext<JobID>(
+                jobID,
+                jobID,
+                jobStatus,
+                new Configuration(),
+                metricGroup,
+                getRestClusterClientSupplier());
+    }
+
     public static SupplierWithException<RestClusterClient<String>, Exception>
             getRestClusterClientSupplier() {
         return () ->


### PR DESCRIPTION
This PR does not yet contain tests since I would like to first reach consensus on the general approach.

## What is the purpose of the change

Currently the autoscaler uses a preconfigured restart time for the job. This PR adds the ability to dynamically adjust this based on the observed restart times for scale operations

## Brief change log

  - Adds `ScalingTracking` for tracking job-scoped scaling data.
  - Adds autoscaler properties for enabling the observed restart times usage in the rescaling logic(opt in).


**High level approach:**
The autoscaler adds a `ScalingTracking` object into the config map in the following format:
```
 scalingTracking: |                                                                                                                                                         
 ---
    scalingRecords: 
      "2023-11-13T13:36:35.240245Z": 
         endTime: null
           targetParallelism: 
             e44d8435128fbb8c0406b9ae78407aec: 2                                                                                                                                           
```
It contains a map of applied scaling decisions together with the target topology and the `endTime`, sorted by the time when the scaling was applied (map's key). When the job transitions into the RUNNING state, the latest record is fetched, the current parallelism is compared with the target one and the `endTime` is set to now (only if was not previously set).
  
## Verifying this change

Manual. Testing implementation will follow after the general approach gets approved.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / **no**)
  - Core observer or reconciler logic that is regularly executed: (**yes** / no)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / **JavaDocs** / not documented) 
