### PR TITLE
[FLINK-33763] Support savepoint redeployment through a nonce

### DIFF
--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -306,7 +306,7 @@ It is possible to redeploy a `FlinkDeployment` or `FlinkSessionJob` resource fro
    savepointRedeployNonce: 1
 ```
 
-When changing the `savepointRedeployNonce` the operator will redeploy the job to the savepoint defined in the `initialSavepointPath` or empty state if the path is null. 
+When changing the `savepointRedeployNonce` the operator will redeploy the job to the savepoint defined in the `initialSavepointPath`. The savepoint path must not be empty. 
 
 {{< hint warning >}}
 Rollbacks are not supported after redeployments.

--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -302,7 +302,8 @@ It is possible to redeploy a `FlinkDeployment` or `FlinkSessionJob` resource fro
 ```yaml
  job:
    initialSavepointPath: file://redeploy-target-savepoint
-   savepointRedeployNonce: null -> 1
+   # If not set previously, set to 1, otherwise increment, e.g. 2
+   savepointRedeployNonce: 1
 ```
 
 When changing the `savepointRedeployNonce` the operator will redeploy the job to the savepoint defined in the `initialSavepointPath` or empty state if the path is null. 

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -121,11 +121,11 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | args | java.lang.String[] | Arguments for the Flink job main class. |
 | state | org.apache.flink.kubernetes.operator.api.spec.JobState | Desired state for the job. |
 | savepointTriggerNonce | java.lang.Long | Nonce used to manually trigger savepoint for the running job. In order to trigger a savepoint, change the number to a different non-null value. |
-| initialSavepointPath | java.lang.String | Savepoint path used by the job the first time it is deployed. Upgrades/redeployments will not be affected. |
+| initialSavepointPath | java.lang.String | Savepoint path used by the job the first time it is deployed or during savepoint redeployments (triggered by changing the savepointRedeployNonce). |
 | checkpointTriggerNonce | java.lang.Long | Nonce used to manually trigger checkpoint for the running job. In order to trigger a checkpoint, change the number to a different non-null value. |
 | upgradeMode | org.apache.flink.kubernetes.operator.api.spec.UpgradeMode | Upgrade mode of the Flink job. |
 | allowNonRestoredState | java.lang.Boolean | Allow checkpoint state that cannot be mapped to any job vertex in tasks. |
-| savepointRedeployNonce | java.lang.Long | Nonce used to trigger a full redeployment of the job from the savepoint path specified in initialSavepointPath or from empty state if initialSavepointPath is null. In order to trigger redeployment, change the number to a different non-null value. Rollback is not possible after redeployment. |
+| savepointRedeployNonce | java.lang.Long | Nonce used to trigger a full redeployment of the job from the savepoint path specified in initialSavepointPath. In order to trigger redeployment, change the number to a different non-null value. Rollback is not possible after redeployment. |
 
 ### JobState
 **Class**: org.apache.flink.kubernetes.operator.api.spec.JobState

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -46,7 +46,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
 | job | org.apache.flink.kubernetes.operator.api.spec.JobSpec | Job specification for application deployments/session job. Null for session clusters. |
-| restartNonce | java.lang.Long | Nonce used to manually trigger restart for the cluster/session job. In order to trigger restart, change the number to anything other than the current value. |
+| restartNonce | java.lang.Long | Nonce used to manually trigger restart for the cluster/session job. In order to trigger restart, change the number to a different non-null value. |
 | flinkConfiguration | java.util.Map<java.lang.String,java.lang.String> | Flink configuration overrides for the Flink deployment or Flink session job. |
 | image | java.lang.String | Flink docker image used to start the Job and TaskManager pods. |
 | imagePullPolicy | java.lang.String | Image pull policy of the Flink docker image. |
@@ -67,7 +67,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
 | job | org.apache.flink.kubernetes.operator.api.spec.JobSpec | Job specification for application deployments/session job. Null for session clusters. |
-| restartNonce | java.lang.Long | Nonce used to manually trigger restart for the cluster/session job. In order to trigger restart, change the number to anything other than the current value. |
+| restartNonce | java.lang.Long | Nonce used to manually trigger restart for the cluster/session job. In order to trigger restart, change the number to a different non-null value. |
 | flinkConfiguration | java.util.Map<java.lang.String,java.lang.String> | Flink configuration overrides for the Flink deployment or Flink session job. |
 | deploymentName | java.lang.String | The name of the target session cluster deployment. |
 
@@ -120,12 +120,12 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | entryClass | java.lang.String | Fully qualified main class name of the Flink job. |
 | args | java.lang.String[] | Arguments for the Flink job main class. |
 | state | org.apache.flink.kubernetes.operator.api.spec.JobState | Desired state for the job. |
-| savepointTriggerNonce | java.lang.Long | Nonce used to manually trigger savepoint for the running job. In order to trigger a savepoint, change the number to anything other than the current value. |
+| savepointTriggerNonce | java.lang.Long | Nonce used to manually trigger savepoint for the running job. In order to trigger a savepoint, change the number to a different non-null value. |
 | initialSavepointPath | java.lang.String | Savepoint path used by the job the first time it is deployed. Upgrades/redeployments will not be affected. |
-| checkpointTriggerNonce | java.lang.Long | Nonce used to manually trigger checkpoint for the running job. In order to trigger a checkpoint, change the number to anything other than the current value. |
+| checkpointTriggerNonce | java.lang.Long | Nonce used to manually trigger checkpoint for the running job. In order to trigger a checkpoint, change the number to a different non-null value. |
 | upgradeMode | org.apache.flink.kubernetes.operator.api.spec.UpgradeMode | Upgrade mode of the Flink job. |
 | allowNonRestoredState | java.lang.Boolean | Allow checkpoint state that cannot be mapped to any job vertex in tasks. |
-| savepointRedeployNonce | java.lang.Long | Nonce used to trigger a full redeployment of the job from the savepoint path specified in initialSavepointPath or from empty state if initialSavepointPath is null. Rollback is not possible after redeployment. |
+| savepointRedeployNonce | java.lang.Long | Nonce used to trigger a full redeployment of the job from the savepoint path specified in initialSavepointPath or from empty state if initialSavepointPath is null. In order to trigger redeployment, change the number to a different non-null value. Rollback is not possible after redeployment. |
 
 ### JobState
 **Class**: org.apache.flink.kubernetes.operator.api.spec.JobState

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -125,6 +125,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | checkpointTriggerNonce | java.lang.Long | Nonce used to manually trigger checkpoint for the running job. In order to trigger a checkpoint, change the number to anything other than the current value. |
 | upgradeMode | org.apache.flink.kubernetes.operator.api.spec.UpgradeMode | Upgrade mode of the Flink job. |
 | allowNonRestoredState | java.lang.Boolean | Allow checkpoint state that cannot be mapped to any job vertex in tasks. |
+| savepointRedeployNonce | java.lang.Long | Nonce used to trigger a full redeployment of the job from the savepoint path specified in initialSavepointPath or from empty state if initialSavepointPath is null. Rollback is not possible after redeployment. |
 
 ### JobState
 **Class**: org.apache.flink.kubernetes.operator.api.spec.JobState

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/diff/DiffType.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/diff/DiffType.java
@@ -19,6 +19,9 @@ package org.apache.flink.kubernetes.operator.api.diff;
 
 import org.apache.flink.annotation.Experimental;
 
+import java.util.Collection;
+import java.util.Comparator;
+
 /** Spec change type. */
 @Experimental
 public enum DiffType {
@@ -32,7 +35,14 @@ public enum DiffType {
     /** Full redeploy from new state. */
     SAVEPOINT_REDEPLOY;
 
-    public static DiffType max(DiffType left, DiffType right) {
-        return (left.ordinal() >= right.ordinal()) ? left : right;
+    /**
+     * Aggregate a collection of {@link DiffType}s into the type that minimally subsumes all the
+     * diffs. We rely on the fact that the enum values are sorted this way.
+     *
+     * @param diffs Collection of diffs.
+     * @return Aggregated {@link DiffType}
+     */
+    public static DiffType from(Collection<DiffType> diffs) {
+        return diffs.stream().max(Comparator.comparing(DiffType::ordinal)).orElse(DiffType.IGNORE);
     }
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/diff/DiffType.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/diff/DiffType.java
@@ -28,7 +28,9 @@ public enum DiffType {
     /** Scalable spec change. */
     SCALE,
     /** Upgradable spec change. */
-    UPGRADE;
+    UPGRADE,
+    /** Full redeploy from new state. */
+    SAVEPOINT_REDEPLOY;
 
     public static DiffType max(DiffType left, DiffType right) {
         return (left.ordinal() >= right.ordinal()) ? left : right;

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/diff/SpecDiff.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/diff/SpecDiff.java
@@ -34,6 +34,8 @@ public @interface SpecDiff {
 
     KubernetesDeploymentMode[] mode() default {};
 
+    boolean onNullIgnore() default false;
+
     /** Spec diff config annotation. */
     @Target(ElementType.FIELD)
     @Retention(RetentionPolicy.RUNTIME)

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
@@ -44,6 +44,7 @@ public abstract class AbstractFlinkSpec implements Diffable<AbstractFlinkSpec> {
      * Nonce used to manually trigger restart for the cluster/session job. In order to trigger
      * restart, change the number to anything other than the current value.
      */
+    @SpecDiff(onNullIgnore = true)
     private Long restartNonce;
 
     /** Flink configuration overrides for the Flink deployment or Flink session job. */

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
@@ -42,7 +42,7 @@ public abstract class AbstractFlinkSpec implements Diffable<AbstractFlinkSpec> {
 
     /**
      * Nonce used to manually trigger restart for the cluster/session job. In order to trigger
-     * restart, change the number to anything other than the current value.
+     * restart, change the number to a different non-null value.
      */
     @SpecDiff(onNullIgnore = true)
     private Long restartNonce;

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
@@ -87,4 +87,12 @@ public class JobSpec implements Diffable<JobSpec> {
     /** Allow checkpoint state that cannot be mapped to any job vertex in tasks. */
     @SpecDiff(DiffType.IGNORE)
     private Boolean allowNonRestoredState;
+
+    /**
+     * Nonce used to trigger a full redeployment of the job from the savepoint path specified in
+     * initialSavepointPath or from empty state if initialSavepointPath is null. Rollback is not
+     * possible after redeployment.
+     */
+    @SpecDiff(value = DiffType.SAVEPOINT_REDEPLOY, onNullIgnore = true)
+    private Long savepointRedeployNonce;
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
@@ -67,8 +67,8 @@ public class JobSpec implements Diffable<JobSpec> {
     private Long savepointTriggerNonce;
 
     /**
-     * Savepoint path used by the job the first time it is deployed. Upgrades/redeployments will not
-     * be affected.
+     * Savepoint path used by the job the first time it is deployed or during savepoint
+     * redeployments (triggered by changing the savepointRedeployNonce).
      */
     @SpecDiff(DiffType.IGNORE)
     private String initialSavepointPath;
@@ -90,9 +90,8 @@ public class JobSpec implements Diffable<JobSpec> {
 
     /**
      * Nonce used to trigger a full redeployment of the job from the savepoint path specified in
-     * initialSavepointPath or from empty state if initialSavepointPath is null. In order to trigger
-     * redeployment, change the number to a different non-null value. Rollback is not possible after
-     * redeployment.
+     * initialSavepointPath. In order to trigger redeployment, change the number to a different
+     * non-null value. Rollback is not possible after redeployment.
      */
     @SpecDiff(value = DiffType.SAVEPOINT_REDEPLOY, onNullIgnore = true)
     private Long savepointRedeployNonce;

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
@@ -61,7 +61,7 @@ public class JobSpec implements Diffable<JobSpec> {
 
     /**
      * Nonce used to manually trigger savepoint for the running job. In order to trigger a
-     * savepoint, change the number to anything other than the current value.
+     * savepoint, change the number to a different non-null value.
      */
     @SpecDiff(DiffType.IGNORE)
     private Long savepointTriggerNonce;
@@ -75,7 +75,7 @@ public class JobSpec implements Diffable<JobSpec> {
 
     /**
      * Nonce used to manually trigger checkpoint for the running job. In order to trigger a
-     * checkpoint, change the number to anything other than the current value.
+     * checkpoint, change the number to a different non-null value.
      */
     @SpecDiff(DiffType.IGNORE)
     private Long checkpointTriggerNonce;
@@ -90,8 +90,9 @@ public class JobSpec implements Diffable<JobSpec> {
 
     /**
      * Nonce used to trigger a full redeployment of the job from the savepoint path specified in
-     * initialSavepointPath or from empty state if initialSavepointPath is null. Rollback is not
-     * possible after redeployment.
+     * initialSavepointPath or from empty state if initialSavepointPath is null. In order to trigger
+     * redeployment, change the number to a different non-null value. Rollback is not possible after
+     * redeployment.
      */
     @SpecDiff(value = DiffType.SAVEPOINT_REDEPLOY, onNullIgnore = true)
     private Long savepointRedeployNonce;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -21,6 +21,7 @@ import org.apache.flink.autoscaler.NoopJobAutoscaler;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.api.diff.DiffType;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
@@ -61,6 +62,7 @@ public class SessionReconciler
 
     @Override
     protected boolean reconcileSpecChange(
+            DiffType diffType,
             FlinkResourceContext<FlinkDeployment> ctx,
             Configuration deployConfig,
             FlinkDeploymentSpec lastReconciledSpec)

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
@@ -101,14 +101,7 @@ public class DiffResult<T> {
     }
 
     private static DiffType getSpechChangeType(List<Diff<?>> diffs) {
-        var type = DiffType.IGNORE;
-        for (var diff : diffs) {
-            type = DiffType.max(type, diff.getType());
-            if (type == DiffType.UPGRADE) {
-                return type;
-            }
-        }
-        return type;
+        return diffs.stream().map(Diff::getType).reduce(DiffType::max).orElse(DiffType.IGNORE);
     }
 
     private static void addField(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
@@ -28,6 +28,7 @@ import lombok.Getter;
 import lombok.NonNull;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Contains a collection of the differences between two {@link Diffable} objects.
@@ -49,7 +50,8 @@ public class DiffResult<T> {
         this.before = before;
         this.after = after;
         this.diffList = diffList;
-        this.type = getSpechChangeType(diffList);
+        this.type =
+                DiffType.from(diffList.stream().map(Diff::getType).collect(Collectors.toList()));
     }
 
     public int getNumDiffs() {
@@ -98,10 +100,6 @@ public class DiffResult<T> {
         builder.setLength(builder.length() - 2);
         builder.append("]");
         return String.format("Diff: %s", builder);
-    }
-
-    private static DiffType getSpechChangeType(List<Diff<?>> diffs) {
-        return diffs.stream().map(Diff::getType).reduce(DiffType::max).orElse(DiffType.IGNORE);
     }
 
     private static void addField(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/ReflectiveDiffBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/ReflectiveDiffBuilder.java
@@ -96,11 +96,13 @@ public class ReflectiveDiffBuilder<T> implements Builder<DiffResult<T>> {
                         var modes = annotation.mode();
                         boolean modeApplies =
                                 modes.length == 0 || Arrays.asList(modes).contains(deploymentMode);
-                        diffBuilder.append(
-                                field.getName(),
-                                leftField,
-                                rightField,
-                                modeApplies ? annotation.value() : UPGRADE);
+                        if (rightField != null || !annotation.onNullIgnore()) {
+                            diffBuilder.append(
+                                    field.getName(),
+                                    leftField,
+                                    rightField,
+                                    modeApplies ? annotation.value() : UPGRADE);
+                        }
                     } else if (Diffable.class.isAssignableFrom(field.getType())
                             && ObjectUtils.allNotNull(leftField, rightField)) {
                         diffBuilder.append(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -448,6 +448,14 @@ public class DefaultValidator implements FlinkResourceValidator {
                                 "Job could not be upgraded to last-state while config key[%s] is not set",
                                 CheckpointingOptions.SAVEPOINT_DIRECTORY.key()));
             }
+
+            if (newJob.getSavepointRedeployNonce() != null
+                    && !newJob.getSavepointRedeployNonce()
+                            .equals(oldJob.getSavepointRedeployNonce())
+                    && StringUtils.isNullOrWhitespaceOnly(newJob.getInitialSavepointPath())) {
+                return Optional.of(
+                        "InitialSavepointPath must not be empty for savepoint redeployment");
+            }
         }
 
         return Optional.empty();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -533,6 +533,94 @@ public class DefaultValidatorTest {
                 validatorWithDefaultConfig);
     }
 
+    @Test
+    public void testSavepointRedeployValidation() {
+        testSuccess(
+                dep -> {
+                    var job = dep.getSpec().getJob();
+                    dep.getStatus()
+                            .getReconciliationStatus()
+                            .serializeAndSetLastReconciledSpec(dep.getSpec(), dep);
+                    job.setSavepointRedeployNonce(1L);
+                    job.setInitialSavepointPath("s");
+                });
+
+        testSuccess(
+                dep -> {
+                    var job = dep.getSpec().getJob();
+                    job.setSavepointRedeployNonce(1L);
+                    job.setInitialSavepointPath("s");
+                    dep.getStatus()
+                            .getReconciliationStatus()
+                            .serializeAndSetLastReconciledSpec(dep.getSpec(), dep);
+
+                    job.setSavepointRedeployNonce(null);
+                    job.setInitialSavepointPath("s");
+                });
+
+        testSuccess(
+                dep -> {
+                    var job = dep.getSpec().getJob();
+                    job.setSavepointRedeployNonce(1L);
+                    job.setInitialSavepointPath("s");
+                    dep.getStatus()
+                            .getReconciliationStatus()
+                            .serializeAndSetLastReconciledSpec(dep.getSpec(), dep);
+
+                    job.setSavepointRedeployNonce(null);
+                    job.setInitialSavepointPath(null);
+                });
+
+        testSuccess(
+                dep -> {
+                    var job = dep.getSpec().getJob();
+                    job.setSavepointRedeployNonce(1L);
+                    job.setInitialSavepointPath("s");
+                    dep.getStatus()
+                            .getReconciliationStatus()
+                            .serializeAndSetLastReconciledSpec(dep.getSpec(), dep);
+
+                    job.setSavepointRedeployNonce(2L);
+                    job.setInitialSavepointPath("s");
+                });
+
+        testError(
+                dep -> {
+                    var job = dep.getSpec().getJob();
+                    dep.getStatus()
+                            .getReconciliationStatus()
+                            .serializeAndSetLastReconciledSpec(dep.getSpec(), dep);
+                    job.setSavepointRedeployNonce(1L);
+                    job.setInitialSavepointPath(null);
+                },
+                "InitialSavepointPath must not be empty for savepoint redeployment");
+
+        testError(
+                dep -> {
+                    var job = dep.getSpec().getJob();
+                    dep.getStatus()
+                            .getReconciliationStatus()
+                            .serializeAndSetLastReconciledSpec(dep.getSpec(), dep);
+                    job.setSavepointRedeployNonce(1L);
+                    job.setInitialSavepointPath(" ");
+                },
+                "InitialSavepointPath must not be empty for savepoint redeployment");
+
+        testError(
+                dep -> {
+                    var job = dep.getSpec().getJob();
+                    job.setSavepointRedeployNonce(1L);
+                    job.setInitialSavepointPath("s");
+                    dep.getStatus()
+                            .getReconciliationStatus()
+                            .serializeAndSetLastReconciledSpec(dep.getSpec(), dep);
+
+                    job.setSavepointRedeployNonce(2L);
+                    job.setInitialSavepointPath(null);
+                },
+                "InitialSavepointPath must not be empty for savepoint redeployment");
+    }
+
     @ParameterizedTest
     @EnumSource(UpgradeMode.class)
     public void testFlinkVersionChangeValidation(UpgradeMode toUpgradeMode) {

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -9645,6 +9645,8 @@ spec:
                     type: string
                   allowNonRestoredState:
                     type: boolean
+                  savepointRedeployNonce:
+                    type: integer
                 type: object
               restartNonce:
                 type: integer

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -64,6 +64,8 @@ spec:
                     type: string
                   allowNonRestoredState:
                     type: boolean
+                  savepointRedeployNonce:
+                    type: integer
                 type: object
               restartNonce:
                 type: integer


### PR DESCRIPTION
## What is the purpose of the change

A common request is to support a streamlined, user friendly way of redeploying from a target savepoint.
Previously this was only possible by deleting the CR and recreating it with initialSavepointPath. A big downside of this approach is a loss of savepoint/checkpoint history in the status that some platforms may need, resulting in non-cleaned up save points etc.

We  introduce a `savepointRedeployNonce` field in the job spec similar to other action trigger nonces.
If the nonce changes to a new non null value the job will be redeployed from the path specified in the initialSavepointPath (or empty state If the path is empty)

As redeployment requires the deletion of HA metadata and previous checkpoint info, rollbacks are not supported after redeployments (changing the nonce)

The PR also introduces an improvement to the restartNonce and savepointRedeployNonce to ignore null changes (when the user nulls out the nonce). This is more practical and inline with the behaviour of the savepoint/checkpoint triggering logic

## Brief change log

  - *Add savepointRedeployNonce to `spec.job`*
  - *Implement redeployment logic*
  - *Tests*
  - *Doc updates*

## Verifying this change

Unit tests and manual validation on local and remote envs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
