### PR TITLE
[FLINK-33814][autoscaler] Autoscaler Standalone control loop supports multiple threads

### DIFF
--- a/docs/layouts/shortcodes/generated/autoscaler_standalone_configuration.html
+++ b/docs/layouts/shortcodes/generated/autoscaler_standalone_configuration.html
@@ -15,6 +15,12 @@
             <td>The interval of autoscaler standalone control loop.</td>
         </tr>
         <tr>
+            <td><h5>autoscaler.standalone.control-loop.parallelism</h5></td>
+            <td style="word-wrap: break-word;">100</td>
+            <td>Integer</td>
+            <td>The parallelism of autoscaler standalone control loop.</td>
+        </tr>
+        <tr>
             <td><h5>autoscaler.standalone.fetcher.flink-cluster.host</h5></td>
             <td style="word-wrap: break-word;">"localhost"</td>
             <td>String</td>

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/JobListFetcher.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/JobListFetcher.java
@@ -20,11 +20,11 @@ package org.apache.flink.autoscaler.standalone;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.autoscaler.JobAutoScalerContext;
 
-import java.util.List;
+import java.util.Collection;
 
 /** The JobListFetcher will fetch the jobContext of all jobs. */
 @Experimental
 public interface JobListFetcher<KEY, Context extends JobAutoScalerContext<KEY>> {
 
-    List<Context> fetch() throws Exception;
+    Collection<Context> fetch() throws Exception;
 }

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerEntrypoint.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerEntrypoint.java
@@ -39,7 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.FLINK_CLIENT_TIMEOUT;
-import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.CONTROL_LOOP_INTERVAL;
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.FETCHER_FLINK_CLUSTER_HOST;
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.FETCHER_FLINK_CLUSTER_PORT;
 
@@ -59,8 +58,7 @@ public class StandaloneAutoscalerEntrypoint {
         var autoScaler = createJobAutoscaler(eventHandler);
 
         var autoscalerExecutor =
-                new StandaloneAutoscalerExecutor<>(
-                        conf.get(CONTROL_LOOP_INTERVAL), jobListFetcher, eventHandler, autoScaler);
+                new StandaloneAutoscalerExecutor<>(conf, jobListFetcher, eventHandler, autoScaler);
         autoscalerExecutor.start();
     }
 

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/config/AutoscalerStandaloneOptions.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/config/AutoscalerStandaloneOptions.java
@@ -38,6 +38,12 @@ public class AutoscalerStandaloneOptions {
                     .withDeprecatedKeys("scalingInterval")
                     .withDescription("The interval of autoscaler standalone control loop.");
 
+    public static final ConfigOption<Integer> CONTROL_LOOP_PARALLELISM =
+            autoscalerStandaloneConfig("control-loop.parallelism")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription("The parallelism of autoscaler standalone control loop.");
+
     public static final ConfigOption<String> FETCHER_FLINK_CLUSTER_HOST =
             autoscalerStandaloneConfig("fetcher.flink-cluster.host")
                     .stringType()

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/flinkcluster/FlinkClusterJobListFetcher.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/flinkcluster/FlinkClusterJobListFetcher.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.rest.messages.job.JobManagerJobConfigurationHead
 import org.apache.flink.util.function.FunctionWithException;
 
 import java.time.Duration;
-import java.util.List;
+import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -51,7 +51,7 @@ public class FlinkClusterJobListFetcher
     }
 
     @Override
-    public List<JobAutoScalerContext<JobID>> fetch() throws Exception {
+    public Collection<JobAutoScalerContext<JobID>> fetch() throws Exception {
         try (var restClusterClient = restClientGetter.apply(new Configuration())) {
             return restClusterClient
                     .listJobs()

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/realizer/RescaleApiScalingRealizerTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/realizer/RescaleApiScalingRealizerTest.java
@@ -99,7 +99,7 @@ class RescaleApiScalingRealizerTest {
                     .isCompletedWithValue(
                             Optional.of(createResourceRequirements(newResourceRequirements)));
             assertThat(eventCollector.events).hasSize(1);
-            var event = eventCollector.events.getFirst();
+            var event = eventCollector.events.peek();
             assertThat(event.getContext()).isEqualTo(jobContext);
             assertThat(event.getReason()).isEqualTo(SCALING);
         } else {

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/event/TestingEventCollector.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/event/TestingEventCollector.java
@@ -26,10 +26,11 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_ENABLED;
 
@@ -37,7 +38,7 @@ import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_ENABL
 public class TestingEventCollector<KEY, Context extends JobAutoScalerContext<KEY>>
         implements AutoScalerEventHandler<KEY, Context> {
 
-    public final LinkedList<Event<KEY, Context>> events = new LinkedList<>();
+    public final Queue<Event<KEY, Context>> events = new LinkedBlockingQueue<>();
 
     public final Map<String, Event<KEY, Context>> eventMap = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
## What is the purpose of the change

When the job list has a lot of jobs, single thread isn't enough. So Autoscaler Standalone control loop supports multiple thread is very useful for massive production, it's similar to `kubernetes.operator.reconcile.parallelism`.


## Brief change log

Introduce `autoscaler.standalone.control-loop.parallelism`.

## Verifying this change

  - Added `StandaloneAutoscalerExecutorTest#testScalingParallelism`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
