### PR TITLE
[FLINK-34438] Wait for Deployments to be deleted on cluster shutdown

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -310,7 +310,7 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.resource.cleanup.timeout</h5></td>
-            <td style="word-wrap: break-word;">1 min</td>
+            <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>
             <td>The timeout for the resource clean up to wait for flink to shutdown cluster.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/system_section.html
+++ b/docs/layouts/shortcodes/generated/system_section.html
@@ -106,7 +106,7 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.resource.cleanup.timeout</h5></td>
-            <td style="word-wrap: break-word;">1 min</td>
+            <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>
             <td>The timeout for the resource clean up to wait for flink to shutdown cluster.</td>
         </tr>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -127,7 +127,7 @@ public class KubernetesOperatorConfigOptions {
     public static final ConfigOption<Duration> OPERATOR_RESOURCE_CLEANUP_TIMEOUT =
             operatorConfig("resource.cleanup.timeout")
                     .durationType()
-                    .defaultValue(Duration.ofSeconds(60))
+                    .defaultValue(Duration.ofMinutes(5))
                     .withDeprecatedKeys(
                             operatorConfigKey("reconciler.flink.cluster.shutdown.timeout"))
                     .withDescription(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -129,8 +129,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.jar.JarOutputStream;
@@ -927,12 +925,10 @@ public abstract class AbstractFlinkService implements FlinkService {
     /** Wait until Deployment is removed, return false if timed out, otherwise return true. */
     @VisibleForTesting
     boolean waitForDeploymentToBeRemoved(String namespace, String deploymentName, long timeout) {
-        ScheduledExecutorService logger = Executors.newSingleThreadScheduledExecutor();
-        logger.scheduleWithFixedDelay(
-                () -> LOG.info("Waiting for Deployment {} to shut down...", deploymentName),
-                5,
-                5,
-                TimeUnit.SECONDS);
+        LOG.info(
+                "Waiting for Deployment {} to shut down with {} ms timeout...",
+                deploymentName,
+                timeout);
 
         try {
             kubernetesClient
@@ -945,8 +941,6 @@ public abstract class AbstractFlinkService implements FlinkService {
             LOG.info("Deployment {} successfully shut down", deploymentName);
         } catch (KubernetesClientTimeoutException e) {
             return false;
-        } finally {
-            logger.shutdown();
         }
         return true;
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -926,9 +926,9 @@ public abstract class AbstractFlinkService implements FlinkService {
     @VisibleForTesting
     boolean waitForDeploymentToBeRemoved(String namespace, String deploymentName, long timeout) {
         LOG.info(
-                "Waiting for Deployment {} to shut down with {} ms timeout...",
+                "Waiting for Deployment {} to shut down with {} seconds timeout...",
                 deploymentName,
-                timeout);
+                timeout / 1000);
 
         try {
             kubernetesClient

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -62,6 +62,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -130,6 +131,11 @@ public class NativeFlinkService extends AbstractFlinkService {
     protected PodList getTmPodList(String namespace, String clusterId) {
         // Native mode does not manage TaskManager
         return new PodList();
+    }
+
+    @Override
+    protected List<String> getDeploymentNames(String namespace, String clusterId) {
+        return List.of(KubernetesUtils.getDeploymentName(clusterId));
     }
 
     protected void submitClusterInternal(Configuration conf) throws Exception {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
@@ -47,6 +47,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -102,6 +103,13 @@ public class StandaloneFlinkService extends AbstractFlinkService {
                 .inNamespace(namespace)
                 .withLabels(StandaloneKubernetesUtils.getTaskManagerSelectors(clusterId))
                 .list();
+    }
+
+    @Override
+    protected List<String> getDeploymentNames(String namespace, String clusterId) {
+        return List.of(
+                StandaloneKubernetesUtils.getJobManagerDeploymentName(clusterId),
+                StandaloneKubernetesUtils.getTaskManagerDeploymentName(clusterId));
     }
 
     @VisibleForTesting

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -628,4 +628,9 @@ public class TestingFlinkService extends AbstractFlinkService {
     public JobDetailsInfo getJobDetailsInfo(JobID jobID, Configuration conf) {
         return NativeFlinkServiceTest.createJobDetailsFor(List.of());
     }
+
+    @Override
+    protected List<String> getDeploymentNames(String namespace, String clusterId) {
+        return List.of(clusterId + "-deployment");
+    }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -33,8 +33,6 @@ import org.apache.flink.kubernetes.operator.utils.StandaloneKubernetesUtils;
 import org.apache.flink.util.concurrent.Executors;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
@@ -121,7 +119,8 @@ public class StandaloneFlinkServiceTest {
                 new Configuration(),
                 true);
 
-        assertEquals(2, service.nbCall);
+        // How many times were getDeploymentNames() called
+        assertEquals(1, service.nbCall);
 
         deployments = kubernetesClient.apps().deployments().list().getItems();
 
@@ -290,14 +289,9 @@ public class StandaloneFlinkServiceTest {
         }
 
         @Override
-        protected PodList getTmPodList(String namespace, String clusterId) {
+        protected List<String> getDeploymentNames(String namespace, String clusterId) {
             nbCall++;
-            PodList podList = new PodList();
-            if (nbCall == 1) {
-                Pod pod = new Pod();
-                podList.setItems(List.of(pod));
-            }
-            return podList;
+            return List.of(clusterId);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Waiting for TaskManager and JobManager pods to be removed might cause issues in a slow Kubernetes cluster. Upon upgrade, there is a slim possibility that the operator will attempt to create a new `Deployment` before the last one was removed. This was mitigated by [FLINK-32334](https://issues.apache.org/jira/browse/FLINK-32334), which worked well for `standalone`  mode.

I wanted to simply implement `getTmPodList` for `native` mode at first, but after some investigation it became clear that all Kubernetes resources created by the operator or the JobManager will be children of a `Deployment` with `blockOwnerDeletion: true`, so it made sense to instead change the logic to poll the `Deployment` resources.

I also removed the `Thread.sleep()` calls, and instead use the Fabric8 Informers API, which will use websockets to ease the stress on the Kubernetes cluster during cluster deletion.

## Brief change log

- Changed `AbstractFlinkService#waitUntilCondition` to use Informer API and check for `Deployment` resources.
- Added unit tests for the new method `AbstractFlinkService#waitForDeploymentToBeRemoved`.
- Added log when cluster shutdown timeout is exceeded

## Verifying this change

- Added new unit test
- Manual verification of timeout and 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

