### PR TITLE
[FLINK-33770] Silence Configuration logging for INFO messages

### DIFF
--- a/helm/flink-kubernetes-operator/conf/log4j-operator.properties
+++ b/helm/flink-kubernetes-operator/conf/log4j-operator.properties
@@ -28,3 +28,7 @@ appender.console.layout.pattern = %style{%d}{yellow} %style{%-30c{1.}}{cyan} %hi
 # Do not log config loading
 logger.conf.name = org.apache.flink.configuration.GlobalConfiguration
 logger.conf.level = WARN
+
+# Avoid logging fallback key INFO messages
+logger.conf.name = org.apache.flink.configuration.Configuration
+logger.conf.level = WARN


### PR DESCRIPTION
In #725 we coverted the deprecated keys fallback keys and added test coverage. This additional change silences logs for fallback keys by setting the configuration logging to WARN instead of the default INFO.

This avoids spamming the log with unneccessary messages on every reconciliation loop, while still reporting warnings and errors.