### PR TITLE
[FLINK-33710] Prevent triggering cluster upgrades for permutations of the same overrides

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -931,6 +931,56 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
                         .get(PipelineOptions.PARALLELISM_OVERRIDES));
     }
 
+    @Test
+    public void testNoSpecChangeForEffectivelyIdenticalParallelismOverrides() throws Exception {
+        var ctxFactory =
+                new TestingFlinkResourceContextFactory(
+                        configManager, operatorMetricGroup, flinkService, eventRecorder);
+        appReconciler =
+                new ApplicationReconciler(eventRecorder, statusRecorder, new NoopJobAutoscaler<>());
+
+        var deployment = TestUtils.buildApplicationCluster();
+
+        var v1 = new JobVertexID(0, 0);
+        var v2 = new JobVertexID(0, 1);
+        var existingOverrides = String.format("%s:1,%s:2", v1, v2);
+
+        // Apply initial overrides
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(PipelineOptions.PARALLELISM_OVERRIDES.key(), existingOverrides);
+
+        // Reconcile overrides
+        appReconciler.reconcile(ctxFactory.getResourceContext(deployment, context));
+        verifyAndSetRunningJobsToStatus(deployment, flinkService.listJobs());
+        assertEquals(
+                ReconciliationState.DEPLOYED,
+                deployment.getStatus().getReconciliationStatus().getState());
+        assertEquals("RUNNING", deployment.getStatus().getJobStatus().getState());
+
+        // Reverse the order of the same overrides
+        var existingOverridesDifferentPermutation = String.format("%s:2,%s:1", v2, v1);
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(
+                        PipelineOptions.PARALLELISM_OVERRIDES.key(),
+                        existingOverridesDifferentPermutation);
+
+        // Ensure that the permutation in the override string does not trigger a deploy
+        appReconciler.reconcile(ctxFactory.getResourceContext(deployment, context));
+        assertEquals(
+                ReconciliationState.DEPLOYED,
+                deployment.getStatus().getReconciliationStatus().getState());
+        assertEquals(
+                existingOverrides,
+                ctxFactory
+                        .getResourceContext(deployment, context)
+                        .getObserveConfig()
+                        .getString(PipelineOptions.PARALLELISM_OVERRIDES.key(), ""));
+    }
+
     @ParameterizedTest
     @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
     public void verifyJobIdNotResetDuringLastStateRecovery(FlinkVersion flinkVersion) {


### PR DESCRIPTION
Previous fix in #720 made the parallelism override string deterministic, but it will likely result in existing deployments to trigger a one-off unneeded spec update.

To prevent this and to update only once an actual scaling occurs, we need to compare the existing overrides with the new ones and check if they are identical. In this case, we restore the current override string with its own permutation.
