### PR TITLE
[FLINK-33764] Track Heap usage and GC pressure to avoid unnecessary scaling

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -45,6 +45,18 @@
             <td>Maximum number of past scaling decisions to retain per vertex.</td>
         </tr>
         <tr>
+            <td><h5>job.autoscaler.memory.gc-pressure.threshold</h5></td>
+            <td style="word-wrap: break-word;">1.0</td>
+            <td>Double</td>
+            <td>Max allowed GC pressure (percentage spent garbage collecting) during scaling operations. Autoscaling will be paused if the GC pressure exceeds this limit.</td>
+        </tr>
+        <tr>
+            <td><h5>job.autoscaler.memory.heap-usage.threshold</h5></td>
+            <td style="word-wrap: break-word;">1.0</td>
+            <td>Double</td>
+            <td>Max allowed percentage of heap usage during scaling operations. Autoscaling will be paused if the heap usage exceeds this threshold.</td>
+        </tr>
+        <tr>
             <td><h5>job.autoscaler.metrics.busy-time.aggregator</h5></td>
             <td style="word-wrap: break-word;">MAX</td>
             <td><p>Enum</p></td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -175,16 +175,16 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
         var evaluatedMetrics =
                 evaluator.evaluate(ctx.getConfiguration(), collectedMetrics, restartTime);
         LOG.debug("Evaluated metrics: {}", evaluatedMetrics);
-        lastEvaluatedMetrics.put(ctx.getJobKey(), evaluatedMetrics);
+        lastEvaluatedMetrics.put(ctx.getJobKey(), evaluatedMetrics.getVertexMetrics());
 
-        initRecommendedParallelism(evaluatedMetrics);
+        initRecommendedParallelism(evaluatedMetrics.getVertexMetrics());
         autoscalerMetrics.registerScalingMetrics(
                 jobTopology.getVerticesInTopologicalOrder(),
                 () -> lastEvaluatedMetrics.get(ctx.getJobKey()));
 
         if (!collectedMetrics.isFullyCollected()) {
             // We have done an upfront evaluation, but we are not ready for scaling.
-            resetRecommendedParallelism(evaluatedMetrics);
+            resetRecommendedParallelism(evaluatedMetrics.getVertexMetrics());
             return;
         }
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -23,12 +23,10 @@ import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.event.AutoScalerEventHandler;
 import org.apache.flink.autoscaler.exceptions.NotReadyException;
 import org.apache.flink.autoscaler.metrics.AutoscalerFlinkMetrics;
-import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
-import org.apache.flink.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.autoscaler.metrics.EvaluatedMetrics;
 import org.apache.flink.autoscaler.realizer.ScalingRealizer;
 import org.apache.flink.autoscaler.state.AutoScalerStateStore;
 import org.apache.flink.configuration.PipelineOptions;
-import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
@@ -63,8 +61,7 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
     private Clock clock = Clock.systemDefaultZone();
 
     @VisibleForTesting
-    final Map<KEY, Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>>
-            lastEvaluatedMetrics = new ConcurrentHashMap<>();
+    final Map<KEY, EvaluatedMetrics> lastEvaluatedMetrics = new ConcurrentHashMap<>();
 
     @VisibleForTesting
     final Map<KEY, AutoscalerFlinkMetrics> flinkMetrics = new ConcurrentHashMap<>();
@@ -175,7 +172,7 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
         var evaluatedMetrics =
                 evaluator.evaluate(ctx.getConfiguration(), collectedMetrics, restartTime);
         LOG.debug("Evaluated metrics: {}", evaluatedMetrics);
