### PR TITLE
[FLINK-30593][autoscaler] Improve restart time tracking

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -179,12 +179,6 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
                 jobTopology.getVerticesInTopologicalOrder(),
                 () -> lastEvaluatedMetrics.get(ctx.getJobKey()));
 
-        if (!collectedMetrics.isFullyCollected()) {
-            // We have done an upfront evaluation, but we are not ready for scaling.
-            resetRecommendedParallelism(evaluatedMetrics.getVertexMetrics());
-            return;
-        }
-
         var scalingHistory = getTrimmedScalingHistory(stateStore, ctx, now);
         // A scaling tracking without an end time gets created whenever a scaling decision is
         // applied. Here, when the job transitions to RUNNING, we record the time for it.
@@ -193,6 +187,12 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
                     now, jobTopology, scalingHistory)) {
                 stateStore.storeScalingTracking(ctx, scalingTracking);
             }
+        }
+
+        if (!collectedMetrics.isFullyCollected()) {
+            // We have done an upfront evaluation, but we are not ready for scaling.
+            resetRecommendedParallelism(evaluatedMetrics.getVertexMetrics());
+            return;
         }
 
         var parallelismChanged =

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -183,7 +183,7 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
         // A scaling tracking without an end time gets created whenever a scaling decision is
         // applied. Here, when the job transitions to RUNNING, we record the time for it.
         if (ctx.getJobStatus() == JobStatus.RUNNING) {
-            if (scalingTracking.setEndTimeIfTrackedAndParallelismMatches(
+            if (scalingTracking.recordRestartDurationIfTrackedAndParallelismMatches(
                     now, jobTopology, scalingHistory)) {
                 stateStore.storeScalingTracking(ctx, scalingTracking);
             }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -181,12 +181,11 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
 
         var scalingHistory = getTrimmedScalingHistory(stateStore, ctx, now);
         // A scaling tracking without an end time gets created whenever a scaling decision is
-        // applied. Here, when the job transitions to RUNNING, we record the time for it.
-        if (ctx.getJobStatus() == JobStatus.RUNNING) {
-            if (scalingTracking.recordRestartDurationIfTrackedAndParallelismMatches(
-                    now, jobTopology, scalingHistory)) {
-                stateStore.storeScalingTracking(ctx, scalingTracking);
-            }
+        // applied. Here, we record the end time for it (runScalingLogic is only called when the job
+        // transitions back into the RUNNING state).
+        if (scalingTracking.recordRestartDurationIfTrackedAndParallelismMatches(
+                now, jobTopology, scalingHistory)) {
+            stateStore.storeScalingTracking(ctx, scalingTracking);
         }
 
         if (!collectedMetrics.isFullyCollected()) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -177,6 +177,7 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
             EvaluatedMetrics evaluatedMetrics,
             Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory,
             Duration restartTime) {
+        LOG.debug("Restart time used in scaling summary computation: {}", restartTime);
 
         if (isJobUnderMemoryPressure(context, evaluatedMetrics.getGlobalMetrics())) {
             LOG.info("Skipping vertex scaling due to memory pressure");

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -69,7 +69,7 @@ public class ScalingMetricEvaluator {
 
     public EvaluatedMetrics evaluate(
             Configuration conf, CollectedMetricHistory collectedMetrics, Duration restartTime) {
-
+        LOG.debug("Restart time used in metrics evaluation: {}", restartTime);
         var scalingOutput = new HashMap<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>>();
         var metricsHistory = collectedMetrics.getMetricHistory();
         var topology = collectedMetrics.getJobTopology();

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingRecord.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingRecord.java
@@ -21,7 +21,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.Instant;
+import java.time.Duration;
 
 /**
  * Class for tracking scaling details, including time it took for the job to transition to the
@@ -31,5 +31,5 @@ import java.time.Instant;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ScalingRecord {
-    private Instant endTime;
+    private Duration restartDuration;
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingTracking.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingTracking.java
@@ -100,6 +100,10 @@ public class ScalingTracking {
                                             now);
                                     return true;
                                 }
+                            } else {
+                                LOG.debug(
+                                        "Cannot record end time because already set in the latest record: {}",
+                                        value.getEndTime());
                             }
                             return false;
                         })
@@ -129,7 +133,15 @@ public class ScalingTracking {
                             var vertexID = entry.getKey();
                             var targetParallelism = entry.getValue();
                             var actualParallelism = actualParallelisms.getOrDefault(vertexID, -1);
-                            return actualParallelism.equals(targetParallelism);
+                            boolean isEqual = actualParallelism.equals(targetParallelism);
+                            if (!isEqual) {
+                                LOG.debug(
+                                        "Vertex {} actual parallelism {} does not match target parallelism {}",
+                                        vertexID,
+                                        actualParallelism,
+                                        targetParallelism);
+                            }
+                            return isEqual;
                         });
     }
 
@@ -150,6 +162,7 @@ public class ScalingTracking {
                     maxRestartTime = Math.max(restartTime, maxRestartTime);
                 }
             }
+            LOG.debug("Maximum tracked restart time: {}", maxRestartTime);
         }
         var restartTimeFromConfig = conf.get(AutoScalerOptions.RESTART_TIME);
         long maxRestartTimeFromConfig =

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
@@ -346,7 +346,7 @@ public class BacklogBasedScalingTest {
     }
 
     @Test
-    public void shouldTrackEndOfScalingTimeCorrectly() throws Exception {
+    public void shouldTrackRestartDurationCorrectly() throws Exception {
         var now = Instant.ofEpochMilli(0);
         setClocksTo(now);
         metricsCollector.setJobUpdateTs(now);
@@ -406,7 +406,13 @@ public class BacklogBasedScalingTest {
     private void assertLastTrackingEndTimeIs(Instant expectedEndTime) throws Exception {
         var scalingTracking = stateStore.getScalingTracking(context);
         var latestScalingRecordEntry = scalingTracking.getLatestScalingRecordEntry().get();
-        assertThat(latestScalingRecordEntry.getValue().getEndTime()).isEqualTo(expectedEndTime);
+        var startTime = latestScalingRecordEntry.getKey();
+        var restartDuration = latestScalingRecordEntry.getValue().getRestartDuration();
+        if (expectedEndTime == null) {
+            assertThat(restartDuration).isNull();
+        } else {
+            assertThat(restartDuration).isEqualTo(Duration.between(startTime, expectedEndTime));
+        }
     }
 
     @Test

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -288,11 +288,9 @@ public class ScalingMetricEvaluatorTest {
 
         var scalingTracking = new ScalingTracking();
         scalingTracking.addScalingRecord(
-                Instant.parse("2023-11-15T16:00:00.00Z"),
-                new ScalingRecord(Instant.parse("2023-11-15T16:03:00.00Z")));
+                Instant.parse("2023-11-15T16:00:00.00Z"), new ScalingRecord(Duration.ofMinutes(3)));
         scalingTracking.addScalingRecord(
-                Instant.parse("2023-11-15T16:20:00.00Z"),
-                new ScalingRecord(Instant.parse("2023-11-15T16:25:00.00Z")));
+                Instant.parse("2023-11-15T16:20:00.00Z"), new ScalingRecord(Duration.ofMinutes(5)));
 
         var restartTimeSec = scalingTracking.getMaxRestartTimeOrDefault(conf);
         // Restart time does not factor in


### PR DESCRIPTION
This PR contains the following improvements to the restart tracking logic:
* Adds more debug logs
* Stores restart Duration directly instead of the endTime Instant
* Fixes a bug that makes restart duration tracking dependent on whether metrics are considered fully collected