### PR TITLE
[FLINK-33454] [Operator] Add IngressTls to support TLS within the managed Ingress, also add Label Passthrough

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -96,6 +96,8 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | template | java.lang.String | Ingress template for the JobManager service. |
 | className | java.lang.String | Ingress className for the Flink deployment. |
 | annotations | java.util.Map<java.lang.String,java.lang.String> | Ingress annotations. |
+| labels | java.util.Map<java.lang.String,java.lang.String> | Ingress labels. |
+| tls | java.util.List<io.fabric8.kubernetes.api.model.networking.v1.IngressTLS> | Ingress tls. |
 
 ### JobManagerSpec
 **Class**: org.apache.flink.kubernetes.operator.api.spec.JobManagerSpec

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/IngressSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/IngressSpec.java
@@ -20,11 +20,13 @@ package org.apache.flink.kubernetes.operator.api.spec;
 import org.apache.flink.annotation.Experimental;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressTLS;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
 import java.util.Map;
 
 /** Ingress spec. */
@@ -44,4 +46,10 @@ public class IngressSpec {
 
     /** Ingress annotations. */
     private Map<String, String> annotations;
+
+    /** Ingress labels. */
+    private Map<String, String> labels;
+
+    /** Ingress tls. */
+    private List<IngressTLS> tls;
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
@@ -27,12 +27,14 @@ import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 
 import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressTLS;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -255,5 +257,266 @@ public class IngressUtilsTest {
         assertThrows(
                 ReconciliationException.class,
                 () -> IngressUtils.getIngressUrl("example.com:port", "basic-ingress", "default"));
+    }
+
+    @Test
+    public void testIngressTls() {
+        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
+        Configuration config =
+                new FlinkConfigManager(new Configuration())
+                        .getDeployConfig(appCluster.getMetadata(), appCluster.getSpec());
+
+        // no tls when tls spec is empty
+        IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
+        builder.template("{{name}}.{{namespace}}.example.com");
+        builder.tls(new ArrayList<>());
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+        Ingress ingress = null;
+        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingressV1beta1 = null;
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        List<IngressTLS> tls = null;
+        List<io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLS> tlsV1beta1 = null;
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                0, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+
+        // no tls when hosts spec is empty
+        builder.template("{{name}}.{{namespace}}.example.com");
+        IngressTLS ingressTlsSpecSecretOnly = new IngressTLS();
+        ingressTlsSpecSecretOnly.setSecretName("secret");
+        builder.tls(List.of(ingressTlsSpecSecretOnly));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+        assertEquals(
+                "secret",
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? tls.get(0).getSecretName()
+                        : tlsV1beta1.get(0).getSecretName());
+
+        // tls with no secretName
+        builder.template("{{name}}.{{namespace}}.example.com");
+        IngressTLS ingressTlsSpecHostsOnly = new IngressTLS();
+        ingressTlsSpecHostsOnly.setHosts(List.of("example.com"));
+        builder.tls(List.of(ingressTlsSpecHostsOnly));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+        assertEquals(
+                "example.com",
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? tls.get(0).getHosts().get(0)
+                        : tlsV1beta1.get(0).getHosts().get(0));
+
+        // tls with secretName and hosts
+        builder.template("{{name}}.{{namespace}}.example.com");
+        IngressTLS ingressTlsSpecSingleTLSWithHost =
+                new IngressTLS(List.of("example.com"), "secret");
+        builder.tls(List.of(ingressTlsSpecSingleTLSWithHost));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            assertEquals("secret", tls.get(0).getSecretName());
+            assertEquals(1, tls.get(0).getHosts().size());
+            assertEquals("example.com", tls.get(0).getHosts().get(0));
+        } else {
+            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
+            assertEquals(1, tlsV1beta1.get(0).getHosts().size());
+            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
+        }
+
+        // tls with secretName and multiple hosts
+        builder.template("{{name}}.{{namespace}}.example.com");
+        IngressTLS ingressTlsSpecSingleTLSWithHosts =
+                new IngressTLS(List.of("example.com", "example2.com"), "secret");
+        builder.tls(List.of(ingressTlsSpecSingleTLSWithHosts));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            assertEquals("secret", tls.get(0).getSecretName());
+            assertEquals(2, tls.get(0).getHosts().size());
+            assertEquals("example.com", tls.get(0).getHosts().get(0));
+            assertEquals("example2.com", tls.get(0).getHosts().get(1));
+        } else {
+            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
+            assertEquals(2, tlsV1beta1.get(0).getHosts().size());
+            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
+            assertEquals("example2.com", tlsV1beta1.get(0).getHosts().get(1));
+        }
+
+        // tls with secretName and multiple hosts and multiple tls
+        builder.template("{{name}}.{{namespace}}.example.com");
+        IngressTLS ingressTlsSpecMultipleTLSWithHosts1 =
+                new IngressTLS(List.of("example.com", "example2.com"), "secret");
+        IngressTLS ingressTlsSpecMultipleTLSWithHosts2 =
+                new IngressTLS(List.of("example3.com", "example4.com"), "secret2");
+        builder.tls(
+                List.of(ingressTlsSpecMultipleTLSWithHosts1, ingressTlsSpecMultipleTLSWithHosts2));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                2, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            assertEquals("secret", tls.get(0).getSecretName());
+            assertEquals(2, tls.get(0).getHosts().size());
+            assertEquals("example.com", tls.get(0).getHosts().get(0));
+            assertEquals("example2.com", tls.get(0).getHosts().get(1));
+            assertEquals("secret2", tls.get(1).getSecretName());
+            assertEquals(2, tls.get(1).getHosts().size());
+            assertEquals("example3.com", tls.get(1).getHosts().get(0));
+            assertEquals("example4.com", tls.get(1).getHosts().get(1));
+        } else {
+            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
+            assertEquals(2, tlsV1beta1.get(0).getHosts().size());
+            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
+            assertEquals("example2.com", tlsV1beta1.get(0).getHosts().get(1));
+            assertEquals("secret2", tlsV1beta1.get(1).getSecretName());
+            assertEquals(2, tlsV1beta1.get(1).getHosts().size());
+            assertEquals("example3.com", tlsV1beta1.get(1).getHosts().get(0));
+            assertEquals("example4.com", tlsV1beta1.get(1).getHosts().get(1));
+        }
     }
 }

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -57,6 +57,21 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  tls:
+                    items:
+                      properties:
+                        hosts:
+                          items:
+                            type: string
+                          type: array
+                        secretName:
+                          type: string
+                      type: object
+                    type: array
                 type: object
               podTemplate:
                 properties:


