### PR TITLE
[FLINK-33813][autoscaler] Improve time formatting for easier reading inside the autoscaler

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
@@ -67,6 +67,7 @@ import java.util.stream.Stream;
 
 import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.updateVertexList;
 import static org.apache.flink.autoscaler.utils.AutoScalerUtils.excludeVerticesFromScaling;
+import static org.apache.flink.autoscaler.utils.DateTimeUtils.readable;
 
 /** Metric collector using flink rest api. */
 public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerContext<KEY>> {
@@ -106,7 +107,7 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
         // We detect job change compared to our collected metrics by checking against the earliest
         // metric timestamp
         if (!metricHistory.isEmpty() && jobUpdateTs.isAfter(metricHistory.firstKey())) {
-            LOG.info("Job updated at {}. Clearing metrics.", jobUpdateTs);
+            LOG.info("Job updated at {}. Clearing metrics.", readable(jobUpdateTs));
             stateStore.removeCollectedMetrics(ctx);
             cleanup(ctx.getJobKey());
             metricHistory.clear();
@@ -134,14 +135,14 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
         metricHistory.put(now, scalingMetrics);
 
         if (isStabilizing) {
-            LOG.info("Stabilizing until {}", stableTime);
+            LOG.info("Stabilizing until {}", readable(stableTime));
             stateStore.storeCollectedMetrics(ctx, metricHistory);
             return new CollectedMetricHistory(topology, Collections.emptySortedMap());
         }
 
         var collectedMetrics = new CollectedMetricHistory(topology, metricHistory);
         if (now.isBefore(windowFullTime)) {
-            LOG.info("Metric window not full until {}", windowFullTime);
+            LOG.info("Metric window not full until {}", readable(windowFullTime));
         } else {
             collectedMetrics.setFullyCollected(true);
             // Trim metrics outside the metric window from metrics history

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/DateTimeUtils.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/DateTimeUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.utils;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/** Date and time related utilities. */
+public class DateTimeUtils {
+
+    private static final DateTimeFormatter DEFAULT_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    /**
+     * Convert an Instant to a readable format for the system default zone.
+     *
+     * @param instant The Instant to convert.
+     * @return The readable format in the system default zone.
+     */
+    public static String readable(Instant instant) {
+        return readable(instant, ZoneId.systemDefault());
+    }
+
+    /**
+     * Convert an Instant to a readable format for a given zone.
+     *
+     * @param instant The Instant to convert.
+     * @param zoneId The ZoneId to apply.
+     * @return The readable format in the specified time zone.
+     */
+    public static String readable(Instant instant, ZoneId zoneId) {
+        ZonedDateTime dateTime = instant.atZone(zoneId);
+        return dateTime.format(DEFAULT_FORMATTER);
+    }
+}

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/utils/DateTimeUtilsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/utils/DateTimeUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link DateTimeUtils}. */
+public class DateTimeUtilsTest {
+
+    @Test
+    public void testConvertInstantToReadableFormat() {
+        Instant instant = Instant.ofEpochMilli(1702456327000L);
+        String readableFormat1 = DateTimeUtils.readable(instant, ZoneId.of("Asia/Shanghai"));
+        String readableFormat2 = DateTimeUtils.readable(instant, ZoneId.of("Europe/Berlin"));
+        assertThat(readableFormat1).isEqualTo("2023-12-13 16:32:07");
+        assertThat(readableFormat2).isEqualTo("2023-12-13 09:32:07");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-33813][autoscaler] Improve time formatting for easier reading inside the autoscaler

The default format of Instant is UTC time, it's better to format it to the corresponding Time Zone.It will be easier reading.

## Test

- Added the DateTimeUtilsTest

## The log before this PR

![image](https://github.com/apache/flink-kubernetes-operator/assets/38427477/f923cea7-781b-4081-872a-b8dd38d5e415)


## The log after this PR

<img width="1106" alt="image" src="https://github.com/apache/flink-kubernetes-operator/assets/38427477/ce6fca43-7263-4ba3-87f9-77fb22015a7a">



