### PR TITLE
[FLINK-34311] Do not change min resource requirements when rescaling with adaptive scheduler

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -229,7 +229,9 @@ public class NativeFlinkServiceTest {
         var reconStatus = flinkDep.getStatus().getReconciliationStatus();
         reconStatus.serializeAndSetLastReconciledSpec(spec, flinkDep);
 
-        appConfig.set(PipelineOptions.PARALLELISM_OVERRIDES, Map.of(v1.toHexString(), "4"));
+        appConfig.set(
+                PipelineOptions.PARALLELISM_OVERRIDES,
+                Map.of(v1.toHexString(), "4", v2.toHexString(), "1"));
         spec.setFlinkConfiguration(appConfig.toMap());
 
         flinkDep.getStatus().getJobStatus().setState("RUNNING");
@@ -256,13 +258,15 @@ public class NativeFlinkServiceTest {
                 Map.of(
                         v1,
                                 new JobVertexResourceRequirements(
-                                        new JobVertexResourceRequirements.Parallelism(4, 4)),
+                                        new JobVertexResourceRequirements.Parallelism(1, 4)),
                         v2,
                                 new JobVertexResourceRequirements(
-                                        new JobVertexResourceRequirements.Parallelism(2, 2))),
+                                        new JobVertexResourceRequirements.Parallelism(1, 1))),
                 updated.get());
 
         // Baseline
+        appConfig.set(PipelineOptions.PARALLELISM_OVERRIDES, Map.of(v1.toHexString(), "4"));
+        spec.setFlinkConfiguration(appConfig.toMap());
         testScaleConditionDep(
                 flinkDep, service, d -> {}, FlinkService.ScalingResult.SCALING_TRIGGERED);
         testScaleConditionLastSpec(


### PR DESCRIPTION
## What is the purpose of the change

Do not change the min parallelism requirements when rescaling pipelines with the adaptive scheduler in order to avoid unnecessary failures.

## Brief change log
 - Set min to previous min

## Verifying this change
Unit tests added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs 