### PR DESCRIPTION
## What is the purpose of the change
The managed ingress `IngressSpec` doesn't support TLS. It means that the ingress can't be used with secrets to secure the hosts. We can extend the `IngressSpec` to have `tls: List<IngressTlsSpec>`. In theory we shouldn't need a List spec here since the template only supports one host but I thought it was better to follow the Kubernetes spec since the change is pretty simple.

The managed ingress also doesn't have the ability to pass labels through to the Ingress. It would be nice to support this. It could be in a separate PR if we'd like but is very trivial.

Open to `IngressTLSSpec` if folks think that is better. I didn't like the double capital S beside each other.

## Brief change log
Added an `IngressTlsSpec` to support tls entries in the `IngressSpec`
Added a labels entry to the `IngressSpec` to support label passthrough to the Ingress similar to annotations.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.
- I did not add tests for the labels as we don't have explicit tests for the annotations. I wasn't sure if this was intentional. I'd be happy to add tests for the labels.

This change added tests and can be verified as follows:
- Added tests for IngressTls from the IngressUtils including
1. Empty tls
2. empty hosts with single secretName, single tls entry
3. empty secretName with single hosts, single tls entry
4. single hosts and single secretName, single tls entry
5. multiple hosts and single secretName, single tls entry
6. multiple tls entries

I still need to manually validate the ingress spec with a job.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes 
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