-        lastEvaluatedMetrics.put(ctx.getJobKey(), evaluatedMetrics.getVertexMetrics());
+        lastEvaluatedMetrics.put(ctx.getJobKey(), evaluatedMetrics);
 
         initRecommendedParallelism(evaluatedMetrics.getVertexMetrics());
         autoscalerMetrics.registerScalingMetrics(

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/RestApiMetricsCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/RestApiMetricsCollector.java
@@ -18,26 +18,47 @@
 package org.apache.flink.autoscaler;
 
 import org.apache.flink.autoscaler.metrics.FlinkMetric;
+import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
 import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.job.metrics.AggregateTaskManagerMetricsParameters;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
+import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetricsResponseBody;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedSubtaskMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedSubtaskMetricsParameters;
+import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedTaskManagerMetricsHeaders;
+import org.apache.flink.runtime.rest.messages.job.metrics.MetricsAggregationParameter;
+import org.apache.flink.runtime.rest.messages.job.metrics.MetricsFilterParameter;
 
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static org.apache.flink.autoscaler.metrics.FlinkMetric.HEAP_MAX;
+import static org.apache.flink.autoscaler.metrics.FlinkMetric.HEAP_USED;
+import static org.apache.flink.autoscaler.metrics.FlinkMetric.TOTAL_GC_TIME_PER_SEC;
 
 /** Metric collector using flink rest api. */
 public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<KEY>>
         extends ScalingMetricCollector<KEY, Context> {
     private static final Logger LOG = LoggerFactory.getLogger(RestApiMetricsCollector.class);
+
+    private static final Map<String, FlinkMetric> COMMON_TM_METRIC_NAMES =
+            Map.of(
+                    "Status.JVM.Memory.Heap.Max", HEAP_MAX,
+                    "Status.JVM.Memory.Heap.Used", HEAP_USED);
+    private static final Map<String, FlinkMetric> TM_METRIC_NAMES_WITH_GC =
+            Map.of(
+                    "Status.JVM.Memory.Heap.Max", HEAP_MAX,
+                    "Status.JVM.Memory.Heap.Used", HEAP_USED,
+                    "Status.JVM.GarbageCollector.All.TimeMsPerSecond", TOTAL_GC_TIME_PER_SEC);
 
     @Override
     protected Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>> queryAllAggregatedMetrics(
@@ -78,19 +99,89 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
                                     EmptyRequestBody.getInstance())
                             .get();
 
-            return responseBody.getMetrics().stream()
-                    .collect(
-                            Collectors.toMap(
-                                    m -> metrics.get(m.getId()),
-                                    m -> m,
-                                    (m1, m2) ->
-                                            new AggregatedMetric(
-                                                    m1.getId() + " merged with " + m2.getId(),
-                                                    Math.min(m1.getMin(), m2.getMin()),
-                                                    Math.max(m1.getMax(), m2.getMax()),
-                                                    // Average can't be computed
-                                                    Double.NaN,
-                                                    m1.getSum() + m2.getSum())));
+            return aggregateByFlinkMetric(metrics, responseBody);
         }
+    }
+
+    protected Map<FlinkMetric, AggregatedMetric> queryTmMetrics(Context ctx) throws Exception {
+        try (var restClient = ctx.getRestClusterClient()) {
+            // Unfortunately we cannot simply query for all metric names as Flink doesn't return
+            // anything if any of the metric names is missing
+            boolean hasGcMetrics =
+                    jobsWithGcMetrics.computeIfAbsent(
+                            ctx.getJobKey(),
+                            k -> {
+                                boolean gcMetricsFound =
+                                        !queryAggregatedTmMetrics(
+                                                        restClient, TM_METRIC_NAMES_WITH_GC)
+                                                .isEmpty();
+                                if (!gcMetricsFound) {
+                                    LOG.debug("No GC metrics found, using only heap information");
+                                } else {
+                                    LOG.debug("TaskManager GC metrics found");
+                                }
+                                return gcMetricsFound;
+                            });
+            var tmMetrics =
+                    queryAggregatedTmMetrics(
+                            restClient,
+                            hasGcMetrics ? TM_METRIC_NAMES_WITH_GC : COMMON_TM_METRIC_NAMES);
+            if (!tmMetrics.isEmpty()) {
+                return tmMetrics;
+            } else {
+                // If metrics are missing that means we cant find even the required ones
+                // Let's error out and retry in the next loop.
+                jobsWithGcMetrics.remove(ctx.getJobKey());
+                throw new RuntimeException("Missing required TM metrics");
+            }
+        }
+    }
+
+    @SneakyThrows
+    protected Map<FlinkMetric, AggregatedMetric> queryAggregatedTmMetrics(
+            RestClusterClient<?> restClient, Map<String, FlinkMetric> metrics) {
+
+        var parameters = new AggregateTaskManagerMetricsParameters();
+        var queryParamIt = parameters.getQueryParameters().iterator();
+
+        MetricsFilterParameter filterParameter = (MetricsFilterParameter) queryParamIt.next();
+        filterParameter.resolve(List.copyOf(metrics.keySet()));
+
+        MetricsAggregationParameter aggregationParameter =
+                (MetricsAggregationParameter) queryParamIt.next();
+        aggregationParameter.resolve(List.of(MetricsAggregationParameter.AggregationMode.MAX));
+
+        var responseBody =
+                restClient
+                        .sendRequest(
+                                AggregatedTaskManagerMetricsHeaders.getInstance(),
+                                parameters,
+                                EmptyRequestBody.getInstance())
+                        .get();
+
+        return aggregateByFlinkMetric(metrics, responseBody);
+    }
+
+    private Map<FlinkMetric, AggregatedMetric> aggregateByFlinkMetric(
+            Map<String, FlinkMetric> metrics, AggregatedMetricsResponseBody responseBody) {
+        return responseBody.getMetrics().stream()
+                .collect(
+                        Collectors.toMap(
+                                m -> metrics.get(m.getId()),
+                                m -> m,
+                                (m1, m2) ->
+                                        new AggregatedMetric(
+                                                m1.getId() + "-" + m2.getId(),
+                                                m1.getMin() != null
+                                                        ? Math.min(m1.getMin(), m2.getMin())
+                                                        : null,
+                                                m1.getMax() != null
+                                                        ? Math.max(m1.getMax(), m2.getMax())
+                                                        : null,
+                                                // Average can't be computed
+                                                null,
+                                                m1.getSum() != null
+                                                        ? m1.getSum() + m2.getSum()
+                                                        : null)));
     }
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
@@ -75,9 +75,9 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
 
     private final Map<KEY, Map<JobVertexID, Map<String, FlinkMetric>>> availableVertexMetricNames =
             new ConcurrentHashMap<>();
-
     private final Map<KEY, SortedMap<Instant, CollectedMetrics>> histories =
             new ConcurrentHashMap<>();
