### PR TITLE
[FLINK-34131] Ensure cluster.health-check.checkpoint-progress.window is well configure

### DIFF
--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
@@ -170,7 +170,9 @@ public class BaseTestUtils {
                 KubernetesHaServicesFactory.class.getCanonicalName());
         conf.put(HighAvailabilityOptions.HA_STORAGE_PATH.key(), "test");
         conf.put(CheckpointingOptions.SAVEPOINT_DIRECTORY.key(), "test-savepoint-dir");
-        conf.put(CheckpointingOptions.CHECKPOINTS_DIRECTORY.key(), "test-checkpoint-dir");
+        conf.put(
+                CheckpointingOptions.CHECKPOINTS_DIRECTORY.key(),
+                "file:///test/test-checkpoint-dir");
 
         return FlinkDeploymentSpec.builder()
                 .image(IMAGE)

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -73,7 +73,7 @@ public class TestingFlinkDeploymentController
 
     @Getter private TestingFlinkResourceContextFactory contextFactory;
 
-    private StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder;
+    @Getter private StatusRecorder<FlinkDeployment, FlinkDeploymentStatus> statusRecorder;
     @Getter private CanaryResourceManager<FlinkDeployment> canaryResourceManager;
 
     private Map<ResourceID, Tuple2<FlinkDeploymentSpec, Long>> currentGenerations = new HashMap<>();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add a check on the cluster.health-check.checkpoint-progress.window before to access if the cluster is healthy from checkpointing

cluster.health-check.checkpoint-progress.window must be greater than max(execution.checkpointing.interval * execution.checkpointing.tolerable-failed-checkpoints, execution.checkpointing.timeout * execution.checkpointing.tolerable-failed-checkpoints)

If it is below it can leads to unwanted restart of the flink cluster

## Brief change log

  - *Ensure cluster.health-check.checkpoint-progress.window is well configure*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
*(Please pick either of the following options)*

This change added tests and can be verified as follows:

  - *Added unittest ensuring the checkpoint evalutaion is always true if the window value is not well configured*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
