### PR TITLE
[FLINK-33930] Canceled stop job status exception

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -304,6 +304,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                         }
                     }
                     deleteClusterDeployment(deployment.getMetadata(), deploymentStatus, conf, true);
+                    deploymentStatus.getJobStatus().setState(JobStatus.CANCELED.name());
                     break;
                 case SAVEPOINT:
                     final String savepointDirectory =
@@ -369,16 +370,17 @@ public abstract class AbstractFlinkService implements FlinkService {
                         deleteClusterDeployment(
                                 deployment.getMetadata(), deploymentStatus, conf, true);
                     }
+                    deploymentStatus.getJobStatus().setState(JobStatus.FINISHED.name());
                     break;
                 case LAST_STATE:
                     deleteClusterDeployment(
                             deployment.getMetadata(), deploymentStatus, conf, false);
+                    deploymentStatus.getJobStatus().setState(JobStatus.FINISHED.name());
                     break;
                 default:
                     throw new RuntimeException("Unsupported upgrade mode " + upgradeMode);
             }
         }
-        deploymentStatus.getJobStatus().setState(JobStatus.FINISHED.name());
         savepointOpt.ifPresent(
                 location -> {
                     Savepoint sp =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -426,6 +426,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                                         TimeUnit.SECONDS);
                         LOG.info("Job successfully cancelled.");
                         break;
+                    jobStatus.setState(JobStatus.Ca.name());
                     case SAVEPOINT:
                         if (ReconciliationUtils.isJobRunning(sessionJobStatus)) {
                             LOG.info("Suspending job with savepoint.");
@@ -467,6 +468,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                                     "Unexpected non-terminal status: " + jobStatus.getState());
                         }
                         break;
+                    jobStatus.setState(JobStatus.FINISHED.name());
                     case LAST_STATE:
                     default:
                         throw new RuntimeException("Unsupported upgrade mode " + upgradeMode);
@@ -476,7 +478,6 @@ public abstract class AbstractFlinkService implements FlinkService {
             LOG.debug("Job is in terminal state, skipping cancel");
         }
 
-        jobStatus.setState(JobStatus.FINISHED.name());
         savepointOpt.ifPresent(
                 location -> {
                     Savepoint sp = Savepoint.of(location, SnapshotTriggerType.UPGRADE);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -424,9 +424,9 @@ public abstract class AbstractFlinkService implements FlinkService {
                                 .get(
                                         operatorConfig.getFlinkCancelJobTimeout().toSeconds(),
                                         TimeUnit.SECONDS);
+                        jobStatus.setState(JobStatus.CANCELED.name());
                         LOG.info("Job successfully cancelled.");
                         break;
-                    jobStatus.setState(JobStatus.Ca.name());
                     case SAVEPOINT:
                         if (ReconciliationUtils.isJobRunning(sessionJobStatus)) {
                             LOG.info("Suspending job with savepoint.");
@@ -450,6 +450,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                                                                         .OPERATOR_SAVEPOINT_FORMAT_TYPE))
                                                 .get(timeout, TimeUnit.SECONDS);
                                 savepointOpt = Optional.of(savepoint);
+                                jobStatus.setState(JobStatus.FINISHED.name());
                                 LOG.info(
                                         "Job successfully suspended with savepoint {}.", savepoint);
                             } catch (TimeoutException exception) {
@@ -468,7 +469,6 @@ public abstract class AbstractFlinkService implements FlinkService {
                                     "Unexpected non-terminal status: " + jobStatus.getState());
                         }
                         break;
-                    jobStatus.setState(JobStatus.FINISHED.name());
                     case LAST_STATE:
                     default:
                         throw new RuntimeException("Unsupported upgrade mode " + upgradeMode);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -288,6 +288,7 @@ public class AbstractFlinkServiceTest {
         assertTrue(cancelFuture.isDone());
         assertEquals(jobID, cancelFuture.get());
         assertNull(jobStatus.getSavepointInfo().getLastSavepoint());
+        assertEquals(org.apache.flink.api.common.JobStatus.CANCELED.name(), jobStatus.getState());
     }
 
     @ParameterizedTest
@@ -455,7 +456,7 @@ public class AbstractFlinkServiceTest {
         assertTrue(stopWithSavepointFuture.isDone());
         assertEquals(jobID, stopWithSavepointFuture.get().f0);
         assertEquals(savepointPath, jobStatus.getSavepointInfo().getLastSavepoint().getLocation());
-        assertEquals(jobStatus.getState(), org.apache.flink.api.common.JobStatus.FINISHED.name());
+        assertEquals(org.apache.flink.api.common.JobStatus.FINISHED.name(), jobStatus.getState());
 
         if (drainOnSavepoint) {
             assertTrue(stopWithSavepointFuture.get().f1);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -487,7 +487,7 @@ public class AbstractFlinkServiceTest {
         JobStatus jobStatus = job.getStatus().getJobStatus();
         jobStatus.setJobId(jobID.toHexString());
         jobStatus.setState(org.apache.flink.api.common.JobStatus.RUNNING.name());
-        ReconciliationUtils.updateStatusForDeployedSpec(job, new Configuration());
+        ReconciliationUtils.updateStatusForDeployedSpec(job, configuration);
 
         var deployConf = configManager.getSessionJobConfig(session, job.getSpec());
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -456,7 +456,7 @@ public class AbstractFlinkServiceTest {
         assertTrue(stopWithSavepointFuture.isDone());
         assertEquals(jobID, stopWithSavepointFuture.get().f0);
         assertEquals(savepointPath, jobStatus.getSavepointInfo().getLastSavepoint().getLocation());
-        assertEquals(org.apache.flink.api.common.JobStatus.FINISHED.name(), jobStatus.getState());
+        assertEquals(jobStatus.getState(), org.apache.flink.api.common.JobStatus.FINISHED.name());
 
         if (drainOnSavepoint) {
             assertTrue(stopWithSavepointFuture.get().f1);
@@ -496,7 +496,7 @@ public class AbstractFlinkServiceTest {
         assertTrue(cancelFuture.isDone());
         assertEquals(jobID, cancelFuture.get());
         assertNull(jobStatus.getSavepointInfo().getLastSavepoint());
-        assertEquals(jobStatus.getState(), org.apache.flink.api.common.JobStatus.CANCELED.name());
+        assertEquals(org.apache.flink.api.common.JobStatus.CANCELED.name(), jobStatus.getState());
     }
 
     @Test


### PR DESCRIPTION
## Brief change log
  - Run flink session job in k8s operator mode. 
  - cancel a job. setState(suspended) & setUppradeMode(STATELESS) use flink k8s api. 
  - But the status of this job will change from completed to canceled.

## Verifying this change
Existing and new unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
