### PR TITLE
Fix Typo in Standalone Autoscaler Documentation

### DIFF
--- a/flink-autoscaler-standalone/README.md
+++ b/flink-autoscaler-standalone/README.md
@@ -33,7 +33,7 @@ It can be any type of Flink cluster, includes:
 You can start a Flink Streaming job with the following ConfigOptions.
 
 ```
-# Enable Adaptvie scheduler to play the in-place rescaling.
+# Enable Adaptive scheduler to play the in-place rescaling.
 jobmanager.scheduler : adaptive
 
 # Enable autoscale and scaling


### PR DESCRIPTION
## What is the purpose of the change

Fix a minor typo in `Adaptive` word in Standalone Autoscaler Documentation. 

## Brief change log

Doc update

## Verifying this change
N/A

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no 
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no) no
  - Core observer or reconciler logic that is regularly executed: (yes / no) no 

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no 
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) N/A
