### PR TITLE
[FLINK-34178][autoscaler] Fix the bug that observed scaling restart time is always great than `stabilization.interval`

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
@@ -149,10 +149,10 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
         if (isStabilizing) {
             LOG.info("Stabilizing until {}", readable(stableTime));
             stateStore.storeCollectedMetrics(ctx, metricHistory);
-            return new CollectedMetricHistory(topology, Collections.emptySortedMap());
+            return new CollectedMetricHistory(topology, Collections.emptySortedMap(), jobRunningTs);
         }
 
-        var collectedMetrics = new CollectedMetricHistory(topology, metricHistory);
+        var collectedMetrics = new CollectedMetricHistory(topology, metricHistory, jobRunningTs);
         if (now.isBefore(windowFullTime)) {
             LOG.info("Metric window not full until {}", readable(windowFullTime));
         } else {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingTracking.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingTracking.java
@@ -69,7 +69,8 @@ public class ScalingTracking {
      * Sets restart duration for the latest scaling record if its parallelism matches the current
      * job parallelism.
      *
-     * @param now The instant to be used as the end time when calculating the restart duration.
+     * @param jobRunningTs The instant when the JobStatus is switched to RUNNING, it will be used as
+     *     the end time when calculating the restart duration.
      * @param jobTopology The current job topology containing details of the job's parallelism.
      * @param scalingHistory The scaling history.
      * @return true if the restart duration is successfully recorded, false if the restart duration
@@ -77,7 +78,7 @@ public class ScalingTracking {
      *     not match the actual parallelism.
      */
     public boolean recordRestartDurationIfTrackedAndParallelismMatches(
-            Instant now,
+            Instant jobRunningTs,
             JobTopology jobTopology,
             Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory) {
         return getLatestScalingRecordEntry()
@@ -94,12 +95,13 @@ public class ScalingTracking {
                                 if (targetParallelismMatchesActual(
                                         targetParallelism, actualParallelism)) {
                                     value.setRestartDuration(
-                                            Duration.between(scalingTimestamp, now));
+                                            Duration.between(scalingTimestamp, jobRunningTs));
                                     LOG.debug(
                                             "Recorded restart duration of {} seconds (from {} till {})",
-                                            Duration.between(scalingTimestamp, now).getSeconds(),
+                                            Duration.between(scalingTimestamp, jobRunningTs)
+                                                    .getSeconds(),
                                             scalingTimestamp,
-                                            now);
+                                            jobRunningTs);
                                     return true;
                                 }
                             } else {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/CollectedMetricHistory.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/CollectedMetricHistory.java
@@ -30,5 +30,6 @@ import java.util.SortedMap;
 public class CollectedMetricHistory {
     final JobTopology jobTopology;
     final SortedMap<Instant, CollectedMetrics> metricHistory;
+    final Instant jobRunningTs;
     @Setter private boolean fullyCollected;
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
@@ -398,9 +398,12 @@ public class BacklogBasedScalingTest {
                 new JobTopology(
                         new VertexInfo(source1, Set.of(), 4, 720),
                         new VertexInfo(sink, Set.of(source1), 4, 720)));
+
+        var expectedEndTime = Instant.ofEpochMilli(10);
+        metricsCollector.setJobUpdateTs(expectedEndTime);
         autoscaler.scale(context);
 
-        assertLastTrackingEndTimeIs(now);
+        assertLastTrackingEndTimeIs(expectedEndTime);
     }
 
     private void assertLastTrackingEndTimeIs(Instant expectedEndTime) throws Exception {

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
@@ -95,7 +95,7 @@ public class ScalingMetricCollectorTest {
                         Map.of(),
                         new JobPlanInfo.RawJson(""));
         var metricsCollector = new RestApiMetricsCollector<>();
-        assertEquals(Instant.ofEpochMilli(3L), metricsCollector.getJobUpdateTs(details));
+        assertEquals(Instant.ofEpochMilli(3L), metricsCollector.getJobRunningTs(details));
     }
 
     @Test

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -118,7 +118,7 @@ public class ScalingMetricEvaluatorTest {
                 evaluator
                         .evaluate(
                                 conf,
-                                new CollectedMetricHistory(topology, metricHistory),
+                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
                                 Duration.ZERO)
                         .getVertexMetrics();
 
@@ -152,7 +152,7 @@ public class ScalingMetricEvaluatorTest {
                 evaluator
                         .evaluate(
                                 conf,
-                                new CollectedMetricHistory(topology, metricHistory),
+                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
                                 Duration.ZERO)
                         .getVertexMetrics();
         assertEquals(
@@ -175,7 +175,7 @@ public class ScalingMetricEvaluatorTest {
                 evaluator
                         .evaluate(
                                 conf,
-                                new CollectedMetricHistory(topology, metricHistory),
+                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
                                 Duration.ZERO)
                         .getVertexMetrics();
         assertEquals(
@@ -197,7 +197,7 @@ public class ScalingMetricEvaluatorTest {
                 evaluator
                         .evaluate(
                                 conf,
-                                new CollectedMetricHistory(topology, metricHistory),
+                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
                                 Duration.ZERO)
                         .getVertexMetrics();
         assertEquals(
@@ -243,7 +243,7 @@ public class ScalingMetricEvaluatorTest {
                 evaluator
                         .evaluate(
                                 conf,
-                                new CollectedMetricHistory(topology, metricHistory),
+                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
                                 Duration.ZERO)
                         .getVertexMetrics();
         assertEquals(
@@ -461,7 +461,7 @@ public class ScalingMetricEvaluatorTest {
                 evaluator
                         .evaluate(
                                 conf,
-                                new CollectedMetricHistory(topology, metricHistory),
+                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
                                 restartTime)
                         .getVertexMetrics()
                         .get(source)
@@ -476,7 +476,7 @@ public class ScalingMetricEvaluatorTest {
                 evaluator
                         .evaluate(
                                 conf,
-                                new CollectedMetricHistory(topology, metricHistory),
+                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
                                 restartTime)
                         .getVertexMetrics()
                         .get(source)
@@ -489,7 +489,7 @@ public class ScalingMetricEvaluatorTest {
                 evaluator
                         .evaluate(
                                 conf,
-                                new CollectedMetricHistory(topology, metricHistory),
+                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
                                 restartTime)
                         .getVertexMetrics()
                         .get(source)
@@ -531,7 +531,7 @@ public class ScalingMetricEvaluatorTest {
                 evaluator
                         .evaluate(
                                 conf,
-                                new CollectedMetricHistory(topology, metricHistory),
+                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
                                 restartTime)
                         .getVertexMetrics()
                         .get(source)
@@ -562,7 +562,7 @@ public class ScalingMetricEvaluatorTest {
                 evaluator
                         .evaluate(
                                 conf,
-                                new CollectedMetricHistory(topology, metricHistory),
+                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
                                 restartTime)
                         .getVertexMetrics()
                         .get(source)

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/TestingMetricsCollector.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/TestingMetricsCollector.java
@@ -97,7 +97,7 @@ public class TestingMetricsCollector<KEY, Context extends JobAutoScalerContext<K
     }
 
     @Override
-    protected Instant getJobUpdateTs(JobDetailsInfo jobDetailsInfo) {
+    protected Instant getJobRunningTs(JobDetailsInfo jobDetailsInfo) {
         return jobUpdateTs;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

The ScalingTracking of autoscaler is wrong, it's always greater than AutoScalerOptions#STABILIZATION_INTERVAL.

### Reason

When flink job isStabilizing, ScalingMetricCollector#updateMetrics will return a empty metric history. In the JobAutoScalerImpl#runScalingLogic method, if `collectedMetrics.getMetricHistory().isEmpty()` , we don't update the ScalingTracking.

The default value of AutoScalerOptions#STABILIZATION_INTERVAL is 5 min, so the restartTime is always greater than 5 min.

However, it's quick when we use rescale api.


## Brief change log

Update the scaling tracking even if the job is stabilizing.

## Verifying this change

Adding the test later.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no

