### PR TITLE
Adding affinity rule.

### DIFF
--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -57,20 +57,19 @@ spec:
       {{- end }}
       {{- if .Values.operatorPod.affinity }}
       affinity:
-        podAntiAffinity:
-          {{ if eq .Values.operatorPod.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
+        podAntiAffinity: {{ if eq .Values.operatorPod.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
           {{ .Values.operatorPod.affinity.type }}:
           - labelSelector:
-              matchExpressions:
-                {{- include "flink-operator.selectorLabels" . | nindent 16 }}
+              matchLabels:
+                {{- include "flink-operator.labels" . | nindent 16 }}
             topologyKey: "kubernetes.io/hostname"
           {{ else }}
           {{ .Values.operatorPod.affinity.type }}:
             - weight: 100
               podAffinityTerm:
                 labelSelector:
-                  matchExpressions:
-                    {{- include "flink-operator.selectorLabels" . | nindent 20 }}
+                  matchLabels:
+                    {{- include "flink-operator.labels" . | nindent 20 }}
                 topologyKey: "kubernetes.io/hostname"
           {{ end }}
       {{- end }}

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -55,6 +55,9 @@ spec:
       {{- if .Values.operatorPod.nodeSelector }}
       nodeSelector: {{ toYaml .Values.operatorPod.nodeSelector | nindent 8 }}
       {{- end }}
+      {{- if .Values.operatorPod.affinity }}
+      affinity: {{ toYaml .Values.operatorPod.affinity | nindent 8 }}
+      {{- end }}
       {{- with .Values.operatorPod.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -56,7 +56,23 @@ spec:
       nodeSelector: {{ toYaml .Values.operatorPod.nodeSelector | nindent 8 }}
       {{- end }}
       {{- if .Values.operatorPod.affinity }}
-      affinity: {{ toYaml .Values.operatorPod.affinity | nindent 8 }}
+      affinity:
+        podAntiAffinity:
+          {{ if eq .Values.operatorPod.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
+          {{ .Values.operatorPod.affinity.type }}:
+          - labelSelector:
+              matchExpressions:
+                {{- include "flink-operator.selectorLabels" . | nindent 16 }}
+            topologyKey: "kubernetes.io/hostname"
+          {{ else }}
+          {{ .Values.operatorPod.affinity.type }}:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    {{- include "flink-operator.selectorLabels" . | nindent 20 }}
+                topologyKey: "kubernetes.io/hostname"
+          {{ end }}
       {{- end }}
       {{- with .Values.operatorPod.tolerations }}
       tolerations:

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -78,6 +78,11 @@ operatorPod:
   # - configMapRef:
   #     name: ""
   nodeSelector: {}
+  affinity:
+    # Set the anti affinity type. Valid values:
+    # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
+    # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
+    type: requiredDuringSchedulingIgnoredDuringExecution  
   # Node tolerations for operator pod assignment
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: []


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Improving the optimization of pod distribution and placement within a Kubernetes cluster is essential for enhancing resource utilization. Affinity proves to be a potent feature for this.

## Brief change log

  - *Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).*
  - *Affinity rule is introduced to the flink-operator.yaml*
  - *Updated values.yaml with affinity value - Set the anti affinity type with default values*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change added tests and can be verified as follows:

  - *Manually verified the change by running a 4 node cluster with multiple replics scaling from 2-10*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (yes)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
  	https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/