### PR TITLE
[FLINK-34389][autoscaler] JdbcAutoscalerStateStore explicitly writes update_time

### DIFF
--- a/flink-autoscaler-plugin-jdbc/src/main/resources/schema/derby_schema.sql
+++ b/flink-autoscaler-plugin-jdbc/src/main/resources/schema/derby_schema.sql
@@ -17,8 +17,8 @@
 
 CREATE TABLE t_flink_autoscaler_state_store
 (
-    id            BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
-    update_time   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    id            BIGINT       NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),
+    update_time   TIMESTAMP    NOT NULL,
     job_key       VARCHAR(191) NOT NULL,
     state_type    VARCHAR(100) NOT NULL,
     state_value   CLOB NOT NULL,

--- a/flink-autoscaler-plugin-jdbc/src/main/resources/schema/mysql_schema.sql
+++ b/flink-autoscaler-plugin-jdbc/src/main/resources/schema/mysql_schema.sql
@@ -22,7 +22,7 @@ use `flink_autoscaler`;
 create table `t_flink_autoscaler_state_store`
 (
     `id`            bigint       not null auto_increment,
-    `update_time`   datetime     not null default current_timestamp on update current_timestamp comment 'update time',
+    `update_time`   datetime     not null comment 'The update time',
     `job_key`       varchar(191) not null comment 'The job key',
     `state_type`    varchar(100) not null comment 'The state type',
     `state_value`   longtext     not null comment 'The real state',

--- a/flink-autoscaler-plugin-jdbc/src/main/resources/schema/postgres_schema.sql
+++ b/flink-autoscaler-plugin-jdbc/src/main/resources/schema/postgres_schema.sql
@@ -21,24 +21,10 @@ CREATE DATABASE flink_autoscaler;
 CREATE TABLE t_flink_autoscaler_state_store
 (
     id            BIGSERIAL     NOT NULL,
-    update_time   TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time   TIMESTAMP     NOT NULL,
     job_key       TEXT          NOT NULL,
     state_type    TEXT          NOT NULL,
     state_value   TEXT          NOT NULL,
     PRIMARY KEY (id),
     UNIQUE (job_key, state_type)
 );
-
-CREATE OR REPLACE FUNCTION update_flink_autoscaler_update_time_column()
-RETURNS TRIGGER AS $$
-BEGIN
-   NEW.update_time = CURRENT_TIMESTAMP;
-RETURN NEW;
-END;
-$$ language 'plpgsql';
-
-CREATE TRIGGER update_t_flink_autoscaler_state_store_modtime
-    BEFORE UPDATE ON t_flink_autoscaler_state_store
-    FOR EACH ROW
-    EXECUTE FUNCTION update_flink_autoscaler_update_time_column();
-

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/derby/DerbyExtension.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/derby/DerbyExtension.java
@@ -44,8 +44,8 @@ public class DerbyExtension implements BeforeAllCallback, AfterAllCallback, Afte
         var stateStoreDDL =
                 "CREATE TABLE t_flink_autoscaler_state_store\n"
                         + "(\n"
-                        + "    id            BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),\n"
-                        + "    update_time   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,\n"
+                        + "    id            BIGINT       NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 1, INCREMENT BY 1),\n"
+                        + "    update_time   TIMESTAMP    NOT NULL,\n"
                         + "    job_key       VARCHAR(191) NOT NULL,\n"
                         + "    state_type    VARCHAR(100) NOT NULL,\n"
                         + "    state_value   CLOB NOT NULL,\n"

--- a/flink-autoscaler-plugin-jdbc/src/test/resources/test_schema/mysql_schema.sql
+++ b/flink-autoscaler-plugin-jdbc/src/test/resources/test_schema/mysql_schema.sql
@@ -18,7 +18,7 @@
 create table `t_flink_autoscaler_state_store`
 (
     `id`            bigint       not null auto_increment,
-    `update_time`   datetime     not null default current_timestamp on update current_timestamp comment 'update time',
+    `update_time`   datetime     not null comment 'The update time',
     `job_key`       varchar(191) not null comment 'The job key',
     `state_type`    varchar(100) not null comment 'The state type',
     `state_value`   longtext     not null comment 'The real state',

--- a/flink-autoscaler-plugin-jdbc/src/test/resources/test_schema/postgres_schema.sql
+++ b/flink-autoscaler-plugin-jdbc/src/test/resources/test_schema/postgres_schema.sql
@@ -18,7 +18,7 @@
 CREATE TABLE t_flink_autoscaler_state_store
 (
     id            BIGSERIAL     NOT NULL,
-    update_time   TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    update_time   TIMESTAMP     NOT NULL,
     job_key       TEXT          NOT NULL,
     state_type    TEXT          NOT NULL,
     state_value   TEXT          NOT NULL,


### PR DESCRIPTION
## What is the purpose of the change

JdbcAutoscalerStateStore explicitly writes update_time instead of relying on the database to update.

Some databases doesn't support update the timestamp column automatically. For example, Derby doesn't support update the update_time automatically when we update any data. It's hard to do a general test during I developing the test for JdbcAutoscalerEventHandler.

As the common&open source service, in order to support all databases well, it's better to handle it inside of the service.

In order to unify the design for JdbcAutoscalerEventHandler and JdbcAutoscalerStateStore, we update the design of JdbcAutoscalerStateStore in this PR.

## Brief change log

[FLINK-34389][autoscaler] JdbcAutoscalerStateStore explicitly writes update_time