### PR TITLE
[FLINK-33770] Promote deprecated autoscaler keys to fallback keys

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -27,11 +27,11 @@ import java.util.List;
 /** Config options related to the autoscaler module. */
 public class AutoScalerOptions {
 
-    public static final String DEPRECATED_K8S_OP_CONF_PREFIX = "kubernetes.operator.";
+    public static final String OLD_K8S_OP_CONF_PREFIX = "kubernetes.operator.";
     public static final String AUTOSCALER_CONF_PREFIX = "job.autoscaler.";
 
-    private static String deprecatedOperatorConfigKey(String key) {
-        return DEPRECATED_K8S_OP_CONF_PREFIX + AUTOSCALER_CONF_PREFIX + key;
+    private static String oldOperatorConfigKey(String key) {
+        return OLD_K8S_OP_CONF_PREFIX + AUTOSCALER_CONF_PREFIX + key;
     }
 
     private static String autoScalerConfigKey(String key) {
@@ -46,14 +46,14 @@ public class AutoScalerOptions {
             autoScalerConfig("enabled")
                     .booleanType()
                     .defaultValue(false)
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("enabled"))
+                    .withFallbackKeys(oldOperatorConfigKey("enabled"))
                     .withDescription("Enable job autoscaler module.");
 
     public static final ConfigOption<Boolean> SCALING_ENABLED =
             autoScalerConfig("scaling.enabled")
                     .booleanType()
                     .defaultValue(true)
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("scaling.enabled"))
+                    .withFallbackKeys(oldOperatorConfigKey("scaling.enabled"))
                     .withDescription(
                             "Enable vertex scaling execution by the autoscaler. If disabled, the autoscaler will only collect metrics and evaluate the suggested parallelism for each vertex but will not upgrade the jobs.");
 
@@ -61,14 +61,14 @@ public class AutoScalerOptions {
             autoScalerConfig("metrics.window")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(15))
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("metrics.window"))
+                    .withFallbackKeys(oldOperatorConfigKey("metrics.window"))
                     .withDescription("Scaling metrics aggregation window size.");
 
     public static final ConfigOption<Duration> STABILIZATION_INTERVAL =
             autoScalerConfig("stabilization.interval")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(5))
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("stabilization.interval"))
+                    .withFallbackKeys(oldOperatorConfigKey("stabilization.interval"))
                     .withDescription(
                             "Stabilization period in which no new scaling will be executed");
 
@@ -76,14 +76,14 @@ public class AutoScalerOptions {
             autoScalerConfig("target.utilization")
                     .doubleType()
                     .defaultValue(0.7)
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("target.utilization"))
+                    .withFallbackKeys(oldOperatorConfigKey("target.utilization"))
                     .withDescription("Target vertex utilization");
 
     public static final ConfigOption<Double> TARGET_UTILIZATION_BOUNDARY =
             autoScalerConfig("target.utilization.boundary")
                     .doubleType()
                     .defaultValue(0.3)
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("target.utilization.boundary"))
+                    .withFallbackKeys(oldOperatorConfigKey("target.utilization.boundary"))
                     .withDescription(
                             "Target vertex utilization boundary. Scaling won't be performed if the current processing rate is within [target_rate / (target_utilization - boundary), (target_rate / (target_utilization + boundary)]");
 
@@ -91,7 +91,7 @@ public class AutoScalerOptions {
             autoScalerConfig("scale-up.grace-period")
                     .durationType()
                     .defaultValue(Duration.ofHours(1))
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("scale-up.grace-period"))
+                    .withFallbackKeys(oldOperatorConfigKey("scale-up.grace-period"))
                     .withDescription(
                             "Duration in which no scale down of a vertex is allowed after it has been scaled up.");
 
