### PR TITLE
[FLINK-31220] Replace Pod with PodTemplateSpec for the pod template properties

### DIFF
--- a/docs/content/docs/custom-resource/pod-template.md
+++ b/docs/content/docs/custom-resource/pod-template.md
@@ -55,10 +55,6 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
   podTemplate:
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: pod-template
     spec:
       containers:
         # Do not change the main container name
@@ -85,10 +81,6 @@ spec:
       memory: "2048m"
       cpu: 1
     podTemplate:
-      apiVersion: v1
-      kind: Pod
-      metadata:
-        name: task-manager-pod-template
       spec:
         initContainers:
           # Sample sidecar container

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -53,7 +53,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | serviceAccount | java.lang.String | Kubernetes service used by the Flink deployment. |
 | flinkVersion | org.apache.flink.kubernetes.operator.api.spec.FlinkVersion | Flink image version. |
 | ingress | org.apache.flink.kubernetes.operator.api.spec.IngressSpec | Ingress specs. |
-| podTemplate | io.fabric8.kubernetes.api.model.Pod | Base pod template for job and task manager pods. Can be overridden by the jobManager and taskManager pod templates. |
+| podTemplate | io.fabric8.kubernetes.api.model.PodTemplateSpec | Base pod template for job and task manager pods. Can be overridden by the jobManager and taskManager pod templates. |
 | jobManager | org.apache.flink.kubernetes.operator.api.spec.JobManagerSpec | JobManager specs. |
 | taskManager | org.apache.flink.kubernetes.operator.api.spec.TaskManagerSpec | TaskManager specs. |
 | logConfiguration | java.util.Map<java.lang.String,java.lang.String> | Log configuration overrides for the Flink deployment. Format logConfigFileName -> configContent. |
@@ -108,7 +108,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | resource | org.apache.flink.kubernetes.operator.api.spec.Resource | Resource specification for the JobManager pods. |
 | replicas | int | Number of JobManager replicas. Must be 1 for non-HA deployments. |
-| podTemplate | io.fabric8.kubernetes.api.model.Pod | JobManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. |
+| podTemplate | io.fabric8.kubernetes.api.model.PodTemplateSpec | JobManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. |
 
 ### JobSpec
 **Class**: org.apache.flink.kubernetes.operator.api.spec.JobSpec
@@ -169,7 +169,7 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----------| ---- | ---- |
 | resource | org.apache.flink.kubernetes.operator.api.spec.Resource | Resource specification for the TaskManager pods. |
 | replicas | java.lang.Integer | Number of TaskManager replicas. If defined, takes precedence over parallelism |
-| podTemplate | io.fabric8.kubernetes.api.model.Pod | TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. |
+| podTemplate | io.fabric8.kubernetes.api.model.PodTemplateSpec | TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. |
 
 ### UpgradeMode
 **Class**: org.apache.flink.kubernetes.operator.api.spec.UpgradeMode

--- a/e2e-tests/data/multi-sessionjob.yaml
+++ b/e2e-tests/data/multi-sessionjob.yaml
@@ -85,10 +85,6 @@ spec:
     state.savepoints.dir: file:///opt/flink/volume/flink-sp
   serviceAccount: flink
   podTemplate:
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: pod-template
     spec:
       containers:
         # Do not change the main container name

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -27,10 +27,6 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
   serviceAccount: flink
   podTemplate:
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: pod-template
     spec:
       containers:
         # Do not change the main container name
@@ -57,10 +53,6 @@ spec:
       memory: "2048m"
       cpu: 1
     podTemplate:
