### PR TITLE
[FLINK-33966] Fix the getNumRecordsInPerSecond Utility Function

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -221,7 +221,7 @@ public class ScalingMetrics {
             numRecordsInPerSecond =
                     flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC);
         }
-        if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
+        if (!isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
             numRecordsInPerSecond =
                     flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC);
         }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -216,14 +216,15 @@ public class ScalingMetrics {
             Map<FlinkMetric, AggregatedMetric> flinkMetrics,
             JobVertexID jobVertexID,
             boolean isSource) {
-        // If the vertex is not the source, use NUM_RECORDS_IN_PER_SEC metric
+        // Generate numRecordsInPerSecond from 3 metrics:
+        // 1. If the vertex is not the source, use NUM_RECORDS_IN_PER_SEC metric
         var numRecordsInPerSecond = flinkMetrics.get(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
-        // If the vertex is the source, use SOURCE_TASK_NUM_RECORDS_IN_PER_SEC metric
+        // 2. If the vertex is the source, use SOURCE_TASK_NUM_RECORDS_IN_PER_SEC metric first.
         if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
             numRecordsInPerSecond =
                     flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC);
         }
-        // If the vertex is the source and SOURCE_TASK_NUM_RECORDS_IN_PER_SEC metric not available
+        // 3. If the vertex is the source and SOURCE_TASK_NUM_RECORDS_IN_PER_SEC metric not available
         // then use SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC metric
         if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
             numRecordsInPerSecond =

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -217,14 +217,13 @@ public class ScalingMetrics {
             JobVertexID jobVertexID,
             boolean isSource) {
         var numRecordsInPerSecond = flinkMetrics.get(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
+
+        // If the vertex is the source, then use SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC metric
         if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
-            numRecordsInPerSecond =
-                    flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC);
-        }
-        if (!isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
             numRecordsInPerSecond =
                     flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC);
         }
+
         if (numRecordsInPerSecond == null) {
             LOG.warn("Received null input rate for {}. Returning NaN.", jobVertexID);
             return Double.NaN;

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -219,12 +219,14 @@ public class ScalingMetrics {
         // Generate numRecordsInPerSecond from 3 metrics:
         // 1. If available, directly use the NUM_RECORDS_IN_PER_SEC task metric.
         var numRecordsInPerSecond = flinkMetrics.get(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
-        // 2. If the former is unavailable and the vertex contains a source operator, use the corresponding source operator metric.
+        // 2. If the former is unavailable and the vertex contains a source operator, use the
+        // corresponding source operator metric.
         if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
             numRecordsInPerSecond =
                     flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC);
         }
-        // 3. If the vertex contains a source operator which does not emit input metrics, use output metrics instead.
+        // 3. If the vertex contains a source operator which does not emit input metrics, use output
+        // metrics instead.
         // then use SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC metric
         if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
             numRecordsInPerSecond =

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -217,7 +217,7 @@ public class ScalingMetrics {
             JobVertexID jobVertexID,
             boolean isSource) {
         // Generate numRecordsInPerSecond from 3 metrics:
-        // 1. If the vertex is not the source, use NUM_RECORDS_IN_PER_SEC metric
+        // 1. If available, directly use the NUM_RECORDS_IN_PER_SEC task metric.
         var numRecordsInPerSecond = flinkMetrics.get(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
         // 2. If the vertex is the source, use SOURCE_TASK_NUM_RECORDS_IN_PER_SEC metric first.
         if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -227,7 +227,6 @@ public class ScalingMetrics {
         }
         // 3. If the vertex contains a source operator which does not emit input metrics, use output
         // metrics instead.
-        // then use SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC metric
         if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
             numRecordsInPerSecond =
                     flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -219,7 +219,7 @@ public class ScalingMetrics {
         // Generate numRecordsInPerSecond from 3 metrics:
         // 1. If available, directly use the NUM_RECORDS_IN_PER_SEC task metric.
         var numRecordsInPerSecond = flinkMetrics.get(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
-        // 2. If the vertex is the source, use SOURCE_TASK_NUM_RECORDS_IN_PER_SEC metric first.
+        // 2. If the former is unavailable and the vertex contains a source operator, use the corresponding source operator metric.
         if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
             numRecordsInPerSecond =
                     flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -224,7 +224,7 @@ public class ScalingMetrics {
             numRecordsInPerSecond =
                     flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC);
         }
-        // 3. If the vertex is the source and SOURCE_TASK_NUM_RECORDS_IN_PER_SEC metric not available
+        // 3. If the vertex contains a source operator which does not emit input metrics, use output metrics instead.
         // then use SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC metric
         if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
             numRecordsInPerSecond =

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -216,9 +216,15 @@ public class ScalingMetrics {
             Map<FlinkMetric, AggregatedMetric> flinkMetrics,
             JobVertexID jobVertexID,
             boolean isSource) {
+        // If the vertex is not the source, use NUM_RECORDS_IN_PER_SEC metric
         var numRecordsInPerSecond = flinkMetrics.get(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
-
-        // If the vertex is the source, then use SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC metric
+        // If the vertex is the source, use SOURCE_TASK_NUM_RECORDS_IN_PER_SEC metric
+        if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
+            numRecordsInPerSecond =
+                    flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC);
+        }
+        // If the vertex is the source and SOURCE_TASK_NUM_RECORDS_IN_PER_SEC metric not available
+        // then use SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC metric
         if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
             numRecordsInPerSecond =
                     flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix the getNumRecordsInPerSecond Utility Function to addresses the redundant check and ensures correct metric fetching for non-source operators.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
