### PR TITLE
[FLINK-34021][autoscaler] Print jobKey in the Autoscaler standalone log

### DIFF
--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
@@ -28,6 +28,7 @@ import org.apache.flink.shaded.guava30.com.google.common.util.concurrent.ThreadF
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import javax.annotation.Nonnull;
 
@@ -136,6 +137,7 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
     @VisibleForTesting
     protected void scalingSingleJob(Context jobContext) {
         try {
+            MDC.put("job.key", jobContext.getJobKey().toString());
             autoScaler.scale(jobContext);
         } catch (Throwable e) {
             LOG.error("Error while scaling job", e);
@@ -146,6 +148,8 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
                     e.getMessage(),
                     null,
                     null);
+        } finally {
+            MDC.clear();
         }
     }
 }

--- a/flink-autoscaler-standalone/src/main/resources/log4j2.properties
+++ b/flink-autoscaler-standalone/src/main/resources/log4j2.properties
@@ -23,5 +23,5 @@ rootLogger.appenderRef.console.ref = ConsoleAppender
 appender.console.name = ConsoleAppender
 appender.console.type = CONSOLE
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %style{%d}{yellow} %style{%-30c{1.}}{cyan} %highlight{[%-5level] [%X{resource.namespace}.%X{resource.name}] %msg%n%throwable}
+appender.console.layout.pattern = %style{%d}{yellow} %style{%-30c{1.}}{cyan} %highlight{[%-5level] [%X{job.key}] %msg%n%throwable}
 


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-33814](https://issues.apache.org/jira/browse/FLINK-33814) has supported the multiple threads scaling for autoscaler standalone. When a lot of jobs are scaling, autoscaler standalone will print too many logs. Currently, all logs don't have the job key, it's hard to maintain.

## Brief change log

- [FLINK-34021][autoscaler] Print jobKey in the Autoscaler standalone log
  - Add `job.key` to the MDC
  - `log4j.properties` print the `job.key`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed:  no

## Documentation

  - Does this pull request introduce a new feature? no