@@ -99,14 +99,14 @@ public class AutoScalerOptions {
             autoScalerConfig("vertex.min-parallelism")
                     .intType()
                     .defaultValue(1)
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("vertex.min-parallelism"))
+                    .withFallbackKeys(oldOperatorConfigKey("vertex.min-parallelism"))
                     .withDescription("The minimum parallelism the autoscaler can use.");
 
     public static final ConfigOption<Integer> VERTEX_MAX_PARALLELISM =
             autoScalerConfig("vertex.max-parallelism")
                     .intType()
                     .defaultValue(200)
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("vertex.max-parallelism"))
+                    .withFallbackKeys(oldOperatorConfigKey("vertex.max-parallelism"))
                     .withDescription(
                             "The maximum parallelism the autoscaler can use. Note that this limit will be ignored if it is higher than the max parallelism configured in the Flink config or directly on each operator.");
 
@@ -114,7 +114,7 @@ public class AutoScalerOptions {
             autoScalerConfig("scale-down.max-factor")
                     .doubleType()
                     .defaultValue(0.6)
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("scale-down.max-factor"))
+                    .withFallbackKeys(oldOperatorConfigKey("scale-down.max-factor"))
                     .withDescription(
                             "Max scale down factor. 1 means no limit on scale down, 0.6 means job can only be scaled down with 60% of the original parallelism.");
 
@@ -122,7 +122,7 @@ public class AutoScalerOptions {
             autoScalerConfig("scale-up.max-factor")
                     .doubleType()
                     .defaultValue(100000.)
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("scale-up.max-factor"))
+                    .withFallbackKeys(oldOperatorConfigKey("scale-up.max-factor"))
                     .withDescription(
                             "Max scale up factor. 2.0 means job can only be scaled up with 200% of the current parallelism.");
 
@@ -130,7 +130,7 @@ public class AutoScalerOptions {
             autoScalerConfig("catch-up.duration")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(30))
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("catch-up.duration"))
+                    .withFallbackKeys(oldOperatorConfigKey("catch-up.duration"))
                     .withDescription(
                             "The target duration for fully processing any backlog after a scaling operation. Set to 0 to disable backlog based scaling.");
 
@@ -138,7 +138,7 @@ public class AutoScalerOptions {
             autoScalerConfig("restart.time")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(5))
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("restart.time"))
+                    .withFallbackKeys(oldOperatorConfigKey("restart.time"))
                     .withDescription(
                             "Expected restart time to be used until the operator can determine it reliably from history.");
 
