### PR TITLE
[FLINK-33917] fix hostname can't be null for certain edgecases

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -126,6 +126,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.kubernetes.operator.api.status.SavepointFormatType.NATIVE;
 import static org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder.FLINK_VERSION;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_FORMAT_TYPE;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -1022,6 +1023,26 @@ public class AbstractFlinkServiceTest {
         try (var socket = new ServerSocket(port)) {
             assertTrue(flinkService.isJobManagerPortReady(configuration));
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {"http://127.0.0.1:8081", "http://dev-test:8081", "http://dev-test.01:8081"})
+    void testValidSocketAddresses(String inputAddress) throws Exception {
+
+        var clusterClient =
+                new TestingClusterClient<String>(configuration) {
+                    @Override
+                    public String getWebInterfaceURL() {
+                        return inputAddress;
+                    }
+                };
+        var flinkService = new TestingService(clusterClient);
+
+        assertDoesNotThrow(
+                () -> {
+                    flinkService.getSocketAddress(clusterClient);
+                });
     }
 
     class TestingService extends AbstractFlinkService {


### PR DESCRIPTION
## What is the purpose of the change
https://issues.apache.org/jira/browse/FLINK-33917

Fix hostname being null under certain edgecases. 


## Brief change log

  - refactor AbstractFlinkService#isJobManagerReady to use URL instead of URI
You can reproduce this locally

```
    @ParameterizedTest
    @ValueSource(
            strings = {"http://127.0.0.1:8081", "http://dev-test:8081", "http://dev-test.01:8081"})
    void testURLAddresses(String inputAddress) {

        assertDoesNotThrow(
                () -> {
                    final URL url = new URL(inputAddress);
                    new InetSocketAddress(url.getHost(), url.getPort());
                });
    }

    @ParameterizedTest
    @ValueSource(
            strings = {"http://127.0.0.1:8081", "http://dev-test:8081", "http://dev-test.01:8081"})
    void testURIAddresses(String inputAddress) {

        assertDoesNotThrow(
                () -> {
                    final URI uri= new URI(inputAddress);
                    new InetSocketAddress(uri.getHost(), uri.getPort());
                });
    }

```

The URL passes all test case but the URI fails on the test case `http://dev-test.01:8081`

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change added tests and can be verified as follows:

*(example:)*
  - *Add new test cases to test different url form factors 
  - *Manually verified that the reconciliation loop still works as expected

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): NO
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:  NO
  - Core observer or reconciler logic that is regularly executed:   YES

## Documentation

  - Does this pull request introduce a new feature? NO
