### PR TITLE
[FLINK-34439] Move chown operations to COPY commands in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,19 +48,15 @@ WORKDIR /flink-kubernetes-operator
 RUN groupadd --system --gid=9999 flink && \
     useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
 
-COPY --from=build /app/flink-kubernetes-operator/target/$OPERATOR_JAR .
-COPY --from=build /app/flink-kubernetes-webhook/target/$WEBHOOK_JAR .
-COPY --from=build /app/flink-kubernetes-standalone/target/$KUBERNETES_STANDALONE_JAR .
-COPY --from=build /app/flink-kubernetes-operator/target/plugins $FLINK_HOME/plugins
-COPY --from=build /app/tools/license/licenses-output/NOTICE .
-COPY --from=build /app/tools/license/licenses-output/licenses ./licenses
-COPY docker-entrypoint.sh /
+RUN chown -R flink:flink $FLINK_HOME
 
-RUN chown -R flink:flink $FLINK_HOME && \
-    chown flink:flink $OPERATOR_JAR && \
-    chown flink:flink $WEBHOOK_JAR && \
-    chown flink:flink $KUBERNETES_STANDALONE_JAR && \
-    chown flink:flink /docker-entrypoint.sh
+COPY --chown=flink:flink --from=build /app/flink-kubernetes-operator/target/$OPERATOR_JAR .
+COPY --chown=flink:flink --from=build /app/flink-kubernetes-webhook/target/$WEBHOOK_JAR .
+COPY --chown=flink:flink --from=build /app/flink-kubernetes-standalone/target/$KUBERNETES_STANDALONE_JAR .
+COPY --chown=flink:flink --from=build /app/flink-kubernetes-operator/target/plugins $FLINK_HOME/plugins
+COPY --chown=flink:flink --from=build /app/tools/license/licenses-output/NOTICE .
+COPY --chown=flink:flink --from=build /app/tools/license/licenses-output/licenses ./licenses
+COPY --chown=flink:flink docker-entrypoint.sh /
 
 ARG SKIP_OS_UPDATE=true
 


### PR DESCRIPTION
## What is the purpose of the change

Removed unnecessary `RUN chown ...` commands from Dockerfile to reduce output size image. With this change, the size of the image has been reduced from 469MB to 360MB.

A side-effect of this PR will be that the `NOTICE` file and `licenses` folder will be owned by `flink:flink` instead of `root:root` as well now, but I think that's acceptable.

## Brief change log

- Remove most `RUN chown ...` commands from Dockerfile

## Verifying this change

- Built the image, ran some example deployments
- Inspected the images file structure before and after and verified that all permissions are the same

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
