### PR TITLE
[FLINK-33965][autoscaler] Introducing the AutoscalerStandaloneOptions to simplify options for autoscaler standalone

### DIFF
--- a/docs/content/docs/operations/configuration.md
+++ b/docs/content/docs/operations/configuration.md
@@ -134,6 +134,12 @@ Like other resource options these can be configured on both an operator and a pe
 
 {{< generated/auto_scaler_configuration >}}
 
+### Autoscaler Standalone Configuration
+
+Unlike other resource options, these options only work with autoscaler standalone process.
+
+{{< generated/autoscaler_standalone_configuration >}}
+
 ### System Metrics Configuration
 
 Operator system metrics configuration. Cannot be overridden on a per-resource basis.

--- a/docs/layouts/shortcodes/generated/autoscaler_standalone_configuration.html
+++ b/docs/layouts/shortcodes/generated/autoscaler_standalone_configuration.html
@@ -1,0 +1,30 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>autoscaler.standalone.control-loop.interval</h5></td>
+            <td style="word-wrap: break-word;">10 s</td>
+            <td>Duration</td>
+            <td>The interval of autoscaler standalone control loop.</td>
+        </tr>
+        <tr>
+            <td><h5>autoscaler.standalone.fetcher.flink-cluster.host</h5></td>
+            <td style="word-wrap: break-word;">"localhost"</td>
+            <td>String</td>
+            <td>The host name of flink cluster when the flink-cluster fetcher is used.</td>
+        </tr>
+        <tr>
+            <td><h5>autoscaler.standalone.fetcher.flink-cluster.port</h5></td>
+            <td style="word-wrap: break-word;">8081</td>
+            <td>Integer</td>
+            <td>The port of flink cluster when the flink-cluster fetcher is used.</td>
+        </tr>
+    </tbody>
+</table>

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/config/AutoscalerStandaloneOptions.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/config/AutoscalerStandaloneOptions.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.standalone.config;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import java.time.Duration;
+
+/** Config options related to the autoscaler standalone module. */
+public class AutoscalerStandaloneOptions {
+
+    private static final String AUTOSCALER_STANDALONE_CONF_PREFIX = "autoscaler.standalone.";
+
+    private static ConfigOptions.OptionBuilder autoscalerStandaloneConfig(String key) {
+        return ConfigOptions.key(AUTOSCALER_STANDALONE_CONF_PREFIX + key);
+    }
+
+    public static final ConfigOption<Duration> CONTROL_LOOP_INTERVAL =
+            autoscalerStandaloneConfig("control-loop.interval")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(10))
+                    .withDeprecatedKeys("scalingInterval")
+                    .withDescription("The interval of autoscaler standalone control loop.");
+
+    public static final ConfigOption<String> FETCHER_FLINK_CLUSTER_HOST =
+            autoscalerStandaloneConfig("fetcher.flink-cluster.host")
+                    .stringType()
+                    .defaultValue("localhost")
+                    .withDeprecatedKeys("flinkClusterHost")
+                    .withDescription(
+                            "The host name of flink cluster when the flink-cluster fetcher is used.");
+
+    public static final ConfigOption<Integer> FETCHER_FLINK_CLUSTER_PORT =
+            autoscalerStandaloneConfig("fetcher.flink-cluster.port")
+                    .intType()
+                    .defaultValue(8081)
+                    .withDeprecatedKeys("flinkClusterPort")
+                    .withDescription(
+                            "The port of flink cluster when the flink-cluster fetcher is used.");
+}

--- a/flink-kubernetes-docs/pom.xml
+++ b/flink-kubernetes-docs/pom.xml
@@ -49,6 +49,13 @@ under the License.
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-autoscaler-standalone</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/flink-kubernetes-docs/src/main/java/org/apache/flink/kubernetes/operator/docs/configuration/ConfigOptionsDocGenerator.java
+++ b/flink-kubernetes-docs/src/main/java/org/apache/flink/kubernetes/operator/docs/configuration/ConfigOptionsDocGenerator.java
@@ -76,7 +76,10 @@ public class ConfigOptionsDocGenerator {
                 new OptionsClassLocation(
                         "flink-kubernetes-operator",
                         "org.apache.flink.kubernetes.operator.metrics"),
-                new OptionsClassLocation("flink-autoscaler", "org.apache.flink.autoscaler.config")
+                new OptionsClassLocation("flink-autoscaler", "org.apache.flink.autoscaler.config"),
+                new OptionsClassLocation(
+                        "flink-autoscaler-standalone",
+                        "org.apache.flink.autoscaler.standalone.config")
             };
     static final String DEFAULT_PATH_PREFIX = "src/main/java";
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, all configurations of autoscaler standalone are maintained in string key.

When autoscaler standalone has a little options, it's easy to maintain. However, I found it's hard to maintain when we add more options.

During I developing the JDBC autoscaler state store and control loop supports multiple thread. It will introduce more options.




## Brief change log

Introducing the AutoscalerStandaloneOptions to manage all options of autoscaler standalone. And output the doc for it.

- [FLINK-33965][autoscaler] Introducing the AutoscalerStandaloneOptions to simplify options for autoscaler standalone
- [FLINK-33965][autoscaler] Generate the configuration doc for autoscaler standalone

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Generated the docs
