### PR TITLE
[FLINK-34104][autoscaler] Improve the ScalingReport format of autoscaling

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoScalerEventHandler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoScalerEventHandler.java
@@ -40,7 +40,7 @@ import static org.apache.flink.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_
 @Experimental
 public interface AutoScalerEventHandler<KEY, Context extends JobAutoScalerContext<KEY>> {
     String SCALING_SUMMARY_ENTRY =
-            " Vertex ID %s | Parallelism %d -> %d | Processing capacity %.2f -> %.2f | Target data rate %.2f";
+            "{ Vertex ID %s | Parallelism %d -> %d | Processing capacity %.2f -> %.2f | Target data rate %.2f}";
     String SCALING_EXECUTION_DISABLED_REASON = "%s:%s, recommended parallelism change:";
     String SCALING_SUMMARY_HEADER_SCALING_EXECUTION_DISABLED =
             "Scaling execution disabled by config ";

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoscalerEventUtils.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoscalerEventUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.event;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/** The utils of {@link AutoScalerEventHandler}. */
+@Experimental
+public class AutoscalerEventUtils {
+
+    private static final Pattern SCALING_REPORT_SEPARATOR = Pattern.compile("\\{(.+?)\\}");
+    private static final Pattern VERTEX_SCALING_REPORT_PATTERN =
+            Pattern.compile(
+                    "Vertex ID (.*?) \\| Parallelism (.*?) -> (.*?) \\| Processing capacity (.*?) -> (.*?) \\| Target data rate (.*)");
+
+    /** Parse the scaling report from original scaling report event. */
+    public static List<VertexScalingReport> parseVertexScalingReports(String scalingReport) {
+        final List<String> originalVertexScalingReports =
+                extractOriginalVertexScalingReports(scalingReport);
+        return originalVertexScalingReports.stream()
+                .map(AutoscalerEventUtils::extractVertexScalingReport)
+                .collect(Collectors.toList());
+    }
+
+    private static List<String> extractOriginalVertexScalingReports(String scalingReport) {
+        var result = new ArrayList<String>();
+        var m = SCALING_REPORT_SEPARATOR.matcher(scalingReport);
+
+        while (m.find()) {
+            result.add(m.group(1));
+        }
+        return result;
+    }
+
+    private static VertexScalingReport extractVertexScalingReport(String vertexScalingReportStr) {
+        final var vertexScalingReport = new VertexScalingReport();
+        var m = VERTEX_SCALING_REPORT_PATTERN.matcher(vertexScalingReportStr);
+
+        if (m.find()) {
+            vertexScalingReport.setVertexId(m.group(1));
+            vertexScalingReport.setCurrentParallelism(Integer.parseInt(m.group(2)));
+            vertexScalingReport.setNewParallelism(Integer.parseInt(m.group(3)));
+            vertexScalingReport.setCurrentProcessCapacity(Double.parseDouble(m.group(4)));
+            vertexScalingReport.setExpectedProcessCapacity(Double.parseDouble(m.group(5)));
+            vertexScalingReport.setTargetDataRate(Double.parseDouble(m.group(6)));
+        }
+        return vertexScalingReport;
+    }
+}

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/VertexScalingReport.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/VertexScalingReport.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.event;
+
+import org.apache.flink.annotation.Experimental;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** The scaling report of single vertex. */
+@Experimental
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VertexScalingReport {
+
+    private String vertexId;
+
+    private int currentParallelism;
+
+    private int newParallelism;
+
+    private double currentProcessCapacity;
+
+    private double expectedProcessCapacity;
+
+    private double targetDataRate;
+}

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/event/AutoScalerEventHandlerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/event/AutoScalerEventHandlerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.event;
+
+import org.apache.flink.autoscaler.ScalingSummary;
+import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.EXPECTED_PROCESSING_RATE;
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.TARGET_DATA_RATE;
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_RATE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link AutoScalerEventHandler}. */
+class AutoScalerEventHandlerTest {
+
+    @Test
+    void testScalingReport() {
+        var expectedJson =
+                "Scaling execution enabled, begin scaling vertices:"
+                        + "{ Vertex ID ea632d67b7d595e5b851708ae9ad79d6 | Parallelism 3 -> 1 | "
+                        + "Processing capacity 424.68 -> 123.40 | Target data rate 403.67}"
+                        + "{ Vertex ID bc764cd8ddf7a0cff126f51c16239658 | Parallelism 4 -> 2 | "
+                        + "Processing capacity Infinity -> Infinity | Target data rate 812.58}"
+                        + "{ Vertex ID 0a448493b4782967b150582570326227 | Parallelism 5 -> 8 | "
+                        + "Processing capacity 404.73 -> 645.00 | Target data rate 404.27}";
+
+        final var scalingSummaries = buildScalingSummaries();
+        assertThat(
+                        AutoScalerEventHandler.scalingReport(
+                                scalingSummaries,
+                                AutoScalerEventHandler
+                                        .SCALING_SUMMARY_HEADER_SCALING_EXECUTION_ENABLED))
+                .isEqualTo(expectedJson);
+
+        assertThat(AutoscalerEventUtils.parseVertexScalingReports(expectedJson))
+                .containsExactlyInAnyOrderElementsOf(buildExpectedScalingResults());
+    }
+
+    private HashMap<JobVertexID, ScalingSummary> buildScalingSummaries() {
+        final var jobVertex1 = JobVertexID.fromHexString("0a448493b4782967b150582570326227");
+        final var jobVertex2 = JobVertexID.fromHexString("bc764cd8ddf7a0cff126f51c16239658");
+        final var jobVertex3 = JobVertexID.fromHexString("ea632d67b7d595e5b851708ae9ad79d6");
+
+        final var scalingSummaries = new HashMap<JobVertexID, ScalingSummary>();
+        scalingSummaries.put(
+                jobVertex2,
+                generateScalingSummary(
+                        4, 2, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY, 812.583));
+        scalingSummaries.put(jobVertex3, generateScalingSummary(3, 1, 424.678, 123.4, 403.673));
+        scalingSummaries.put(jobVertex1, generateScalingSummary(5, 8, 404.727, 645.0, 404.268));
+
+        return scalingSummaries;
+    }
+
+    private List<VertexScalingReport> buildExpectedScalingResults() {
+        return List.of(
+                new VertexScalingReport(
+                        "0a448493b4782967b150582570326227", 5, 8, 404.73, 645.0, 404.27),
+                new VertexScalingReport(
+                        "bc764cd8ddf7a0cff126f51c16239658",
+                        4,
+                        2,
+                        Double.POSITIVE_INFINITY,
+                        Double.POSITIVE_INFINITY,
+                        812.58),
+                new VertexScalingReport(
+                        "ea632d67b7d595e5b851708ae9ad79d6", 3, 1, 424.68, 123.4, 403.67));
+    }
+
+    private ScalingSummary generateScalingSummary(
+            int currentParallelism,
+            int newParallelism,
+            double currentProcessCapacity,
+            double expectedProcessCapacity,
+            double targetDataRate) {
+        final var scalingSummary = new ScalingSummary();
+        scalingSummary.setCurrentParallelism(currentParallelism);
+        scalingSummary.setNewParallelism(newParallelism);
+
+        final var metrics =
+                Map.of(
+                        TRUE_PROCESSING_RATE,
+                        new EvaluatedScalingMetric(400, currentProcessCapacity),
+                        EXPECTED_PROCESSING_RATE,
+                        new EvaluatedScalingMetric(expectedProcessCapacity, 400),
+                        TARGET_DATA_RATE,
+                        new EvaluatedScalingMetric(400, targetDataRate));
+        scalingSummary.setMetrics(metrics);
+        return scalingSummary;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently, the scaling report format is  `Vertex ID %s | Parallelism %d -> %d | Processing capacity %.2f -> %.2f | Target data rate %.2f`.

It has 2 disadvantages:

1. When one job has multiple vertices, the report of all vertices are mixed together without any separator, here is an example:
    - `Scaling execution enabled, begin scaling vertices: Vertex ID ea632d67b7d595e5b851708ae9ad79d6 | Parallelism 2 -> 1 | Processing capacity 800466.67 -> 320186.67 | Target data rate 715.10 Vertex ID bc764cd8ddf7a0cff126f51c16239658 | Parallelism 2 -> 1 | Processing capacity 79252.08 -> 31700.83 | Target data rate 895.93 Vertex ID 0a448493b4782967b150582570326227 | Parallelism 8 -> 16 | Processing capacity 716.05 -> 1141.00 | Target data rate 715.54`
    - We can see the Vertex ID is the beginning of each vertex report, it doesn't have any separator with the last vertex.
2. This format is non-standard, it's hard to deserialize.
    - When job enables the autoscaler and disable the scaling.
    - Flink platform maintainer wants to show the scaling report in WebUI, it's helpful to using the report result for flink users.
    - So easy to deserialize is useful for these flink platform.

## Brief change log

- [FLINK-34104][autoscaler] Improve the ScalingReport format of autoscaling
    - Adding the `{` and `}` as the separator between multiple vertices.
        - Here is the scaling report message after this PR:  ``Scaling execution enabled, begin scaling vertices:{ Vertex ID ea632d67b7d595e5b851708ae9ad79d6 | Parallelism 2 -> 1 | Processing capacity 800466.67 -> 320186.67 | Target data rate 715.10}{ Vertex ID bc764cd8ddf7a0cff126f51c16239658 | Parallelism 2 -> 1 | Processing capacity 79252.08 -> 31700.83 | Target data rate 895.93}{ Vertex ID 0a448493b4782967b150582570326227 | Parallelism 8 -> 16 | Processing capacity 716.05 -> 1141.00 | Target data rate 715.54}``.
    - Adding the `AutoscalerEventUtils` to easy deserialize the `ScalingReport` message.



## Verifying this change

  - Added `AutoScalerEventHandlerTest` to test the ScalingReport can be deserialized.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no

