### PR TITLE
[FLINK-33632] Adding custom flink mutator

### DIFF
--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -208,18 +208,6 @@ under the License.
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>io.javaoperatorsdk</groupId>
-            <artifactId>kubernetes-webhooks-framework-core</artifactId>
-            <version>${operator.sdk.webhook-framework.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -208,6 +208,18 @@ under the License.
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.javaoperatorsdk</groupId>
+            <artifactId>kubernetes-webhooks-framework-core</artifactId>
+            <version>${operator.sdk.webhook-framework.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/DefaultFlinkMutator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/DefaultFlinkMutator.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.mutator;
+
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+
+import java.util.Optional;
+
+/** Default Flink Mutator. */
+public class DefaultFlinkMutator implements FlinkResourceMutator {
+
+    @Override
+    public FlinkDeployment mutateDeployment(FlinkDeployment deployment) {
+
+        return deployment;
+    }
+
+    @Override
+    public FlinkSessionJob mutateSessionJob(
+            FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
+
+        return sessionJob;
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/DefaultFlinkMutator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/DefaultFlinkMutator.java
@@ -17,9 +17,11 @@
 
 package org.apache.flink.kubernetes.operator.mutator;
 
+import org.apache.flink.kubernetes.operator.api.CrdConstants;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 
+import java.util.HashMap;
 import java.util.Optional;
 
 /** Default Flink Mutator. */
@@ -35,6 +37,23 @@ public class DefaultFlinkMutator implements FlinkResourceMutator {
     public FlinkSessionJob mutateSessionJob(
             FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
 
+        setSessionTargetLabel(sessionJob);
+
         return sessionJob;
+    }
+
+    private void setSessionTargetLabel(FlinkSessionJob flinkSessionJob) {
+        var labels = flinkSessionJob.getMetadata().getLabels();
+        if (labels == null) {
+            labels = new HashMap<>();
+        }
+        var deploymentName = flinkSessionJob.getSpec().getDeploymentName();
+        if (deploymentName != null
+                && !deploymentName.equals(labels.get(CrdConstants.LABEL_TARGET_SESSION))) {
+            labels.put(
+                    CrdConstants.LABEL_TARGET_SESSION,
+                    flinkSessionJob.getSpec().getDeploymentName());
+            flinkSessionJob.getMetadata().setLabels(labels);
+        }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/FlinkResourceMutator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/FlinkResourceMutator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.mutator;
+
+import org.apache.flink.core.plugin.Plugin;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+
+import java.util.Optional;
+
+/** Mutator for Flink Resources. */
+public interface FlinkResourceMutator extends Plugin {
+
+    /**
+     * Mutate deployment and return the mutated Object.
+     *
+     * @param deployment A Flink application or session cluster deployment.
+     */
+    FlinkDeployment mutateDeployment(FlinkDeployment deployment);
+
+    /**
+     * Mutate session job and return the mutated Object.
+     *
+     * @param sessionJob the session job to be mutated.
+     * @param session the target session cluster of the session job to be Mutated.
+     */
+    FlinkSessionJob mutateSessionJob(FlinkSessionJob sessionJob, Optional<FlinkDeployment> session);
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/MutatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/MutatorUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.mutator.DefaultFlinkMutator;
+import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/** Mutator utilities. */
+public final class MutatorUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MutatorUtils.class);
+
+    /**
+     * discovers mutators.
+     *
+     * @param configManager Flink Config manager
+     * @return Set of FlinkResourceMutator
+     */
+    public static Set<FlinkResourceMutator> discoverMutators(FlinkConfigManager configManager) {
+        var conf = configManager.getDefaultConfig();
+        Set<FlinkResourceMutator> flinkmutator = new HashSet<>();
+        DefaultFlinkMutator defaultFlinkMutator = new DefaultFlinkMutator();
+        defaultFlinkMutator.configure(conf);
+        flinkmutator.add(defaultFlinkMutator);
+        PluginUtils.createPluginManagerFromRootFolder(conf)
+                .load(FlinkResourceMutator.class)
+                .forEachRemaining(
+                        mutator -> {
+                            LOG.info(
+                                    "Discovered mutator from plugin directory[{}]: {}.",
+                                    System.getenv()
+                                            .getOrDefault(
+                                                    ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+                                                    ConfigConstants.DEFAULT_FLINK_PLUGINS_DIRS),
+                                    mutator.getClass().getName());
+                            mutator.configure(conf);
+                            flinkmutator.add(mutator);
+                        });
+        return flinkmutator;
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/mutator/TestMutator.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/mutator/TestMutator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.mutator;
+
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+
+import java.util.Optional;
+
+/** Test validator implementation of {@link FlinkResourceMutator}. */
+public class TestMutator implements FlinkResourceMutator {
+
+    @Override
+    public FlinkDeployment mutateDeployment(FlinkDeployment deployment) {
+        return deployment;
+    }
+
+    @Override
+    public FlinkSessionJob mutateSessionJob(
+            FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
+        return sessionJob;
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/MutatorUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/MutatorUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.mutator.DefaultFlinkMutator;
+import org.apache.flink.kubernetes.operator.mutator.TestMutator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Test class for {@link MutatorUtils}. */
+public class MutatorUtilsTest {
+
+    @TempDir public Path temporaryFolder;
+
+    @Test
+    public void testDiscoverMutators() throws IOException {
+        Map<String, String> originalEnv = System.getenv();
+        try {
+            Map<String, String> systemEnv = new HashMap<>(originalEnv);
+            systemEnv.put(
+                    ConfigConstants.ENV_FLINK_PLUGINS_DIR,
+                    TestUtils.getTestPluginsRootDir(temporaryFolder));
+            TestUtils.setEnv(systemEnv);
+            assertEquals(
+                    new HashSet<>(
+                            Arrays.asList(
+                                    DefaultFlinkMutator.class.getName(),
+                                    TestMutator.class.getName())),
+                    MutatorUtils.discoverMutators(new FlinkConfigManager(new Configuration()))
+                            .stream()
+                            .map(v -> v.getClass().getName())
+                            .collect(Collectors.toSet()));
+        } finally {
+            TestUtils.setEnv(originalEnv);
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/test/resources/META-INF/services/org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator
+++ b/flink-kubernetes-operator/src/test/resources/META-INF/services/org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.kubernetes.operator.mutator.TestMutator

--- a/flink-kubernetes-webhook/pom.xml
+++ b/flink-kubernetes-webhook/pom.xml
@@ -31,6 +31,11 @@ under the License.
     <name>Flink Kubernetes Webhook</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <surefire-plugin.version>2.22.2</surefire-plugin.version>
+    </properties>
+
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -126,6 +131,11 @@ under the License.
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire-plugin.version}</version>
             </plugin>
         </plugins>
     </build>

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
@@ -21,8 +21,10 @@ import org.apache.flink.kubernetes.operator.admission.informer.InformerManager;
 import org.apache.flink.kubernetes.operator.admission.mutator.FlinkMutator;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.fs.FileSystemWatchService;
+import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
 import org.apache.flink.kubernetes.operator.ssl.ReloadableSslContext;
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
+import org.apache.flink.kubernetes.operator.utils.MutatorUtils;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
 
@@ -63,10 +65,12 @@ public class FlinkOperatorWebhook {
             informerManager.setNamespaces(operatorConfig.getWatchedNamespaces());
         }
         Set<FlinkResourceValidator> validators = ValidatorUtils.discoverValidators(configManager);
+        Set<FlinkResourceMutator> mutators = MutatorUtils.discoverMutators(configManager);
 
         AdmissionHandler endpoint =
                 new AdmissionHandler(
-                        new FlinkValidator(validators, informerManager), new FlinkMutator());
+                        new FlinkValidator(validators, informerManager),
+                        new FlinkMutator(mutators, informerManager));
 
         ChannelInitializer<SocketChannel> initializer = createChannelInitializer(endpoint);
         NioEventLoopGroup bossGroup = new NioEventLoopGroup(1);

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
@@ -51,13 +51,11 @@ public class FlinkMutator implements Mutator<HasMetadata> {
     @Override
     public HasMetadata mutate(HasMetadata resource, Operation operation)
             throws NotAllowedException {
-        if (operation == Operation.CREATE) {
+        if (operation == Operation.CREATE || operation == Operation.UPDATE) {
             LOG.debug("Mutating resource {}", resource);
             if (CrdConstants.KIND_SESSION_JOB.equals(resource.getKind())) {
                 return mutateSessionJob(resource);
             }
-        }
-        if (operation == Operation.CREATE || operation == Operation.UPDATE) {
             if (CrdConstants.KIND_FLINK_DEPLOYMENT.equals(resource.getKind())) {
                 return mutateDeployment(resource);
             }

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
@@ -72,9 +72,7 @@ public class FlinkMutator implements Mutator<HasMetadata> {
                     informerManager.getFlinkDepInformer(namespace).getStore().getByKey(key);
 
             for (FlinkResourceMutator mutator : mutators) {
-                FlinkSessionJob flinkSessionJob =
-                        mutator.mutateSessionJob(sessionJob, Optional.ofNullable(deployment));
-                sessionJob = flinkSessionJob;
+                sessionJob = mutator.mutateSessionJob(sessionJob, Optional.ofNullable(deployment));
             }
 
             return sessionJob;
@@ -87,8 +85,7 @@ public class FlinkMutator implements Mutator<HasMetadata> {
         try {
             var flinkDeployment = mapper.convertValue(resource, FlinkDeployment.class);
             for (FlinkResourceMutator mutator : mutators) {
-                FlinkDeployment deployment = mutator.mutateDeployment(flinkDeployment);
-                flinkDeployment = deployment;
+                flinkDeployment = mutator.mutateDeployment(flinkDeployment);
             }
             return flinkDeployment;
         } catch (Exception e) {

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
@@ -32,7 +32,6 @@ import io.javaoperatorsdk.webhook.admission.mutation.Mutator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
 import java.util.Optional;
 import java.util.Set;
 
@@ -72,8 +71,6 @@ public class FlinkMutator implements Mutator<HasMetadata> {
             var deployment =
                     informerManager.getFlinkDepInformer(namespace).getStore().getByKey(key);
 
-            setSessionTargetLabel(sessionJob);
-
             for (FlinkResourceMutator mutator : mutators) {
                 FlinkSessionJob flinkSessionJob =
                         mutator.mutateSessionJob(sessionJob, Optional.ofNullable(deployment));
@@ -96,21 +93,6 @@ public class FlinkMutator implements Mutator<HasMetadata> {
             return flinkDeployment;
         } catch (Exception e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private void setSessionTargetLabel(FlinkSessionJob flinkSessionJob) {
-        var labels = flinkSessionJob.getMetadata().getLabels();
-        if (labels == null) {
-            labels = new HashMap<>();
-        }
-        var deploymentName = flinkSessionJob.getSpec().getDeploymentName();
-        if (deploymentName != null
-                && !deploymentName.equals(labels.get(CrdConstants.LABEL_TARGET_SESSION))) {
-            labels.put(
-                    CrdConstants.LABEL_TARGET_SESSION,
-                    flinkSessionJob.getSpec().getDeploymentName());
-            flinkSessionJob.getMetadata().setLabels(labels);
         }
     }
 }

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
@@ -17,11 +17,15 @@
 
 package org.apache.flink.kubernetes.operator.admission.mutator;
 
+import org.apache.flink.kubernetes.operator.admission.informer.InformerManager;
 import org.apache.flink.kubernetes.operator.api.CrdConstants;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.informers.cache.Cache;
 import io.javaoperatorsdk.webhook.admission.NotAllowedException;
 import io.javaoperatorsdk.webhook.admission.Operation;
 import io.javaoperatorsdk.webhook.admission.mutation.Mutator;
@@ -29,29 +33,72 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.Optional;
+import java.util.Set;
 
 /** The default mutator. */
 public class FlinkMutator implements Mutator<HasMetadata> {
     private static final Logger LOG = LoggerFactory.getLogger(FlinkMutator.class);
     private static final ObjectMapper mapper = new ObjectMapper();
+    private final Set<FlinkResourceMutator> mutators;
+    private final InformerManager informerManager;
+
+    public FlinkMutator(Set<FlinkResourceMutator> mutators, InformerManager informerManager) {
+        this.mutators = mutators;
+        this.informerManager = informerManager;
+    }
 
     @Override
     public HasMetadata mutate(HasMetadata resource, Operation operation)
             throws NotAllowedException {
         if (operation == Operation.CREATE) {
             LOG.debug("Mutating resource {}", resource);
-
             if (CrdConstants.KIND_SESSION_JOB.equals(resource.getKind())) {
-                try {
-                    var sessionJob = mapper.convertValue(resource, FlinkSessionJob.class);
-                    setSessionTargetLabel(sessionJob);
-                    return sessionJob;
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+                return mutateSessionJob(resource);
+            }
+        }
+        if (operation == Operation.CREATE || operation == Operation.UPDATE) {
+            if (CrdConstants.KIND_FLINK_DEPLOYMENT.equals(resource.getKind())) {
+                return mutateDeployment(resource);
             }
         }
         return resource;
+    }
+
+    private FlinkSessionJob mutateSessionJob(HasMetadata resource) {
+        try {
+            var sessionJob = mapper.convertValue(resource, FlinkSessionJob.class);
+            var namespace = sessionJob.getMetadata().getNamespace();
+            var deploymentName = sessionJob.getSpec().getDeploymentName();
+            var key = Cache.namespaceKeyFunc(namespace, deploymentName);
+            var deployment =
+                    informerManager.getFlinkDepInformer(namespace).getStore().getByKey(key);
+
+            setSessionTargetLabel(sessionJob);
+
+            for (FlinkResourceMutator mutator : mutators) {
+                FlinkSessionJob flinkSessionJob =
+                        mutator.mutateSessionJob(sessionJob, Optional.ofNullable(deployment));
+                sessionJob = flinkSessionJob;
+            }
+
+            return sessionJob;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private FlinkDeployment mutateDeployment(HasMetadata resource) {
+        try {
+            var flinkDeployment = mapper.convertValue(resource, FlinkDeployment.class);
+            for (FlinkResourceMutator mutator : mutators) {
+                FlinkDeployment deployment = mutator.mutateDeployment(flinkDeployment);
+                flinkDeployment = deployment;
+            }
+            return flinkDeployment;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private void setSessionTargetLabel(FlinkSessionJob flinkSessionJob) {

--- a/flink-kubernetes-webhook/src/test/assembly/test-plugins-assembly.xml
+++ b/flink-kubernetes-webhook/src/test/assembly/test-plugins-assembly.xml
@@ -28,10 +28,7 @@ under the License.
             <outputDirectory>/</outputDirectory>
             <!-- the service impl -->
             <includes>
-                <include>org/apache/flink/kubernetes/operator/validation/TestValidator.class</include>
-                <include>org/apache/flink/kubernetes/operator/listener/TestingListener.class</include>
-                <include>org/apache/flink/kubernetes/operator/autoscaler/TestingAutoscaler.class</include>
-                <include>org/apache/flink/kubernetes/operator/mutator/TestMutator.java</include>
+                <include>org/apache/flink/kubernetes/operator/admission/TestMutator.java</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
+++ b/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
@@ -42,13 +42,15 @@ import io.fabric8.kubernetes.api.model.GroupVersionKind;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionRequest;
 import io.fabric8.kubernetes.api.model.admission.v1.AdmissionReview;
-import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Base64;
 
+import static io.javaoperatorsdk.operator.api.reconciler.Constants.DEFAULT_NAMESPACES_SET;
 import static io.javaoperatorsdk.webhook.admission.Operation.CREATE;
 import static org.apache.flink.kubernetes.operator.admission.AdmissionHandler.MUTATOR_REQUEST_PATH;
 import static org.apache.flink.kubernetes.operator.admission.AdmissionHandler.VALIDATE_REQUEST_PATH;
@@ -62,16 +64,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * @link AdmissionHandler unit tests
  */
+@EnableKubernetesMockClient(crud = true)
 public class AdmissionHandlerTest {
 
-    private final AdmissionHandler admissionHandler =
+    private KubernetesClient kubernetesClient;
+    private AdmissionHandler admissionHandler =
             new AdmissionHandler(
                     new FlinkValidator(
                             ValidatorUtils.discoverValidators(new FlinkConfigManager(ns -> {})),
                             new InformerManager(null)),
                     new FlinkMutator(
                             MutatorUtils.discoverMutators(new FlinkConfigManager(ns -> {})),
-                            new InformerManager(new KubernetesClientBuilder().build())));
+                            new InformerManager(kubernetesClient)));
 
     @Test
     public void testHandleIllegalRequest() {
@@ -138,6 +142,18 @@ public class AdmissionHandlerTest {
 
     @Test
     public void testMutateHandler() throws Exception {
+
+        var informerManager = new InformerManager(kubernetesClient);
+        informerManager.setNamespaces(DEFAULT_NAMESPACES_SET);
+        admissionHandler =
+                new AdmissionHandler(
+                        new FlinkValidator(
+                                ValidatorUtils.discoverValidators(new FlinkConfigManager(ns -> {})),
+                                new InformerManager(null)),
+                        new FlinkMutator(
+                                MutatorUtils.discoverMutators(new FlinkConfigManager(ns -> {})),
+                                informerManager));
+
         final EmbeddedChannel embeddedChannel = new EmbeddedChannel(admissionHandler);
         var sessionJob = new FlinkSessionJob();
         ObjectMeta objectMeta = new ObjectMeta();
@@ -177,6 +193,44 @@ public class AdmissionHandlerTest {
         var review = new ObjectMapper().readValue(str, AdmissionReview.class);
         var patch = new String(Base64.getDecoder().decode(review.getResponse().getPatch()));
         Assertions.assertTrue(patch.contains(CrdConstants.LABEL_TARGET_SESSION));
+        assertTrue(embeddedChannel.finish());
+    }
+
+    @Test
+    public void testmutateHandlerFlinkDeployment() throws Exception {
+
+        final EmbeddedChannel embeddedChannel = new EmbeddedChannel(admissionHandler);
+        final FlinkDeployment flinkDeployment = new FlinkDeployment();
+        ObjectMeta objectMeta = new ObjectMeta();
+        objectMeta.setName("basic-session-cluster");
+        flinkDeployment.setMetadata(objectMeta);
+        flinkDeployment.setSpec(new FlinkDeploymentSpec());
+
+        final AdmissionRequest admissionRequest = new AdmissionRequest();
+        admissionRequest.setOperation(CREATE.name());
+        admissionRequest.setObject(flinkDeployment);
+        admissionRequest.setKind(
+                new GroupVersionKind(
+                        flinkDeployment.getGroup(),
+                        flinkDeployment.getVersion(),
+                        flinkDeployment.getKind()));
+        final AdmissionReview admissionReview = new AdmissionReview();
+        admissionReview.setRequest(admissionRequest);
+        embeddedChannel.writeInbound(
+                new DefaultFullHttpRequest(
+                        HTTP_1_1,
+                        GET,
+                        MUTATOR_REQUEST_PATH,
+                        Unpooled.wrappedBuffer(
+                                new ObjectMapper()
+                                        .writeValueAsString(admissionReview)
+                                        .getBytes())));
+        embeddedChannel.writeOutbound(new DefaultFullHttpResponse(HTTP_1_1, OK));
+        final DefaultHttpResponse response = embeddedChannel.readOutbound();
+        assertEquals(OK, response.status());
+        Assertions.assertFalse(embeddedChannel.outboundMessages().isEmpty());
+        var body = embeddedChannel.readOutbound();
+        Assertions.assertNotNull(body);
         assertTrue(embeddedChannel.finish());
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR is to provide pluggable mutators. Currently the operator allows for pluggable validators, we would like to extend this capability to provide custom mutation. Our organisation, for example, requires certain fields to be present on the deployment. Whilst we can do this using the podTemplate overrides it makes the CR quite unwieldy. Having a custom mutator would mean we could automatically add these values to the CR.

## Brief change log

Implemented custom mutator for the flink kuberenetes operator.
* Implemented the interface FlinkResourceMutator.
* FlinkResourceMutator interface contains - mutateDeployment and mutateSessionJob which is implemented by Default and custom mutator.
* MutatorUtils discoverMutators methods helps to identify all the mutators which are implemented using FlinkResourceMutator interface.
* The Flink-kubernetes-Webhook contains a FlinkOperatorWebhook class with a main method which is invoked for the webhoook validations. All the mutators (custom and default mutators) are discovered/identified over here. This is intern send to the AdmissionHandler.
* AdmissionHandler handles the mutator which does the actual mutate by invoking the mutate method.
* The Flink Mutator has the mutate method which does the mutation and also iterates through the default and custom mutator and performs the mutate function.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->


This change is already covered by existing tests, such as  AdmissionHandlerTests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) No
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no) :No
  - Core observer or reconciler logic that is regularly executed: (yes / no) :No

## Documentation

  - Does this pull request introduce a new feature? (yes / no) Yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
Docs