### PR TITLE
[FLINK-33535] Support autoscaler for session jobs

### DIFF
--- a/docs/content/docs/custom-resource/autoscaler.md
+++ b/docs/content/docs/custom-resource/autoscaler.md
@@ -95,6 +95,8 @@ The autoscaler currently only works with [Flink 1.17](https://hub.docker.com/_/f
    - [Fix logic for determining downstream subtasks for partitioner replacement](https://github.com/apache/flink/commit/fb482fe39844efda33a4c05858903f5b64e158a3)
  - [Support timespan for busyTime metrics](https://github.com/apache/flink/commit/a7fdab8b23cddf568fa32ee7eb804d7c3eb23a35) (good to have)
 
+For session job auto-scaling, a latest custom build of Flink 1.19 or 1.18 is required that contains the fix for [FLINK-33534](https://issues.apache.org/jira/browse/FLINK-33534).
+
 ### Limitations
 
 By default the autoscaler can work for all job vertices in the processing graph.
@@ -199,37 +201,37 @@ For a detailed config reference check the [general configuration page]({{< ref "
 
 ## Extensibility of Autoscaler
 
-The Autoscaler exposes a set of interfaces for storing autoscaler state, handling autoscaling events, 
-and executing scaling decisions. How these are implemented is specific to the orchestration framework 
-used (e.g. Kubernetes), but the interfaces are designed to be as generic as possible. The following 
+The Autoscaler exposes a set of interfaces for storing autoscaler state, handling autoscaling events,
+and executing scaling decisions. How these are implemented is specific to the orchestration framework
+used (e.g. Kubernetes), but the interfaces are designed to be as generic as possible. The following
 are the introduction of these generic interfaces:
 
 - **AutoScalerEventHandler** : Handling autoscaler events, such as: ScalingReport,
   AutoscalerError, etc. `LoggingEventHandler` is the default implementation, it logs events.
-- **AutoScalerStateStore** : Storing all state during scaling. `InMemoryAutoScalerStateStore` is 
-  the default implementation, it's based on the Java Heap, so the state will be discarded after 
+- **AutoScalerStateStore** : Storing all state during scaling. `InMemoryAutoScalerStateStore` is
+  the default implementation, it's based on the Java Heap, so the state will be discarded after
   process restarts. We will implement persistent State Store in the future, such as : `JdbcAutoScalerStateStore`.
 - **ScalingRealizer** : Applying scaling actions.
 - **JobAutoScalerContext** : Including all details related to the current job.
 
 ## Autoscaler Standalone
 
-**Flink Autoscaler Standalone** is an implementation of **Flink Autoscaler**, it runs as a separate java 
-process. It computes the reasonable parallelism of all job vertices by monitoring the metrics, such as: 
+**Flink Autoscaler Standalone** is an implementation of **Flink Autoscaler**, it runs as a separate java
+process. It computes the reasonable parallelism of all job vertices by monitoring the metrics, such as:
 processing rate, busy time, etc.
 
-Flink Autoscaler Standalone rescales flink job in-place by rest api of 
+Flink Autoscaler Standalone rescales flink job in-place by rest api of
 [Externalized Declarative Resource Management](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/elastic_scaling/#externalized-declarative-resource-management).
-`RescaleApiScalingRealizer` is the default implementation of `ScalingRealizer`, it uses the Rescale API 
+`RescaleApiScalingRealizer` is the default implementation of `ScalingRealizer`, it uses the Rescale API
 to apply parallelism changes.
 
-Kubernetes Operator is well integrated with Autoscaler, we strongly recommend using Kubernetes Operator 
-directly for the kubernetes flink jobs, and only flink jobs in non-kubernetes environments use Autoscaler 
+Kubernetes Operator is well integrated with Autoscaler, we strongly recommend using Kubernetes Operator
+directly for the kubernetes flink jobs, and only flink jobs in non-kubernetes environments use Autoscaler
 Standalone.
 
 ### How To Use Autoscaler Standalone
 
-Currently, `Flink Autoscaler Standalone` only supports a single Flink cluster. It can be any type of 
+Currently, `Flink Autoscaler Standalone` only supports a single Flink cluster. It can be any type of
 Flink cluster, includes:
 
 - Flink Standalone Cluster
@@ -272,7 +274,7 @@ In general, the host and port are the same as Flink WebUI.
 
 ### Extensibility of autoscaler standalone
 
-Please click [here]({{< ref "docs/custom-resource/autoscaler#extensibility-of-autoscaler" >}}) 
+Please click [here]({{< ref "docs/custom-resource/autoscaler#extensibility-of-autoscaler" >}})
 to check out extensibility of generic autoscaler.
 
 `Autoscaler Standalone` isn't responsible for job management, so it doesn't have job information.

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -189,7 +189,8 @@ public class FlinkOperator {
         var metricManager =
                 MetricManager.createFlinkSessionJobMetricManager(baseConfig, metricGroup);
         var statusRecorder = StatusRecorder.create(client, metricManager, listeners);
-        var reconciler = new SessionJobReconciler(eventRecorder, statusRecorder);
+        var autoscaler = AutoscalerFactory.create(client, eventRecorder);
+        var reconciler = new SessionJobReconciler(eventRecorder, statusRecorder, autoscaler);
         var observer = new FlinkSessionJobObserver(eventRecorder);
         var canaryResourceManager = new CanaryResourceManager<FlinkSessionJob>(configManager);
         HealthProbe.INSTANCE.registerCanaryResourceManager(canaryResourceManager);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.observer;
 
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.status.JobStatus;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
@@ -55,6 +56,14 @@ public abstract class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
      */
     public boolean observe(FlinkResourceContext<R> ctx) {
         var resource = ctx.getResource();
+        if (resource.getStatus()
+                        .getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getState()
+                == JobState.SUSPENDED) {
+            return false;
+        }
         var jobStatus = resource.getStatus().getJobStatus();
         LOG.debug("Observing job status");
         var previousJobStatus = jobStatus.getState();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -222,11 +222,10 @@ public abstract class AbstractFlinkService implements FlinkService {
     public JobID submitJobToSessionCluster(
             ObjectMeta meta,
             FlinkSessionJobSpec spec,
+            JobID jobID,
             Configuration conf,
             @Nullable String savepoint)
             throws Exception {
-        // we generate jobID in advance to help deduplicate job submission.
-        var jobID = FlinkUtils.generateSessionJobFixedJobID(meta);
         runJar(spec.getJob(), jobID, uploadJar(meta, spec, conf), conf, savepoint);
         LOG.info("Submitted job: {} to session cluster.", jobID);
         return jobID;
@@ -804,7 +803,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                             conf.get(FLINK_VERSION).isNewerVersionThan(FlinkVersion.v1_16)
                                     ? conf.toMap()
                                     : null);
-            LOG.info("Submitting job: {} to session cluster.", jobID.toHexString());
+            LOG.info("Submitting job: {} to session cluster.", jobID);
             clusterClient
                     .sendRequest(headers, parameters, runRequestBody)
                     .get(operatorConfig.getFlinkClientTimeout().toSeconds(), TimeUnit.SECONDS);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -64,6 +64,7 @@ public interface FlinkService {
     JobID submitJobToSessionCluster(
             ObjectMeta meta,
             FlinkSessionJobSpec spec,
+            JobID jobID,
             Configuration conf,
             @Nullable String savepoint)
             throws Exception;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HighAvailabilityOptions;
@@ -32,7 +31,6 @@ import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.rest.messages.DashboardConfigurationHeaders;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
-import org.apache.flink.util.Preconditions;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -43,7 +41,6 @@ import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HTTPGetAction;
 import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Probe;
@@ -61,7 +58,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 
@@ -394,29 +390,6 @@ public class FlinkUtils {
                                 .orElse(Collections.emptyMap()));
         labels.put(CR_GENERATION_LABEL, generation.toString());
         conf.set(KubernetesConfigOptions.JOB_MANAGER_ANNOTATIONS, labels);
-    }
-
-    /**
-     * The jobID's lower part is the resource uid, the higher part is the resource generation.
-     *
-     * @param meta the meta of the resource.
-     * @return the generated jobID.
-     */
-    public static JobID generateSessionJobFixedJobID(ObjectMeta meta) {
-        return generateSessionJobFixedJobID(meta.getUid(), meta.getGeneration());
-    }
-
-    /**
-     * The jobID's lower part is the resource uid, the higher part is the resource generation.
-     *
-     * @param uid the uid of the resource.
-     * @param generation the generation of the resource.
-     * @return the generated jobID.
-     */
-    public static JobID generateSessionJobFixedJobID(String uid, Long generation) {
-        return new JobID(
-                UUID.fromString(Preconditions.checkNotNull(uid)).getMostSignificantBits(),
-                Preconditions.checkNotNull(generation));
     }
 
     /**

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -52,7 +52,6 @@ import org.apache.flink.kubernetes.operator.service.AbstractFlinkService;
 import org.apache.flink.kubernetes.operator.service.CheckpointHistoryWrapper;
 import org.apache.flink.kubernetes.operator.service.NativeFlinkServiceTest;
 import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfigOptionsInternal;
-import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
@@ -251,6 +250,7 @@ public class TestingFlinkService extends AbstractFlinkService {
     public JobID submitJobToSessionCluster(
             ObjectMeta meta,
             FlinkSessionJobSpec spec,
+            JobID jobID,
             Configuration conf,
             @Nullable String savepoint)
             throws Exception {
@@ -258,7 +258,6 @@ public class TestingFlinkService extends AbstractFlinkService {
         if (deployFailure) {
             throw new Exception("Deployment failure");
         }
-        JobID jobID = FlinkUtils.generateSessionJobFixedJobID(meta);
         JobStatusMessage jobStatusMessage =
                 new JobStatusMessage(
                         jobID,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
@@ -116,7 +116,7 @@ class FlinkSessionJobControllerTest {
         updateControl = testController.reconcile(sessionJob, context);
 
         assertEquals(JobStatus.RUNNING.name(), sessionJob.getStatus().getJobStatus().getState());
-        assertEquals(5, testController.getInternalStatusUpdateCount());
+        assertEquals(6, testController.getInternalStatusUpdateCount());
         assertFalse(updateControl.isUpdateStatus());
 
         FlinkSessionJobReconciliationStatus reconciliationStatus =
@@ -574,7 +574,7 @@ class FlinkSessionJobControllerTest {
         // Reconciling
         assertEquals(
                 JobStatus.RECONCILING.name(), sessionJob.getStatus().getJobStatus().getState());
-        assertEquals(3, testController.getInternalStatusUpdateCount());
+        assertEquals(4, testController.getInternalStatusUpdateCount());
         assertFalse(updateControl.isUpdateStatus());
         assertEquals(
                 Optional.of(
@@ -591,7 +591,7 @@ class FlinkSessionJobControllerTest {
         // Running
         updateControl = testController.reconcile(sessionJob, context);
         assertEquals(JobStatus.RUNNING.name(), sessionJob.getStatus().getJobStatus().getState());
-        assertEquals(4, testController.getInternalStatusUpdateCount());
+        assertEquals(5, testController.getInternalStatusUpdateCount());
         assertFalse(updateControl.isUpdateStatus());
         assertEquals(
                 Optional.of(
@@ -601,7 +601,7 @@ class FlinkSessionJobControllerTest {
         // Stable loop
         updateControl = testController.reconcile(sessionJob, context);
         assertEquals(JobStatus.RUNNING.name(), sessionJob.getStatus().getJobStatus().getState());
-        assertEquals(4, testController.getInternalStatusUpdateCount());
+        assertEquals(5, testController.getInternalStatusUpdateCount());
         assertFalse(updateControl.isUpdateStatus());
         assertEquals(
                 Optional.of(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.controller;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.autoscaler.NoopJobAutoscaler;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkResourceContextFactory;
@@ -90,7 +91,8 @@ public class TestingFlinkSessionJobController
                 new FlinkSessionJobController(
                         ValidatorUtils.discoverValidators(configManager),
                         ctxFactory,
-                        new SessionJobReconciler(eventRecorder, statusRecorder),
+                        new SessionJobReconciler(
+                                eventRecorder, statusRecorder, new NoopJobAutoscaler<>()),
                         new FlinkSessionJobObserver(eventRecorder),
                         statusRecorder,
                         eventRecorder,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -197,7 +197,8 @@ public class AbstractFlinkServiceTest {
 
         var job = TestUtils.buildSessionJob();
         var deployConf = configManager.getSessionJobConfig(session, job.getSpec());
-        flinkService.submitJobToSessionCluster(job.getMetadata(), job.getSpec(), deployConf, null);
+        flinkService.submitJobToSessionCluster(
+                job.getMetadata(), job.getSpec(), JobID.generate(), deployConf, null);
 
         // Make sure that deploy conf was passed to jar run
         if (flinkVersion.isNewerVersionThan(FlinkVersion.v1_16)) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
@@ -355,13 +355,6 @@ public class FlinkUtilsTest {
         assertEquals(List.of(v1merged, volume2, volume3), mergedPod.getSpec().getVolumes());
     }
 
-    @Test
-    public void testJobIDGeneration() {
-        JobID jobID =
-                FlinkUtils.generateSessionJobFixedJobID("ffffffff-ffff-ffff-aaaa-aaaaaaaaaaaa", 2L);
-        assertEquals("ffffffffffffffff0000000000000002", jobID.toString());
-    }
-
     private void createHAConfigMapWithData(
             String configMapName, String namespace, String clusterId, Map<String, String> data) {
         final ConfigMap kubernetesConfigMap =


### PR DESCRIPTION
## What is the purpose of the change

This PR resolves some bugs related to the job id management for session jobs which prevent submitting jobs when the spec generation doesn't change (causing a collision and error currently).

This is required for autoscaler support without the rescale api.

## Brief change log

  - *Generate random job ids for session jobs*
  - *Improve / simplify deployment checks and test coverage*


## Verifying this change

Existing and new unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
