### PR TITLE
[FLINK-33522] Be ware of SerializedThrowable when checking for StopWithSavepointStoppingException

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -331,8 +331,10 @@ public abstract class AbstractFlinkService implements FlinkService {
                                     exception);
                         } catch (Exception e) {
                             var stopWithSavepointException =
-                                    ExceptionUtils.findThrowable(
-                                            e, StopWithSavepointStoppingException.class);
+                                    ExceptionUtils.findThrowableSerializedAware(
+                                            e,
+                                            StopWithSavepointStoppingException.class,
+                                            getClass().getClassLoader());
                             if (stopWithSavepointException.isPresent()) {
                                 // Handle edge case where the savepoint completes but the job fails
                                 // right afterward.

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -651,8 +651,9 @@ public class AbstractFlinkServiceTest {
                     if (failAfterSavepointCompletes) {
                         stopWithSavepointFuture.completeExceptionally(
                                 new CompletionException(
-                                        new StopWithSavepointStoppingException(
-                                                savepointPath, jobID)));
+                                        new SerializedThrowable(
+                                                new StopWithSavepointStoppingException(
+                                                        savepointPath, jobID))));
                     } else {
                         stopWithSavepointFuture.complete(
                                 new Tuple3<>(id, formatType, savepointDir));


### PR DESCRIPTION
Turns out that the previous detection code in #706 may not always fire correctly due to an encapsulated serialized throwable. This minor change fixes that.