### PR TITLE
[hotfix] Remove unnecessary fields from podTemplate examples

### DIFF
--- a/docs/content/docs/custom-resource/pod-template.md
+++ b/docs/content/docs/custom-resource/pod-template.md
@@ -55,10 +55,6 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
   podTemplate:
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: pod-template
     spec:
       containers:
         # Do not change the main container name
@@ -85,10 +81,6 @@ spec:
       memory: "2048m"
       cpu: 1
     podTemplate:
-      apiVersion: v1
-      kind: Pod
-      metadata:
-        name: task-manager-pod-template
       spec:
         initContainers:
           # Sample sidecar container

--- a/e2e-tests/data/multi-sessionjob.yaml
+++ b/e2e-tests/data/multi-sessionjob.yaml
@@ -85,10 +85,6 @@ spec:
     state.savepoints.dir: file:///opt/flink/volume/flink-sp
   serviceAccount: flink
   podTemplate:
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: pod-template
     spec:
       containers:
         # Do not change the main container name

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -27,10 +27,6 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
   podTemplate:
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: pod-template
     spec:
       containers:
         # Do not change the main container name
@@ -57,10 +53,6 @@ spec:
       memory: "2048m"
       cpu: 1
     podTemplate:
-      apiVersion: v1
-      kind: Pod
-      metadata:
-        name: task-manager-pod-template
       spec:
         initContainers:
           # Sample init container for fetching remote artifacts


### PR DESCRIPTION
## What is the purpose of the change

While the proper solution should be implemented in the next (breaking) CR version, we should remove all the unnecessary properties that would cause backward compatibility issues for users later from our examples.

## Brief change log

Clean up example/test podTemplates

## Verifying this change

e2e / manual test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?no
