### PR TITLE
[FLINK-33006] add e2e for Flink operator HA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           - test_sessionjob_operations.sh
           - test_multi_sessionjob.sh
           - test_autoscaler.sh
+          - test_flink_operator_ha.sh
         include:
           - namespace: flink
             extraArgs: '--create-namespace --set "watchNamespaces={default,flink}"'
@@ -113,12 +114,18 @@ jobs:
             test: test_autoscaler.sh
           - version: v1_15
             test: test_dynamic_config.sh
+          - version: v1_15
+            test: test_flink_operator_ha.sh
           - version: v1_16
             test: test_autoscaler.sh
           - version: v1_16
             test: test_dynamic_config.sh
+          - version: v1_16
+            test: test_flink_operator_ha.sh
           - version: v1_17
             test: test_dynamic_config.sh
+          - version: v1_17
+            test: test_flink_operator_ha.sh
           - version: v1_15
             java-version: 17
           - version: v1_16
@@ -164,9 +171,14 @@ jobs:
           docker images
       - name: Start the operator
         run: |
+          if [[ "${{ matrix.test }}" == "test_flink_operator_ha.sh" ]]; then
+            sed -i "s/# kubernetes.operator.leader-election.enabled: false/kubernetes.operator.leader-election.enabled: true/" helm/flink-kubernetes-operator/conf/flink-conf.yaml
+            sed -i "s/# kubernetes.operator.leader-election.lease-name: flink-operator-lease/kubernetes.operator.leader-election.lease-name: flink-operator-lease/" helm/flink-kubernetes-operator/conf/flink-conf.yaml
+            sed -i "s/replicas: 1/replicas: 2/" helm/flink-kubernetes-operator/values.yaml
+          fi 
           helm --debug install flink-kubernetes-operator -n ${{ matrix.namespace }} helm/flink-kubernetes-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-latest ${{ matrix.extraArgs }}
           kubectl wait --for=condition=Available --timeout=120s -n ${{ matrix.namespace }} deploy/flink-kubernetes-operator
-          kubectl get pods
+          kubectl get pods -n ${{ matrix.namespace }}
       - name: Run Flink e2e tests
         run: |
           sed -i "s/image: flink:.*/image: ${{ matrix.image }}/" e2e-tests/data/*.yaml

--- a/e2e-tests/test_dynamic_config.sh
+++ b/e2e-tests/test_dynamic_config.sh
@@ -28,11 +28,13 @@ on_exit operator_cleanup_and_exit
 
 TIMEOUT=360
 
-operator_namespace=${get_operator_pod_namespace}
+operator_namespace=$(get_operator_pod_namespace)
+operator_pod=$(get_operator_pod_name)
+echo "Current operator pod is ${operator_pod}"
 create_namespace dynamic
 
 kubectl config set-context --current --namespace="${operator_namespace}"
 patch_flink_config '{"data": {"flink-conf.yaml": "kubernetes.operator.watched.namespaces: default,flink,dynamic"}}'
-wait_for_operator_logs "Setting default configuration to {kubernetes.operator.watched.namespaces=default,flink,dynamic}" ${TIMEOUT} || exit 1
+wait_for_operator_logs "${operator_pod}" "Setting default configuration to {kubernetes.operator.watched.namespaces=default,flink,dynamic}" ${TIMEOUT} || exit 1
 
 echo "Successfully run the dynamic property test"

--- a/e2e-tests/test_flink_operator_ha.sh
+++ b/e2e-tests/test_flink_operator_ha.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#######################
+
+# This script tests the operator HA:
+# 1. Deploy a new flink deployment and wait for job manager to come up
+# 2. Verify the operator log on existing leader
+# 3. Delete the leader operator pod
+# 4. Verify the new leader is different with the old one
+# 5. Check operator log for the flink deployment in the new leader
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_DIR}/utils.sh"
+
+CLUSTER_ID="flink-example-statemachine"
+APPLICATION_YAML="${SCRIPT_DIR}/data/flinkdep-cr.yaml"
+TIMEOUT=300
+
+on_exit cleanup_and_exit "$APPLICATION_YAML" $TIMEOUT $CLUSTER_ID
+
+retry_times 5 30 "kubectl apply -f $APPLICATION_YAML" || exit 1
+
+wait_for_jobmanager_running $CLUSTER_ID $TIMEOUT
+jm_pod_name=$(get_jm_pod_name $CLUSTER_ID)
+
+wait_for_logs $jm_pod_name "Completed checkpoint [0-9]+ for job" ${TIMEOUT} || exit 1
+wait_for_status flinkdep/flink-example-statemachine '.status.jobManagerDeploymentStatus' READY ${TIMEOUT} || exit 1
+wait_for_status flinkdep/flink-example-statemachine '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
+
+job_id=$(kubectl logs $jm_pod_name -c flink-main-container | grep -E -o 'Job [a-z0-9]+ is submitted' | awk '{print $2}')
+
+
+# Verify operator status
+operator_namespace=$(get_operator_pod_namespace)
+display_current_lease_info
+old_operator_leader=$(find_operator_pod_with_leadership)
+
+echo "Current operator pod with leadership is ${old_operator_leader}"
+wait_for_operator_logs "${old_operator_leader}" ".default/flink-example-statemachine. Resource fully reconciled, nothing to do" ${TIMEOUT} || exit 1
+
+# Delete the leader operator pod
+delete_operator_pod_with_leadership
+
+# Wait for 20 seconds for leader election
+sleep 20
+display_current_lease_info
+new_operator_leader=$(find_operator_pod_with_leadership)
+echo "Current operator pod with leadership is ${new_operator_leader}"
+
+if [ "${new_operator_leader}" == "${old_operator_leader}" ];then
+  echo "The new operator pod with leadership is the same as old operator pod. New operator pod haven't acquire leadership"
+  exit 1
+fi
+
+wait_for_operator_logs "${new_operator_leader}" ".default/flink-example-statemachine. Resource fully reconciled, nothing to do" ${TIMEOUT} || exit 1
+echo "Successfully run the Flink Kubernetes application HA test in the new operator leader"


### PR DESCRIPTION
## What is the purpose of the change

Add E2E for Flink operator high availability to verify whether the flink deployment core logic function well when the leader operator instance is deleted.


## Brief change log
  - Add delete_operator_pod_with_leadership in util.sh
  - Add the test_flink_operator_ha.sh for the testing
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
