### PR TITLE
[FLINK-33645] Taskmanager env vars in config not given to taskmanager

### DIFF
--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesTaskManagerParameters.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesTaskManagerParameters.java
@@ -19,6 +19,8 @@ package org.apache.flink.kubernetes.operator.kubeclient.parameters;
 
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
@@ -73,8 +75,8 @@ public class StandaloneKubernetesTaskManagerParameters extends AbstractKubernete
 
     @Override
     public Map<String, String> getEnvironments() {
-        // TMs have environment set using the pod template.
-        return new HashMap<>();
+        // TMs have environment set using the pod template and config containerized.taskmanager.env
+        return new HashMap<>(ConfigurationUtils.getPrefixedKeyValuePairs(ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX, flinkConfig));
     }
 
     @Override

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesTaskManagerParameters.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/parameters/StandaloneKubernetesTaskManagerParameters.java
@@ -76,7 +76,9 @@ public class StandaloneKubernetesTaskManagerParameters extends AbstractKubernete
     @Override
     public Map<String, String> getEnvironments() {
         // TMs have environment set using the pod template and config containerized.taskmanager.env
-        return new HashMap<>(ConfigurationUtils.getPrefixedKeyValuePairs(ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX, flinkConfig));
+        return new HashMap<>(
+                ConfigurationUtils.getPrefixedKeyValuePairs(
+                        ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX, flinkConfig));
     }
 
     @Override

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/utils/TestUtils.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/utils/TestUtils.java
@@ -21,7 +21,6 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
@@ -110,8 +109,6 @@ public class TestUtils {
                 TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
         flinkConf.setString(BlobServerOptions.PORT, String.valueOf(Constants.BLOB_SERVER_PORT));
         flinkConf.setString(RestOptions.BIND_PORT, String.valueOf(Constants.REST_PORT));
-        flinkConf.setString(ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX + USER_ENV_VAR, JM_ENV_VALUE);
-        flinkConf.setString(ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX + USER_ENV_VAR, TM_ENV_VALUE);
         return flinkConf;
     }
 }

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/utils/TestUtils.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/utils/TestUtils.java
@@ -21,6 +21,7 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
@@ -53,6 +54,11 @@ public class TestUtils {
 
     public static final double TASK_MANAGER_CPU = 4;
     public static final double JOB_MANAGER_CPU = 2;
+
+    public static final String USER_ENV_VAR = "USER_ENV";
+
+    public static final String JM_ENV_VALUE = "TEST_JM";
+    public static final String TM_ENV_VALUE = "TEST_TM";
 
     public static Map<String, String> generateTestStringStringMap(
             String keyPrefix, String valuePrefix, int entries) {
@@ -104,6 +110,8 @@ public class TestUtils {
                 TaskManagerOptions.RPC_PORT, String.valueOf(Constants.TASK_MANAGER_RPC_PORT));
         flinkConf.setString(BlobServerOptions.PORT, String.valueOf(Constants.BLOB_SERVER_PORT));
         flinkConf.setString(RestOptions.BIND_PORT, String.valueOf(Constants.REST_PORT));
+        flinkConf.setString(ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX + USER_ENV_VAR, JM_ENV_VALUE);
+        flinkConf.setString(ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX + USER_ENV_VAR, TM_ENV_VALUE);
         return flinkConf;
     }
 }

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/standalone/KubernetesStandaloneClusterDescriptorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/standalone/KubernetesStandaloneClusterDescriptorTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
@@ -44,9 +45,11 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.kubernetes.operator.kubeclient.utils.TestUtils.*;
+import static org.apache.flink.kubernetes.operator.kubeclient.utils.TestUtils.JM_ENV_VALUE;
+import static org.apache.flink.kubernetes.operator.kubeclient.utils.TestUtils.TEST_NAMESPACE;
+import static org.apache.flink.kubernetes.operator.kubeclient.utils.TestUtils.TM_ENV_VALUE;
+import static org.apache.flink.kubernetes.operator.kubeclient.utils.TestUtils.USER_ENV_VAR;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -78,6 +81,12 @@ public class KubernetesStandaloneClusterDescriptorTest {
         flinkConfig.setString(BlobServerOptions.PORT, String.valueOf(0));
         flinkConfig.setString(TaskManagerOptions.RPC_PORT, String.valueOf(0));
         flinkConfig.setString(RestOptions.BIND_PORT, String.valueOf(0));
+        flinkConfig.setString(
+                ResourceManagerOptions.CONTAINERIZED_MASTER_ENV_PREFIX + USER_ENV_VAR,
+                JM_ENV_VALUE);
+        flinkConfig.setString(
+                ResourceManagerOptions.CONTAINERIZED_TASK_MANAGER_ENV_PREFIX + USER_ENV_VAR,
+                TM_ENV_VALUE);
 
         var clusterClientProvider = clusterDescriptor.deploySessionCluster(clusterSpecification);
 
@@ -113,16 +122,17 @@ public class KubernetesStandaloneClusterDescriptorTest {
         assertTrue(
                 jmDeployment.getSpec().getTemplate().getSpec().getContainers().stream()
                         .anyMatch(c -> c.getArgs().contains("jobmanager")));
-        List<EnvVar> envVars = jmDeployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
-        assertTrue(envVars.stream().anyMatch(env -> env.getName().equals(USER_ENV_VAR) && env.getValue().equals(JM_ENV_VALUE)));
+        List<EnvVar> envVars =
+                jmDeployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
+        assertTrue(envVars.contains(new EnvVar(USER_ENV_VAR, JM_ENV_VALUE, null)));
+
         Deployment tmDeployment =
                 deployments.stream()
                         .filter(d -> d.getMetadata().getName().equals(expectedTMDeploymentName))
                         .findFirst()
                         .orElse(null);
         envVars = tmDeployment.getSpec().getTemplate().getSpec().getContainers().get(0).getEnv();
-        assertTrue(envVars.stream().anyMatch(env -> env.getName().equals(USER_ENV_VAR) && env.getValue().equals(TM_ENV_VALUE)));
-
+        assertTrue(envVars.contains(new EnvVar(USER_ENV_VAR, TM_ENV_VALUE, null)));
 
         var clusterClient = clusterClientProvider.getClusterClient();
 


### PR DESCRIPTION
## What is the purpose of the change

Bug fix. In standalone mode if config defining env vars for taskmanager are defined they are not being propagated to the taskmanagers


## Brief change log

  - Modify getEnvironments in StandaloneKubernetesTaskManagerParameters to retrieve env vars from config
  - Extended KubernetesStandaloneClusterDescriptorTest to check envVars are correctly set

## Verifying this change

This change added tests and can be verified as follows:

  - KubernetesStandaloneClusterDescriptorTest extended to include check for env vars from additional config

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
