### PR TITLE
[FLINK-33812] Autoscale not working properly for standalone application deployment

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -854,6 +854,20 @@ public class FlinkConfigBuilderTest {
                 5,
                 configuration.get(
                         StandaloneKubernetesConfigOptionsInternal.KUBERNETES_TASKMANAGER_REPLICAS));
+
+        dep.getSpec()
+                .getFlinkConfiguration()
+                .put(PipelineOptions.PARALLELISM_OVERRIDES.key(), "vertex1:10,vertex2:20");
+        configuration =
+                new FlinkConfigBuilder(dep, new Configuration())
+                        .applyFlinkConfiguration()
+                        .applyTaskManagerSpec()
+                        .applyJobOrSessionSpec()
+                        .build();
+        assertEquals(
+                10,
+                configuration.get(
+                        StandaloneKubernetesConfigOptionsInternal.KUBERNETES_TASKMANAGER_REPLICAS));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This pull request tries to fix a bug, that when the autoscaler decides to scale up/down a standalone application deployment, the taskmanager's replica number does not change accordingly.


## Brief change log
  - When calculating the number of tm replicas, give priority to `PipelineOptions.PARALLELISM_OVERRIDES`

## Verifying this change
Unit tests + manual validation

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
