### PR TITLE
[FLINK-33710] Prevent NOOP spec updates from the autoscaler parallelism override map

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizer.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizer.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.PipelineOptions;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 
 import java.util.Map;
+import java.util.TreeMap;
 
 /** The Kubernetes implementation for applying parallelism overrides. */
 public class KubernetesScalingRealizer
@@ -32,6 +33,9 @@ public class KubernetesScalingRealizer
     @Override
     public void realize(
             KubernetesJobAutoScalerContext context, Map<String, String> parallelismOverrides) {
+        // Make sure the keys are sorted via TreeMap to prevent changing the spec when none of the
+        // entries changed but the key order is different!
+        parallelismOverrides = new TreeMap<>(parallelismOverrides);
         context.getResource()
                 .getSpec()
                 .getFlinkConfiguration()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.autoscaler;
+
+import org.apache.flink.configuration.PipelineOptions;
+
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/** Tests for KubernetesScalingRealizer. */
+public class KubernetesScalingRealizerTest {
+
+    @Test
+    public void testAutoscalerOverridesVertexIdsAreSorted() {
+
+        KubernetesJobAutoScalerContext ctx =
+                TestingKubernetesAutoscalerUtils.createContext("test", null);
+
+        // Create map which returns keys unsorted
+        Map<String, String> overrides = new LinkedHashMap<>();
+        overrides.put("b", "2");
+        overrides.put("a", "1");
+
+        new KubernetesScalingRealizer().realize(ctx, overrides);
+
+        assertThat(
+                ctx.getResource()
+                        .getSpec()
+                        .getFlinkConfiguration()
+                        .get(PipelineOptions.PARALLELISM_OVERRIDES.key()),
+                is("a:1,b:2"));
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizerTest.java
@@ -19,13 +19,12 @@ package org.apache.flink.kubernetes.operator.autoscaler;
 
 import org.apache.flink.configuration.PipelineOptions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for KubernetesScalingRealizer. */
 public class KubernetesScalingRealizerTest {
@@ -44,10 +43,10 @@ public class KubernetesScalingRealizerTest {
         new KubernetesScalingRealizer().realize(ctx, overrides);
 
         assertThat(
-                ctx.getResource()
-                        .getSpec()
-                        .getFlinkConfiguration()
-                        .get(PipelineOptions.PARALLELISM_OVERRIDES.key()),
-                is("a:1,b:2"));
+                        ctx.getResource()
+                                .getSpec()
+                                .getFlinkConfiguration()
+                                .get(PipelineOptions.PARALLELISM_OVERRIDES.key()))
+                .isEqualTo("a:1,b:2");
     }
 }


### PR DESCRIPTION
The operator supports two modes to apply autoscaler changes:

1. Use the internal Flink config {{pipeline.jobvertex-parallelism-overrides}} 
2. Make use of Flink's Rescale API 

For (1), a string has to be generated for the Flink config with the actual overrides. This string has to be deterministic for a given map. But it is not.

Consider the following observed log:

```
  >>> Event  | Info    | SPECCHANGED     | SCALE change(s) detected (Diff: FlinkDeploymentSpec[flinkConfiguration.pipeline.jobvertex-parallelism-overrides : 92542d1280187bd464274368a5f86977:3,9f979ed859083299d29f281832cb5be0:1,84881d7bda0dc3d44026e37403420039:1,1652184ffd0522859c7840a24936847c:1 -> 9f979ed859083299d29f281832cb5be0:1,84881d7bda0dc3d44026e37403420039:1,92542d1280187bd464274368a5f86977:3,1652184ffd0522859c7840a24936847c:1]), starting reconciliation. 
```

The overrides are identical but the order is different which triggers a redeploy. This does not seem to happen often but some deterministic string generation (e.g. sorting by key) is required to prevent any NOOP updates.