### PR TITLE
[FLINK-33632] Adding custom flink mutator

### DIFF
--- a/flink-kubernetes-mutator/pom.xml
+++ b/flink-kubernetes-mutator/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-kubernetes-operator-parent</artifactId>
+        <version>1.6.1</version>
+        <relativePath>..</relativePath>
+    </parent>
+
+    <artifactId>flink-kubernetes-mutator</artifactId>
+    <name>Flink Kubernetes Mutator</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <assertj.version>3.24.2</assertj.version>
+        <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-kubernetes-operator</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.javaoperatorsdk</groupId>
+            <artifactId>kubernetes-webhooks-framework-core</artifactId>
+            <version>${operator.sdk.webhook-framework.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-kubernetes-operator</artifactId>
+            <version>1.8-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-kubernetes-mutator/src/main/java/org/apache/flink/mutator/CustomFlinkMutator.java
+++ b/flink-kubernetes-mutator/src/main/java/org/apache/flink/mutator/CustomFlinkMutator.java
@@ -1,0 +1,24 @@
+package org.apache.flink.mutator;
+
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
+
+import java.util.Optional;
+
+/** Custom Flink Mutator. */
+public class CustomFlinkMutator implements FlinkResourceMutator {
+
+    @Override
+    public FlinkDeployment mutateDeployment(FlinkDeployment deployment) {
+
+        return deployment;
+    }
+
+    @Override
+    public FlinkSessionJob mutateSessionJob(
+            FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
+
+        return sessionJob;
+    }
+}

--- a/flink-kubernetes-mutator/src/main/resources/META-INF/services/org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator
+++ b/flink-kubernetes-mutator/src/main/resources/META-INF/services/org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator
@@ -1,0 +1,1 @@
+org.apache.flink.mutator.CustomFlinkMutator

--- a/flink-kubernetes-mutator/tools/maven/checkstyle.xml
+++ b/flink-kubernetes-mutator/tools/maven/checkstyle.xml
@@ -1,0 +1,567 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE module PUBLIC
+	"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+	"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html.
+
+This file is based on the checkstyle file of Apache Beam.
+-->
+
+<module name="Checker">
+
+	<module name="NewlineAtEndOfFile">
+		<!-- windows can use \r\n vs \n, so enforce the most used one ie UNIx style -->
+		<property name="lineSeparator" value="lf"/>
+	</module>
+
+	<module name="RegexpSingleline">
+		<!-- Checks that TODOs don't have stuff in parenthesis, e.g., username. -->
+		<property name="format" value="((//.*)|(\*.*))TODO\("/>
+		<property name="message" value="TODO comments must not include usernames."/>
+		<property name="severity" value="error"/>
+	</module>
+
+	<module name="RegexpSingleline">
+		<property name="format" value="\s+$"/>
+		<property name="message" value="Trailing whitespace"/>
+		<property name="severity" value="error"/>
+	</module>
+
+	<module name="RegexpSingleline">
+		<property name="format" value="Throwables.propagate\("/>
+		<property name="message" value="Throwables.propagate is deprecated"/>
+		<property name="severity" value="error"/>
+	</module>
+
+	<!-- Prevent *Tests.java as tools may not pick them up -->
+	<!--<module name="RegexpOnFilename">-->
+	<!--<property name="fileNamePattern" value=".*Tests\.java$" />-->
+	<!--</module>-->
+
+	<module name="SuppressionFilter">
+		<property name="file" value="${checkstyle.suppressions.file}" default="suppressions.xml"/>
+	</module>
+
+	<!-- Check that every module has a package-info.java -->
+	<!--<module name="JavadocPackage"/>-->
+
+	<!--
+
+	FLINK CUSTOM CHECKS
+
+	-->
+
+	<module name="FileLength">
+		<property name="max" value="3000"/>
+	</module>
+
+	<!-- All Java AST specific tests live under TreeWalker module. -->
+	<module name="TreeWalker">
+
+		<!-- Allow use of comment to suppress javadocstyle -->
+		<module name="SuppressionCommentFilter">
+			<property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+			<property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+			<property name="checkFormat" value="$1"/>
+		</module>
+
+		<!--
+
+		FLINK CUSTOM CHECKS
+
+		-->
+
+		<!-- Prohibit T.getT() methods for standard boxed types -->
+		<module name="Regexp">
+			<property name="format" value="Boolean\.getBoolean"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use System.getProperties() to get system properties."/>
+		</module>
+
+		<module name="Regexp">
+			<property name="format" value="Integer\.getInteger"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use System.getProperties() to get system properties."/>
+		</module>
+
+		<module name="Regexp">
+			<property name="format" value="Long\.getLong"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use System.getProperties() to get system properties."/>
+		</module>
+
+		<!--
+
+		IllegalImport cannot blacklist classes so we have to fall back to Regexp.
+
+		-->
+
+		<!-- forbid use of commons lang validate -->
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang3\.Validate"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Guava Checks instead of Commons Validate. Please refer to the coding guidelines."/>
+		</module>
+		<!-- forbid the use of google.common.base.Preconditions -->
+		<module name="Regexp">
+			<property name="format" value="import com\.google\.common\.base\.Preconditions"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's Preconditions instead of Guava's Preconditions"/>
+		</module>
+		<!-- forbid the use of com.google.common.annotations.VisibleForTesting -->
+		<module name="Regexp">
+			<property name="format"
+					  value="import com\.google\.common\.annotations\.VisibleForTesting"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's VisibleForTesting instead of Guava's VisibleForTesting"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="import static com\.google\.common\.base\.Preconditions"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's Preconditions instead of Guava's Preconditions"/>
+		</module>
+		<!-- forbid the use of org.apache.commons.lang.SerializationUtils -->
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang\.SerializationUtils"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's InstantiationUtil instead of common's SerializationUtils"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang3\.SerializationUtils"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's InstantiationUtil instead of common's SerializationUtils"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang\."/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use commons-lang3 instead of commons-lang."/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.codehaus\.jettison"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use com.fasterxml.jackson instead of jettison."/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.junit\.Assert\."/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use org.junit.jupiter.api.Assertions."/>
+		</module>
+
+		<!-- Enforce Java-style array declarations -->
+		<module name="ArrayTypeStyle"/>
+
+		<module name="TodoComment">
+			<!-- Checks that disallowed strings are not used in comments.  -->
+			<property name="format" value="(FIXME)|(XXX)|(@author)"/>
+		</module>
+
+		<!--
+
+		IMPORT CHECKS
+
+		-->
+
+		<module name="RedundantImport">
+			<!-- Checks for redundant import statements. -->
+			<property name="severity" value="error"/>
+			<message key="import.redundancy"
+					 value="Redundant import {0}."/>
+		</module>
+
+		<module name="ImportOrder">
+			<!-- Checks for out of order import statements. -->
+			<property name="severity" value="error"/>
+			<property name="groups"
+					  value="org.apache.flink,org.apache.flink.shaded,*,javax,java,scala"/>
+			<property name="separated" value="true"/>
+			<property name="sortStaticImportsAlphabetically" value="true"/>
+			<property name="option" value="bottom"/>
+			<property name="tokens" value="STATIC_IMPORT, IMPORT"/>
+			<message key="import.ordering"
+					 value="Import {0} appears after other imports that it should precede"/>
+		</module>
+
+		<module name="AvoidStarImport">
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="IllegalImport">
+			<property name="illegalPkgs"
+					  value="autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged"/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="org.codehaus.jackson"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-jackson instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="org.objectweb.asm"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-asm instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="io.netty"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-netty instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="com.google.common"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-guava instead."/>
+		</module>
+
+		<module name="RedundantModifier">
+			<!-- Checks for redundant modifiers on various symbol definitions.
+			  See: http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier
+
+			  We exclude METHOD_DEF to allow final methods in final classes to make them more future-proof.
+			-->
+			<property name="tokens"
+					  value="VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF, CLASS_DEF, ENUM_DEF"/>
+		</module>
+
+		<!--
+			IllegalImport cannot blacklist classes, and c.g.api.client.util is used for some shaded
+			code and some useful code. So we need to fall back to Regexp.
+		-->
+		<!--<module name="RegexpSinglelineJava">-->
+		<!--<property name="format" value="com\.google\.api\.client\.util\.(ByteStreams|Charsets|Collections2|Joiner|Lists|Maps|Objects|Preconditions|Sets|Strings|Throwables)"/>-->
+		<!--</module>-->
+
+		<!--
+			 Require static importing from Preconditions.
+		-->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^import com.google.common.base.Preconditions;$"/>
+			<property name="message" value="Static import functions from Guava Preconditions"/>
+		</module>
+
+		<module name="UnusedImports">
+			<property name="severity" value="error"/>
+			<property name="processJavadoc" value="true"/>
+			<message key="import.unused"
+					 value="Unused import: {0}."/>
+		</module>
+
+		<!--
+
+		JAVADOC CHECKS
+
+		-->
+
+		<!-- Checks for Javadoc comments.                     -->
+		<!-- See http://checkstyle.sf.net/config_javadoc.html -->
+		<module name="JavadocMethod">
+			<property name="scope" value="protected"/>
+			<property name="severity" value="error"/>
+			<property name="allowMissingJavadoc" value="true"/>
+			<property name="allowMissingParamTags" value="true"/>
+			<property name="allowMissingReturnTag" value="true"/>
+			<property name="allowMissingThrowsTags" value="true"/>
+			<property name="allowThrowsTagsForSubclasses" value="true"/>
+			<property name="allowUndeclaredRTE" value="true"/>
+			<!-- This check sometimes failed for with "Unable to get class information for @throws tag" for custom exceptions -->
+			<property name="suppressLoadErrors" value="true"/>
+		</module>
+
+		<!-- Check that paragraph tags are used correctly in Javadoc. -->
+		<module name="JavadocParagraph"/>
+
+		<module name="JavadocType">
+			<property name="scope" value="protected"/>
+			<property name="severity" value="error"/>
+			<property name="allowMissingParamTags" value="true"/>
+		</module>
+
+		<module name="JavadocStyle">
+			<property name="severity" value="error"/>
+			<property name="checkHtml" value="true"/>
+		</module>
+
+		<!--
+
+		NAMING CHECKS
+
+		-->
+
+		<!-- Item 38 - Adhere to generally accepted naming conventions -->
+
+		<module name="PackageName">
+			<!-- Validates identifiers for package names against the
+			  supplied expression. -->
+			<!-- Here the default checkstyle rule restricts package name parts to
+			  seven characters, this is not in line with common practice at Google.
+			-->
+			<property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="TypeNameCheck">
+			<!-- Validates static, final fields against the
+			expression "^[A-Z][a-zA-Z0-9]*$". -->
+			<metadata name="altname" value="TypeName"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="ConstantNameCheck">
+			<!-- Validates non-private, static, final fields against the supplied
+			public/package final fields "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$". -->
+			<metadata name="altname" value="ConstantName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="false"/>
+			<property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|FLAG_.*)$"/>
+			<message key="name.invalidPattern"
+					 value="Variable ''{0}'' should be in ALL_CAPS (if it is a constant) or be private (otherwise)."/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="StaticVariableNameCheck">
+			<!-- Validates static, non-final fields against the supplied
+			expression "^[a-z][a-zA-Z0-9]*_?$". -->
+			<metadata name="altname" value="StaticVariableName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="true"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*_?$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="MemberNameCheck">
+			<!-- Validates non-static members against the supplied expression. -->
+			<metadata name="altname" value="MemberName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="true"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="MethodNameCheck">
+			<!-- Validates identifiers for method names. -->
+			<metadata name="altname" value="MethodName"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="ParameterName">
+			<!-- Validates identifiers for method parameters against the
+			  expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="LocalFinalVariableName">
+			<!-- Validates identifiers for local final variables against the
+			  expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="LocalVariableName">
+			<!-- Validates identifiers for local variables against the
+			  expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="error"/>
+		</module>
+
+		<!-- Type parameters must be either one of the four blessed letters
+		T, K, V, W, X or else be capital-case terminated with a T,
+		such as MyGenericParameterT -->
+		<!--<module name="ClassTypeParameterName">-->
+		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
+		<!--<property name="severity" value="error"/>-->
+		<!--</module>-->
+
+		<!--<module name="MethodTypeParameterName">-->
+		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
+		<!--<property name="severity" value="error"/>-->
+		<!--</module>-->
+
+		<!--<module name="InterfaceTypeParameterName">-->
+		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
+		<!--<property name="severity" value="error"/>-->
+		<!--</module>-->
+
+		<!--
+
+		LENGTH and CODING CHECKS
+
+		-->
+
+		<!--<module name="LineLength">-->
+		<!--&lt;!&ndash; Checks if a line is too long. &ndash;&gt;-->
+		<!--<property name="max" value="100"/>-->
+		<!--<property name="severity" value="error"/>-->
+
+		<!--&lt;!&ndash;-->
+		<!--The default ignore pattern exempts the following elements:-->
+		<!-- - import statements-->
+		<!-- - long URLs inside comments-->
+		<!--&ndash;&gt;-->
+
+		<!--<property name="ignorePattern"-->
+		<!--value="^(package .*;\s*)|(import .*;\s*)|( *\* .*https?://.*)$"/>-->
+		<!--</module>-->
+
+		<!-- Checks for braces around if and else blocks -->
+		<module name="NeedBraces">
+			<property name="severity" value="error"/>
+			<property name="tokens"
+					  value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO"/>
+		</module>
+
+		<module name="UpperEll">
+			<!-- Checks that long constants are defined with an upper ell.-->
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="FallThrough">
+			<!-- Warn about falling through to the next case statement.  Similar to
+			javac -Xlint:fallthrough, but the check is suppressed if a single-line comment
+			on the last non-blank line preceding the fallen-into case contains 'fall through' (or
+			some other variants that we don't publicized to promote consistency).
+			-->
+			<property name="reliefPattern"
+					  value="fall through|Fall through|fallthru|Fallthru|falls through|Falls through|fallthrough|Fallthrough|No break|NO break|no break|continue on"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<!-- Checks for over-complicated boolean expressions. -->
+		<module name="SimplifyBooleanExpression"/>
+
+		<!-- Detects empty statements (standalone ";" semicolon). -->
+		<module name="EmptyStatement"/>
+
+		<!-- Detect multiple consecutive semicolons (e.g. ";;"). -->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value=";{2,}"/>
+			<property name="message" value="Use one semicolon"/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+
+		<!--
+
+		MODIFIERS CHECKS
+
+		-->
+
+		<module name="ModifierOrder">
+			<!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
+				 8.4.3.  The prescribed order is:
+				 public, protected, private, abstract, static, final, transient, volatile,
+				 synchronized, native, strictfp
+			  -->
+			<property name="severity" value="error"/>
+		</module>
+
+
+		<!--
+
+		WHITESPACE CHECKS
+
+		-->
+
+		<module name="EmptyLineSeparator">
+			<!-- Checks for empty line separator between tokens. The only
+				 excluded token is VARIABLE_DEF, allowing class fields to
+				 be declared on consecutive lines.
+			-->
+			<property name="allowMultipleEmptyLines" value="false"/>
+			<property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+			<property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF,
+        INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF,
+        CTOR_DEF"/>
+		</module>
+
+		<module name="WhitespaceAround">
+			<!-- Checks that various tokens are surrounded by whitespace.
+				 This includes most binary operators and keywords followed
+				 by regular or curly braces.
+			-->
+			<property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR,
+        BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN,
+        EQUAL, GE, GT, LAMBDA, LAND, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+        LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
+        LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
+        MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
+        SL, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="WhitespaceAfter">
+			<!-- Checks that commas, semicolons and typecasts are followed by
+				 whitespace.
+			-->
+			<property name="tokens" value="COMMA, SEMI, TYPECAST"/>
+		</module>
+
+		<module name="NoWhitespaceAfter">
+			<!-- Checks that there is no whitespace after various unary operators.
+				 Linebreaks are allowed.
+			-->
+			<property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS,
+        UNARY_PLUS"/>
+			<property name="allowLineBreaks" value="true"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="NoWhitespaceBefore">
+			<!-- Checks that there is no whitespace before various unary operators.
+				 Linebreaks are allowed.
+			-->
+			<property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC"/>
+			<property name="allowLineBreaks" value="true"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<!--<module name="OperatorWrap">-->
+		<!--&lt;!&ndash; Checks that operators like + and ? appear at newlines rather than-->
+		<!--at the end of the previous line.-->
+		<!--&ndash;&gt;-->
+		<!--<property name="option" value="NL"/>-->
+		<!--<property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL,-->
+		<!--GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD,-->
+		<!--NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>-->
+		<!--</module>-->
+
+		<module name="OperatorWrap">
+			<!-- Checks that assignment operators are at the end of the line. -->
+			<property name="option" value="eol"/>
+			<property name="tokens" value="ASSIGN"/>
+		</module>
+
+		<module name="ParenPad">
+			<!-- Checks that there is no whitespace before close parens or after
+				 open parens.
+			-->
+			<property name="severity" value="error"/>
+		</module>
+
+	</module>
+</module>
+

--- a/flink-kubernetes-mutator/tools/maven/suppressions.xml
+++ b/flink-kubernetes-mutator/tools/maven/suppressions.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!DOCTYPE suppressions PUBLIC
+		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
+		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+</suppressions>

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -208,6 +208,18 @@ under the License.
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.javaoperatorsdk</groupId>
+            <artifactId>kubernetes-webhooks-framework-core</artifactId>
+            <version>${operator.sdk.webhook-framework.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/DefaultFlinkMutator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/DefaultFlinkMutator.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.mutator;
+
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+
+import java.util.Optional;
+
+/** Default Flink Mutator. */
+public class DefaultFlinkMutator implements FlinkResourceMutator {
+
+    @Override
+    public FlinkDeployment mutateDeployment(FlinkDeployment deployment) {
+
+        return deployment;
+    }
+
+    @Override
+    public FlinkSessionJob mutateSessionJob(
+            FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
+
+        return sessionJob;
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/FlinkResourceMutator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/FlinkResourceMutator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.mutator;
+
+import org.apache.flink.core.plugin.Plugin;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+
+import java.util.Optional;
+
+/** Mutator for Flink Resources. */
+public interface FlinkResourceMutator extends Plugin {
+
+    /**
+     * Mutate deployment and return the mutated Object.
+     *
+     * @param deployment A Flink application or session cluster deployment.
+     */
+    FlinkDeployment mutateDeployment(FlinkDeployment deployment);
+
+    /**
+     * Mutate session job and return the mutated Object.
+     *
+     * @param sessionJob the session job to be mutated.
+     * @param session the target session cluster of the session job to be Mutated.
+     */
+    FlinkSessionJob mutateSessionJob(FlinkSessionJob sessionJob, Optional<FlinkDeployment> session);
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/MutatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/MutatorUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.mutator.DefaultFlinkMutator;
+import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** Mutator utilities. */
+public final class MutatorUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MutatorUtils.class);
+
+    /**
+     * discovers mutators.
+     *
+     * @param configManager Flink Config manager
+     * @return Set of FlinkResourceMutator
+     */
+    public static Set<FlinkResourceMutator> discoverMutators(FlinkConfigManager configManager) {
+        var conf = configManager.getDefaultConfig();
+        Set<FlinkResourceMutator> flinkmutator = new HashSet<>();
+        DefaultFlinkMutator defaultFlinkMutator = new DefaultFlinkMutator();
+        defaultFlinkMutator.configure(conf);
+        flinkmutator.add(defaultFlinkMutator);
+        PluginUtils.createPluginManagerFromRootFolder(conf)
+                .load(FlinkResourceMutator.class)
+                .forEachRemaining(
+                        mutator -> {
+                            LOG.info(
+                                    "Discovered mutator from plugin directory[{}]: {}.",
+                                    System.getenv()
+                                            .getOrDefault(
+                                                    ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+                                                    ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS),
+                                    mutator.getClass().getName());
+                            mutator.configure(conf);
+                            flinkmutator.add(mutator);
+                        });
+        return flinkmutator;
+    }
+}

--- a/flink-kubernetes-webhook/pom.xml
+++ b/flink-kubernetes-webhook/pom.xml
@@ -31,6 +31,11 @@ under the License.
     <name>Flink Kubernetes Webhook</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    </properties>
+
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -126,6 +131,11 @@ under the License.
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
@@ -21,8 +21,10 @@ import org.apache.flink.kubernetes.operator.admission.informer.InformerManager;
 import org.apache.flink.kubernetes.operator.admission.mutator.FlinkMutator;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.fs.FileSystemWatchService;
+import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
 import org.apache.flink.kubernetes.operator.ssl.ReloadableSslContext;
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
+import org.apache.flink.kubernetes.operator.utils.MutatorUtils;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
 
@@ -63,10 +65,12 @@ public class FlinkOperatorWebhook {
             informerManager.setNamespaces(operatorConfig.getWatchedNamespaces());
         }
         Set<FlinkResourceValidator> validators = ValidatorUtils.discoverValidators(configManager);
+        Set<FlinkResourceMutator> mutators = MutatorUtils.discoverMutators(configManager);
 
         AdmissionHandler endpoint =
                 new AdmissionHandler(
-                        new FlinkValidator(validators, informerManager), new FlinkMutator());
+                        new FlinkValidator(validators, informerManager),
+                        new FlinkMutator(mutators, informerManager));
 
         ChannelInitializer<SocketChannel> initializer = createChannelInitializer(endpoint);
         NioEventLoopGroup bossGroup = new NioEventLoopGroup(1);

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
@@ -17,11 +17,15 @@
 
 package org.apache.flink.kubernetes.operator.admission.mutator;
 
+import org.apache.flink.kubernetes.operator.admission.informer.InformerManager;
 import org.apache.flink.kubernetes.operator.api.CrdConstants;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.informers.cache.Cache;
 import io.javaoperatorsdk.webhook.admission.NotAllowedException;
 import io.javaoperatorsdk.webhook.admission.Operation;
 import io.javaoperatorsdk.webhook.admission.mutation.Mutator;
@@ -29,29 +33,72 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.Optional;
+import java.util.Set;
 
 /** The default mutator. */
 public class FlinkMutator implements Mutator<HasMetadata> {
     private static final Logger LOG = LoggerFactory.getLogger(FlinkMutator.class);
     private static final ObjectMapper mapper = new ObjectMapper();
+    private final Set<FlinkResourceMutator> mutators;
+    private final InformerManager informerManager;
+
+    public FlinkMutator(Set<FlinkResourceMutator> mutators, InformerManager informerManager) {
+        this.mutators = mutators;
+        this.informerManager = informerManager;
+    }
 
     @Override
     public HasMetadata mutate(HasMetadata resource, Operation operation)
             throws NotAllowedException {
         if (operation == Operation.CREATE) {
             LOG.debug("Mutating resource {}", resource);
-
             if (CrdConstants.KIND_SESSION_JOB.equals(resource.getKind())) {
-                try {
-                    var sessionJob = mapper.convertValue(resource, FlinkSessionJob.class);
-                    setSessionTargetLabel(sessionJob);
-                    return sessionJob;
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+                return mutateSessionJob(resource);
+            }
+        }
+        if (operation == Operation.CREATE || operation == Operation.UPDATE) {
+            if (CrdConstants.KIND_FLINK_DEPLOYMENT.equals(resource.getKind())) {
+                return mutateDeployment(resource);
             }
         }
         return resource;
+    }
+
+    private FlinkSessionJob mutateSessionJob(HasMetadata resource) {
+        try {
+            var sessionJob = mapper.convertValue(resource, FlinkSessionJob.class);
+            var namespace = sessionJob.getMetadata().getNamespace();
+            var deploymentName = sessionJob.getSpec().getDeploymentName();
+            var key = Cache.namespaceKeyFunc(namespace, deploymentName);
+            var deployment =
+                    informerManager.getFlinkDepInformer(namespace).getStore().getByKey(key);
+
+            setSessionTargetLabel(sessionJob);
+
+            for (FlinkResourceMutator mutator : mutators) {
+                FlinkSessionJob flinkSessionJob =
+                        mutator.mutateSessionJob(sessionJob, Optional.ofNullable(deployment));
+                sessionJob = flinkSessionJob;
+            }
+
+            return sessionJob;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private FlinkDeployment mutateDeployment(HasMetadata resource) {
+        try {
+            var flinkDeployment = mapper.convertValue(resource, FlinkDeployment.class);
+            for (FlinkResourceMutator mutator : mutators) {
+                FlinkDeployment deployment = mutator.mutateDeployment(flinkDeployment);
+                flinkDeployment = deployment;
+            }
+            return flinkDeployment;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void setSessionTargetLabel(FlinkSessionJob flinkSessionJob) {

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@ under the License.
         <module>flink-kubernetes-operator-api</module>
         <module>flink-kubernetes-webhook</module>
         <module>flink-kubernetes-docs</module>
+        <module>flink-kubernetes-mutator</module>
         <module>flink-autoscaler</module>
         <module>flink-autoscaler-standalone</module>
         <module>examples/flink-sql-runner-example</module>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

To add the custom flink mutator.


## Brief change log

*(for example:)*
  - *Periodic savepoint trigger is introduced to the custom resource*
  - *The operator checks on reconciliation whether the required time has passed*
  - *The JobManager's dispose savepoint API is used to clean up obsolete savepoints*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no)
  - Core observer or reconciler logic that is regularly executed: (yes / no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