+    protected final Map<KEY, Boolean> jobsWithGcMetrics = new ConcurrentHashMap<KEY, Boolean>();
 
     private Clock clock = Clock.systemDefaultZone();
 
@@ -127,9 +127,12 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
         // Aggregated job vertex metrics collected from Flink based on the filtered metric names
         var collectedVertexMetrics = queryAllAggregatedMetrics(ctx, filteredVertexMetricNames);
 
+        var collectedTmMetrics = queryTmMetrics(ctx);
+
         // The computed scaling metrics based on the collected aggregated vertex metrics
         var scalingMetrics =
-                convertToScalingMetrics(jobKey, collectedVertexMetrics, topology, conf);
+                convertToScalingMetrics(
+                        jobKey, collectedVertexMetrics, collectedTmMetrics, topology, conf);
 
         // Add scaling metrics to history if they were computed successfully
         metricHistory.put(now, scalingMetrics);
@@ -151,6 +154,9 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
         stateStore.storeCollectedMetrics(ctx, metricHistory);
         return collectedMetrics;
     }
+
+    protected abstract Map<FlinkMetric, AggregatedMetric> queryTmMetrics(Context ctx)
+            throws Exception;
 
     protected Duration getMetricWindowSize(Configuration conf) {
         return conf.get(AutoScalerOptions.METRICS_WINDOW);
@@ -219,7 +225,6 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                     var sourceVertex = entry.getKey();
                     var numPartitions =
                             queryAggregatedMetricNames(restClient, jobId, sourceVertex).stream()
-                                    .map(AggregatedMetric::getId)
                                     .filter(partitionRegex.asMatchPredicate())
                                     .count();
                     if (numPartitions > 0) {
@@ -247,6 +252,7 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
     private CollectedMetrics convertToScalingMetrics(
             KEY jobKey,
             Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>> collectedMetrics,
+            Map<FlinkMetric, AggregatedMetric> collectedTmMetrics,
             JobTopology jobTopology,
             Configuration conf) {
 
@@ -307,7 +313,11 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
 
         var outputRatios = ScalingMetrics.computeOutputRatios(collectedMetrics, jobTopology);
         LOG.debug("Output ratios: {}", outputRatios);
-        return new CollectedMetrics(out, outputRatios);
+
+        var globalMetrics = ScalingMetrics.computeGlobalMetrics(collectedTmMetrics);
+        LOG.debug("Global metrics: {}", globalMetrics);
+
+        return new CollectedMetrics(out, outputRatios, globalMetrics);
     }
 
     private static Supplier<Double> observedTprAvg(
@@ -463,7 +473,7 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
 
     @VisibleForTesting
     @SneakyThrows
-    protected Collection<AggregatedMetric> queryAggregatedMetricNames(
+    protected Collection<String> queryAggregatedMetricNames(
             RestClusterClient<?> restClient, JobID jobID, JobVertexID jobVertexID) {
         var parameters = new AggregatedSubtaskMetricsParameters();
         var pathIt = parameters.getPathParameters().iterator();
@@ -477,7 +487,10 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                         parameters,
                         EmptyRequestBody.getInstance())
                 .get()
-                .getMetrics();
+                .getMetrics()
+                .stream()
+                .map(AggregatedMetric::getId)
+                .collect(Collectors.toSet());
     }
 
     protected abstract Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>>
@@ -497,6 +510,7 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
     public void cleanup(KEY jobKey) {
         histories.remove(jobKey);
         availableVertexMetricNames.remove(jobKey);
+        jobsWithGcMetrics.remove(jobKey);
     }
 
     @VisibleForTesting

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -41,6 +41,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.SortedMap;
 
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.BACKLOG_PROCESSING_LAG_THRESHOLD;
@@ -150,6 +151,9 @@ public class ScalingMetricEvaluator {
                 LOAD,
                 new EvaluatedScalingMetric(
                         latestVertexMetrics.get(LOAD), getAverage(LOAD, vertex, metricsHistory)));
+
+        Optional.ofNullable(latestVertexMetrics.get(LAG))
+                .ifPresent(l -> evaluatedMetrics.put(LAG, EvaluatedScalingMetric.of(l)));
 
         evaluatedMetrics.put(
                 PARALLELISM, EvaluatedScalingMetric.of(topology.getParallelisms().get(vertex)));

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -219,6 +219,22 @@ public class AutoScalerOptions {
                     .withDescription(
                             "Processing rate increase threshold for detecting ineffective scaling threshold. 0.1 means if we do not accomplish at least 10% of the desired capacity increase with scaling, the action is marked ineffective.");
 
+    public static final ConfigOption<Double> GC_PRESSURE_THRESHOLD =
+            autoScalerConfig("memory.gc-pressure.threshold")
+                    .doubleType()
+                    .defaultValue(1.)
+                    .withFallbackKeys(oldOperatorConfigKey("memory.gc-pressure.threshold"))
+                    .withDescription(
+                            "Max allowed GC pressure (percentage spent garbage collecting) during scaling operations. Autoscaling will be paused if the GC pressure exceeds this limit.");
+
+    public static final ConfigOption<Double> HEAP_USAGE_THRESHOLD =
+            autoScalerConfig("memory.heap-usage.threshold")
+                    .doubleType()
+                    .defaultValue(1.)
+                    .withFallbackKeys(oldOperatorConfigKey("memory.heap-usage.threshold"))
+                    .withDescription(
+                            "Max allowed percentage of heap usage during scaling operations. Autoscaling will be paused if the heap usage exceeds this threshold.");
+
     public static final ConfigOption<Integer> VERTEX_SCALING_HISTORY_COUNT =
             autoScalerConfig("history.max.count")
                     .intType()

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/EvaluatedMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/EvaluatedMetrics.java
@@ -29,8 +29,7 @@ import java.util.Map;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class CollectedMetrics {
-    private Map<JobVertexID, Map<ScalingMetric, Double>> vertexMetrics;
-    private Map<Edge, Double> outputRatios;
-    private Map<ScalingMetric, Double> globalMetrics;
+public class EvaluatedMetrics {
+    private Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> vertexMetrics;
+    private Map<ScalingMetric, EvaluatedScalingMetric> globalMetrics;
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
@@ -39,7 +39,11 @@ public enum FlinkMetric {
     SOURCE_TASK_NUM_RECORDS_IN_PER_SEC(
             s -> s.startsWith("Source__") && s.endsWith(".numRecordsInPerSecond")),
     PENDING_RECORDS(s -> s.endsWith(".pendingRecords")),
-    BACKPRESSURE_TIME_PER_SEC(s -> s.equals("backPressuredTimeMsPerSecond"));
+    BACKPRESSURE_TIME_PER_SEC(s -> s.equals("backPressuredTimeMsPerSecond")),
+
+    HEAP_MAX(s -> s.equals("Status.JVM.Memory.Heap.Max")),
+    HEAP_USED(s -> s.equals("Status.JVM.Memory.Heap.Used")),
+    TOTAL_GC_TIME_PER_SEC(s -> s.equals("Status.JVM.GarbageCollector.All.TimeMsPerSecond"));
 
     public static final Map<FlinkMetric, AggregatedMetric> FINISHED_METRICS =
             Map.of(
@@ -56,15 +60,12 @@ public enum FlinkMetric {
         this.predicate = predicate;
     }
 
-    public Optional<String> findAny(Collection<AggregatedMetric> metrics) {
-        return metrics.stream().map(AggregatedMetric::getId).filter(predicate).findAny();
+    public Optional<String> findAny(Collection<String> metrics) {
+        return metrics.stream().filter(predicate).findAny();
     }
 
-    public List<String> findAll(Collection<AggregatedMetric> metrics) {
-        return metrics.stream()
-                .map(AggregatedMetric::getId)
-                .filter(predicate)
-                .collect(Collectors.toList());
+    public List<String> findAll(Collection<String> metrics) {
+        return metrics.stream().filter(predicate).collect(Collectors.toList());
     }
 
     private static AggregatedMetric zero() {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
@@ -65,7 +65,16 @@ public enum ScalingMetric {
     SCALE_DOWN_RATE_THRESHOLD(false),
 
     /** Expected true processing rate after scale up. */
-    EXPECTED_PROCESSING_RATE(false);
+    EXPECTED_PROCESSING_RATE(false),
+
+    /**
+     * Maximum GC pressure across taskmanagers. Percentage of time spent garbage collecting between
+     * 0 (no time in GC) and 1 (100% time in GC).
+     */
+    GC_PRESSURE(false),
+
+    /** Percentage of max heap used (between 0 and 1). */
+    HEAP_USAGE(true);
 
     private final boolean calculateAverage;
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
@@ -17,6 +17,10 @@
 
 package org.apache.flink.autoscaler.metrics;
 
+import lombok.Getter;
+
+import java.util.Set;
+
 /**
  * Supported scaling metrics. These represent high level metrics computed from Flink job metrics
  * that are used for scaling decisions in the autoscaler module.
@@ -76,13 +80,24 @@ public enum ScalingMetric {
     /** Percentage of max heap used (between 0 and 1). */
     HEAP_USAGE(true);
 
-    private final boolean calculateAverage;
+    @Getter private final boolean calculateAverage;
+
+    /** List of {@link ScalingMetric}s to be reported as per vertex Flink metrics. */
+    public static final Set<ScalingMetric> REPORTED_VERTEX_METRICS =
+            Set.of(
+                    LOAD,
+                    TRUE_PROCESSING_RATE,
+                    TARGET_DATA_RATE,
+                    CATCH_UP_DATA_RATE,
+                    LAG,
+                    PARALLELISM,
+                    RECOMMENDED_PARALLELISM,
+                    MAX_PARALLELISM,
+                    SCALE_UP_RATE_THRESHOLD,
+                    SCALE_DOWN_RATE_THRESHOLD,
+                    EXPECTED_PROCESSING_RATE);
 
     ScalingMetric(boolean calculateAverage) {
         this.calculateAverage = calculateAverage;
-    }
-
-    public boolean isCalculateAverage() {
-        return calculateAverage;
     }
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -160,6 +160,28 @@ public class ScalingMetrics {
         return out;
     }
 
+    public static Map<ScalingMetric, Double> computeGlobalMetrics(
+            Map<FlinkMetric, AggregatedMetric> collectedTmMetrics) {
+        if (collectedTmMetrics == null) {
+            return null;
+        }
+
+        var out = new HashMap<ScalingMetric, Double>();
+
+        var gcTime = collectedTmMetrics.get(FlinkMetric.TOTAL_GC_TIME_PER_SEC);
+        if (gcTime != null) {
+            out.put(ScalingMetric.GC_PRESSURE, gcTime.getMax() / 1000);
+        }
+
+        var heapMax = collectedTmMetrics.get(FlinkMetric.HEAP_MAX);
+        var heapUsed = collectedTmMetrics.get(FlinkMetric.HEAP_USED);
+        if (heapMax != null && heapUsed != null) {
+            out.put(ScalingMetric.HEAP_USAGE, heapUsed.getMax() / heapMax.getMax());
+        }
+
+        return out;
+    }
+
     public static void computeLagMetrics(
             Map<FlinkMetric, AggregatedMetric> flinkMetrics,
             Map<ScalingMetric, Double> scalingMetrics) {

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/AutoScalerFlinkMetricsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/AutoScalerFlinkMetricsTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.autoscaler;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.autoscaler.metrics.AutoscalerFlinkMetrics;
+import org.apache.flink.autoscaler.metrics.EvaluatedMetrics;
 import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.autoscaler.metrics.ScalingMetric;
 import org.apache.flink.metrics.Gauge;
@@ -76,10 +77,9 @@ public class AutoScalerFlinkMetricsTest {
 
     @Test
     public void testMetricsRegistration() {
-        var evaluatedMetrics = Map.of(jobVertexID, testMetrics());
-        var lastEvaluatedMetrics =
-                new HashMap<JobID, Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>>();
-        initRecommendedParallelism(evaluatedMetrics);
+        var evaluatedMetrics = new EvaluatedMetrics(Map.of(jobVertexID, testMetrics()), Map.of());
+        var lastEvaluatedMetrics = new HashMap<JobID, EvaluatedMetrics>();
+        initRecommendedParallelism(evaluatedMetrics.getVertexMetrics());
         lastEvaluatedMetrics.put(jobID, evaluatedMetrics);
 
         metrics.registerScalingMetrics(List.of(jobVertexID), () -> lastEvaluatedMetrics.get(jobID));
@@ -92,11 +92,11 @@ public class AutoScalerFlinkMetricsTest {
     }
 
     @Test
-    public void testAllScalingMetricsAreRegistered() {
+    public void testAllVertexScalingMetricsAreRegistered() {
         int numMetricsAlreadyRegistered = collectedMetrics.size();
         metrics.registerScalingMetrics(List.of(jobVertexID), () -> null);
         int numScalingMetrics = 0;
-        for (ScalingMetric scalingMetric : ScalingMetric.values()) {
+        for (ScalingMetric scalingMetric : ScalingMetric.REPORTED_VERTEX_METRICS) {
             if (scalingMetric.isCalculateAverage()) {
                 numScalingMetrics += 2;
             } else {
@@ -108,10 +108,9 @@ public class AutoScalerFlinkMetricsTest {
 
     @Test
     public void testMetricsCleanup() {
-        var evaluatedMetrics = Map.of(jobVertexID, testMetrics());
-        var lastEvaluatedMetrics =
-                new HashMap<JobID, Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>>();
-        initRecommendedParallelism(evaluatedMetrics);
+        var evaluatedMetrics = new EvaluatedMetrics(Map.of(jobVertexID, testMetrics()), Map.of());
+        var lastEvaluatedMetrics = new HashMap<JobID, EvaluatedMetrics>();
+        initRecommendedParallelism(evaluatedMetrics.getVertexMetrics());
         lastEvaluatedMetrics.put(jobID, evaluatedMetrics);
         metrics.registerScalingMetrics(List.of(jobVertexID), () -> lastEvaluatedMetrics.get(jobID));
 
@@ -129,11 +128,10 @@ public class AutoScalerFlinkMetricsTest {
 
     @Test
     public void testRecommendedParallelismWithinMetricWindow() {
-        var evaluatedMetrics = Map.of(jobVertexID, testMetrics());
-        var lastEvaluatedMetrics =
-                new HashMap<JobID, Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>>();
-        initRecommendedParallelism(evaluatedMetrics);
-        resetRecommendedParallelism(evaluatedMetrics);
+        var evaluatedMetrics = new EvaluatedMetrics(Map.of(jobVertexID, testMetrics()), Map.of());
+        var lastEvaluatedMetrics = new HashMap<JobID, EvaluatedMetrics>();
+        initRecommendedParallelism(evaluatedMetrics.getVertexMetrics());
+        resetRecommendedParallelism(evaluatedMetrics.getVertexMetrics());
         lastEvaluatedMetrics.put(jobID, evaluatedMetrics);
 
         metrics.registerScalingMetrics(List.of(jobVertexID), () -> lastEvaluatedMetrics.get(jobID));
@@ -145,10 +143,9 @@ public class AutoScalerFlinkMetricsTest {
 
     @Test
     public void testRecommendedParallelismPastMetricWindow() {
-        var evaluatedMetrics = Map.of(jobVertexID, testMetrics());
-        var lastEvaluatedMetrics =
-                new HashMap<JobID, Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>>();
-        initRecommendedParallelism(evaluatedMetrics);
+        var evaluatedMetrics = new EvaluatedMetrics(Map.of(jobVertexID, testMetrics()), Map.of());
+        var lastEvaluatedMetrics = new HashMap<JobID, EvaluatedMetrics>();
+        initRecommendedParallelism(evaluatedMetrics.getVertexMetrics());
         lastEvaluatedMetrics.put(jobID, evaluatedMetrics);
 
         metrics.registerScalingMetrics(List.of(jobVertexID), () -> lastEvaluatedMetrics.get(jobID));

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
@@ -158,7 +158,7 @@ public class JobAutoScalerImplTest {
                 collectorWhichThrowsRecoverableException =
                         new TestingMetricsCollector<>(new JobTopology(Collections.emptySet())) {
                             @Override
-                            protected Collection<AggregatedMetric> queryAggregatedMetricNames(
+                            protected Collection<String> queryAggregatedMetricNames(
                                     RestClusterClient<?> restClient,
                                     JobID jobID,
                                     JobVertexID jobVertexID) {

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -480,6 +480,8 @@ public class JobVertexScalerTest {
         metrics.put(
                 ScalingMetric.TRUE_PROCESSING_RATE,
                 new EvaluatedScalingMetric(trueProcessingRate, trueProcessingRate));
+        metrics.put(ScalingMetric.GC_PRESSURE, EvaluatedScalingMetric.of(Double.NaN));
+        metrics.put(ScalingMetric.HEAP_USAGE, EvaluatedScalingMetric.of(Double.NaN));
         ScalingMetricEvaluator.computeProcessingRateThresholds(metrics, conf, false, restartTime);
         return metrics;
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.autoscaler.event.TestingEventCollector;
 import org.apache.flink.autoscaler.exceptions.NotReadyException;
 import org.apache.flink.autoscaler.metrics.CollectedMetricHistory;
 import org.apache.flink.autoscaler.metrics.CollectedMetrics;
-import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.autoscaler.metrics.FlinkMetric;
 import org.apache.flink.autoscaler.metrics.MetricNotFoundException;
 import org.apache.flink.autoscaler.metrics.ScalingMetric;
@@ -255,18 +254,12 @@ public class MetricsCollectionAndEvaluationTest {
                 Map.of(
                         source1,
                         List.of(
-                                new AggregatedMetric(
-                                        "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.testTopic.partition.0.anotherMetric"),
-                                new AggregatedMetric(
-                                        "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.anotherTopic.partition.0.currentOffset"),
-                                new AggregatedMetric(
-                                        "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.testTopic.partition.0.currentOffset"),
-                                new AggregatedMetric(
-                                        "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.testTopic.partition.1.currentOffset"),
-                                new AggregatedMetric(
-                                        "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.testTopic.partition.2.currentOffset"),
-                                new AggregatedMetric(
-                                        "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.testTopic.partition.3.currentOffset"))));
+                                "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.testTopic.partition.0.anotherMetric",
+                                "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.anotherTopic.partition.0.currentOffset",
+                                "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.testTopic.partition.0.currentOffset",
+                                "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.testTopic.partition.1.currentOffset",
+                                "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.testTopic.partition.2.currentOffset",
+                                "1.Source__Kafka_Source_(testTopic).KafkaSourceReader.topic.testTopic.partition.3.currentOffset")));
 
         collectedMetrics = metricsCollector.updateMetrics(context, stateStore);
         assertEquals(5, collectedMetrics.getJobTopology().getMaxParallelisms().get(source1));
@@ -371,20 +364,36 @@ public class MetricsCollectionAndEvaluationTest {
                                         "", Double.NaN, Double.NaN, Double.NaN, 500.))));
 
         var collectedMetrics = collectMetrics();
-
-        Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluation =
+        var evaluation =
                 evaluator.evaluate(context.getConfiguration(), collectedMetrics, restartTime);
         assertEquals(
-                500., evaluation.get(source1).get(ScalingMetric.TARGET_DATA_RATE).getCurrent());
+                500.,
+                evaluation
+                        .getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getCurrent());
         assertEquals(
                 5000.,
-                evaluation.get(source1).get(ScalingMetric.TRUE_PROCESSING_RATE).getCurrent());
+                evaluation
+                        .getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.TRUE_PROCESSING_RATE)
+                        .getCurrent());
         assertEquals(
                 1250.,
-                evaluation.get(source1).get(ScalingMetric.SCALE_DOWN_RATE_THRESHOLD).getCurrent());
+                evaluation
+                        .getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.SCALE_DOWN_RATE_THRESHOLD)
+                        .getCurrent());
         assertEquals(
                 500.,
-                evaluation.get(source1).get(ScalingMetric.SCALE_UP_RATE_THRESHOLD).getCurrent());
+                evaluation
+                        .getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.SCALE_UP_RATE_THRESHOLD)
+                        .getCurrent());
 
         scalingExecutor.scaleResource(
                 context, evaluation, new HashMap<>(), new ScalingTracking(), clock.instant());
@@ -644,18 +653,36 @@ public class MetricsCollectionAndEvaluationTest {
 
         var collectedMetrics = collectMetrics();
 
-        Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluation =
+        var evaluation =
                 evaluator.evaluate(context.getConfiguration(), collectedMetrics, restartTime);
-        assertEquals(0, evaluation.get(source1).get(ScalingMetric.TARGET_DATA_RATE).getCurrent());
+        assertEquals(
+                0,
+                evaluation
+                        .getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getCurrent());
         assertEquals(
                 Double.POSITIVE_INFINITY,
-                evaluation.get(source1).get(ScalingMetric.TRUE_PROCESSING_RATE).getAverage());
+                evaluation
+                        .getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.TRUE_PROCESSING_RATE)
+                        .getAverage());
         assertEquals(
                 0.,
-                evaluation.get(source1).get(ScalingMetric.SCALE_DOWN_RATE_THRESHOLD).getCurrent());
+                evaluation
+                        .getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.SCALE_DOWN_RATE_THRESHOLD)
+                        .getCurrent());
         assertEquals(
                 0.,
-                evaluation.get(source1).get(ScalingMetric.SCALE_UP_RATE_THRESHOLD).getCurrent());
+                evaluation
+                        .getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.SCALE_UP_RATE_THRESHOLD)
+                        .getCurrent());
 
         scalingExecutor.scaleResource(
                 context, evaluation, new HashMap<>(), new ScalingTracking(), clock.instant());
@@ -673,11 +700,17 @@ public class MetricsCollectionAndEvaluationTest {
                 .getMetricHistory()
                 .put(
                         Instant.ofEpochSecond(1234),
-                        new CollectedMetrics(newMetrics, lastCollected.getOutputRatios()));
+                        new CollectedMetrics(
+                                newMetrics, lastCollected.getOutputRatios(), Map.of()));
 
         evaluation = evaluator.evaluate(context.getConfiguration(), collectedMetrics, restartTime);
         assertEquals(
-                3., evaluation.get(source1).get(ScalingMetric.TRUE_PROCESSING_RATE).getAverage());
+                3.,
+                evaluation
+                        .getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.TRUE_PROCESSING_RATE)
+                        .getAverage());
     }
 
     private CollectedMetricHistory collectMetrics() throws Exception {

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -187,6 +187,13 @@ public class MetricsCollectionAndEvaluationTest {
 
         assertNotNull(metricsCollector.getHistories().get(context.getJobKey()));
 
+        // Make sure all reported vertex metrics are evaluated, we expect complete metrics when a
+        // vertex is actually scaled
+        // Also for sources we have LAG metrics that is not available for other vertices
+        assertEquals(
+                ScalingMetric.REPORTED_VERTEX_METRICS,
+                evaluation.getVertexMetrics().get(source1).keySet());
+
         metricsCollector.cleanup(context.getJobKey());
         assertNull(metricsCollector.getHistories().get(context.getJobKey()));
         assertNull(metricsCollector.getAvailableVertexMetricNames().get(context.getJobKey()));

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
@@ -59,7 +59,6 @@ public class RecommendedParallelismTest {
     private AutoScalerStateStore<JobID, JobAutoScalerContext<JobID>> stateStore;
 
     private TestingMetricsCollector<JobID, JobAutoScalerContext<JobID>> metricsCollector;
-    private ScalingExecutor<JobID, JobAutoScalerContext<JobID>> scalingExecutor;
 
     private JobVertexID source, sink;
 
@@ -72,8 +71,6 @@ public class RecommendedParallelismTest {
         TestingEventCollector<JobID, JobAutoScalerContext<JobID>> eventCollector =
                 new TestingEventCollector<>();
         stateStore = new InMemoryAutoScalerStateStore<>();
-
-        scalingExecutor = new ScalingExecutor<>(eventCollector, stateStore);
 
         source = new JobVertexID();
         sink = new JobVertexID();
@@ -100,7 +97,7 @@ public class RecommendedParallelismTest {
                 new JobAutoScalerImpl<>(
                         metricsCollector,
                         new ScalingMetricEvaluator(),
-                        scalingExecutor,
+                        new ScalingExecutor<>(eventCollector, stateStore),
                         eventCollector,
                         new TestingScalingRealizer<>(),
                         stateStore);
@@ -239,6 +236,7 @@ public class RecommendedParallelismTest {
                 autoscaler
                         .lastEvaluatedMetrics
                         .get(context.getJobKey())
+                        .getVertexMetrics()
                         .get(jobVertexID)
                         .get(scalingMetric);
         return metric == null ? null : metric.getCurrent();

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -142,6 +142,10 @@ public class ScalingMetricEvaluatorTest {
         assertEquals(
                 EvaluatedScalingMetric.of(1000),
                 evaluatedMetrics.get(sink).get(ScalingMetric.CATCH_UP_DATA_RATE));
+        assertEquals(
+                EvaluatedScalingMetric.of(1000),
+                evaluatedMetrics.get(source).get(ScalingMetric.LAG));
+        assertFalse(evaluatedMetrics.get(sink).containsKey(ScalingMetric.LAG));
 
         conf.set(CATCH_UP_DURATION, Duration.ofSeconds(1));
         evaluatedMetrics =

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/TestingMetricsCollector.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/TestingMetricsCollector.java
@@ -48,7 +48,7 @@ public class TestingMetricsCollector<KEY, Context extends JobAutoScalerContext<K
     @Setter
     private Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>> currentMetrics = new HashMap<>();
 
-    @Setter private Map<JobVertexID, Collection<AggregatedMetric>> metricNames = new HashMap<>();
+    @Setter private Map<JobVertexID, Collection<String>> metricNames = new HashMap<>();
 
     public TestingMetricsCollector(JobTopology jobTopology) {
         this.jobTopology = jobTopology;
@@ -72,9 +72,14 @@ public class TestingMetricsCollector<KEY, Context extends JobAutoScalerContext<K
     }
 
     @Override
-    protected Collection<AggregatedMetric> queryAggregatedMetricNames(
+    protected Collection<String> queryAggregatedMetricNames(
             RestClusterClient<?> restClient, JobID jobID, JobVertexID jobVertexID) {
         return metricNames.getOrDefault(jobVertexID, Collections.emptyList());
+    }
+
+    @Override
+    protected Map<FlinkMetric, AggregatedMetric> queryTmMetrics(Context ctx) {
+        return Map.of();
     }
 
     @Override

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
@@ -480,7 +480,29 @@ public class ScalingMetricsTest {
         return scalingMetrics.get(ScalingMetric.OBSERVED_TPR);
     }
 
+    @Test
+    public void testGlobalMetrics() {
+        assertEquals(Map.of(), ScalingMetrics.computeGlobalMetrics(Map.of()));
+        assertEquals(
+                Map.of(),
+                ScalingMetrics.computeGlobalMetrics(Map.of(FlinkMetric.HEAP_USED, aggMax(100))));
+        assertEquals(
+                Map.of(ScalingMetric.HEAP_USAGE, 0.5, ScalingMetric.GC_PRESSURE, 0.25),
+                ScalingMetrics.computeGlobalMetrics(
+                        Map.of(
+                                FlinkMetric.HEAP_USED,
+                                aggMax(100),
+                                FlinkMetric.HEAP_MAX,
+                                aggMax(200.),
+                                FlinkMetric.TOTAL_GC_TIME_PER_SEC,
+                                aggMax(250.))));
+    }
+
     private static AggregatedMetric aggSum(double sum) {
         return new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, sum);
+    }
+
+    private static AggregatedMetric aggMax(double max) {
+        return new AggregatedMetric("", Double.NaN, max, Double.NaN, Double.NaN);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
@@ -27,6 +27,7 @@ import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.kubernetes.operator.autoscaler.KubernetesJobAutoScalerContext;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -71,7 +72,8 @@ public class KubernetesAutoScalerStateStore
     protected static final ObjectMapper YAML_MAPPER =
             new ObjectMapper(yamlFactory())
                     .registerModule(new JavaTimeModule())
-                    .registerModule(new AutoScalerSerDeModule());
+                    .registerModule(new AutoScalerSerDeModule())
+                    .setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
     private final ConfigMapStore configMapStore;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -248,6 +248,7 @@ public class EventRecorder {
         RestartUnhealthyJob,
         ScalingReport,
         IneffectiveScaling,
+        MemoryPressure,
         AutoscalerError,
         Scaling,
         UnsupportedFlinkVersion

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStoreTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStoreTest.java
@@ -195,7 +195,9 @@ public class KubernetesAutoScalerStateStoreTest {
         metricHistory.put(
                 jobUpdateTs,
                 new CollectedMetrics(
-                        Map.of(v1, Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 1.)), Map.of()));
+                        Map.of(v1, Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 1.)),
+                        Map.of(),
+                        Map.of()));
 
         var scalingHistory = new HashMap<JobVertexID, SortedMap<Instant, ScalingSummary>>();
         scalingHistory.put(v1, new TreeMap<>());
@@ -245,7 +247,8 @@ public class KubernetesAutoScalerStateStoreTest {
                         new JobVertexID(),
                         Map.of(ScalingMetric.TRUE_PROCESSING_RATE, rnd.nextDouble()));
             }
-            metricHistory.put(Instant.now(), new CollectedMetrics(m, Collections.emptyMap()));
+            metricHistory.put(
+                    Instant.now(), new CollectedMetrics(m, Collections.emptyMap(), Map.of()));
         }
 
         var scalingHistory = new HashMap<JobVertexID, SortedMap<Instant, ScalingSummary>>();


### PR DESCRIPTION
## What is the purpose of the change

The autoscaler currently doesn't use any GC/HEAP metrics as part of the scaling decisions.
While the long term goal may be to support vertical scaling (increasing TM sizes) currently this is out of scope for the autoscaler.

However it is very important to detect cases where the throughput of certain vertices or the entire pipeline is critically affected by long GC pauses. In these cases the current autoscaler logic would wrongly assume a low true processing rate and scale the pipeline too high, ramping up costs and causing further issues.

Using the improved GC metrics introduced in https://issues.apache.org/jira/browse/FLINK-33318 we should measure the GC pauses and simply block scaling decisions if the pipeline spends too much time garbage collecting and notify the user about the required action to increase memory.

*Complete GC pause tracking requires Flink 1.19 or the commit back ported to earlier versions, however heap usage tracking works already on earlier versions*

## Brief change log

  - *Introduce TM level metrics for the autoscaler and track HEAP/GC usage*
  - *Trigger event and block scaling if gc is above threshold*
  - *Tests*

## Verifying this change

Unit tests + manual validation in various envs.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs [TODO]
