### PR TITLE
[FLINK-33993] Fix misleading events for scaling effectiveness detection

### DIFF
--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -431,7 +431,9 @@ public class JobVertexScalerTest {
         var event = eventCollector.events.poll();
         assertThat(event).isNotNull();
         assertThat(event.getMessage())
-                .isEqualTo(String.format(INEFFECTIVE_MESSAGE_FORMAT, jobVertexID));
+                .isEqualTo(
+                        String.format(
+                                INEFFECTIVE_MESSAGE_FORMAT, jobVertexID, 90.0, 5.0, "enabled"));
         assertThat(event.getReason()).isEqualTo(INEFFECTIVE_SCALING);
         assertEquals(1, event.getCount());
 
@@ -463,9 +465,26 @@ public class JobVertexScalerTest {
         event = eventCollector.events.poll();
         assertThat(event).isNotNull();
         assertThat(event.getMessage())
-                .isEqualTo(String.format(INEFFECTIVE_MESSAGE_FORMAT, jobVertexID));
+                .isEqualTo(
+                        String.format(
+                                INEFFECTIVE_MESSAGE_FORMAT, jobVertexID, 90.0, 5.0, "enabled"));
         assertThat(event.getReason()).isEqualTo(INEFFECTIVE_SCALING);
         assertEquals(2, event.getCount());
+
+        // Test ineffective scaling switched off
+        conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, false);
+        assertEquals(
+                40,
+                vertexScaler.computeScaleTargetParallelism(
+                        context, jobVertexID, evaluated, history, restartTime));
+        assertEquals(1, eventCollector.events.size());
+        event = eventCollector.events.poll();
+        assertThat(event).isNotNull();
+        assertThat(event.getMessage())
+                .isEqualTo(
+                        String.format(
+                                INEFFECTIVE_MESSAGE_FORMAT, jobVertexID, 90.0, 5.0, "disabled"));
+        assertThat(event.getReason()).isEqualTo(INEFFECTIVE_SCALING);
     }
 
     private Map<ScalingMetric, EvaluatedScalingMetric> evaluated(


### PR DESCRIPTION
When the ineffective scaling decision feature is turned off, events are regenerated which look like this:

```
Skipping further scale up after ineffective previous scale up for 65c763af14a952c064c400d516c25529
```

This is misleading because no action will be taken. It is fair to inform users about ineffective scale up even when the feature is disabled but a different message should be printed to convey that no action will be taken.