### PR TITLE
[hotfix][autoscaler] Fix the StandaloneAutoscalerExecutorTest.testScaling fails occasionally due to race condition

### DIFF
--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
@@ -133,7 +133,8 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
         }
     }
 
-    private void scalingSingleJob(Context jobContext) {
+    @VisibleForTesting
+    protected void scalingSingleJob(Context jobContext) {
         try {
             autoScaler.scale(jobContext);
         } catch (Throwable e) {

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutorTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutorTest.java
@@ -93,7 +93,7 @@ class StandaloneAutoscalerExecutorTest {
                 }) {
 
             autoscalerExecutor.scaling();
-            // Wait for all scalings are finished.
+            // Wait for all scalings to go finished.
             countDownLatch.await();
 
             assertThat(actualScaleContexts).isEqualTo(jobList);


### PR DESCRIPTION
Sorry for this fix!

After #744 is merged, I rebased it. During developing other features, I found `StandaloneAutoscalerExecutorTest.testScaling fails occasionally due to race condition`.

Here is my fork repo, it fails with :

https://github.com/1996fanrui/flink-kubernetes-operator/actions/runs/7405774151/job/20149240482#step:5:22232

```
Error:  Failures: 
Error:    StandaloneAutoscalerExecutorTest.testScaling:93 
Actual and expected should have same size but actual size is:
  1
while expected size is:
  2
Actual was:
  [org.apache.flink.autoscaler.event.TestingEventCollector$Event@6b580b88,
    org.apache.flink.autoscaler.event.TestingEventCollector$Event@6d91790b]
Expected was:
  [9fe5243cd23e0727710fcd0b4d423970, 9eec17388e32cb02ec205ac9f638e2fe]
```

From this log, we know the reason is race condition. The Actual was has 2 events, but when we check the actual size, it was one.

## Why it fails occasionally?


https://github.com/apache/flink-kubernetes-operator/pull/744 supports multiple threads for autoscaler standalone, and the scaling control loop thread doesn't wait for the actual scaling of all jobs.

So I introduced the `CountDownLatch` to let test wait all scaling are finished. But the `eventHandler.handleEvent` is called inside of the `scalingSingleJob`. We should call `countDownLatch.countDown();` after `scalingSingleJob`.