### PR TITLE
[FLINK-34398][flink-kubernetes-operator] Consider FlinkSessionJob's flinkConfiguration overrides during session job spec validation

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -497,6 +497,10 @@ public class DefaultValidator implements FlinkResourceValidator {
             effectiveConfig.putAll(sessionCluster.getSpec().getFlinkConfiguration());
         }
 
+        if (sessionJob.getSpec().getFlinkConfiguration() != null) {
+            effectiveConfig.putAll(sessionJob.getSpec().getFlinkConfiguration());
+        }
+
         return firstPresent(
                 validateNotApplicationCluster(sessionCluster),
                 validateSessionClusterId(sessionJob, sessionCluster),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -745,6 +745,23 @@ public class DefaultValidatorTest {
                 },
                 flinkDeployment -> {},
                 "The deploymentName can't be changed");
+
+        testSessionJobValidateWithModifier(
+                sessionJob -> {
+                    sessionJob.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
+                    sessionJob
+                            .getSpec()
+                            .setFlinkConfiguration(
+                                    Map.of(
+                                            CheckpointingOptions.SAVEPOINT_DIRECTORY.key(),
+                                                    "test-savepoint-dir",
+                                            CheckpointingOptions.CHECKPOINTS_DIRECTORY.key(),
+                                                    "test-checkpoint-dir"));
+                },
+                flinkDeployment -> {
+                    flinkDeployment.getSpec().setFlinkConfiguration(Map.of());
+                },
+                null);
     }
 
     private void testSessionJobValidateWithModifier(


### PR DESCRIPTION


<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request adds sessionJob's flinkConfiguration to effective config when validating FlinkSessionJob and FlinkDeployment resources.


## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change added tests and can be verified as follows:

  - Extended unit test for *DefaultValidator*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
