### PR TITLE
[FLINK-34266] Compute Autoscaler metrics correctly over metric window

### DIFF
--- a/docs/content/docs/custom-resource/autoscaler.md
+++ b/docs/content/docs/custom-resource/autoscaler.md
@@ -42,8 +42,8 @@ The autoscaler relies on the metrics exposed by the Flink metric system for the 
 Collected metrics:
  - Backlog information at each source
  - Incoming data rate at the sources (e.g. records/sec written into the Kafka topic)
- - Number of records processed per second in each job vertex
- - Busy time per second of each job vertex (current utilization)
+ - Record processing rate at each job vertex
+ - Busy and backpressured time at each job vertex
 
 {{< hint info >}}
 Please note that we are not using any container memory / CPU utilization metrics directly here. High utilization will be reflected in the processing rate and busy time metrics of the individual job vertexes.
@@ -260,7 +260,7 @@ job.autoscaler.metrics.window : 3m
 > `ScalingReport` will show the recommended parallelism for each vertex.
 
 After the flink job starts, please start the StandaloneAutoscaler process by the
-following command. Please download released autoscaler-standalone jar from 
+following command. Please download released autoscaler-standalone jar from
 [here](https://repo.maven.apache.org/maven2/org/apache/flink/flink-autoscaler-standalone/) first.
 
 ```
@@ -270,12 +270,12 @@ org.apache.flink.autoscaler.standalone.StandaloneAutoscalerEntrypoint \
 --autoscaler.standalone.fetcher.flink-cluster.port 8081
 ```
 
-Updating the `autoscaler.standalone.fetcher.flink-cluster.host` and `autoscaler.standalone.fetcher.flink-cluster.port` 
+Updating the `autoscaler.standalone.fetcher.flink-cluster.host` and `autoscaler.standalone.fetcher.flink-cluster.port`
 based on your flink cluster. In general, the host and port are the same as Flink WebUI.
 
 ### Using the JDBC Autoscaler State Store
 
-A driver dependency is required to connect to a specified database. Here are drivers currently supported, 
+A driver dependency is required to connect to a specified database. Here are drivers currently supported,
 please download JDBC driver and initialize database and table first.
 
 | Driver     | Group Id                   | Artifact Id            | JAR                                                                             | Schema                  |
@@ -298,7 +298,7 @@ org.apache.flink.autoscaler.standalone.StandaloneAutoscalerEntrypoint \
 --autoscaler.standalone.state-store.jdbc.username root
 ```
 
-All supported options for autoscaler standalone can be viewed 
+All supported options for autoscaler standalone can be viewed
 [here]({{< ref "docs/operations/configuration#autoscaler-standalone-configuration" >}}).
 
 ### Extensibility of autoscaler standalone

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -189,7 +189,9 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
             stateStore.storeScalingTracking(ctx, scalingTracking);
         }
 
-        if (collectedMetrics.getMetricHistory().isEmpty()) {
+        // We require at least 2 metric collections for evaluation as required by rate computations
+        // from accumulated metrics
+        if (collectedMetrics.getMetricHistory().size() < 2) {
             return;
         }
         LOG.debug("Collected metrics: {}", collectedMetrics);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
@@ -433,9 +433,6 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                     .findAny(allMetricNames)
                     .ifPresent(
                             m -> filteredMetrics.put(m, FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT));
-        } else {
-            // Not a source so we must have numRecordsInPerSecond
-            requiredMetrics.add(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
         }
 
         for (FlinkMetric flinkMetric : requiredMetrics) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -47,7 +47,6 @@ import static org.apache.flink.autoscaler.config.AutoScalerOptions.BACKLOG_PROCE
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.CATCH_UP_DATA_RATE;
-import static org.apache.flink.autoscaler.metrics.ScalingMetric.CURRENT_PROCESSING_RATE;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.GC_PRESSURE;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.HEAP_MAX_USAGE_RATIO;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.HEAP_USED;
@@ -104,12 +103,12 @@ public class ScalingMetricEvaluator {
                 .anyMatch(
                         vertex -> {
                             double lag = lastMetrics.get(vertex).getOrDefault(LAG, 0.0);
-                            double avgProcRate =
-                                    getAverage(CURRENT_PROCESSING_RATE, vertex, metricsHistory);
-                            if (Double.isNaN(avgProcRate)) {
+                            double inputRateAvg =
+                                    getRate(ScalingMetric.NUM_RECORDS_IN, vertex, metricsHistory);
+                            if (Double.isNaN(inputRateAvg)) {
                                 return false;
                             }
-                            double lagSeconds = lag / avgProcRate;
+                            double lagSeconds = lag / inputRateAvg;
                             if (lagSeconds
                                     > conf.get(BACKLOG_PROCESSING_LAG_THRESHOLD).toSeconds()) {
                                 LOG.info("Currently processing backlog at source {}", vertex);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
@@ -33,11 +33,12 @@ import java.util.stream.Collectors;
 public enum FlinkMetric {
     BUSY_TIME_PER_SEC(s -> s.equals("busyTimeMsPerSecond")),
     NUM_RECORDS_IN_PER_SEC(s -> s.equals("numRecordsInPerSecond")),
-    NUM_RECORDS_OUT_PER_SEC(s -> s.equals("numRecordsOutPerSecond")),
-    SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC(
-            s -> s.startsWith("Source__") && s.endsWith(".numRecordsOutPerSecond")),
     SOURCE_TASK_NUM_RECORDS_IN_PER_SEC(
             s -> s.startsWith("Source__") && s.endsWith(".numRecordsInPerSecond")),
+    SOURCE_TASK_NUM_RECORDS_OUT(s -> s.startsWith("Source__") && s.endsWith(".numRecordsOut")),
+    SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC(
+            s -> s.startsWith("Source__") && s.endsWith(".numRecordsOutPerSecond")),
+    SOURCE_TASK_NUM_RECORDS_IN(s -> s.startsWith("Source__") && s.endsWith(".numRecordsIn")),
     PENDING_RECORDS(s -> s.endsWith(".pendingRecords")),
     BACKPRESSURE_TIME_PER_SEC(s -> s.equals("backPressuredTimeMsPerSecond")),
 
@@ -52,9 +53,9 @@ public enum FlinkMetric {
                     FlinkMetric.BUSY_TIME_PER_SEC, zero(),
                     FlinkMetric.PENDING_RECORDS, zero(),
                     FlinkMetric.NUM_RECORDS_IN_PER_SEC, zero(),
-                    FlinkMetric.NUM_RECORDS_OUT_PER_SEC, zero(),
                     FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC, zero(),
-                    FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC, zero());
+                    FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN, zero(),
+                    FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT, zero());
 
     public final Predicate<String> predicate;
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
  */
 public enum FlinkMetric {
     BUSY_TIME_PER_SEC(s -> s.equals("busyTimeMsPerSecond")),
-    NUM_RECORDS_IN_PER_SEC(s -> s.equals("numRecordsInPerSecond")),
     SOURCE_TASK_NUM_RECORDS_IN_PER_SEC(
             s -> s.startsWith("Source__") && s.endsWith(".numRecordsInPerSecond")),
     SOURCE_TASK_NUM_RECORDS_OUT(s -> s.startsWith("Source__") && s.endsWith(".numRecordsOut")),
@@ -52,7 +51,6 @@ public enum FlinkMetric {
             Map.of(
                     FlinkMetric.BUSY_TIME_PER_SEC, zero(),
                     FlinkMetric.PENDING_RECORDS, zero(),
-                    FlinkMetric.NUM_RECORDS_IN_PER_SEC, zero(),
                     FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC, zero(),
                     FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN, zero(),
                     FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT, zero());

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
@@ -39,12 +39,6 @@ public enum ScalingMetric {
     /** Current processing rate. */
     CURRENT_PROCESSING_RATE(true),
 
-    /**
-     * Incoming data rate to the source, e.g. rate of records written to the Kafka topic
-     * (records/sec).
-     */
-    SOURCE_DATA_RATE(true),
-
     /** Target processing rate of operators as derived from source inputs (records/sec). */
     TARGET_DATA_RATE(true),
 
@@ -70,6 +64,12 @@ public enum ScalingMetric {
 
     /** Expected true processing rate after scale up. */
     EXPECTED_PROCESSING_RATE(false),
+
+    NUM_RECORDS_IN(false),
+
+    NUM_RECORDS_OUT(false),
+
+    ACCUMULATED_BUSY_TIME(false),
 
     /**
      * Maximum GC pressure across taskmanagers. Percentage of time spent garbage collecting between

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
@@ -36,9 +36,6 @@ public enum ScalingMetric {
     /** Observed true processing rate for sources. */
     OBSERVED_TPR(true),
 
-    /** Current processing rate. */
-    CURRENT_PROCESSING_RATE(true),
-
     /** Target processing rate of operators as derived from source inputs (records/sec). */
     TARGET_DATA_RATE(true),
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -87,7 +87,7 @@ public class ScalingMetrics {
         double numRecordsInPerSecond =
                 getNumRecordsInPerSecond(flinkMetrics, ioMetrics, jobVertexID, isSource);
         double numRecordsIn =
-                getNumRecordsAccumulated(flinkMetrics, ioMetrics, jobVertexID, isSource);
+                getNumRecordsInAccumulated(flinkMetrics, ioMetrics, jobVertexID, isSource);
 
         scalingMetrics.put(ScalingMetric.NUM_RECORDS_IN, numRecordsIn);
         scalingMetrics.put(ScalingMetric.NUM_RECORDS_OUT, (double) ioMetrics.getNumRecordsOut());
@@ -208,18 +208,18 @@ public class ScalingMetrics {
             IOMetrics ioMetrics,
             JobVertexID jobVertexID,
             boolean isSource) {
-        return getNumRecordsInternal(flinkMetrics, ioMetrics, jobVertexID, isSource, true);
+        return getNumRecordsInInternal(flinkMetrics, ioMetrics, jobVertexID, isSource, true);
     }
 
-    private static double getNumRecordsAccumulated(
+    private static double getNumRecordsInAccumulated(
             Map<FlinkMetric, AggregatedMetric> flinkMetrics,
             IOMetrics ioMetrics,
             JobVertexID jobVertexID,
             boolean isSource) {
-        return getNumRecordsInternal(flinkMetrics, ioMetrics, jobVertexID, isSource, false);
+        return getNumRecordsInInternal(flinkMetrics, ioMetrics, jobVertexID, isSource, false);
     }
 
-    private static double getNumRecordsInternal(
+    private static double getNumRecordsInInternal(
             Map<FlinkMetric, AggregatedMetric> flinkMetrics,
             IOMetrics ioMetrics,
             JobVertexID jobVertexID,

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -18,6 +18,7 @@
 package org.apache.flink.autoscaler.metrics;
 
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.autoscaler.topology.IOMetrics;
 import org.apache.flink.autoscaler.topology.JobTopology;
 import org.apache.flink.autoscaler.tuning.MemoryTuning;
 import org.apache.flink.autoscaler.utils.AutoScalerUtils;
@@ -44,10 +45,32 @@ public class ScalingMetrics {
             JobVertexID jobVertexID,
             Map<FlinkMetric, AggregatedMetric> flinkMetrics,
             Map<ScalingMetric, Double> scalingMetrics,
+            IOMetrics ioMetrics,
             Configuration conf) {
 
-        double busyTimeMsPerSecond = getBusyTimeMsPerSecond(flinkMetrics, conf, jobVertexID);
-        scalingMetrics.put(ScalingMetric.LOAD, busyTimeMsPerSecond / 1000);
+        scalingMetrics.put(
+                ScalingMetric.LOAD,
+                getBusyTimeMsPerSecond(flinkMetrics, conf, jobVertexID) / 1000.);
+        scalingMetrics.put(ScalingMetric.ACCUMULATED_BUSY_TIME, ioMetrics.getAccumulatedBusyTime());
+    }
+
+    private static double getBusyTimeMsPerSecond(
+            Map<FlinkMetric, AggregatedMetric> flinkMetrics,
+            Configuration conf,
+            JobVertexID jobVertexId) {
+        var busyTimeAggregator = conf.get(AutoScalerOptions.BUSY_TIME_AGGREGATOR);
+        var busyTimeMsPerSecond =
+                busyTimeAggregator.get(flinkMetrics.get(FlinkMetric.BUSY_TIME_PER_SEC));
+        if (!Double.isFinite(busyTimeMsPerSecond)) {
+            if (AutoScalerUtils.excludeVertexFromScaling(conf, jobVertexId)) {
+                // We only want to log this once
+                LOG.warn(
+                        "No busyTimeMsPerSecond metric available for {}. No scaling will be performed for this vertex.",
+                        jobVertexId);
+            }
+            return Double.NaN;
+        }
+        return Math.max(0, busyTimeMsPerSecond);
     }
 
     public static void computeDataRateMetrics(
@@ -55,38 +78,28 @@ public class ScalingMetrics {
             Map<FlinkMetric, AggregatedMetric> flinkMetrics,
             Map<ScalingMetric, Double> scalingMetrics,
             JobTopology topology,
-            double lagGrowthRate,
             Configuration conf,
             Supplier<Double> observedTprAvg) {
 
         var isSource = topology.isSource(jobVertexID);
+        var ioMetrics = topology.get(jobVertexID).getIoMetrics();
 
         double numRecordsInPerSecond =
-                getNumRecordsInPerSecond(flinkMetrics, jobVertexID, isSource);
+                getNumRecordsInPerSecond(flinkMetrics, ioMetrics, jobVertexID, isSource);
+        double numRecordsIn =
+                getNumRecordsAccumulated(flinkMetrics, ioMetrics, jobVertexID, isSource);
 
-        if (isSource) {
-            double sourceDataRate = Math.max(0, numRecordsInPerSecond + lagGrowthRate);
-            LOG.debug("Using computed source data rate {} for {}", sourceDataRate, jobVertexID);
-            scalingMetrics.put(ScalingMetric.SOURCE_DATA_RATE, sourceDataRate);
-            scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, numRecordsInPerSecond);
-        }
+        scalingMetrics.put(ScalingMetric.NUM_RECORDS_IN, numRecordsIn);
+        scalingMetrics.put(ScalingMetric.NUM_RECORDS_OUT, (double) ioMetrics.getNumRecordsOut());
+        scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, numRecordsInPerSecond);
 
         if (!Double.isNaN(numRecordsInPerSecond)) {
-            double busyTimeMsPerSecond = getBusyTimeMsPerSecond(flinkMetrics, conf, jobVertexID);
-            double trueProcessingRate =
-                    computeTprFromBusyTime(conf, numRecordsInPerSecond, busyTimeMsPerSecond);
             if (isSource) {
                 var observedTprOpt =
                         getObservedTpr(flinkMetrics, scalingMetrics, numRecordsInPerSecond, conf)
                                 .orElseGet(observedTprAvg);
                 scalingMetrics.put(ScalingMetric.OBSERVED_TPR, observedTprOpt);
             }
-            scalingMetrics.put(ScalingMetric.TRUE_PROCESSING_RATE, trueProcessingRate);
-            scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, numRecordsInPerSecond);
-        } else {
-            LOG.warn("Cannot compute true processing rate without numRecordsInPerSecond");
-            scalingMetrics.put(ScalingMetric.TRUE_PROCESSING_RATE, Double.NaN);
-            scalingMetrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, Double.NaN);
         }
     }
 
@@ -127,39 +140,6 @@ public class ScalingMetrics {
         }
         double nonBackpressuredRate = (1 - (backpressureMsPerSeconds / 1000));
         return numRecordsInPerSecond / nonBackpressuredRate;
-    }
-
-    public static Map<Edge, Double> computeOutputRatios(
-            Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>> flinkMetrics,
-            JobTopology topology) {
-
-        var out = new HashMap<Edge, Double>();
-        for (JobVertexID from : flinkMetrics.keySet()) {
-            var outputs = topology.getOutputs().get(from);
-            if (outputs.isEmpty()) {
-                continue;
-            }
-
-            double numRecordsInPerSecond =
-                    getNumRecordsInPerSecond(flinkMetrics.get(from), from, topology.isSource(from));
-
-            for (JobVertexID to : outputs) {
-                double outputRatio = 0;
-                // If the input rate is zero, we also need to flatten the output rate.
-                // Otherwise, the OUTPUT_RATIO would be outrageously large, leading to
-                // a rapid scale up.
-                if (numRecordsInPerSecond > 0) {
-                    double edgeOutPerSecond =
-                            computeEdgeOutPerSecond(topology, flinkMetrics, from, to);
-                    if (edgeOutPerSecond > 0) {
-                        outputRatio = edgeOutPerSecond / numRecordsInPerSecond;
-                    }
-                }
-                out.put(new Edge(from, to), outputRatio);
-            }
-        }
-
-        return out;
     }
 
     public static Map<ScalingMetric, Double> computeGlobalMetrics(
@@ -223,128 +203,65 @@ public class ScalingMetrics {
         }
     }
 
-    // TODO: FLINK-34213: Consider using accumulated busy time instead of busyMsPerSecond
-    private static double getBusyTimeMsPerSecond(
-            Map<FlinkMetric, AggregatedMetric> flinkMetrics,
-            Configuration conf,
-            JobVertexID jobVertexId) {
-        var busyTimeAggregator = conf.get(AutoScalerOptions.BUSY_TIME_AGGREGATOR);
-        var busyTimeMsPerSecond =
-                busyTimeAggregator.get(flinkMetrics.get(FlinkMetric.BUSY_TIME_PER_SEC));
-        if (!Double.isFinite(busyTimeMsPerSecond)) {
-            if (AutoScalerUtils.excludeVertexFromScaling(conf, jobVertexId)) {
-                // We only want to log this once
-                LOG.warn(
-                        "No busyTimeMsPerSecond metric available for {}. No scaling will be performed for this vertex.",
-                        jobVertexId);
-            }
-            return Double.NaN;
-        }
-        return Math.max(0, busyTimeMsPerSecond);
-    }
-
     private static double getNumRecordsInPerSecond(
             Map<FlinkMetric, AggregatedMetric> flinkMetrics,
+            IOMetrics ioMetrics,
             JobVertexID jobVertexID,
             boolean isSource) {
+        return getNumRecordsInternal(flinkMetrics, ioMetrics, jobVertexID, isSource, true);
+    }
+
+    private static double getNumRecordsAccumulated(
+            Map<FlinkMetric, AggregatedMetric> flinkMetrics,
+            IOMetrics ioMetrics,
+            JobVertexID jobVertexID,
+            boolean isSource) {
+        return getNumRecordsInternal(flinkMetrics, ioMetrics, jobVertexID, isSource, false);
+    }
+
+    private static double getNumRecordsInternal(
+            Map<FlinkMetric, AggregatedMetric> flinkMetrics,
+            IOMetrics ioMetrics,
+            JobVertexID jobVertexID,
+            boolean isSource,
+            boolean perSecond) {
         // Generate numRecordsInPerSecond from 3 metrics:
         // 1. If available, directly use the NUM_RECORDS_IN_PER_SEC task metric.
-        var numRecordsInPerSecond = flinkMetrics.get(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
+        var numRecords =
+                perSecond
+                        ? flinkMetrics.get(FlinkMetric.NUM_RECORDS_IN_PER_SEC)
+                        : new AggregatedMetric(
+                                "n",
+                                Double.NaN,
+                                Double.NaN,
+                                Double.NaN,
+                                (double) ioMetrics.getNumRecordsIn());
         // 2. If the former is unavailable and the vertex contains a source operator, use the
         // corresponding source operator metric.
-        if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
-            numRecordsInPerSecond =
-                    flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC);
+        if (isSource && (numRecords == null || numRecords.getSum() == 0)) {
+            var sourceTaskIn =
+                    flinkMetrics.get(
+                            perSecond
+                                    ? FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC
+                                    : FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN);
+            numRecords = sourceTaskIn != null ? sourceTaskIn : numRecords;
         }
         // 3. If the vertex contains a source operator which does not emit input metrics, use output
         // metrics instead.
-        if (isSource && (numRecordsInPerSecond == null || numRecordsInPerSecond.getSum() == 0)) {
-            numRecordsInPerSecond =
-                    flinkMetrics.get(FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC);
+        if (isSource && (numRecords == null || numRecords.getSum() == 0)) {
+            var sourceTaskOut =
+                    flinkMetrics.get(
+                            perSecond
+                                    ? FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC
+                                    : FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT);
+            numRecords = sourceTaskOut != null ? sourceTaskOut : numRecords;
         }
 
-        if (numRecordsInPerSecond == null) {
-            LOG.warn("Received null input rate for {}. Returning NaN.", jobVertexID);
+        if (numRecords == null) {
+            LOG.debug("Received null input rate for {}. Returning NaN.", jobVertexID);
             return Double.NaN;
         }
-        return Math.max(0, numRecordsInPerSecond.getSum());
-    }
-
-    private static double getNumRecordsOutPerSecond(
-            Map<FlinkMetric, AggregatedMetric> flinkMetrics, JobVertexID jobVertexID) {
-
-        AggregatedMetric numRecordsOutPerSecond =
-                flinkMetrics.get(FlinkMetric.NUM_RECORDS_OUT_PER_SEC);
-
-        if (numRecordsOutPerSecond == null) {
-            LOG.warn("Received null output rate for {}. Returning NaN.", jobVertexID);
-            return Double.NaN;
-        }
-        return numRecordsOutPerSecond.getSum();
-    }
-
-    private static double computeEdgeOutPerSecond(
-            JobTopology topology,
-            Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>> flinkMetrics,
-            JobVertexID from,
-            JobVertexID to) {
-        var toMetrics = flinkMetrics.get(to);
-
-        var toVertexInputs = topology.getInputs().get(to);
-        // Case 1: Downstream vertex has a single input (from) so we can use the most reliable num
-        // records in
-        if (toVertexInputs.size() == 1) {
-            LOG.debug(
-                    "Computing edge ({}, {}) data rate for single input downstream task", from, to);
-            return getNumRecordsInPerSecond(toMetrics, to, false);
-        }
-
-        // Case 2: Downstream vertex has only inputs from upstream vertices which don't have other
-        // outputs
-        double numRecordsOutFromUpstreamInputs = 0;
-        for (JobVertexID input : toVertexInputs) {
-            if (input.equals(from)) {
-                // Exclude source edge because we only want to consider other input edges
-                continue;
-            }
-            if (topology.getOutputs().get(input).size() == 1) {
-                numRecordsOutFromUpstreamInputs +=
-                        getNumRecordsOutPerSecond(flinkMetrics.get(input), input);
-            } else {
-                // Output vertex has multiple outputs, cannot use this information...
-                numRecordsOutFromUpstreamInputs = Double.NaN;
-                break;
-            }
-        }
-        if (!Double.isNaN(numRecordsOutFromUpstreamInputs)) {
-            LOG.debug(
-                    "Computing edge ({}, {}) data rate by subtracting upstream input rates",
-                    from,
-                    to);
-            return getNumRecordsInPerSecond(toMetrics, to, false) - numRecordsOutFromUpstreamInputs;
-        }
-        var fromMetrics = flinkMetrics.get(from);
-
-        // Case 3: We fall back simply to num records out, this is the least reliable
-        LOG.debug(
-                "Computing edge ({}, {}) data rate by falling back to from num records out",
-                from,
-                to);
-        return getNumRecordsOutPerSecond(fromMetrics, from);
-    }
-
-    private static double computeTprFromBusyTime(
-            Configuration conf, double rate, double busyTimeMsPerSecond) {
-        if (rate == 0) {
-            // Nothing is coming in, we assume infinite processing power
-            // until we can sample the true processing rate (i.e. data flows).
-            return Double.POSITIVE_INFINITY;
-        }
-        // Pretend that the load is balanced because we don't know any better
-        if (Double.isNaN(busyTimeMsPerSecond)) {
-            busyTimeMsPerSecond = conf.get(AutoScalerOptions.TARGET_UTILIZATION) * 1000;
-        }
-        return rate / (busyTimeMsPerSecond / 1000);
+        return Math.max(0, numRecords.getSum());
     }
 
     public static double roundMetric(double value) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/IOMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/IOMetrics.java
@@ -15,21 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.autoscaler.metrics;
+package org.apache.flink.autoscaler.topology;
 
-import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Value;
 
-import java.util.Map;
+/** Vertex io metrics. */
+@Value
+public class IOMetrics {
 
-/** Collected scaling metrics. */
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
-public class CollectedMetrics {
-    private Map<JobVertexID, Map<ScalingMetric, Double>> vertexMetrics;
-    private Map<ScalingMetric, Double> globalMetrics;
+    public static final IOMetrics FINISHED_METRICS = new IOMetrics(0, 0, 0);
+
+    long numRecordsIn;
+    long numRecordsOut;
+    double accumulatedBusyTime;
+
+    public static IOMetrics from(IOMetricsInfo metricsInfo) {
+        return new IOMetrics(
+                metricsInfo.getRecordsRead(),
+                metricsInfo.getRecordsWritten(),
+                metricsInfo.getAccumulatedBusy());
+    }
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/VertexInfo.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/VertexInfo.java
@@ -22,8 +22,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import lombok.Data;
 
-import javax.annotation.Nullable;
-
 import java.util.Set;
 
 /** Job vertex information. */
@@ -34,7 +32,7 @@ public class VertexInfo {
 
     private final Set<JobVertexID> inputs;
 
-    private @Nullable Set<JobVertexID> outputs;
+    private Set<JobVertexID> outputs;
 
     private final int parallelism;
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/VertexInfo.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/VertexInfo.java
@@ -17,30 +17,68 @@
 
 package org.apache.flink.autoscaler.topology;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
-import lombok.RequiredArgsConstructor;
-import lombok.Value;
+import lombok.Data;
+
+import javax.annotation.Nullable;
 
 import java.util.Set;
 
 /** Job vertex information. */
-@Value
-@RequiredArgsConstructor
+@Data
 public class VertexInfo {
 
-    JobVertexID id;
+    private final JobVertexID id;
 
-    Set<JobVertexID> inputs;
+    private final Set<JobVertexID> inputs;
 
-    int parallelism;
+    private @Nullable Set<JobVertexID> outputs;
 
-    int maxParallelism;
+    private final int parallelism;
 
-    boolean finished;
+    private int maxParallelism;
+
+    private final int originalMaxParallelism;
+
+    private final boolean finished;
+
+    private IOMetrics ioMetrics;
 
     public VertexInfo(
+            JobVertexID id,
+            Set<JobVertexID> inputs,
+            int parallelism,
+            int maxParallelism,
+            boolean finished,
+            IOMetrics ioMetrics) {
+        this.id = id;
+        this.inputs = inputs;
+        this.parallelism = parallelism;
+        this.maxParallelism = maxParallelism;
+        this.originalMaxParallelism = maxParallelism;
+        this.finished = finished;
+        this.ioMetrics = ioMetrics;
+    }
+
+    @VisibleForTesting
+    public VertexInfo(
+            JobVertexID id,
+            Set<JobVertexID> inputs,
+            int parallelism,
+            int maxParallelism,
+            IOMetrics ioMetrics) {
+        this(id, inputs, parallelism, maxParallelism, false, ioMetrics);
+    }
+
+    @VisibleForTesting
+    public VertexInfo(
             JobVertexID id, Set<JobVertexID> inputs, int parallelism, int maxParallelism) {
-        this(id, inputs, parallelism, maxParallelism, false);
+        this(id, inputs, parallelism, maxParallelism, null);
+    }
+
+    public void updateMaxParallelism(int maxParallelism) {
+        setMaxParallelism(Math.min(originalMaxParallelism, maxParallelism));
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -419,8 +419,6 @@ public class MetricsCollectionAndEvaluationTest {
                 Map.of(
                         ScalingMetric.LAG,
                         0.,
-                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                        0.,
                         ScalingMetric.OBSERVED_TPR,
                         Double.POSITIVE_INFINITY,
                         ScalingMetric.NUM_RECORDS_IN,

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -280,7 +280,7 @@ public class ScalingExecutorTest {
                         ScalingMetric.GC_PRESSURE,
                         EvaluatedScalingMetric.of(Double.NaN));
         var vertexMetrics =
-                Map.of(source, evaluated(10, 50, 100, 50, 0), sink, evaluated(10, 50, 100, 50, 0));
+                Map.of(source, evaluated(10, 100, 50, 0), sink, evaluated(10, 100, 50, 0));
         var metrics = new EvaluatedMetrics(vertexMetrics, globalMetrics);
 
         assertTrue(
@@ -443,11 +443,10 @@ public class ScalingExecutorTest {
     }
 
     private Map<ScalingMetric, EvaluatedScalingMetric> evaluated(
-            int parallelism, double current, double target, double procRate, double catchupRate) {
+            int parallelism, double target, double procRate, double catchupRate) {
         var metrics = new HashMap<ScalingMetric, EvaluatedScalingMetric>();
         metrics.put(ScalingMetric.PARALLELISM, EvaluatedScalingMetric.of(parallelism));
         metrics.put(ScalingMetric.MAX_PARALLELISM, EvaluatedScalingMetric.of(720));
-        metrics.put(ScalingMetric.CURRENT_PROCESSING_RATE, EvaluatedScalingMetric.avg(current));
         metrics.put(ScalingMetric.TARGET_DATA_RATE, new EvaluatedScalingMetric(target, target));
         metrics.put(ScalingMetric.CATCH_UP_DATA_RATE, EvaluatedScalingMetric.of(catchupRate));
         metrics.put(
@@ -457,11 +456,6 @@ public class ScalingExecutorTest {
         ScalingMetricEvaluator.computeProcessingRateThresholds(
                 metrics, context.getConfiguration(), false, restartTime);
         return metrics;
-    }
-
-    private Map<ScalingMetric, EvaluatedScalingMetric> evaluated(
-            int parallelism, double target, double procRate, double catchupRate) {
-        return evaluated(parallelism, Double.NaN, target, procRate, catchupRate);
     }
 
     private Map<ScalingMetric, EvaluatedScalingMetric> evaluated(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
@@ -395,7 +395,7 @@ public class ScalingMetricCollectorTest {
     }
 
     private List<String> getRequiredMetrics() {
-        return List.of("busyTimeMsPerSecond", "numRecordsInPerSecond");
+        return List.of("busyTimeMsPerSecond");
     }
 
     @Test

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.autoscaler.metrics.FlinkMetric;
 import org.apache.flink.autoscaler.metrics.MetricNotFoundException;
+import org.apache.flink.autoscaler.topology.IOMetrics;
 import org.apache.flink.autoscaler.topology.JobTopology;
 import org.apache.flink.autoscaler.topology.VertexInfo;
 import org.apache.flink.client.program.rest.RestClusterClient;
@@ -70,11 +71,159 @@ public class ScalingMetricCollectorTest {
     @Test
     public void testJobTopologyParsingFromJobDetails() throws Exception {
         String s =
-                "{\"jid\":\"8b6cdb9a1db8876d3dd803d5e6108ae3\",\"name\":\"State machine job\",\"isStoppable\":false,\"state\":\"RUNNING\",\"start-time\":1686216314565,\"end-time\":-1,\"duration\":25867,\"maxParallelism\":-1,\"now\":1686216340432,\"timestamps\":{\"INITIALIZING\":1686216314565,\"RECONCILING\":0,\"CANCELLING\":0,\"FAILING\":0,\"CREATED\":1686216314697,\"SUSPENDED\":0,\"RUNNING\":1686216314900,\"FAILED\":0,\"CANCELED\":0,\"FINISHED\":0,\"RESTARTING\":0},\"vertices\":[{\"id\":\"bc764cd8ddf7a0cff126f51c16239658\",\"name\":\"Source: Custom Source\",\"maxParallelism\":128,\"parallelism\":2,\"status\":\"RUNNING\",\"start-time\":1686216324513,\"end-time\":-1,\"duration\":15919,\"tasks\":{\"DEPLOYING\":0,\"RUNNING\":2,\"FINISHED\":0,\"CANCELING\":0,\"SCHEDULED\":0,\"RECONCILING\":0,\"INITIALIZING\":0,\"CREATED\":0,\"FAILED\":0,\"CANCELED\":0},\"metrics\":{\"read-bytes\":0,\"read-bytes-complete\":true,\"write-bytes\":297883,\"write-bytes-complete\":true,\"read-records\":0,\"read-records-complete\":true,\"write-records\":22972,\"write-records-complete\":true,\"accumulated-backpressured-time\":0,\"accumulated-idle-time\":0,\"accumulated-busy-time\":\"NaN\"}},{\"id\":\"20ba6b65f97481d5570070de90e4e791\",\"name\":\"Flat Map -> Sink: Print to Std. Out\",\"maxParallelism\":128,\"parallelism\":2,\"status\":\"RUNNING\",\"start-time\":1686216324570,\"end-time\":-1,\"duration\":15862,\"tasks\":{\"DEPLOYING\":0,\"RUNNING\":2,\"FINISHED\":0,\"CANCELING\":0,\"SCHEDULED\":0,\"RECONCILING\":0,\"INITIALIZING\":0,\"CREATED\":0,\"FAILED\":0,\"CANCELED\":0},\"metrics\":{\"read-bytes\":321025,\"read-bytes-complete\":true,\"write-bytes\":0,\"write-bytes-complete\":true,\"read-records\":22957,\"read-records-complete\":true,\"write-records\":0,\"write-records-complete\":true,\"accumulated-backpressured-time\":0,\"accumulated-idle-time\":28998,\"accumulated-busy-time\":0.0}}],\"status-counts\":{\"DEPLOYING\":0,\"RUNNING\":2,\"FINISHED\":0,\"CANCELING\":0,\"SCHEDULED\":0,\"RECONCILING\":0,\"INITIALIZING\":0,\"CREATED\":0,\"FAILED\":0,\"CANCELED\":0},\"plan\":{\"jid\":\"8b6cdb9a1db8876d3dd803d5e6108ae3\",\"name\":\"State machine job\",\"type\":\"STREAMING\",\"nodes\":[{\"id\":\"20ba6b65f97481d5570070de90e4e791\",\"parallelism\":2,\"operator\":\"\",\"operator_strategy\":\"\",\"description\":\"Flat Map<br/>+- Sink: Print to Std. Out<br/>\",\"inputs\":[{\"num\":0,\"id\":\"bc764cd8ddf7a0cff126f51c16239658\",\"ship_strategy\":\"HASH\",\"exchange\":\"pipelined_bounded\"}],\"optimizer_properties\":{}},{\"id\":\"bc764cd8ddf7a0cff126f51c16239658\",\"parallelism\":2,\"operator\":\"\",\"operator_strategy\":\"\",\"description\":\"Source: Custom Source<br/>\",\"optimizer_properties\":{}}]}}";
+                "{\n"
+                        + "  \"jid\": \"bb8f15efbb37f2ce519f55cdc0e049bf\",\n"
+                        + "  \"name\": \"State machine job\",\n"
+                        + "  \"isStoppable\": false,\n"
+                        + "  \"state\": \"RUNNING\",\n"
+                        + "  \"start-time\": 1707893512027,\n"
+                        + "  \"end-time\": -1,\n"
+                        + "  \"duration\": 214716,\n"
+                        + "  \"maxParallelism\": -1,\n"
+                        + "  \"now\": 1707893726743,\n"
+                        + "  \"timestamps\": {\n"
+                        + "    \"SUSPENDED\": 0,\n"
+                        + "    \"CREATED\": 1707893512139,\n"
+                        + "    \"FAILING\": 0,\n"
+                        + "    \"FAILED\": 0,\n"
+                        + "    \"INITIALIZING\": 1707893512027,\n"
+                        + "    \"RECONCILING\": 0,\n"
+                        + "    \"RUNNING\": 1707893512217,\n"
+                        + "    \"RESTARTING\": 0,\n"
+                        + "    \"CANCELLING\": 0,\n"
+                        + "    \"FINISHED\": 0,\n"
+                        + "    \"CANCELED\": 0\n"
+                        + "  },\n"
+                        + "  \"vertices\": [\n"
+                        + "    {\n"
+                        + "      \"id\": \"bc764cd8ddf7a0cff126f51c16239658\",\n"
+                        + "      \"name\": \"Source: Custom Source\",\n"
+                        + "      \"maxParallelism\": 128,\n"
+                        + "      \"parallelism\": 2,\n"
+                        + "      \"status\": \"FINISHED\",\n"
+                        + "      \"start-time\": 1707893517277,\n"
+                        + "      \"end-time\": -1,\n"
+                        + "      \"duration\": 209466,\n"
+                        + "      \"tasks\": {\n"
+                        + "        \"DEPLOYING\": 0,\n"
+                        + "        \"INITIALIZING\": 0,\n"
+                        + "        \"SCHEDULED\": 0,\n"
+                        + "        \"CANCELING\": 0,\n"
+                        + "        \"CANCELED\": 0,\n"
+                        + "        \"RECONCILING\": 0,\n"
+                        + "        \"RUNNING\": 2,\n"
+                        + "        \"FAILED\": 0,\n"
+                        + "        \"CREATED\": 0,\n"
+                        + "        \"FINISHED\": 0\n"
+                        + "      },\n"
+                        + "      \"metrics\": {\n"
+                        + "        \"read-bytes\": 0,\n"
+                        + "        \"read-bytes-complete\": true,\n"
+                        + "        \"write-bytes\": 4036982,\n"
+                        + "        \"write-bytes-complete\": true,\n"
+                        + "        \"read-records\": 0,\n"
+                        + "        \"read-records-complete\": true,\n"
+                        + "        \"write-records\": 291629,\n"
+                        + "        \"write-records-complete\": true,\n"
+                        + "        \"accumulated-backpressured-time\": 0,\n"
+                        + "        \"accumulated-idle-time\": 0,\n"
+                        + "        \"accumulated-busy-time\": \"NaN\"\n"
+                        + "      }\n"
+                        + "    },\n"
+                        + "    {\n"
+                        + "      \"id\": \"20ba6b65f97481d5570070de90e4e791\",\n"
+                        + "      \"name\": \"Flat Map -> Sink: Print to Std. Out\",\n"
+                        + "      \"maxParallelism\": 128,\n"
+                        + "      \"parallelism\": 2,\n"
+                        + "      \"status\": \"RUNNING\",\n"
+                        + "      \"start-time\": 1707893517280,\n"
+                        + "      \"end-time\": -1,\n"
+                        + "      \"duration\": 209463,\n"
+                        + "      \"tasks\": {\n"
+                        + "        \"DEPLOYING\": 0,\n"
+                        + "        \"INITIALIZING\": 0,\n"
+                        + "        \"SCHEDULED\": 0,\n"
+                        + "        \"CANCELING\": 0,\n"
+                        + "        \"CANCELED\": 0,\n"
+                        + "        \"RECONCILING\": 0,\n"
+                        + "        \"RUNNING\": 2,\n"
+                        + "        \"FAILED\": 0,\n"
+                        + "        \"CREATED\": 0,\n"
+                        + "        \"FINISHED\": 0\n"
+                        + "      },\n"
+                        + "      \"metrics\": {\n"
+                        + "        \"read-bytes\": 4078629,\n"
+                        + "        \"read-bytes-complete\": true,\n"
+                        + "        \"write-bytes\": 0,\n"
+                        + "        \"write-bytes-complete\": true,\n"
+                        + "        \"read-records\": 291532,\n"
+                        + "        \"read-records-complete\": true,\n"
+                        + "        \"write-records\": 1,\n"
+                        + "        \"write-records-complete\": true,\n"
+                        + "        \"accumulated-backpressured-time\": 0,\n"
+                        + "        \"accumulated-idle-time\": 407702,\n"
+                        + "        \"accumulated-busy-time\": 2\n"
+                        + "      }\n"
+                        + "    }\n"
+                        + "  ],\n"
+                        + "  \"status-counts\": {\n"
+                        + "    \"DEPLOYING\": 0,\n"
+                        + "    \"INITIALIZING\": 0,\n"
+                        + "    \"SCHEDULED\": 0,\n"
+                        + "    \"CANCELING\": 0,\n"
+                        + "    \"CANCELED\": 0,\n"
+                        + "    \"RECONCILING\": 0,\n"
+                        + "    \"RUNNING\": 2,\n"
+                        + "    \"FAILED\": 0,\n"
+                        + "    \"CREATED\": 0,\n"
+                        + "    \"FINISHED\": 0\n"
+                        + "  },\n"
+                        + "  \"plan\": {\n"
+                        + "    \"jid\": \"bb8f15efbb37f2ce519f55cdc0e049bf\",\n"
+                        + "    \"name\": \"State machine job\",\n"
+                        + "    \"type\": \"STREAMING\",\n"
+                        + "    \"nodes\": [\n"
+                        + "      {\n"
+                        + "        \"id\": \"20ba6b65f97481d5570070de90e4e791\",\n"
+                        + "        \"parallelism\": 2,\n"
+                        + "        \"operator\": \"\",\n"
+                        + "        \"operator_strategy\": \"\",\n"
+                        + "        \"description\": \"Flat Map<br/>+- Sink: Print to Std. Out<br/>\",\n"
+                        + "        \"inputs\": [\n"
+                        + "          {\n"
+                        + "            \"num\": 0,\n"
+                        + "            \"id\": \"bc764cd8ddf7a0cff126f51c16239658\",\n"
+                        + "            \"ship_strategy\": \"HASH\",\n"
+                        + "            \"exchange\": \"pipelined_bounded\"\n"
+                        + "          }\n"
+                        + "        ],\n"
+                        + "        \"optimizer_properties\": {}\n"
+                        + "      },\n"
+                        + "      {\n"
+                        + "        \"id\": \"bc764cd8ddf7a0cff126f51c16239658\",\n"
+                        + "        \"parallelism\": 2,\n"
+                        + "        \"operator\": \"\",\n"
+                        + "        \"operator_strategy\": \"\",\n"
+                        + "        \"description\": \"Source: Custom Source<br/>\",\n"
+                        + "        \"optimizer_properties\": {}\n"
+                        + "      }\n"
+                        + "    ]\n"
+                        + "  }\n"
+                        + "}";
         JobDetailsInfo jobDetailsInfo = new ObjectMapper().readValue(s, JobDetailsInfo.class);
 
         var metricsCollector = new RestApiMetricsCollector<>();
-        metricsCollector.getJobTopology(jobDetailsInfo);
+
+        var sourceId = JobVertexID.fromHexString("bc764cd8ddf7a0cff126f51c16239658");
+        var sinkId = JobVertexID.fromHexString("20ba6b65f97481d5570070de90e4e791");
+
+        var source = new VertexInfo(sourceId, Set.of(), 2, 128, true, IOMetrics.FINISHED_METRICS);
+        var sink =
+                new VertexInfo(
+                        sinkId, Set.of(sourceId), 2, 128, false, new IOMetrics(291532, 1, 2));
+
+        assertEquals(
+                new JobTopology(source, sink), metricsCollector.getJobTopology(jobDetailsInfo));
     }
 
     @Test
@@ -154,7 +303,7 @@ public class ScalingMetricCollectorTest {
         // Mark source finished, should not be queried again
         t2 =
                 new JobTopology(
-                        new VertexInfo(source2, Set.of(), 1, 1, true),
+                        new VertexInfo(source2, Set.of(), 1, 1, true, null),
                         new VertexInfo(sink, Set.of(source2), 1, 1));
         collector.queryFilteredMetricNames(context, t2);
         assertEquals(3, metricNameQueryCounter.get(source));

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -331,37 +331,38 @@ public class ScalingMetricEvaluatorTest {
 
         // 0 lag
         metricHistory.put(
-                Instant.now(),
+                Instant.ofEpochMilli(0),
                 new CollectedMetrics(
                         Map.of(
                                 source,
-                                Map.of(
-                                        ScalingMetric.LAG,
-                                        0.,
-                                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                                        100.),
+                                Map.of(ScalingMetric.LAG, 0., ScalingMetric.NUM_RECORDS_IN, 0.),
                                 sink,
-                                Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 2000.)),
+                                Map.of()),
+                        Map.of()));
+
+        metricHistory.put(
+                Instant.ofEpochMilli(1000),
+                new CollectedMetrics(
+                        Map.of(
+                                source,
+                                Map.of(ScalingMetric.LAG, 0., ScalingMetric.NUM_RECORDS_IN, 100.),
+                                sink,
+                                Map.of()),
                         Map.of()));
         assertFalse(ScalingMetricEvaluator.isProcessingBacklog(topology, metricHistory, conf));
 
         // Missing lag
-        metricHistory.clear();
         metricHistory.put(
-                Instant.now(),
+                Instant.ofEpochMilli(1000),
                 new CollectedMetrics(
-                        Map.of(
-                                source,
-                                Map.of(ScalingMetric.CURRENT_PROCESSING_RATE, 100.),
-                                sink,
-                                Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 2000.)),
+                        Map.of(source, Map.of(ScalingMetric.NUM_RECORDS_IN, 100.), sink, Map.of()),
                         Map.of()));
 
         assertFalse(ScalingMetricEvaluator.isProcessingBacklog(topology, metricHistory, conf));
 
         // Catch up time is more than a minute at avg proc rate (200)
         metricHistory.put(
-                Instant.now(),
+                Instant.ofEpochMilli(1000),
                 new CollectedMetrics(
                         Map.of(
                                 source,
@@ -372,17 +373,17 @@ public class ScalingMetricEvaluatorTest {
                                                                 AutoScalerOptions
                                                                         .BACKLOG_PROCESSING_LAG_THRESHOLD)
                                                         .toSeconds(),
-                                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                                        300.),
+                                        ScalingMetric.NUM_RECORDS_IN,
+                                        200.),
                                 sink,
-                                Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 2000.)),
+                                Map.of()),
                         Map.of()));
 
         assertTrue(ScalingMetricEvaluator.isProcessingBacklog(topology, metricHistory, conf));
 
         // Catch up time is less than a minute at avg proc rate (200)
         metricHistory.put(
-                Instant.now(),
+                Instant.ofEpochMilli(1000),
                 new CollectedMetrics(
                         Map.of(
                                 source,
@@ -393,10 +394,10 @@ public class ScalingMetricEvaluatorTest {
                                                                 AutoScalerOptions
                                                                         .BACKLOG_PROCESSING_LAG_THRESHOLD)
                                                         .toSeconds(),
-                                        ScalingMetric.CURRENT_PROCESSING_RATE,
+                                        ScalingMetric.NUM_RECORDS_IN,
                                         200.),
                                 sink,
-                                Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 2000.)),
+                                Map.of()),
                         Map.of()));
         assertFalse(ScalingMetricEvaluator.isProcessingBacklog(topology, metricHistory, conf));
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -664,13 +664,15 @@ public class ScalingMetricEvaluatorTest {
 
         assertEquals(
                 2.,
-                ScalingMetricEvaluator.computeOutputRatio(source1, op1, topology, metricHistory));
+                ScalingMetricEvaluator.computeEdgeOutputRatio(
+                        source1, op1, topology, metricHistory));
         assertEquals(
                 0.5,
-                ScalingMetricEvaluator.computeOutputRatio(source2, op1, topology, metricHistory));
+                ScalingMetricEvaluator.computeEdgeOutputRatio(
+                        source2, op1, topology, metricHistory));
         assertEquals(
                 0.2,
-                ScalingMetricEvaluator.computeOutputRatio(op1, sink1, topology, metricHistory));
+                ScalingMetricEvaluator.computeEdgeOutputRatio(op1, sink1, topology, metricHistory));
     }
 
     @Test
@@ -720,16 +722,20 @@ public class ScalingMetricEvaluatorTest {
 
         assertEquals(
                 2.,
-                ScalingMetricEvaluator.computeOutputRatio(source1, op1, topology, metricHistory));
+                ScalingMetricEvaluator.computeEdgeOutputRatio(
+                        source1, op1, topology, metricHistory));
         assertEquals(
                 0.5,
-                ScalingMetricEvaluator.computeOutputRatio(source2, op1, topology, metricHistory));
+                ScalingMetricEvaluator.computeEdgeOutputRatio(
+                        source2, op1, topology, metricHistory));
         assertEquals(
                 2.,
-                ScalingMetricEvaluator.computeOutputRatio(source1, op2, topology, metricHistory));
+                ScalingMetricEvaluator.computeEdgeOutputRatio(
+                        source1, op2, topology, metricHistory));
         assertEquals(
                 0.5,
-                ScalingMetricEvaluator.computeOutputRatio(source2, op2, topology, metricHistory));
+                ScalingMetricEvaluator.computeEdgeOutputRatio(
+                        source2, op2, topology, metricHistory));
     }
 
     @Test

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -21,8 +21,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.metrics.CollectedMetricHistory;
 import org.apache.flink.autoscaler.metrics.CollectedMetrics;
-import org.apache.flink.autoscaler.metrics.Edge;
 import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
+import org.apache.flink.autoscaler.metrics.MetricAggregator;
 import org.apache.flink.autoscaler.metrics.ScalingMetric;
 import org.apache.flink.autoscaler.topology.JobTopology;
 import org.apache.flink.autoscaler.topology.VertexInfo;
@@ -51,6 +51,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /** Scaling evaluator test. */
 public class ScalingMetricEvaluatorTest {
 
+    private ScalingMetricEvaluator evaluator = new ScalingMetricEvaluator();
+
     @Test
     public void testLagBasedSourceScaling() {
         var source = new JobVertexID();
@@ -58,57 +60,49 @@ public class ScalingMetricEvaluatorTest {
 
         var topology =
                 new JobTopology(
-                        new VertexInfo(source, Collections.emptySet(), 1, 1),
-                        new VertexInfo(sink, Set.of(source), 1, 1));
-
-        var evaluator = new ScalingMetricEvaluator();
+                        new VertexInfo(source, Collections.emptySet(), 1, 1, null),
+                        new VertexInfo(sink, Set.of(source), 1, 1, null));
 
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
 
         metricHistory.put(
-                Instant.now(),
+                Instant.ofEpochMilli(1000),
                 new CollectedMetrics(
                         Map.of(
                                 source,
                                 Map.of(
-                                        ScalingMetric.SOURCE_DATA_RATE,
-                                        100.,
                                         ScalingMetric.LAG,
+                                        950.,
+                                        ScalingMetric.NUM_RECORDS_IN,
                                         0.,
-                                        ScalingMetric.TRUE_PROCESSING_RATE,
-                                        200.,
+                                        ScalingMetric.NUM_RECORDS_OUT,
+                                        0.,
                                         ScalingMetric.LOAD,
                                         .8),
                                 sink,
-                                Map.of(
-                                        ScalingMetric.TRUE_PROCESSING_RATE,
-                                        2000.,
-                                        ScalingMetric.LOAD,
-                                        .4)),
-                        Map.of(new Edge(source, sink), 2.),
+                                Map.of(ScalingMetric.NUM_RECORDS_IN, 0., ScalingMetric.LOAD, .4)),
                         Map.of()));
 
+        // Lag 950 -> 1000
+        // Input records 0 -> 100
+        // -> Source Data rate = 150
+        // Output ratio 2
         metricHistory.put(
-                Instant.now(),
+                Instant.ofEpochMilli(2000),
                 new CollectedMetrics(
                         Map.of(
                                 source,
                                 Map.of(
-                                        ScalingMetric.SOURCE_DATA_RATE,
-                                        200.,
                                         ScalingMetric.LAG,
                                         1000.,
-                                        ScalingMetric.TRUE_PROCESSING_RATE,
+                                        ScalingMetric.NUM_RECORDS_IN,
+                                        100.,
+                                        ScalingMetric.NUM_RECORDS_OUT,
                                         200.,
                                         ScalingMetric.LOAD,
                                         .6),
                                 sink,
-                                Map.of(
-                                        ScalingMetric.TRUE_PROCESSING_RATE,
-                                        2000.,
-                                        ScalingMetric.LOAD,
-                                        .3)),
-                        Map.of(new Edge(source, sink), 2.),
+                                Map.of(ScalingMetric.NUM_RECORDS_IN, 200., ScalingMetric.LOAD, .3)),
                         Map.of()));
 
         var conf = new Configuration();
@@ -123,21 +117,21 @@ public class ScalingMetricEvaluatorTest {
                         .getVertexMetrics();
 
         assertEquals(
-                new EvaluatedScalingMetric(.6, .7),
+                EvaluatedScalingMetric.avg(.7),
                 evaluatedMetrics.get(source).get(ScalingMetric.LOAD));
 
         assertEquals(
-                new EvaluatedScalingMetric(.3, .35),
+                EvaluatedScalingMetric.avg(.35),
                 evaluatedMetrics.get(sink).get(ScalingMetric.LOAD));
 
         assertEquals(
-                new EvaluatedScalingMetric(200, 150),
+                EvaluatedScalingMetric.avg(150),
                 evaluatedMetrics.get(source).get(ScalingMetric.TARGET_DATA_RATE));
         assertEquals(
-                EvaluatedScalingMetric.of(500),
+                EvaluatedScalingMetric.of(500.),
                 evaluatedMetrics.get(source).get(ScalingMetric.CATCH_UP_DATA_RATE));
         assertEquals(
-                new EvaluatedScalingMetric(400, 300),
+                EvaluatedScalingMetric.avg(300),
                 evaluatedMetrics.get(sink).get(ScalingMetric.TARGET_DATA_RATE));
         assertEquals(
                 EvaluatedScalingMetric.of(1000),
@@ -156,13 +150,13 @@ public class ScalingMetricEvaluatorTest {
                                 Duration.ZERO)
                         .getVertexMetrics();
         assertEquals(
-                new EvaluatedScalingMetric(200, 150),
+                EvaluatedScalingMetric.avg(150),
                 evaluatedMetrics.get(source).get(ScalingMetric.TARGET_DATA_RATE));
         assertEquals(
                 EvaluatedScalingMetric.of(1000),
                 evaluatedMetrics.get(source).get(ScalingMetric.CATCH_UP_DATA_RATE));
         assertEquals(
-                new EvaluatedScalingMetric(400, 300),
+                EvaluatedScalingMetric.avg(300),
                 evaluatedMetrics.get(sink).get(ScalingMetric.TARGET_DATA_RATE));
         assertEquals(
                 EvaluatedScalingMetric.of(2000),
@@ -179,13 +173,13 @@ public class ScalingMetricEvaluatorTest {
                                 Duration.ZERO)
                         .getVertexMetrics();
         assertEquals(
-                new EvaluatedScalingMetric(200, 150),
+                EvaluatedScalingMetric.avg(150),
                 evaluatedMetrics.get(source).get(ScalingMetric.TARGET_DATA_RATE));
         assertEquals(
                 EvaluatedScalingMetric.of(1000),
                 evaluatedMetrics.get(source).get(ScalingMetric.CATCH_UP_DATA_RATE));
         assertEquals(
-                new EvaluatedScalingMetric(400, 300),
+                EvaluatedScalingMetric.avg(300),
                 evaluatedMetrics.get(sink).get(ScalingMetric.TARGET_DATA_RATE));
         assertEquals(
                 EvaluatedScalingMetric.of(2000),
@@ -201,13 +195,13 @@ public class ScalingMetricEvaluatorTest {
                                 Duration.ZERO)
                         .getVertexMetrics();
         assertEquals(
-                new EvaluatedScalingMetric(200, 150),
+                EvaluatedScalingMetric.avg(150),
                 evaluatedMetrics.get(source).get(ScalingMetric.TARGET_DATA_RATE));
         assertEquals(
                 EvaluatedScalingMetric.of(0),
                 evaluatedMetrics.get(source).get(ScalingMetric.CATCH_UP_DATA_RATE));
         assertEquals(
-                new EvaluatedScalingMetric(400, 300),
+                EvaluatedScalingMetric.avg(300),
                 evaluatedMetrics.get(sink).get(ScalingMetric.TARGET_DATA_RATE));
         assertEquals(
                 EvaluatedScalingMetric.of(0),
@@ -216,26 +210,39 @@ public class ScalingMetricEvaluatorTest {
         // Test 0 lag
         metricHistory.clear();
         metricHistory.put(
-                Instant.now(),
+                Instant.ofEpochMilli(3000),
                 new CollectedMetrics(
                         Map.of(
                                 source,
                                 Map.of(
-                                        ScalingMetric.SOURCE_DATA_RATE,
-                                        100.,
                                         ScalingMetric.LAG,
                                         0.,
-                                        ScalingMetric.TRUE_PROCESSING_RATE,
+                                        ScalingMetric.NUM_RECORDS_IN,
+                                        100.,
+                                        ScalingMetric.NUM_RECORDS_OUT,
                                         200.,
                                         ScalingMetric.LOAD,
-                                        .85),
+                                        .6),
                                 sink,
+                                Map.of(ScalingMetric.NUM_RECORDS_IN, 200., ScalingMetric.LOAD, .3)),
+                        Map.of()));
+
+        metricHistory.put(
+                Instant.ofEpochMilli(4000),
+                new CollectedMetrics(
+                        Map.of(
+                                source,
                                 Map.of(
-                                        ScalingMetric.TRUE_PROCESSING_RATE,
-                                        2000.,
+                                        ScalingMetric.LAG,
+                                        0.,
+                                        ScalingMetric.NUM_RECORDS_IN,
+                                        200.,
+                                        ScalingMetric.NUM_RECORDS_OUT,
+                                        400.,
                                         ScalingMetric.LOAD,
-                                        .85)),
-                        Map.of(new Edge(source, sink), 2.),
+                                        .6),
+                                sink,
+                                Map.of(ScalingMetric.NUM_RECORDS_IN, 400., ScalingMetric.LOAD, .3)),
                         Map.of()));
 
         conf.set(CATCH_UP_DURATION, Duration.ofMinutes(1));
@@ -247,10 +254,10 @@ public class ScalingMetricEvaluatorTest {
                                 Duration.ZERO)
                         .getVertexMetrics();
         assertEquals(
-                new EvaluatedScalingMetric(100, 100),
+                EvaluatedScalingMetric.avg(100),
                 evaluatedMetrics.get(source).get(ScalingMetric.TARGET_DATA_RATE));
         assertEquals(
-                new EvaluatedScalingMetric(200, 200),
+                EvaluatedScalingMetric.avg(200),
                 evaluatedMetrics.get(sink).get(ScalingMetric.TARGET_DATA_RATE));
     }
 
@@ -335,7 +342,6 @@ public class ScalingMetricEvaluatorTest {
                                         100.),
                                 sink,
                                 Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 2000.)),
-                        Collections.emptyMap(),
                         Map.of()));
         assertFalse(ScalingMetricEvaluator.isProcessingBacklog(topology, metricHistory, conf));
 
@@ -349,7 +355,6 @@ public class ScalingMetricEvaluatorTest {
                                 Map.of(ScalingMetric.CURRENT_PROCESSING_RATE, 100.),
                                 sink,
                                 Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 2000.)),
-                        Collections.emptyMap(),
                         Map.of()));
 
         assertFalse(ScalingMetricEvaluator.isProcessingBacklog(topology, metricHistory, conf));
@@ -371,7 +376,6 @@ public class ScalingMetricEvaluatorTest {
                                         300.),
                                 sink,
                                 Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 2000.)),
-                        Collections.emptyMap(),
                         Map.of()));
 
         assertTrue(ScalingMetricEvaluator.isProcessingBacklog(topology, metricHistory, conf));
@@ -393,7 +397,6 @@ public class ScalingMetricEvaluatorTest {
                                         200.),
                                 sink,
                                 Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 2000.)),
-                        Collections.emptyMap(),
                         Map.of()));
         assertFalse(ScalingMetricEvaluator.isProcessingBacklog(topology, metricHistory, conf));
     }
@@ -402,177 +405,77 @@ public class ScalingMetricEvaluatorTest {
     public void testObservedTprEvaluation() {
         var source = new JobVertexID();
         var conf = new Configuration();
-        var restartTime = conf.get(AutoScalerOptions.RESTART_TIME);
-
-        var topology = new JobTopology(new VertexInfo(source, Collections.emptySet(), 1, 1));
-        var evaluator = new ScalingMetricEvaluator();
 
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
         metricHistory.put(
-                Instant.ofEpochMilli(100),
+                Instant.ofEpochMilli(1000),
                 new CollectedMetrics(
-                        Map.of(
-                                source,
-                                Map.of(
-                                        ScalingMetric.LAG,
-                                        0.,
-                                        ScalingMetric.TRUE_PROCESSING_RATE,
-                                        300.,
-                                        ScalingMetric.OBSERVED_TPR,
-                                        200.,
-                                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                                        100.,
-                                        ScalingMetric.SOURCE_DATA_RATE,
-                                        50.,
-                                        ScalingMetric.LOAD,
-                                        10.)),
-                        Map.of(),
-                        Map.of()));
+                        Map.of(source, Map.of(ScalingMetric.OBSERVED_TPR, 200.)), Map.of()));
         metricHistory.put(
-                Instant.ofEpochMilli(200),
+                Instant.ofEpochMilli(2000),
                 new CollectedMetrics(
-                        Map.of(
-                                source,
-                                Map.of(
-                                        ScalingMetric.LAG,
-                                        0.,
-                                        ScalingMetric.TRUE_PROCESSING_RATE,
-                                        400.,
-                                        ScalingMetric.OBSERVED_TPR,
-                                        400.,
-                                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                                        100.,
-                                        ScalingMetric.SOURCE_DATA_RATE,
-                                        50.,
-                                        ScalingMetric.LOAD,
-                                        10.)),
-                        Map.of(),
-                        Map.of()));
+                        Map.of(source, Map.of(ScalingMetric.OBSERVED_TPR, 400.)), Map.of()));
 
         // Observed TPR average : 300
-        // Bust Time TPR average: 350
 
         // Set diff threshold to 20% -> within threshold
         conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_SWITCH_THRESHOLD, 0.2);
 
         // Test that we used busy time based TPR
         assertEquals(
-                new EvaluatedScalingMetric(400., 350.),
-                evaluator
-                        .evaluate(
-                                conf,
-                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
-                                restartTime)
-                        .getVertexMetrics()
-                        .get(source)
-                        .get(ScalingMetric.TRUE_PROCESSING_RATE));
+                350,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        100, 35, metricHistory, source, conf));
 
         // Set diff threshold to 10% -> outside threshold
         conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_SWITCH_THRESHOLD, 0.1);
 
         // Test that we used the observed TPR
         assertEquals(
-                new EvaluatedScalingMetric(400, 300.),
-                evaluator
-                        .evaluate(
-                                conf,
-                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
-                                restartTime)
-                        .getVertexMetrics()
-                        .get(source)
-                        .get(ScalingMetric.TRUE_PROCESSING_RATE));
+                300,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        100, 35, metricHistory, source, conf));
 
         // Test that observed tpr min observations are respected. If less, use busy time
         conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_MIN_OBSERVATIONS, 3);
         assertEquals(
-                new EvaluatedScalingMetric(400., 350.),
-                evaluator
-                        .evaluate(
-                                conf,
-                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
-                                restartTime)
-                        .getVertexMetrics()
-                        .get(source)
-                        .get(ScalingMetric.TRUE_PROCESSING_RATE));
+                350,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        100, 35, metricHistory, source, conf));
     }
 
     @Test
     public void testMissingObservedTpr() {
         var source = new JobVertexID();
         var conf = new Configuration();
-        var restartTime = conf.get(AutoScalerOptions.RESTART_TIME);
-
-        var topology = new JobTopology(new VertexInfo(source, Collections.emptySet(), 1, 1));
-        var evaluator = new ScalingMetricEvaluator();
-
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
-        metricHistory.put(
-                Instant.ofEpochMilli(100),
-                new CollectedMetrics(
-                        Map.of(
-                                source,
-                                Map.of(
-                                        ScalingMetric.LAG,
-                                        0.,
-                                        ScalingMetric.TRUE_PROCESSING_RATE,
-                                        300.,
-                                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                                        100.,
-                                        ScalingMetric.SOURCE_DATA_RATE,
-                                        50.,
-                                        ScalingMetric.LOAD,
-                                        10.)),
-                        Map.of(),
-                        Map.of()));
 
-        // Test that we used busy time based TPR
+        // Test that we used busy time based TPR even if infinity
         assertEquals(
-                new EvaluatedScalingMetric(300., 300.),
-                evaluator
-                        .evaluate(
-                                conf,
-                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
-                                restartTime)
-                        .getVertexMetrics()
-                        .get(source)
-                        .get(ScalingMetric.TRUE_PROCESSING_RATE));
+                350.,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        100, 35, metricHistory, source, conf));
 
-        metricHistory.put(
-                Instant.ofEpochMilli(100),
-                new CollectedMetrics(
-                        Map.of(
-                                source,
-                                Map.of(
-                                        ScalingMetric.LAG,
-                                        0.,
-                                        ScalingMetric.TRUE_PROCESSING_RATE,
-                                        Double.POSITIVE_INFINITY,
-                                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                                        100.,
-                                        ScalingMetric.SOURCE_DATA_RATE,
-                                        50.,
-                                        ScalingMetric.LOAD,
-                                        10.)),
-                        Map.of(),
-                        Map.of()));
-
-        // Test that we used busy time based TPR even when infinity
         assertEquals(
-                new EvaluatedScalingMetric(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY),
-                evaluator
-                        .evaluate(
-                                conf,
-                                new CollectedMetricHistory(topology, metricHistory, Instant.now()),
-                                restartTime)
-                        .getVertexMetrics()
-                        .get(source)
-                        .get(ScalingMetric.TRUE_PROCESSING_RATE));
+                Double.POSITIVE_INFINITY,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        0, 100, metricHistory, source, conf));
+
+        assertEquals(
+                Double.POSITIVE_INFINITY,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        0, 0, metricHistory, source, conf));
+
+        assertEquals(
+                Double.NaN,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        Double.NaN, Double.NaN, metricHistory, source, conf));
     }
 
     @Test
     public void testGlobalMetricEvaluation() {
         var globalMetrics = new TreeMap<Instant, CollectedMetrics>();
-        globalMetrics.put(Instant.now(), new CollectedMetrics(Map.of(), Map.of(), Map.of()));
+        globalMetrics.put(Instant.now(), new CollectedMetrics(Map.of(), Map.of()));
 
         assertEquals(
                 Map.of(
@@ -589,7 +492,6 @@ public class ScalingMetricEvaluatorTest {
         globalMetrics.put(
                 Instant.now(),
                 new CollectedMetrics(
-                        Map.of(),
                         Map.of(),
                         Map.of(
                                 ScalingMetric.HEAP_MAX_USAGE_RATIO,
@@ -614,7 +516,6 @@ public class ScalingMetricEvaluatorTest {
                 Instant.now(),
                 new CollectedMetrics(
                         Map.of(),
-                        Map.of(),
                         Map.of(
                                 ScalingMetric.HEAP_MAX_USAGE_RATIO,
                                 0.7,
@@ -635,6 +536,226 @@ public class ScalingMetricEvaluatorTest {
                         ScalingMetric.NUM_TASK_SLOTS_USED,
                         EvaluatedScalingMetric.of(42.)),
                 ScalingMetricEvaluator.evaluateGlobalMetrics(globalMetrics));
+    }
+
+    @Test
+    public void testZeroValuesForRatesOrBusyness() {
+        assertInfiniteTpr(0, 0);
+        assertInfiniteTpr(0, 1);
+        assertInfiniteTpr(1, 0);
+    }
+
+    private static void assertInfiniteTpr(long busyTime, long inputRate) {
+        assertEquals(
+                Double.POSITIVE_INFINITY,
+                ScalingMetricEvaluator.computeTrueProcessingRate(
+                        busyTime,
+                        inputRate,
+                        new TreeMap<>(),
+                        new JobVertexID(),
+                        new Configuration()));
+    }
+
+    @Test
+    public void testBusyTimeEvaluation() {
+        var v = new JobVertexID();
+        var conf = new Configuration();
+        var metricHistory = new TreeMap<Instant, CollectedMetrics>();
+
+        metricHistory.put(
+                Instant.ofEpochMilli(1000),
+                new CollectedMetrics(
+                        Map.of(
+                                v,
+                                Map.of(
+                                        ScalingMetric.LOAD, 0.2,
+                                        ScalingMetric.ACCUMULATED_BUSY_TIME, 10000.)),
+                        Map.of()));
+
+        metricHistory.put(
+                Instant.ofEpochMilli(2000),
+                new CollectedMetrics(
+                        Map.of(
+                                v,
+                                Map.of(
+                                        ScalingMetric.LOAD, 0.3,
+                                        ScalingMetric.ACCUMULATED_BUSY_TIME, 10200.)),
+                        Map.of()));
+
+        metricHistory.put(
+                Instant.ofEpochMilli(3000),
+                new CollectedMetrics(
+                        Map.of(
+                                v,
+                                Map.of(
+                                        ScalingMetric.LOAD, 0.4,
+                                        ScalingMetric.ACCUMULATED_BUSY_TIME, 10400.)),
+                        Map.of()));
+
+        // With MAX or MIN we should compute from LOAD only, parallelism should not matter
+        conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.MAX);
+        assertEquals(300., ScalingMetricEvaluator.computeBusyTimeAvg(conf, metricHistory, v, 2));
+        assertEquals(300., ScalingMetricEvaluator.computeBusyTimeAvg(conf, metricHistory, v, 0));
+
+        conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.MIN);
+        assertEquals(300., ScalingMetricEvaluator.computeBusyTimeAvg(conf, metricHistory, v, 2));
+        assertEquals(300., ScalingMetricEvaluator.computeBusyTimeAvg(conf, metricHistory, v, 0));
+
+        conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.AVG);
+        // With AVG we compute from accumulated busy time
+        // Diff 400 over 2 seconds -> 200 / second (for the whole job -> we need to divide for
+        // parallelism)
+        assertEquals(100., ScalingMetricEvaluator.computeBusyTimeAvg(conf, metricHistory, v, 2));
+        assertEquals(200., ScalingMetricEvaluator.computeBusyTimeAvg(conf, metricHistory, v, 1));
+    }
+
+    @Test
+    public void testComputableOutputRatios() {
+        var source1 = new JobVertexID();
+        var source2 = new JobVertexID();
+
+        var op1 = new JobVertexID();
+        var sink1 = new JobVertexID();
+
+        var topology =
+                new JobTopology(
+                        new VertexInfo(source1, Collections.emptySet(), 1, 1),
+                        new VertexInfo(source2, Collections.emptySet(), 1, 1),
+                        new VertexInfo(op1, Set.of(source1, source2), 1, 1),
+                        new VertexInfo(sink1, Set.of(op1), 1, 1));
+
+        var metricHistory = new TreeMap<Instant, CollectedMetrics>();
+
+        metricHistory.put(
+                Instant.ofEpochMilli(1000),
+                new CollectedMetrics(
+                        Map.of(
+                                source1,
+                                Map.of(
+                                        ScalingMetric.NUM_RECORDS_IN, 100.,
+                                        ScalingMetric.NUM_RECORDS_OUT, 100.),
+                                source2,
+                                Map.of(
+                                        ScalingMetric.NUM_RECORDS_IN, 100.,
+                                        ScalingMetric.NUM_RECORDS_OUT, 100.),
+                                op1,
+                                Map.of(ScalingMetric.NUM_RECORDS_IN, 100.),
+                                sink1,
+                                Map.of(ScalingMetric.NUM_RECORDS_IN, 100.)),
+                        Map.of()));
+
+        metricHistory.put(
+                Instant.ofEpochMilli(2000),
+                new CollectedMetrics(
+                        Map.of(
+                                source1,
+                                Map.of(
+                                        ScalingMetric.NUM_RECORDS_IN, 200.,
+                                        ScalingMetric.NUM_RECORDS_OUT, 300.),
+                                source2,
+                                Map.of(
+                                        ScalingMetric.NUM_RECORDS_IN, 200.,
+                                        ScalingMetric.NUM_RECORDS_OUT, 150.),
+                                op1,
+                                Map.of(ScalingMetric.NUM_RECORDS_IN, 350.),
+                                sink1,
+                                Map.of(ScalingMetric.NUM_RECORDS_IN, 150.)),
+                        Map.of()));
+
+        assertEquals(
+                2.,
+                ScalingMetricEvaluator.computeOutputRatio(source1, op1, topology, metricHistory));
+        assertEquals(
+                0.5,
+                ScalingMetricEvaluator.computeOutputRatio(source2, op1, topology, metricHistory));
+        assertEquals(
+                0.2,
+                ScalingMetricEvaluator.computeOutputRatio(op1, sink1, topology, metricHistory));
+    }
+
+    @Test
+    public void testOutputRatioFallbackToOutPerSecond() {
+        var source1 = new JobVertexID();
+        var source2 = new JobVertexID();
+
+        var op1 = new JobVertexID();
+        var op2 = new JobVertexID();
+
+        var topology =
+                new JobTopology(
+                        new VertexInfo(source1, Collections.emptySet(), 1, 1),
+                        new VertexInfo(source2, Collections.emptySet(), 1, 1),
+                        new VertexInfo(op1, Set.of(source1, source2), 1, 1),
+                        new VertexInfo(op2, Set.of(source1, source2), 1, 1));
+
+        var metricHistory = new TreeMap<Instant, CollectedMetrics>();
+
+        metricHistory.put(
+                Instant.ofEpochMilli(1000),
+                new CollectedMetrics(
+                        Map.of(
+                                source1,
+                                Map.of(
+                                        ScalingMetric.NUM_RECORDS_IN, 0.,
+                                        ScalingMetric.NUM_RECORDS_OUT, 0.),
+                                source2,
+                                Map.of(
+                                        ScalingMetric.NUM_RECORDS_IN, 0.,
+                                        ScalingMetric.NUM_RECORDS_OUT, 0.)),
+                        Map.of()));
+
+        metricHistory.put(
+                Instant.ofEpochMilli(2000),
+                new CollectedMetrics(
+                        Map.of(
+                                source1,
+                                Map.of(
+                                        ScalingMetric.NUM_RECORDS_IN, 100.,
+                                        ScalingMetric.NUM_RECORDS_OUT, 200.),
+                                source2,
+                                Map.of(
+                                        ScalingMetric.NUM_RECORDS_IN, 100.,
+                                        ScalingMetric.NUM_RECORDS_OUT, 50.)),
+                        Map.of()));
+
+        assertEquals(
+                2.,
+                ScalingMetricEvaluator.computeOutputRatio(source1, op1, topology, metricHistory));
+        assertEquals(
+                0.5,
+                ScalingMetricEvaluator.computeOutputRatio(source2, op1, topology, metricHistory));
+        assertEquals(
+                2.,
+                ScalingMetricEvaluator.computeOutputRatio(source1, op2, topology, metricHistory));
+        assertEquals(
+                0.5,
+                ScalingMetricEvaluator.computeOutputRatio(source2, op2, topology, metricHistory));
+    }
+
+    @Test
+    public void getRateTest() {
+        var m1 = ScalingMetric.NUM_RECORDS_IN;
+        var m2 = ScalingMetric.NUM_RECORDS_OUT;
+
+        var v1 = new JobVertexID();
+        var v2 = new JobVertexID();
+
+        var history = new TreeMap<Instant, CollectedMetrics>();
+        history.put(
+                Instant.ofEpochMilli(1000),
+                new CollectedMetrics(Map.of(v1, Map.of(m1, 0.), v2, Map.of()), null));
+        history.put(
+                Instant.ofEpochMilli(2000),
+                new CollectedMetrics(Map.of(v1, Map.of(m1, 0., m2, 10.), v2, Map.of()), null));
+        history.put(
+                Instant.ofEpochMilli(3000),
+                new CollectedMetrics(
+                        Map.of(v1, Map.of(m1, 4., m2, 20.), v2, Map.of(m1, 1.)), null));
+
+        assertEquals(2, ScalingMetricEvaluator.getRate(m1, v1, history));
+        assertEquals(10., ScalingMetricEvaluator.getRate(m2, v1, history));
+        assertEquals(Double.NaN, ScalingMetricEvaluator.getRate(m1, v2, history));
+        assertEquals(Double.NaN, ScalingMetricEvaluator.getRate(m2, v2, history));
     }
 
     private Tuple2<Double, Double> getThresholds(
@@ -661,9 +782,7 @@ public class ScalingMetricEvaluatorTest {
             boolean catchingUp) {
         var map = new HashMap<ScalingMetric, EvaluatedScalingMetric>();
 
-        map.put(
-                ScalingMetric.TARGET_DATA_RATE,
-                new EvaluatedScalingMetric(Double.NaN, inputTargetRate));
+        map.put(ScalingMetric.TARGET_DATA_RATE, EvaluatedScalingMetric.avg(inputTargetRate));
         map.put(ScalingMetric.CATCH_UP_DATA_RATE, EvaluatedScalingMetric.of(catchUpRate));
 
         ScalingMetricEvaluator.computeProcessingRateThresholds(map, conf, catchingUp, restartTime);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.autoscaler.metrics;
 
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.autoscaler.topology.IOMetrics;
 import org.apache.flink.autoscaler.topology.JobTopology;
 import org.apache.flink.autoscaler.topology.VertexInfo;
 import org.apache.flink.autoscaler.tuning.MemoryTuning;
@@ -26,6 +27,8 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,13 +49,12 @@ public class ScalingMetricsTest {
     public void testProcessingAndOutputMetrics() {
         var source = new JobVertexID();
         var op = new JobVertexID();
-        var sink = new JobVertexID();
 
         var topology =
                 new JobTopology(
-                        new VertexInfo(source, Collections.emptySet(), 1, 1),
-                        new VertexInfo(op, Set.of(source), 1, 1),
-                        new VertexInfo(sink, Set.of(op), 1, 1));
+                        new VertexInfo(
+                                source, Collections.emptySet(), 1, 1, new IOMetrics(1, 2, 3)),
+                        new VertexInfo(op, Set.of(source), 1, 1, new IOMetrics(1, 2, 3)));
 
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
         ScalingMetrics.computeDataRateMetrics(
@@ -61,52 +63,20 @@ public class ScalingMetricsTest {
                         FlinkMetric.BUSY_TIME_PER_SEC,
                         new AggregatedMetric("", Double.NaN, 900., Double.NaN, Double.NaN),
                         FlinkMetric.NUM_RECORDS_IN_PER_SEC,
-                        aggSum(1000.),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(2000.)),
+                        aggSum(1000.)),
                 scalingMetrics,
                 topology,
-                15.,
                 new Configuration(),
                 () -> PREV_TPR);
 
         assertEquals(
                 Map.of(
-                        ScalingMetric.TRUE_PROCESSING_RATE,
-                        1000. / 0.9,
+                        ScalingMetric.NUM_RECORDS_IN,
+                        1.,
+                        ScalingMetric.NUM_RECORDS_OUT,
+                        2.,
                         ScalingMetric.OBSERVED_TPR,
                         PREV_TPR,
-                        ScalingMetric.SOURCE_DATA_RATE,
-                        1015.,
-                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                        1000.),
-                scalingMetrics);
-
-        // test negative lag growth (catch up)
-        scalingMetrics.clear();
-        ScalingMetrics.computeDataRateMetrics(
-                source,
-                Map.of(
-                        FlinkMetric.BUSY_TIME_PER_SEC,
-                        new AggregatedMetric("", Double.NaN, 100., Double.NaN, Double.NaN),
-                        FlinkMetric.NUM_RECORDS_IN_PER_SEC,
-                        aggSum(1000.),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(2000.)),
-                scalingMetrics,
-                topology,
-                -50.,
-                new Configuration(),
-                () -> PREV_TPR);
-
-        assertEquals(
-                Map.of(
-                        ScalingMetric.TRUE_PROCESSING_RATE,
-                        10000.,
-                        ScalingMetric.OBSERVED_TPR,
-                        PREV_TPR,
-                        ScalingMetric.SOURCE_DATA_RATE,
-                        950.,
                         ScalingMetric.CURRENT_PROCESSING_RATE,
                         1000.),
                 scalingMetrics);
@@ -118,91 +88,53 @@ public class ScalingMetricsTest {
                         FlinkMetric.BUSY_TIME_PER_SEC,
                         new AggregatedMetric("", Double.NaN, 100., Double.NaN, Double.NaN),
                         FlinkMetric.NUM_RECORDS_IN_PER_SEC,
-                        aggSum(1000.),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(2000.)),
+                        aggSum(1000.)),
                 scalingMetrics,
                 topology,
-                0.,
                 new Configuration(),
                 () -> 0.);
 
         assertEquals(
                 Map.of(
-                        ScalingMetric.TRUE_PROCESSING_RATE,
-                        10000.,
-                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                        1000.),
-                scalingMetrics);
-
-        // Test using avg busyTime aggregator
-        scalingMetrics.clear();
-        var conf = new Configuration();
-        conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.AVG);
-        ScalingMetrics.computeDataRateMetrics(
-                op,
-                Map.of(
-                        FlinkMetric.BUSY_TIME_PER_SEC,
-                        new AggregatedMetric("", Double.NaN, Double.NaN, 100., Double.NaN),
-                        FlinkMetric.NUM_RECORDS_IN_PER_SEC,
-                        aggSum(1000.),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(2000.)),
-                scalingMetrics,
-                topology,
-                0.,
-                conf,
-                () -> 0.);
-
-        assertEquals(
-                Map.of(
-                        ScalingMetric.TRUE_PROCESSING_RATE,
-                        10000.,
+                        ScalingMetric.NUM_RECORDS_IN,
+                        1.,
+                        ScalingMetric.NUM_RECORDS_OUT,
+                        2.,
                         ScalingMetric.CURRENT_PROCESSING_RATE,
                         1000.),
                 scalingMetrics);
     }
 
-    @Test
-    public void testLegacySourceScaling() {
+    @ParameterizedTest
+    @EnumSource(MetricAggregator.class)
+    public void testLegacySourceScaling(MetricAggregator busyTimeAggregator) {
         var source = new JobVertexID();
         var sink = new JobVertexID();
 
-        var topology =
-                new JobTopology(
-                        new VertexInfo(source, Collections.emptySet(), 5, 1),
-                        new VertexInfo(sink, Collections.singleton(source), 10, 100));
+        var ioMetrics = new IOMetrics(0, 0, 0);
 
         Configuration conf = new Configuration();
+        conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, busyTimeAggregator);
         assertTrue(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS).isEmpty());
         conf.set(AutoScalerOptions.VERTEX_EXCLUDE_IDS, List.of(sink.toHexString()));
 
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
-        ScalingMetrics.computeDataRateMetrics(
+        ScalingMetrics.computeLoadMetrics(
                 source,
                 Map.of(
                         // Busy time is NaN for legacy sources
                         FlinkMetric.BUSY_TIME_PER_SEC,
                         aggSum(Double.NaN),
                         FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(2000.),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(4000.)),
+                        aggSum(2000.)),
                 scalingMetrics,
-                topology,
-                0.,
-                conf,
-                () -> PREV_TPR);
+                ioMetrics,
+                conf);
 
         // Make sure vertex won't be scaled
         assertTrue(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS).contains(source.toHexString()));
         // Existing overrides should be preserved
         assertTrue(conf.get(AutoScalerOptions.VERTEX_EXCLUDE_IDS).contains(sink.toHexString()));
-        // Legacy source rates are computed based on the current rate and a balanced utilization
-        assertEquals(
-                2000 / conf.get(AutoScalerOptions.TARGET_UTILIZATION),
-                scalingMetrics.get(ScalingMetric.TRUE_PROCESSING_RATE));
-        assertEquals(2000, scalingMetrics.get(ScalingMetric.SOURCE_DATA_RATE));
     }
 
     @Test
@@ -210,6 +142,7 @@ public class ScalingMetricsTest {
         var source = new JobVertexID();
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
         var conf = new Configuration();
+        var ioMetrics = new IOMetrics(0, 0, 123);
 
         conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.MAX);
         ScalingMetrics.computeLoadMetrics(
@@ -218,9 +151,13 @@ public class ScalingMetricsTest {
                         FlinkMetric.BUSY_TIME_PER_SEC,
                         new AggregatedMetric("", 100., 200., 150., Double.NaN)),
                 scalingMetrics,
+                ioMetrics,
                 conf);
-        assertEquals(.2, scalingMetrics.get(ScalingMetric.LOAD));
+        assertEquals(
+                Map.of(ScalingMetric.LOAD, .2, ScalingMetric.ACCUMULATED_BUSY_TIME, 123.),
+                scalingMetrics);
 
+        scalingMetrics.clear();
         conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.MIN);
         ScalingMetrics.computeLoadMetrics(
                 source,
@@ -228,9 +165,13 @@ public class ScalingMetricsTest {
                         FlinkMetric.BUSY_TIME_PER_SEC,
                         new AggregatedMetric("", 100., 200., 150., Double.NaN)),
                 scalingMetrics,
+                ioMetrics,
                 conf);
-        assertEquals(.1, scalingMetrics.get(ScalingMetric.LOAD));
+        assertEquals(
+                Map.of(ScalingMetric.LOAD, .1, ScalingMetric.ACCUMULATED_BUSY_TIME, 123.),
+                scalingMetrics);
 
+        scalingMetrics.clear();
         conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.AVG);
         ScalingMetrics.computeLoadMetrics(
                 source,
@@ -238,179 +179,11 @@ public class ScalingMetricsTest {
                         FlinkMetric.BUSY_TIME_PER_SEC,
                         new AggregatedMetric("", 100., 200., 150., Double.NaN)),
                 scalingMetrics,
+                ioMetrics,
                 conf);
-        assertEquals(.15, scalingMetrics.get(ScalingMetric.LOAD));
-    }
-
-    @Test
-    public void testZeroValuesForBusyness() {
-        double dataRate = 10;
-        Map<ScalingMetric, Double> scalingMetrics =
-                testZeroValuesForRatesOrBusyness(dataRate, dataRate, 0);
         assertEquals(
-                Map.of(
-                        ScalingMetric.TRUE_PROCESSING_RATE,
-                        // When not busy at all, we have infinite processing power
-                        Double.POSITIVE_INFINITY,
-                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                        10.),
+                Map.of(ScalingMetric.LOAD, .15, ScalingMetric.ACCUMULATED_BUSY_TIME, 123.),
                 scalingMetrics);
-    }
-
-    @Test
-    public void testZeroValuesForRates() {
-        double busyMillisecondPerSec = 100;
-        Map<ScalingMetric, Double> scalingMetrics =
-                testZeroValuesForRatesOrBusyness(0, 0, busyMillisecondPerSec);
-        assertEquals(
-                Map.of(
-                        ScalingMetric.TRUE_PROCESSING_RATE,
-                        // When no records are coming in, we assume infinite processing power
-                        Double.POSITIVE_INFINITY,
-                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                        0.),
-                scalingMetrics);
-    }
-
-    @Test
-    public void testZeroProcessingRateOnly() {
-        Map<ScalingMetric, Double> scalingMetrics = testZeroValuesForRatesOrBusyness(0, 1, 100);
-        assertEquals(
-                Map.of(
-                        // If there is zero input the out ratio must be zero
-                        ScalingMetric.TRUE_PROCESSING_RATE,
-                        // When no records are coming in, we assume infinite processing power
-                        Double.POSITIVE_INFINITY,
-                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                        0.),
-                scalingMetrics);
-    }
-
-    @Test
-    public void testZeroValuesForRatesAndBusyness() {
-        Map<ScalingMetric, Double> scalingMetrics = testZeroValuesForRatesOrBusyness(0, 0, 0);
-        assertEquals(
-                Map.of(
-                        ScalingMetric.TRUE_PROCESSING_RATE,
-                        // Nothing is coming in, we must assume infinite processing power
-                        Double.POSITIVE_INFINITY,
-                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                        0.),
-                scalingMetrics);
-    }
-
-    private static Map<ScalingMetric, Double> testZeroValuesForRatesOrBusyness(
-            double processingRate, double outputRate, double busyness) {
-        var source = new JobVertexID();
-        var op = new JobVertexID();
-        var sink = new JobVertexID();
-
-        var topology =
-                new JobTopology(
-                        new VertexInfo(source, Collections.emptySet(), 1, 1),
-                        new VertexInfo(op, Set.of(source), 1, 1),
-                        new VertexInfo(sink, Set.of(op), 1, 1));
-
-        Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
-        ScalingMetrics.computeDataRateMetrics(
-                op,
-                Map.of(
-                        FlinkMetric.BUSY_TIME_PER_SEC,
-                        new AggregatedMetric("", Double.NaN, busyness, Double.NaN, Double.NaN),
-                        FlinkMetric.NUM_RECORDS_IN_PER_SEC,
-                        new AggregatedMetric(
-                                "", Double.NaN, Double.NaN, Double.NaN, processingRate),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(outputRate)),
-                scalingMetrics,
-                topology,
-                0.,
-                new Configuration(),
-                () -> 0.);
-
-        return scalingMetrics;
-    }
-
-    @Test
-    public void testComputableOutputRatios() {
-        var source1 = new JobVertexID();
-        var source2 = new JobVertexID();
-
-        var op1 = new JobVertexID();
-        var sink1 = new JobVertexID();
-
-        var topology =
-                new JobTopology(
-                        new VertexInfo(source1, Collections.emptySet(), 1, 1),
-                        new VertexInfo(source2, Collections.emptySet(), 1, 1),
-                        new VertexInfo(op1, Set.of(source1, source2), 1, 1),
-                        new VertexInfo(sink1, Set.of(op1), 1, 1));
-
-        var allMetrics = new HashMap<JobVertexID, Map<FlinkMetric, AggregatedMetric>>();
-        allMetrics.put(
-                source1,
-                Map.of(
-                        FlinkMetric.NUM_RECORDS_IN_PER_SEC,
-                        aggSum(100),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(200)));
-        allMetrics.put(
-                source2,
-                Map.of(
-                        FlinkMetric.NUM_RECORDS_IN_PER_SEC,
-                        aggSum(100),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(50)));
-
-        allMetrics.put(op1, Map.of(FlinkMetric.NUM_RECORDS_IN_PER_SEC, aggSum(250)));
-        allMetrics.put(sink1, Map.of(FlinkMetric.NUM_RECORDS_IN_PER_SEC, aggSum(50)));
-
-        assertEquals(
-                Map.of(
-                        new Edge(source1, op1), 2.,
-                        new Edge(source2, op1), 0.5,
-                        new Edge(op1, sink1), 0.2),
-                ScalingMetrics.computeOutputRatios(allMetrics, topology));
-    }
-
-    @Test
-    public void testOutputRatioFallbackToOutPerSecond() {
-        var source1 = new JobVertexID();
-        var source2 = new JobVertexID();
-
-        var op1 = new JobVertexID();
-        var op2 = new JobVertexID();
-
-        var topology =
-                new JobTopology(
-                        new VertexInfo(source1, Collections.emptySet(), 1, 1),
-                        new VertexInfo(source2, Collections.emptySet(), 1, 1),
-                        new VertexInfo(op1, Set.of(source1, source2), 1, 1),
-                        new VertexInfo(op2, Set.of(source1, source2), 1, 1));
-
-        var allMetrics = new HashMap<JobVertexID, Map<FlinkMetric, AggregatedMetric>>();
-        allMetrics.put(
-                source1,
-                Map.of(
-                        FlinkMetric.NUM_RECORDS_IN_PER_SEC,
-                        aggSum(100),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(200)));
-        allMetrics.put(
-                source2,
-                Map.of(
-                        FlinkMetric.NUM_RECORDS_IN_PER_SEC,
-                        aggSum(100),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(50)));
-
-        assertEquals(
-                Map.of(
-                        new Edge(source1, op1), 2.,
-                        new Edge(source2, op1), 0.5,
-                        new Edge(source1, op2), 2.,
-                        new Edge(source2, op2), 0.5),
-                ScalingMetrics.computeOutputRatios(allMetrics, topology));
     }
 
     @Test
@@ -456,8 +229,9 @@ public class ScalingMetricsTest {
         var sink = new JobVertexID();
         var topology =
                 new JobTopology(
-                        new VertexInfo(SOURCE, Collections.emptySet(), 1, 1),
-                        new VertexInfo(sink, Set.of(SOURCE), 1, 1));
+                        new VertexInfo(
+                                SOURCE, Collections.emptySet(), 1, 1, new IOMetrics(0, 0, 0)),
+                        new VertexInfo(sink, Set.of(SOURCE), 1, 1, new IOMetrics(0, 0, 0)));
 
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
         scalingMetrics.put(ScalingMetric.LAG, lag);
@@ -470,12 +244,9 @@ public class ScalingMetricsTest {
                         new AggregatedMetric("", Double.NaN, Double.NaN, backpressure, Double.NaN),
                         FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT_PER_SEC,
                         new AggregatedMetric(
-                                "", Double.NaN, Double.NaN, Double.NaN, processingRate),
-                        FlinkMetric.NUM_RECORDS_OUT_PER_SEC,
-                        aggSum(0)),
+                                "", Double.NaN, Double.NaN, Double.NaN, processingRate)),
                 scalingMetrics,
                 topology,
-                0.,
                 conf,
                 () -> PREV_TPR);
         return scalingMetrics.get(ScalingMetric.OBSERVED_TPR);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
@@ -62,7 +62,7 @@ public class ScalingMetricsTest {
                 Map.of(
                         FlinkMetric.BUSY_TIME_PER_SEC,
                         new AggregatedMetric("", Double.NaN, 900., Double.NaN, Double.NaN),
-                        FlinkMetric.NUM_RECORDS_IN_PER_SEC,
+                        FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC,
                         aggSum(1000.)),
                 scalingMetrics,
                 topology,
@@ -76,9 +76,7 @@ public class ScalingMetricsTest {
                         ScalingMetric.NUM_RECORDS_OUT,
                         2.,
                         ScalingMetric.OBSERVED_TPR,
-                        PREV_TPR,
-                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                        1000.),
+                        PREV_TPR),
                 scalingMetrics);
 
         scalingMetrics.clear();
@@ -87,7 +85,7 @@ public class ScalingMetricsTest {
                 Map.of(
                         FlinkMetric.BUSY_TIME_PER_SEC,
                         new AggregatedMetric("", Double.NaN, 100., Double.NaN, Double.NaN),
-                        FlinkMetric.NUM_RECORDS_IN_PER_SEC,
+                        FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC,
                         aggSum(1000.)),
                 scalingMetrics,
                 topology,
@@ -95,13 +93,7 @@ public class ScalingMetricsTest {
                 () -> 0.);
 
         assertEquals(
-                Map.of(
-                        ScalingMetric.NUM_RECORDS_IN,
-                        1.,
-                        ScalingMetric.NUM_RECORDS_OUT,
-                        2.,
-                        ScalingMetric.CURRENT_PROCESSING_RATE,
-                        1000.),
+                Map.of(ScalingMetric.NUM_RECORDS_IN, 1., ScalingMetric.NUM_RECORDS_OUT, 2.),
                 scalingMetrics);
     }
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/TestMetrics.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/TestMetrics.java
@@ -45,7 +45,7 @@ public class TestMetrics {
             fm.put(FlinkMetric.PENDING_RECORDS, sum(pendingRecords));
         }
         if (numRecordsInPerSec != null) {
-            fm.put(FlinkMetric.NUM_RECORDS_IN_PER_SEC, sum(numRecordsInPerSec));
+            fm.put(FlinkMetric.SOURCE_TASK_NUM_RECORDS_IN_PER_SEC, sum(numRecordsInPerSec));
         }
         fm.put(FlinkMetric.BUSY_TIME_PER_SEC, max(maxBusyTimePerSec));
         fm.put(FlinkMetric.BACKPRESSURE_TIME_PER_SEC, avg(avgBackpressureTimePerSec));

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/TestMetrics.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/TestMetrics.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.metrics;
+
+import org.apache.flink.autoscaler.topology.IOMetrics;
+import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Class to capture collected test metrics. */
+@Data
+@Builder
+public class TestMetrics {
+    private long numRecordsIn;
+    private long numRecordsOut;
+    private long maxBusyTimePerSec;
+    private long avgBackpressureTimePerSec;
+    private long accumulatedBusyTime;
+
+    private Long pendingRecords;
+    private Double numRecordsInPerSec;
+
+    public Map<FlinkMetric, AggregatedMetric> toFlinkMetrics() {
+        var fm = new HashMap<FlinkMetric, AggregatedMetric>();
+        if (pendingRecords != null) {
+            fm.put(FlinkMetric.PENDING_RECORDS, sum(pendingRecords));
+        }
+        if (numRecordsInPerSec != null) {
+            fm.put(FlinkMetric.NUM_RECORDS_IN_PER_SEC, sum(numRecordsInPerSec));
+        }
+        fm.put(FlinkMetric.BUSY_TIME_PER_SEC, max(maxBusyTimePerSec));
+        fm.put(FlinkMetric.BACKPRESSURE_TIME_PER_SEC, avg(avgBackpressureTimePerSec));
+        fm.put(FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT, sum(numRecordsIn));
+        return fm;
+    }
+
+    public IOMetrics toIoMetrics() {
+        return new IOMetrics(numRecordsIn, numRecordsOut, accumulatedBusyTime);
+    }
+
+    private AggregatedMetric sum(double d) {
+        return new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, d);
+    }
+
+    private AggregatedMetric max(double d) {
+        return new AggregatedMetric("", Double.NaN, d, Double.NaN, Double.NaN);
+    }
+
+    private AggregatedMetric avg(double d) {
+        return new AggregatedMetric("", Double.NaN, Double.NaN, d, Double.NaN);
+    }
+}

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/topology/JobTopologyTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/topology/JobTopologyTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -74,28 +75,29 @@ public class JobTopologyTest {
         }
 
         JobTopology jobTopology =
-                JobTopology.fromJsonPlan(jsonPlan, maxParallelism, Collections.emptySet());
+                JobTopology.fromJsonPlan(
+                        jsonPlan, maxParallelism, Map.of(), Collections.emptySet());
 
-        assertTrue(jobTopology.getOutputs().get(vertices.get("Sink: sink1")).isEmpty());
-        assertTrue(jobTopology.getOutputs().get(vertices.get("Sink: sink2")).isEmpty());
-        assertTrue(jobTopology.getOutputs().get(vertices.get("Sink: sink3")).isEmpty());
+        assertTrue(jobTopology.get(vertices.get("Sink: sink1")).getOutputs().isEmpty());
+        assertTrue(jobTopology.get(vertices.get("Sink: sink2")).getOutputs().isEmpty());
+        assertTrue(jobTopology.get(vertices.get("Sink: sink3")).getOutputs().isEmpty());
 
         assertEquals(
                 Set.of(vertices.get("map1")),
-                jobTopology.getOutputs().get(vertices.get("Source: s1")));
+                jobTopology.get(vertices.get("Source: s1")).getOutputs());
         assertEquals(
                 Set.of(vertices.get("map1")),
-                jobTopology.getOutputs().get(vertices.get("Source: s2")));
+                jobTopology.get(vertices.get("Source: s2")).getOutputs());
         assertEquals(
                 Set.of(vertices.get("map2")),
-                jobTopology.getOutputs().get(vertices.get("Source: s3")));
+                jobTopology.get(vertices.get("Source: s3")).getOutputs());
 
         assertEquals(
                 Set.of(vertices.get("Sink: sink2"), vertices.get("Sink: sink3")),
-                jobTopology.getOutputs().get(vertices.get("map2")));
+                jobTopology.get(vertices.get("map2")).getOutputs());
 
-        assertEquals(2, jobTopology.getParallelisms().get(vertices.get("map1")));
-        assertEquals(4, jobTopology.getParallelisms().get(vertices.get("map2")));
-        jobTopology.getMaxParallelisms().forEach((v, p) -> assertEquals(128, p));
+        assertEquals(2, jobTopology.get(vertices.get("map1")).getParallelism());
+        assertEquals(4, jobTopology.get(vertices.get("map2")).getParallelism());
+        jobTopology.getVertexInfos().forEach((v, p) -> assertEquals(128, p.getMaxParallelism()));
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/utils/MemoryTuningTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/utils/MemoryTuningTest.java
@@ -60,15 +60,11 @@ public class MemoryTuningTest {
                 Map.of(
                         jobVertex1,
                         Map.of(
-                                ScalingMetric.CURRENT_PROCESSING_RATE,
-                                        EvaluatedScalingMetric.avg(100),
                                 ScalingMetric.EXPECTED_PROCESSING_RATE,
                                         EvaluatedScalingMetric.of(50),
                                 ScalingMetric.PARALLELISM, EvaluatedScalingMetric.of(50)),
                         jobVertex2,
                         Map.of(
-                                ScalingMetric.CURRENT_PROCESSING_RATE,
-                                        EvaluatedScalingMetric.avg(100),
                                 ScalingMetric.EXPECTED_PROCESSING_RATE,
                                         EvaluatedScalingMetric.of(50),
                                 ScalingMetric.PARALLELISM, EvaluatedScalingMetric.of(50)));

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStoreTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStoreTest.java
@@ -89,9 +89,7 @@ public class KubernetesAutoScalerStateStoreTest
         metricHistory.put(
                 jobUpdateTs,
                 new CollectedMetrics(
-                        Map.of(v1, Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 1.)),
-                        Map.of(),
-                        Map.of()));
+                        Map.of(v1, Map.of(ScalingMetric.TRUE_PROCESSING_RATE, 1.)), Map.of()));
 
         var scalingHistory = new HashMap<JobVertexID, SortedMap<Instant, ScalingSummary>>();
         scalingHistory.put(v1, new TreeMap<>());
@@ -141,8 +139,7 @@ public class KubernetesAutoScalerStateStoreTest
                         new JobVertexID(),
                         Map.of(ScalingMetric.TRUE_PROCESSING_RATE, rnd.nextDouble()));
             }
-            metricHistory.put(
-                    Instant.now(), new CollectedMetrics(m, Collections.emptyMap(), Map.of()));
+            metricHistory.put(Instant.now(), new CollectedMetrics(m, Collections.emptyMap()));
         }
 
         var scalingHistory = new HashMap<JobVertexID, SortedMap<Instant, ScalingSummary>>();


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to cover both [FLINK-34213](https://issues.apache.org/jira/browse/FLINK-34213) and [FLINK-34266](https://issues.apache.org/jira/browse/FLINK-34266).

Currently all metric tracking for input / output data rates, busyTime etc happens based on perSecond metrics in Flink. Depending on the frequency of the autoscaler metric collection and the exact processing pattern of the application perSecond metrics can result in completely erroneous autoscaler metric computations.

The most important example of this would be handling large windowed computations or other burst loads where we have spikes in data rates after periods of inactivity. These use-cases currently completely break down with the autoscaler as the jobs are generally scaled too low because incoming data is not measured correctly.

To solve this we move from perSecond in/out metrics to the accumulated counts which allows us to measure correct input out rates and output ratios over the entire metric window. To do this we have to revise the metric collection logic as some information is not exposed as metric but exposed directly through the job details query we already do to track topology changes.

Summary of changes:

 - Collect accumulated input/output record count + accumulated busy time from JobDetailsInfo rest request instead of metrics
 - Remove TrueProcessRate and OutputRatios from the collected metrics and move the computation to the evaluation phase (this reduces the amount of stored metrics in the store as well)
 - Require at least 2 observations for metric evaluation as needed for rate computation from cumulative metrics
 - Improve and simplify JobTopology structure to allow incorporating io metrics 
 - As TPR and some other metrics are now only evaluated for the entire metric window. Current values will no longer be reported during evaluation (this is relevant for reported metrics) 

The above logic changes required a redesign of many of the tests especially the ones with somewhat complex logic.

Test changes:
 - Move many tests from collection to evaluation phase and simplify as much as possible into smaller unit tests
 - Introduce helper classes to generate metrics for complex integration tests like (MetricsCollectionAndEvaluationTest / BacklogBasedSacalingTest, etc.)
 - Remove some duplicated or non-functional tests 

## Verifying this change

A lot of tests and unit tests have changed, I tried to always preserve or extend the coverage.

[TODO] : Extensive manual testing still in-progress

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?