@@ -146,6 +146,7 @@ public class AutoScalerOptions {
             autoScalerConfig("restart.time-tracking.enabled")
                     .booleanType()
                     .defaultValue(false)
+                    .withFallbackKeys(oldOperatorConfigKey("restart.time-tracking.enabled"))
                     .withDescription(
                             "Whether to use the actual observed rescaling restart times instead of the fixed '"
                                     + RESTART_TIME.key()
@@ -160,6 +161,7 @@ public class AutoScalerOptions {
             autoScalerConfig("restart.time-tracking.limit")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(15))
+                    .withFallbackKeys(oldOperatorConfigKey("restart.time-tracking.limit"))
                     .withDescription(
                             "Maximum cap for the observed restart time when '"
                                     + PREFER_TRACKED_RESTART_TIME.key()
@@ -169,8 +171,7 @@ public class AutoScalerOptions {
             autoScalerConfig("backlog-processing.lag-threshold")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(5))
-                    .withDeprecatedKeys(
-                            deprecatedOperatorConfigKey("backlog-processing.lag-threshold"))
+                    .withFallbackKeys(oldOperatorConfigKey("backlog-processing.lag-threshold"))
                     .withDescription(
                             "Lag threshold which will prevent unnecessary scalings while removing the pending messages responsible for the lag.");
 
@@ -178,9 +179,8 @@ public class AutoScalerOptions {
             autoScalerConfig("observed-true-processing-rate.lag-threshold")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(30))
-                    .withDeprecatedKeys(
-                            deprecatedOperatorConfigKey(
-                                    "observed-true-processing-rate.lag-threshold"))
+                    .withFallbackKeys(
+                            oldOperatorConfigKey("observed-true-processing-rate.lag-threshold"))
                     .withDescription(
                             "Lag threshold for enabling observed true processing rate measurements.");
 
@@ -188,9 +188,8 @@ public class AutoScalerOptions {
             autoScalerConfig("observed-true-processing-rate.switch-threshold")
                     .doubleType()
                     .defaultValue(0.15)
-                    .withDeprecatedKeys(
-                            deprecatedOperatorConfigKey(
-                                    "observed-true-processing-rate.switch-threshold"))
+                    .withFallbackKeys(
+                            oldOperatorConfigKey("observed-true-processing-rate.switch-threshold"))
                     .withDescription(
                             "Percentage threshold for switching to observed from busy time based true processing rate if the measurement is off by at least the configured fraction. For example 0.15 means we switch to observed if the busy time based computation is at least 15% higher during catchup.");
 
@@ -198,9 +197,8 @@ public class AutoScalerOptions {
             autoScalerConfig("observed-true-processing-rate.min-observations")
                     .intType()
                     .defaultValue(2)
-                    .withDeprecatedKeys(
-                            deprecatedOperatorConfigKey(
-                                    "observed-true-processing-rate.min-observations"))
+                    .withFallbackKeys(
+                            oldOperatorConfigKey("observed-true-processing-rate.min-observations"))
                     .withDescription(
                             "Minimum nr of observations used when estimating / switching to observed true processing rate.");
 
@@ -208,8 +206,8 @@ public class AutoScalerOptions {
             autoScalerConfig("scaling.effectiveness.detection.enabled")
                     .booleanType()
                     .defaultValue(false)
-                    .withDeprecatedKeys(
-                            deprecatedOperatorConfigKey("scaling.effectiveness.detection.enabled"))
+                    .withFallbackKeys(
+                            oldOperatorConfigKey("scaling.effectiveness.detection.enabled"))
                     .withDescription(
                             "Whether to enable detection of ineffective scaling operations and allowing the autoscaler to block further scale ups.");
 
@@ -217,8 +215,7 @@ public class AutoScalerOptions {
             autoScalerConfig("scaling.effectiveness.threshold")
                     .doubleType()
                     .defaultValue(0.1)
-                    .withDeprecatedKeys(
-                            deprecatedOperatorConfigKey("scaling.effectiveness.threshold"))
+                    .withFallbackKeys(oldOperatorConfigKey("scaling.effectiveness.threshold"))
                     .withDescription(
                             "Processing rate increase threshold for detecting ineffective scaling threshold. 0.1 means if we do not accomplish at least 10% of the desired capacity increase with scaling, the action is marked ineffective.");
 
@@ -226,7 +223,7 @@ public class AutoScalerOptions {
             autoScalerConfig("history.max.count")
                     .intType()
                     .defaultValue(3)
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("history.max.count"))
+                    .withFallbackKeys(oldOperatorConfigKey("history.max.count"))
                     .withDescription(
                             "Maximum number of past scaling decisions to retain per vertex.");
 
@@ -234,14 +231,14 @@ public class AutoScalerOptions {
             autoScalerConfig("history.max.age")
                     .durationType()
                     .defaultValue(Duration.ofHours(24))
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("history.max.age"))
+                    .withFallbackKeys(oldOperatorConfigKey("history.max.age"))
                     .withDescription("Maximum age for past scaling decisions to retain.");
 
     public static final ConfigOption<MetricAggregator> BUSY_TIME_AGGREGATOR =
             autoScalerConfig("metrics.busy-time.aggregator")
                     .enumType(MetricAggregator.class)
                     .defaultValue(MetricAggregator.MAX)
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("metrics.busy-time.aggregator"))
+                    .withFallbackKeys(oldOperatorConfigKey("metrics.busy-time.aggregator"))
                     .withDescription(
                             "Metric aggregator to use for busyTime metrics. This affects how true processing/output rate will be computed. Using max allows us to handle jobs with data skew more robustly, while avg may provide better stability when we know that the load distribution is even.");
 
@@ -250,7 +247,7 @@ public class AutoScalerOptions {
                     .stringType()
                     .asList()
                     .defaultValues()
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("vertex.exclude.ids"))
+                    .withFallbackKeys(oldOperatorConfigKey("vertex.exclude.ids"))
                     .withDescription(
                             "A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling. Caution: For non-sink vertices this will still scale their downstream operators until https://issues.apache.org/jira/browse/FLINK-31215 is implemented.");
 
@@ -258,12 +255,13 @@ public class AutoScalerOptions {
             autoScalerConfig("scaling.event.interval")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(30))
-                    .withDeprecatedKeys(deprecatedOperatorConfigKey("scaling.event.interval"))
+                    .withFallbackKeys(oldOperatorConfigKey("scaling.event.interval"))
                     .withDescription("Time interval to resend the identical event");
 
     public static final ConfigOption<Duration> FLINK_CLIENT_TIMEOUT =
             autoScalerConfig("flink.rest-client.timeout")
                     .durationType()
                     .defaultValue(Duration.ofSeconds(10))
+                    .withFallbackKeys(oldOperatorConfigKey("flink.rest-client.timeout"))
                     .withDescription("The timeout for waiting the flink rest client to return.");
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/config/AutoScalerOptionsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/config/AutoScalerOptionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.config;
+
+import org.apache.flink.configuration.ConfigOption;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for AutoScalerOptions. */
+public class AutoScalerOptionsTest {
+
+    @Test
+    void testAllConfigurationKeysHaveFallBackConfigured() {
+        assertThat(retrieveAutoscalerConfigOptions())
+                .allSatisfy(
+                        configOption ->
+                                assertThat(configOption.fallbackKeys())
+                                        .anySatisfy(
+                                                fallbackKey -> {
+                                                    assertThat(fallbackKey.getKey())
+                                                            .startsWith(
+                                                                    AutoScalerOptions
+                                                                            .OLD_K8S_OP_CONF_PREFIX);
+                                                    assertThat(
+                                                                    fallbackKey
+                                                                            .getKey()
+                                                                            .substring(
+                                                                                    AutoScalerOptions
+                                                                                            .OLD_K8S_OP_CONF_PREFIX
+                                                                                            .length()))
+                                                            .isEqualTo(configOption.key());
+                                                }));
+    }
+
+    private static List<ConfigOption<?>> retrieveAutoscalerConfigOptions() {
+        List<ConfigOption<?>> configOptions = new ArrayList<>();
+
+        for (Field declaredField : AutoScalerOptions.class.getDeclaredFields()) {
+            if (declaredField.getType().equals(ConfigOption.class)) {
+                try {
+                    ConfigOption<?> configOption = (ConfigOption<?>) declaredField.get(null);
+                    configOptions.add(configOption);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(
+                            "Could not access autoscaler option: " + declaredField, e);
+                }
+            }
+        }
+
+        assertThat(configOptions)
+                .withFailMessage("No default autoscaler configuration discovered")
+                .isNotEmpty();
+
+        return configOptions;
+    }
+}


### PR DESCRIPTION
We moved all autoscaler configuration from `kubernetes.operator.job.autoscaler.` to `job.autoscaler.`

With the latest release, the logs are full with logs like this:

```
level:  WARN
logger:  org.apache.flink.configuration.Configuration
message:  Config uses deprecated configuration key 'kubernetes.operator.job.autoscaler.target.utilization' instead of proper key 'job.autoscaler.target.utilization'
```

The reason is that the configuration is loaded for every reconciliation.

This configuration is already widely adopted across hundreds of pipelines. I propose to remove the deprecation from the config keys and make them "fallback" keys instead which removes the deprecation warning.