-      apiVersion: v1
-      kind: Pod
-      metadata:
-        name: task-manager-pod-template
       spec:
         initContainers:
           # Sample init container for fetching remote artifacts

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkDeploymentSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkDeploymentSpec.java
@@ -20,7 +20,9 @@ package org.apache.flink.kubernetes.operator.api.spec;
 import org.apache.flink.annotation.Experimental;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.fabric8.crd.generator.annotation.SchemaFrom;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -59,7 +61,8 @@ public class FlinkDeploymentSpec extends AbstractFlinkSpec {
      * Base pod template for job and task manager pods. Can be overridden by the jobManager and
      * taskManager pod templates.
      */
-    private Pod podTemplate;
+    @SchemaFrom(type = Pod.class)
+    private PodTemplateSpec podTemplate;
 
     /** JobManager specs. */
     private JobManagerSpec jobManager;

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobManagerSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobManagerSpec.java
@@ -20,7 +20,9 @@ package org.apache.flink.kubernetes.operator.api.spec;
 import org.apache.flink.annotation.Experimental;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.fabric8.crd.generator.annotation.SchemaFrom;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -41,5 +43,6 @@ public class JobManagerSpec {
     private int replicas = 1;
 
     /** JobManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. */
-    private Pod podTemplate;
+    @SchemaFrom(type = Pod.class)
+    private PodTemplateSpec podTemplate;
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/TaskManagerSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/TaskManagerSpec.java
@@ -23,7 +23,9 @@ import org.apache.flink.kubernetes.operator.api.diff.Diffable;
 import org.apache.flink.kubernetes.operator.api.diff.SpecDiff;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.fabric8.crd.generator.annotation.SchemaFrom;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.model.annotation.SpecReplicas;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -47,5 +49,6 @@ public class TaskManagerSpec implements Diffable<TaskManagerSpec> {
     private Integer replicas;
 
     /** TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. */
-    private Pod podTemplate;
+    @SchemaFrom(type = Pod.class)
+    private PodTemplateSpec podTemplate;
 }

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
@@ -39,6 +39,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -185,13 +186,21 @@ public class BaseTestUtils {
                 .build();
     }
 
-    public static Pod getTestPod(String hostname, String apiVersion, List<Container> containers) {
+    public static PodTemplateSpec getTestPodTemplate(String hostname, List<Container> containers) {
         final PodSpec podSpec = new PodSpec();
         podSpec.setHostname(hostname);
         podSpec.setContainers(containers);
-        final Pod pod = new Pod();
-        pod.setApiVersion(apiVersion);
+        var pod = new PodTemplateSpec();
         pod.setSpec(podSpec);
+        return pod;
+    }
+
+    public static Pod getTestPod(String hostname, String apiVersion, List<Container> containers) {
+        var pod = new Pod();
+        var podTemplate = getTestPodTemplate(hostname, containers);
+        pod.setApiVersion(apiVersion);
+        pod.setSpec(podTemplate.getSpec());
+        pod.setMetadata(podTemplate.getMetadata());
         return pod;
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -41,8 +41,8 @@ import io.fabric8.kubernetes.api.model.ConfigMapList;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HTTPGetAction;
 import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentCondition;
@@ -69,7 +69,8 @@ public class FlinkUtils {
 
     public static final String CR_GENERATION_LABEL = "flinkdeployment.flink.apache.org/generation";
 
-    public static Pod mergePodTemplates(Pod toPod, Pod fromPod, boolean mergeArraysByName) {
+    public static PodTemplateSpec mergePodTemplates(
+            PodTemplateSpec toPod, PodTemplateSpec fromPod, boolean mergeArraysByName) {
         if (fromPod == null) {
             return ReconciliationUtils.clone(toPod);
         } else if (toPod == null) {
@@ -79,7 +80,7 @@ public class FlinkUtils {
         JsonNode node2 = MAPPER.valueToTree(fromPod);
         mergeInto(node1, node2, mergeArraysByName);
         try {
-            return MAPPER.treeToValue(node1, Pod.class);
+            return MAPPER.treeToValue(node1, PodTemplateSpec.class);
         } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
@@ -152,7 +153,7 @@ public class FlinkUtils {
         return out;
     }
 
-    public static void addStartupProbe(Pod pod) {
+    public static void addStartupProbe(PodTemplateSpec pod) {
         var spec = pod.getSpec();
         if (spec == null) {
             spec = new PodSpec();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -33,7 +33,7 @@ import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.utils.Constants;
 
-import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -135,7 +135,7 @@ public class FlinkConfigManagerTest {
 
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         deployment.getSpec().setLogConfiguration(Map.of(Constants.CONFIG_FILE_LOG4J_NAME, "test"));
-        deployment.getSpec().setPodTemplate(new Pod());
+        deployment.getSpec().setPodTemplate(new PodTemplateSpec());
 
         ReconciliationUtils.updateStatusForDeployedSpec(deployment, config);
         Configuration deployConfig = configManager.getObserveConfig(deployment);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkUtilsTest.java
@@ -40,7 +40,7 @@ import io.fabric8.kubernetes.api.model.EphemeralVolumeSource;
 import io.fabric8.kubernetes.api.model.HTTPGetAction;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -77,21 +77,17 @@ public class FlinkUtilsTest {
         Container container2 = new Container();
         container2.setName("container2");
 
-        Pod pod1 = TestUtils.getTestPod("pod1 hostname", "pod1 api version", List.of());
+        var pod1 = TestUtils.getTestPodTemplate("pod1 hostname", List.of());
 
-        Pod pod2 =
-                TestUtils.getTestPod(
-                        "pod2 hostname", "pod2 api version", List.of(container1, container2));
+        var pod2 = TestUtils.getTestPodTemplate("pod2 hostname", List.of(container1, container2));
 
-        Pod mergedPod = FlinkUtils.mergePodTemplates(pod1, pod2, false);
-
-        assertEquals(pod2.getApiVersion(), mergedPod.getApiVersion());
+        var mergedPod = FlinkUtils.mergePodTemplates(pod1, pod2, false);
         assertEquals(pod2.getSpec().getContainers(), mergedPod.getSpec().getContainers());
     }
 
     @Test
     public void testAddStartupProbe() {
-        Pod pod = new Pod();
+        var pod = new PodTemplateSpec();
         FlinkUtils.addStartupProbe(pod);
 
         Probe expectedProbe = new Probe();
@@ -332,24 +328,19 @@ public class FlinkUtilsTest {
         Volume volume3 = new Volume();
         volume3.setName("v3");
 
-        Pod pod1 =
-                TestUtils.getTestPod(
-                        "pod1 hostname", "pod1 api version", List.of(container1, container2));
+        var pod1 = TestUtils.getTestPodTemplate("pod1 hostname", List.of(container1, container2));
         pod1.getSpec().setVolumes(List.of(volume1));
 
-        Pod pod2 =
-                TestUtils.getTestPod(
-                        "pod2 hostname", "pod2 api version", List.of(container1, container3));
+        var pod2 = TestUtils.getTestPodTemplate("pod2 hostname", List.of(container1, container3));
         pod2.getSpec().setVolumes(List.of(volume12, volume2, volume3));
 
-        Pod mergedPod = FlinkUtils.mergePodTemplates(pod1, pod2, true);
+        var mergedPod = FlinkUtils.mergePodTemplates(pod1, pod2, true);
 
         Volume v1merged = new Volume();
         v1merged.setName("v1");
         v1merged.setEphemeral(new EphemeralVolumeSource());
         v1merged.setEmptyDir(new EmptyDirVolumeSource());
 
-        assertEquals(pod2.getApiVersion(), mergedPod.getApiVersion());
         assertEquals(
                 List.of(container1, container2, container3), mergedPod.getSpec().getContainers());
         assertEquals(List.of(v1merged, volume2, volume3), mergedPod.getSpec().getVolumes());


### PR DESCRIPTION
## What is the purpose of the change

The PodTemplate fields in the CRD currently incorrectly use the Pod time, when they should be PodTemplateSpec type. This leads to unnecessary (meaningless) fields and a very large CRD for no gain.

Also accidentally changing fields like apiKind would trigger an unnecessary upgrade of the job.

This PR is the first step of correcting this mistake. Unfortunately we cannot simply change the type form Pod to PodTemplateSpec as it's a backward incompatible change for the users.

While Kubernetes itself would drop the now unsupported fields from the stored CRs themselves, users would not be able to submit the same CR again as they would get a validation error from the API server. We should defer the CRD schema change to the next version.


## Brief change log

  - *Change Pod -> PodTemplateSpec but keep the schema in CRD*
  - *Improve SpecDiff logic to avoid accidental upgrade due to the dropped fields*

## Verifying this change

New unit tests + manual verification in local environment.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
