### PR TITLE
[FLINK-34152] Tune all directly observable memory types

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -69,28 +69,22 @@
             <td>If enabled, the initial amount of memory specified for TaskManagers will be reduced according to the observed needs.</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.memory.tuning.heap.min</h5></td>
-            <td style="word-wrap: break-word;">512 mb</td>
+            <td><h5>job.autoscaler.memory.tuning.min</h5></td>
+            <td style="word-wrap: break-word;">256 mb</td>
             <td>MemorySize</td>
-            <td>The minimum amount of TaskManager heap memory, if memory tuning is enabled.</td>
+            <td>If memory tuning is enabled, the minimum amount of TaskManager memory for each memory component (heap, managed, network).</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.memory.tuning.heap.overhead</h5></td>
+            <td><h5>job.autoscaler.memory.tuning.overhead</h5></td>
             <td style="word-wrap: break-word;">0.2</td>
             <td>Double</td>
-            <td>Overhead to add to heap tuning decisions (0-1). This ensures spare capacity and allows the memory to grow beyond the dynamically computed limits, but never beyond the original memory limits.</td>
+            <td>Overhead to add to tuning decisions (0-1). This ensures spare capacity and allows the memory to grow beyond the dynamically computed limits, but never beyond the original memory limits.</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.memory.tuning.heap.target-usage</h5></td>
+            <td><h5>job.autoscaler.memory.tuning.target-usage</h5></td>
             <td style="word-wrap: break-word;">MAX</td>
             <td><p>Enum</p></td>
-            <td>The heap size to target. Average usage (AVG) will yield better savings. Max usage will yield more conservative savings.<br /><br />Possible values:<ul><li>"AVG"</li><li>"MAX"</li></ul></td>
-        </tr>
-        <tr>
-            <td><h5>job.autoscaler.memory.tuning.heap.transfer-to-managed</h5></td>
-            <td style="word-wrap: break-word;">false</td>
-            <td>Boolean</td>
-            <td>If enabled, any reduction of heap memory will increase the managed memory used by RocksDB.</td>
+            <td>The memory usage to target. Average usage (AVG) will yield better savings. Max usage will yield more conservative savings.<br /><br />Possible values:<ul><li>"AVG"</li><li>"MAX"</li></ul></td>
         </tr>
         <tr>
             <td><h5>job.autoscaler.metrics.busy-time.aggregator</h5></td>

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/realizer/RescaleApiScalingRealizer.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/realizer/RescaleApiScalingRealizer.java
@@ -24,6 +24,7 @@ import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.event.AutoScalerEventHandler;
 import org.apache.flink.autoscaler.realizer.ScalingRealizer;
+import org.apache.flink.autoscaler.tuning.ConfigChanges;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
@@ -126,12 +127,12 @@ public class RescaleApiScalingRealizer<KEY, Context extends JobAutoScalerContext
     }
 
     @Override
-    public void realizeConfigOverrides(Context context, Configuration configOverrides) {
+    public void realizeConfigOverrides(Context context, ConfigChanges configChanges) {
         // Not currently supported
         LOG.warn(
                 "{} does not support updating the TaskManager configuration ({})",
                 getClass().getSimpleName(),
-                configOverrides);
+                configChanges);
     }
 
     private Map<JobVertexID, JobVertexResourceRequirements> getVertexResources(

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -168,7 +168,7 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
         }
 
         Configuration configOverrides = stateStore.getConfigOverrides(ctx);
-        LOG.info("Applying config overrides: {}", configOverrides);
+        LOG.debug("Applying config overrides: {}", configOverrides);
         scalingRealizer.realizeConfigOverrides(ctx, configOverrides);
     }
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -26,7 +26,7 @@ import org.apache.flink.autoscaler.metrics.AutoscalerFlinkMetrics;
 import org.apache.flink.autoscaler.metrics.EvaluatedMetrics;
 import org.apache.flink.autoscaler.realizer.ScalingRealizer;
 import org.apache.flink.autoscaler.state.AutoScalerStateStore;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.autoscaler.tuning.ConfigChanges;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.util.Preconditions;
 
@@ -167,9 +167,9 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
             return;
         }
 
-        Configuration configOverrides = stateStore.getConfigOverrides(ctx);
-        LOG.debug("Applying config overrides: {}", configOverrides);
-        scalingRealizer.realizeConfigOverrides(ctx, configOverrides);
+        ConfigChanges configChanges = stateStore.getConfigChanges(ctx);
+        LOG.debug("Applying config overrides: {}", configChanges);
+        scalingRealizer.realizeConfigOverrides(ctx, configChanges);
     }
 
     private void runScalingLogic(Context ctx, AutoscalerFlinkMetrics autoscalerMetrics)

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/RestApiMetricsCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/RestApiMetricsCollector.java
@@ -44,8 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.autoscaler.metrics.FlinkMetric.HEAP_MAX;
-import static org.apache.flink.autoscaler.metrics.FlinkMetric.HEAP_USED;
+import static org.apache.flink.autoscaler.metrics.FlinkMetric.HEAP_MEMORY_MAX;
+import static org.apache.flink.autoscaler.metrics.FlinkMetric.HEAP_MEMORY_USED;
 import static org.apache.flink.autoscaler.metrics.FlinkMetric.TOTAL_GC_TIME_PER_SEC;
 
 /** Metric collector using flink rest api. */
@@ -55,12 +55,12 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
 
     private static final Map<String, FlinkMetric> COMMON_TM_METRIC_NAMES =
             Map.of(
-                    "Status.JVM.Memory.Heap.Max", HEAP_MAX,
-                    "Status.JVM.Memory.Heap.Used", HEAP_USED);
+                    "Status.JVM.Memory.Heap.Max", HEAP_MEMORY_MAX,
+                    "Status.JVM.Memory.Heap.Used", HEAP_MEMORY_USED);
     private static final Map<String, FlinkMetric> TM_METRIC_NAMES_WITH_GC =
             Map.of(
-                    "Status.JVM.Memory.Heap.Max", HEAP_MAX,
-                    "Status.JVM.Memory.Heap.Used", HEAP_USED,
+                    "Status.JVM.Memory.Heap.Max", HEAP_MEMORY_MAX,
+                    "Status.JVM.Memory.Heap.Used", HEAP_MEMORY_USED,
                     "Status.JVM.GarbageCollector.All.TimeMsPerSecond", TOTAL_GC_TIME_PER_SEC);
 
     @Override

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/RestApiMetricsCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/RestApiMetricsCollector.java
@@ -35,6 +35,8 @@ import org.apache.flink.runtime.rest.messages.job.metrics.Metric;
 import org.apache.flink.runtime.rest.messages.job.metrics.MetricsAggregationParameter;
 import org.apache.flink.runtime.rest.messages.job.metrics.MetricsFilterParameter;
 
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
+
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -46,6 +48,9 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.autoscaler.metrics.FlinkMetric.HEAP_MEMORY_MAX;
 import static org.apache.flink.autoscaler.metrics.FlinkMetric.HEAP_MEMORY_USED;
+import static org.apache.flink.autoscaler.metrics.FlinkMetric.MANAGED_MEMORY_USED;
+import static org.apache.flink.autoscaler.metrics.FlinkMetric.METASPACE_MEMORY_USED;
+import static org.apache.flink.autoscaler.metrics.FlinkMetric.NETWORK_MEMORY_USED;
 import static org.apache.flink.autoscaler.metrics.FlinkMetric.TOTAL_GC_TIME_PER_SEC;
 
 /** Metric collector using flink rest api. */
@@ -56,12 +61,15 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
     private static final Map<String, FlinkMetric> COMMON_TM_METRIC_NAMES =
             Map.of(
                     "Status.JVM.Memory.Heap.Max", HEAP_MEMORY_MAX,
-                    "Status.JVM.Memory.Heap.Used", HEAP_MEMORY_USED);
-    private static final Map<String, FlinkMetric> TM_METRIC_NAMES_WITH_GC =
-            Map.of(
-                    "Status.JVM.Memory.Heap.Max", HEAP_MEMORY_MAX,
                     "Status.JVM.Memory.Heap.Used", HEAP_MEMORY_USED,
-                    "Status.JVM.GarbageCollector.All.TimeMsPerSecond", TOTAL_GC_TIME_PER_SEC);
+                    "Status.Flink.Memory.Managed.Used", MANAGED_MEMORY_USED,
+                    "Status.Shuffle.Netty.UsedMemory", NETWORK_MEMORY_USED,
+                    "Status.JVM.Memory.Metaspace.Used", METASPACE_MEMORY_USED);
+    private static final Map<String, FlinkMetric> TM_METRIC_NAMES_WITH_GC =
+            ImmutableMap.<String, FlinkMetric>builder()
+                    .putAll(COMMON_TM_METRIC_NAMES)
+                    .put("Status.JVM.GarbageCollector.All.TimeMsPerSecond", TOTAL_GC_TIME_PER_SEC)
+                    .build();
 
     @Override
     protected Map<JobVertexID, Map<FlinkMetric, AggregatedMetric>> queryAllAggregatedMetrics(

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -51,7 +51,7 @@ import static org.apache.flink.autoscaler.metrics.ScalingMetric.CATCH_UP_DATA_RA
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.CURRENT_PROCESSING_RATE;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.GC_PRESSURE;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.HEAP_MAX_USAGE_RATIO;
-import static org.apache.flink.autoscaler.metrics.ScalingMetric.HEAP_USED;
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.HEAP_MEMORY_USED;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.LAG;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.LOAD;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.MAX_PARALLELISM;
@@ -324,9 +324,9 @@ public class ScalingMetricEvaluator {
                         lastHeapUsage,
                         getAverageGlobalMetric(HEAP_MAX_USAGE_RATIO, metricHistory)));
 
-        var latestObservation = latest.getOrDefault(HEAP_USED, Double.NaN);
-        double heapSizeAverage = getAverageGlobalMetric(HEAP_USED, metricHistory);
-        out.put(HEAP_USED, new EvaluatedScalingMetric(latestObservation, heapSizeAverage));
+        var latestObservation = latest.getOrDefault(HEAP_MEMORY_USED, Double.NaN);
+        double heapSizeAverage = getAverageGlobalMetric(HEAP_MEMORY_USED, metricHistory);
+        out.put(HEAP_MEMORY_USED, new EvaluatedScalingMetric(latestObservation, heapSizeAverage));
 
         out.put(
                 NUM_TASK_SLOTS_USED,

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -54,7 +54,10 @@ import static org.apache.flink.autoscaler.metrics.ScalingMetric.HEAP_MAX_USAGE_R
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.HEAP_MEMORY_USED;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.LAG;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.LOAD;
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.MANAGED_MEMORY_USED;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.MAX_PARALLELISM;
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.METASPACE_MEMORY_USED;
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.NETWORK_MEMORY_USED;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.NUM_TASK_SLOTS_USED;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.OBSERVED_TPR;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.PARALLELISM;
@@ -315,24 +318,31 @@ public class ScalingMetricEvaluator {
         var out = new HashMap<ScalingMetric, EvaluatedScalingMetric>();
 
         var gcPressure = latest.getOrDefault(GC_PRESSURE, Double.NaN);
-        var lastHeapUsage = latest.getOrDefault(HEAP_MAX_USAGE_RATIO, Double.NaN);
-
         out.put(GC_PRESSURE, EvaluatedScalingMetric.of(gcPressure));
-        out.put(
-                HEAP_MAX_USAGE_RATIO,
-                new EvaluatedScalingMetric(
-                        lastHeapUsage,
-                        getAverageGlobalMetric(HEAP_MAX_USAGE_RATIO, metricHistory)));
 
-        var latestObservation = latest.getOrDefault(HEAP_MEMORY_USED, Double.NaN);
-        double heapSizeAverage = getAverageGlobalMetric(HEAP_MEMORY_USED, metricHistory);
-        out.put(HEAP_MEMORY_USED, new EvaluatedScalingMetric(latestObservation, heapSizeAverage));
+        populateMetric(HEAP_MAX_USAGE_RATIO, metricHistory, out);
+        populateMetric(HEAP_MEMORY_USED, metricHistory, out);
+        populateMetric(MANAGED_MEMORY_USED, metricHistory, out);
+        populateMetric(NETWORK_MEMORY_USED, metricHistory, out);
+        populateMetric(METASPACE_MEMORY_USED, metricHistory, out);
 
         out.put(
                 NUM_TASK_SLOTS_USED,
                 EvaluatedScalingMetric.of(latest.getOrDefault(NUM_TASK_SLOTS_USED, Double.NaN)));
 
         return out;
+    }
+
+    private static void populateMetric(
+            ScalingMetric scalingMetric,
+            SortedMap<Instant, CollectedMetrics> metricHistory,
+            Map<ScalingMetric, EvaluatedScalingMetric> out) {
+        var latestMetrics = metricHistory.get(metricHistory.lastKey()).getGlobalMetrics();
+
+        var latestObservation = latestMetrics.getOrDefault(scalingMetric, Double.NaN);
+        double value = getAverageGlobalMetric(scalingMetric, metricHistory);
+
+        out.put(scalingMetric, new EvaluatedScalingMetric(latestObservation, value));
     }
 
     private static double getAverageGlobalMetric(

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -260,38 +260,29 @@ public class AutoScalerOptions {
                     .withDescription(
                             "If enabled, the initial amount of memory specified for TaskManagers will be reduced according to the observed needs.");
 
-    public static final ConfigOption<MemoryTuning.HeapUsageTarget> MEMORY_TUNING_HEAP_TARGET =
-            autoScalerConfig("memory.tuning.heap.target-usage")
-                    .enumType(MemoryTuning.HeapUsageTarget.class)
-                    .defaultValue(MemoryTuning.HeapUsageTarget.MAX)
-                    .withFallbackKeys(oldOperatorConfigKey("memory.tuning.heap.target-usage"))
+    public static final ConfigOption<MemoryTuning.UsageTarget> MEMORY_TUNING_TARGET =
+            autoScalerConfig("memory.tuning.target-usage")
+                    .enumType(MemoryTuning.UsageTarget.class)
+                    .defaultValue(MemoryTuning.UsageTarget.MAX)
+                    .withFallbackKeys(oldOperatorConfigKey("memory.tuning.target-usage"))
                     .withDescription(
-                            "The heap size to target. Average usage (AVG) will yield better savings. Max usage will yield more conservative savings.");
+                            "The memory usage to target. Average usage (AVG) will yield better savings. Max usage will yield more conservative savings.");
 
-    public static final ConfigOption<Double> MEMORY_TUNING_HEAP_OVERHEAD =
-            autoScalerConfig("memory.tuning.heap.overhead")
+    public static final ConfigOption<Double> MEMORY_TUNING_OVERHEAD =
+            autoScalerConfig("memory.tuning.overhead")
                     .doubleType()
                     .defaultValue(0.2)
-                    .withFallbackKeys(oldOperatorConfigKey("memory.tuning.heap.overhead"))
+                    .withFallbackKeys(oldOperatorConfigKey("memory.tuning.overhead"))
                     .withDescription(
-                            "Overhead to add to heap tuning decisions (0-1). This ensures spare capacity and allows the memory to grow beyond the dynamically computed limits, but never beyond the original memory limits.");
+                            "Overhead to add to tuning decisions (0-1). This ensures spare capacity and allows the memory to grow beyond the dynamically computed limits, but never beyond the original memory limits.");
 
-    public static final ConfigOption<MemorySize> MEMORY_TUNING_MIN_HEAP =
-            autoScalerConfig("memory.tuning.heap.min")
+    public static final ConfigOption<MemorySize> MEMORY_TUNING_MIN =
+            autoScalerConfig("memory.tuning.min")
                     .memoryType()
-                    .defaultValue(MemorySize.ofMebiBytes(512L))
-                    .withFallbackKeys(oldOperatorConfigKey("memory.tuning.heap.min"))
+                    .defaultValue(MemorySize.ofMebiBytes(256))
+                    .withFallbackKeys(oldOperatorConfigKey("memory.tuning.min"))
                     .withDescription(
-                            "The minimum amount of TaskManager heap memory, if memory tuning is enabled.");
-
-    public static final ConfigOption<Boolean> MEMORY_TUNING_TRANSFER_HEAP_TO_MANAGED =
-            autoScalerConfig("memory.tuning.heap.transfer-to-managed")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withFallbackKeys(
-                            oldOperatorConfigKey("memory.tuning.heap.transfer-to-managed"))
-                    .withDescription(
-                            "If enabled, any reduction of heap memory will increase the managed memory used by RocksDB.");
+                            "If memory tuning is enabled, the minimum amount of TaskManager memory for each memory component (heap, managed, network).");
 
     public static final ConfigOption<Integer> VERTEX_SCALING_HISTORY_COUNT =
             autoScalerConfig("history.max.count")

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
@@ -43,6 +43,9 @@ public enum FlinkMetric {
 
     HEAP_MEMORY_MAX(s -> s.equals("Status.JVM.Memory.Heap.Max")),
     HEAP_MEMORY_USED(s -> s.equals("Status.JVM.Memory.Heap.Used")),
+    MANAGED_MEMORY_USED(s -> s.equals("Status.Flink.Memory.Managed.Used")),
+    NETWORK_MEMORY_USED(s -> s.equals("Status.Shuffle.Netty.UsedMemory")),
+    METASPACE_MEMORY_USED(s -> s.equals("Status.JVM.Memory.Metaspace.Used")),
 
     TOTAL_GC_TIME_PER_SEC(s -> s.equals("Status.JVM.GarbageCollector.All.TimeMsPerSecond")),
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
@@ -41,9 +41,11 @@ public enum FlinkMetric {
     PENDING_RECORDS(s -> s.endsWith(".pendingRecords")),
     BACKPRESSURE_TIME_PER_SEC(s -> s.equals("backPressuredTimeMsPerSecond")),
 
-    HEAP_MAX(s -> s.equals("Status.JVM.Memory.Heap.Max")),
-    HEAP_USED(s -> s.equals("Status.JVM.Memory.Heap.Used")),
+    HEAP_MEMORY_MAX(s -> s.equals("Status.JVM.Memory.Heap.Max")),
+    HEAP_MEMORY_USED(s -> s.equals("Status.JVM.Memory.Heap.Used")),
+
     TOTAL_GC_TIME_PER_SEC(s -> s.equals("Status.JVM.GarbageCollector.All.TimeMsPerSecond")),
+
     NUM_TASK_SLOTS_TOTAL(s -> s.equals("taskSlotsTotal")),
     NUM_TASK_SLOTS_AVAILABLE(s -> s.equals("taskSlotsAvailable"));
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
@@ -78,7 +78,7 @@ public enum ScalingMetric {
     GC_PRESSURE(false),
 
     /** Measured used heap size in bytes. */
-    HEAP_USED(true),
+    HEAP_MEMORY_USED(true),
 
     /** Percentage of max heap used (between 0 and 1). */
     HEAP_MAX_USAGE_RATIO(true),

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
@@ -80,6 +80,12 @@ public enum ScalingMetric {
     /** Measured used heap size in bytes. */
     HEAP_MEMORY_USED(true),
 
+    MANAGED_MEMORY_USED(true),
+
+    NETWORK_MEMORY_USED(true),
+
+    METASPACE_MEMORY_USED(true),
+
     /** Percentage of max heap used (between 0 and 1). */
     HEAP_MAX_USAGE_RATIO(true),
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -191,17 +191,17 @@ public class ScalingMetrics {
             out.put(ScalingMetric.GC_PRESSURE, gcTime.getMax() / 1000);
         }
 
-        var heapMax = collectedTmMetrics.get(FlinkMetric.HEAP_MAX);
-        var heapUsed = collectedTmMetrics.get(FlinkMetric.HEAP_USED);
+        var heapMax = collectedTmMetrics.get(FlinkMetric.HEAP_MEMORY_MAX);
+        var heapUsed = collectedTmMetrics.get(FlinkMetric.HEAP_MEMORY_USED);
         if (heapMax != null && heapUsed != null) {
             MemoryTuning.HeapUsageTarget heapTarget =
                     conf.get(AutoScalerOptions.MEMORY_TUNING_HEAP_TARGET);
             switch (heapTarget) {
                 case AVG:
-                    out.put(ScalingMetric.HEAP_USED, heapUsed.getAvg());
+                    out.put(ScalingMetric.HEAP_MEMORY_USED, heapUsed.getAvg());
                     break;
                 case MAX:
-                    out.put(ScalingMetric.HEAP_USED, heapUsed.getMax());
+                    out.put(ScalingMetric.HEAP_MEMORY_USED, heapUsed.getMax());
                     break;
                 default:
                     LOG.warn("Unknown value {} for heap target", heapTarget);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/realizer/ScalingRealizer.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/realizer/ScalingRealizer.java
@@ -19,7 +19,7 @@ package org.apache.flink.autoscaler.realizer;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.autoscaler.JobAutoScalerContext;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.autoscaler.tuning.ConfigChanges;
 
 import java.util.Map;
 
@@ -37,5 +37,5 @@ public interface ScalingRealizer<KEY, Context extends JobAutoScalerContext<KEY>>
     void realizeParallelismOverrides(Context context, Map<String, String> parallelismOverrides);
 
     /** Updates the TaskManager memory configuration. */
-    void realizeConfigOverrides(Context context, Configuration configOverrides);
+    void realizeConfigOverrides(Context context, ConfigChanges configChanges);
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
@@ -22,7 +22,7 @@ import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.ScalingSummary;
 import org.apache.flink.autoscaler.ScalingTracking;
 import org.apache.flink.autoscaler.metrics.CollectedMetrics;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.autoscaler.tuning.ConfigChanges;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import javax.annotation.Nonnull;
@@ -70,12 +70,12 @@ public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
 
     void removeParallelismOverrides(Context jobContext) throws Exception;
 
-    void storeConfigOverrides(Context jobContext, Configuration configOverrides) throws Exception;
+    void storeConfigChanges(Context jobContext, ConfigChanges configChanges) throws Exception;
 
     @Nonnull
-    Configuration getConfigOverrides(Context jobContext) throws Exception;
+    ConfigChanges getConfigChanges(Context jobContext) throws Exception;
 
-    void removeConfigOverrides(Context jobContext) throws Exception;
+    void removeConfigChanges(Context jobContext) throws Exception;
 
     /** Removes all data from this context. Flush stil needs to be called. */
     void clearAll(Context jobContext) throws Exception;

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
@@ -21,7 +21,7 @@ import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.ScalingSummary;
 import org.apache.flink.autoscaler.ScalingTracking;
 import org.apache.flink.autoscaler.metrics.CollectedMetrics;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.autoscaler.tuning.ConfigChanges;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import javax.annotation.Nonnull;
@@ -50,7 +50,7 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
 
     private final Map<KEY, Map<String, String>> parallelismOverridesStore;
 
-    private final Map<KEY, Configuration> tmConfigOverrides;
+    private final Map<KEY, ConfigChanges> tmConfigOverrides;
 
     private final Map<KEY, ScalingTracking> scalingTrackingStore;
 
@@ -59,7 +59,7 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
         collectedMetricsStore = new ConcurrentHashMap<>();
         parallelismOverridesStore = new ConcurrentHashMap<>();
         scalingTrackingStore = new ConcurrentHashMap<>();
-        tmConfigOverrides = new ConcurrentHashMap<>();
+        tmConfigOverrides = new ConcurrentHashMap<KEY, ConfigChanges>();
     }
 
     @Override
@@ -122,20 +122,19 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
     }
 
     @Override
-    public void storeConfigOverrides(Context jobContext, Configuration configOverrides)
-            throws Exception {
-        tmConfigOverrides.put(jobContext.getJobKey(), configOverrides);
+    public void storeConfigChanges(Context jobContext, ConfigChanges configChanges) {
+        tmConfigOverrides.put(jobContext.getJobKey(), configChanges);
     }
 
     @Nonnull
     @Override
-    public Configuration getConfigOverrides(Context jobContext) {
+    public ConfigChanges getConfigChanges(Context jobContext) {
         return Optional.ofNullable(tmConfigOverrides.get(jobContext.getJobKey()))
-                .orElse(new Configuration());
+                .orElse(new ConfigChanges());
     }
 
     @Override
-    public void removeConfigOverrides(Context jobContext) {
+    public void removeConfigChanges(Context jobContext) {
         tmConfigOverrides.remove(jobContext.getJobKey());
     }
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/ConfigChanges.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/ConfigChanges.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.tuning;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.FallbackKey;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/** Holds the configuration overrides and removals for a Flink Configuration. */
+public class ConfigChanges {
+
+    /** Overrides which will be applied on top of the existing config. */
+    @Getter private final Map<String, String> overrides = new HashMap<>();
+
+    /** Removals which will be removed from the existing config. */
+    @Getter private final Set<String> removals = new HashSet<>();
+
+    private final transient Configuration confObject = new Configuration();
+
+    public <T> ConfigChanges addOverride(ConfigOption<T> configOption, T value) {
+        // Slightly awkward but safe way to work with the limited API of the Configuration class.
+        // We want to avoid using the serialization code of Configuration and use Strings instead.
+        confObject.set(configOption, value);
+        overrides.putAll(confObject.toMap());
+        confObject.removeKey(configOption.key());
+        return this;
+    }
+
+    public ConfigChanges addOverride(String key, String value) {
+        overrides.put(key, value);
+        return this;
+    }
+
+    public ConfigChanges addRemoval(ConfigOption<?> configOption) {
+        removals.add(configOption.key());
+        for (FallbackKey fallbackKey : configOption.fallbackKeys()) {
+            removals.add(fallbackKey.getKey());
+        }
+        return this;
+    }
+
+    public Configuration applyOverrides(Configuration existingConfig) {
+        Configuration config = new Configuration(existingConfig);
+        for (String key : removals) {
+            config.removeKey(key);
+        }
+        config.addAll(Configuration.fromMap(overrides));
+        return config;
+    }
+}

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryBudget.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryBudget.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.tuning;
+
+import org.apache.flink.util.Preconditions;
+
+/** Accounting for distributing memory over the available pools. */
+public class MemoryBudget {
+
+    private long remaining;
+
+    public MemoryBudget(long remaining) {
+        Preconditions.checkArgument(remaining >= 0);
+        this.remaining = remaining;
+    }
+
+    public long budget(long amount) {
+        Preconditions.checkArgument(amount >= 0);
+        var budgeted = Math.min(amount, remaining);
+        remaining -= budgeted;
+        return budgeted;
+    }
+
+    public long getRemaining() {
+        return remaining;
+    }
+}

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
@@ -174,7 +174,8 @@ public class MemoryTuning {
     private static MemorySize getHeapUsed(EvaluatedMetrics evaluatedMetrics) {
         var globalMetrics = evaluatedMetrics.getGlobalMetrics();
         MemorySize heapUsed =
-                new MemorySize((long) globalMetrics.get(ScalingMetric.HEAP_USED).getAverage());
+                new MemorySize(
+                        (long) globalMetrics.get(ScalingMetric.HEAP_MEMORY_USED).getAverage());
         LOG.info("TM heap used size: {}", heapUsed);
         return heapUsed;
     }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
@@ -21,11 +21,11 @@ import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.event.AutoScalerEventHandler;
 import org.apache.flink.autoscaler.metrics.EvaluatedMetrics;
+import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.autoscaler.metrics.ScalingMetric;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.runtime.util.config.memory.CommonProcessMemorySpec;
@@ -41,6 +41,11 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Map;
 
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.HEAP_MEMORY_USED;
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.MANAGED_MEMORY_USED;
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.METASPACE_MEMORY_USED;
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.NETWORK_MEMORY_USED;
+
 /** Tunes the TaskManager memory. */
 public class MemoryTuning {
 
@@ -48,10 +53,10 @@ public class MemoryTuning {
     public static final ProcessMemoryUtils<TaskExecutorFlinkMemory> FLINK_MEMORY_UTILS =
             new ProcessMemoryUtils<>(getMemoryOptions(), new TaskExecutorFlinkMemoryUtils());
 
-    private static final Configuration EMPTY_CONFIG = new Configuration();
+    private static final ConfigChanges EMPTY_CONFIG = new ConfigChanges();
 
     /** What memory usage to target. */
-    public enum HeapUsageTarget {
+    public enum UsageTarget {
         AVG,
         MAX
     }
@@ -62,7 +67,7 @@ public class MemoryTuning {
      * overrides. This config is persisted separately and applied by the autoscaler. That way we can
      * clear any applied overrides if auto-tuning is disabled.
      */
-    public static Configuration tuneTaskManagerHeapMemory(
+    public static ConfigChanges tuneTaskManagerHeapMemory(
             JobAutoScalerContext<?> context,
             EvaluatedMetrics evaluatedMetrics,
             AutoScalerEventHandler eventHandler) {
@@ -80,56 +85,92 @@ public class MemoryTuning {
             return EMPTY_CONFIG;
         }
 
-        var maxHeapSize = memSpecs.getFlinkMemory().getJvmHeapMemorySize();
-        LOG.debug("Current configured heap size: {}", maxHeapSize);
+        MemorySize specHeapSize = memSpecs.getFlinkMemory().getJvmHeapMemorySize();
+        MemorySize specManagedSize = memSpecs.getFlinkMemory().getManaged();
+        MemorySize specNetworkSize = memSpecs.getFlinkMemory().getNetwork();
+        MemorySize specMetaspaceSize = memSpecs.getJvmMetaspaceSize();
+        LOG.info(
+                "Spec memory - heap: {}, managed: {}, network: {}, meta: {}",
+                specHeapSize.toHumanReadableString(),
+                specManagedSize.toHumanReadableString(),
+                specNetworkSize.toHumanReadableString(),
+                specMetaspaceSize.toHumanReadableString());
 
-        MemorySize newHeapSize = determineNewHeapSize(evaluatedMetrics, config, maxHeapSize);
-        LOG.info("New TM heap memory {}", newHeapSize.toHumanReadableString());
+        MemorySize maxMemoryBySpec = context.getTaskManagerMemory().orElse(MemorySize.ZERO);
+        if (maxMemoryBySpec.compareTo(MemorySize.ZERO) <= 0) {
+            LOG.warn("Spec TaskManager memory size could not be determined.");
+            return EMPTY_CONFIG;
+        }
+        MemoryBudget memBudget = new MemoryBudget(maxMemoryBySpec.getBytes());
+        // Add these current settings from the budget
+        memBudget.budget(memSpecs.getFlinkMemory().getFrameworkOffHeap().getBytes());
+        memBudget.budget(memSpecs.getFlinkMemory().getTaskOffHeap().getBytes());
+        memBudget.budget(memSpecs.getJvmOverheadSize().getBytes());
+
+        var globalMetrics = evaluatedMetrics.getGlobalMetrics();
+        // The order matters in case the memory usage is higher than the maximum available memory.
+        // Managed memory comes last because it can grow arbitrary for RocksDB jobs.
+        MemorySize newHeapSize =
+                determineNewSize(HEAP_MEMORY_USED, globalMetrics, config, memBudget);
+        MemorySize newMetaspaceSize =
+                determineNewSize(METASPACE_MEMORY_USED, globalMetrics, config, memBudget);
+        MemorySize newNetworkSize =
+                determineNewSize(NETWORK_MEMORY_USED, globalMetrics, config, memBudget);
+        MemorySize newManagedSize =
+                determineNewSize(MANAGED_MEMORY_USED, globalMetrics, config, memBudget);
+        LOG.info(
+                "Optimized memory sizes: heap: {} managed: {}, network: {}, meta: {}",
+                newHeapSize.toHumanReadableString(),
+                newManagedSize.toHumanReadableString(),
+                newNetworkSize.toHumanReadableString(),
+                newMetaspaceSize.toHumanReadableString());
 
         // Diff can be negative (memory shrinks) or positive (memory grows)
-        final long heapDiffBytes = newHeapSize.getBytes() - maxHeapSize.getBytes();
+        final long heapDiffBytes = newHeapSize.getBytes() - specHeapSize.getBytes();
+        final long managedDiffBytes = newManagedSize.getBytes() - specManagedSize.getBytes();
+        final long networkDiffBytes = newNetworkSize.getBytes() - specNetworkSize.getBytes();
+        final long flinkMemoryDiffBytes = heapDiffBytes + managedDiffBytes + networkDiffBytes;
 
-        final MemorySize totalMemory = adjustTotalTmMemory(context, heapDiffBytes);
+        // Update total memory according to memory diffs
+        final MemorySize totalMemory =
+                new MemorySize(maxMemoryBySpec.getBytes() - memBudget.getRemaining());
         if (totalMemory.equals(MemorySize.ZERO)) {
             return EMPTY_CONFIG;
         }
 
         // Prepare the tuning config for new configuration values
-        var tuningConfig = new Configuration();
-        // Update total memory according to new heap size
-        // Adjust the total container memory and the JVM heap size accordingly.
-        tuningConfig.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, totalMemory);
-        // Framework and Task heap memory configs add up together yield the max heap memory.
-        // To simplify the calculation, set the framework heap memory to zero.
-        tuningConfig.set(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, MemorySize.ZERO);
-        tuningConfig.set(TaskManagerOptions.TASK_HEAP_MEMORY, newHeapSize);
+        var tuningConfig = new ConfigChanges();
+        // Adjust the total container memory
+        tuningConfig.addOverride(TaskManagerOptions.TOTAL_PROCESS_MEMORY, totalMemory);
+        // We do not set the framework/task heap memory because those are automatically derived from
+        // setting the other mandatory memory options for managed memory, network, metaspace and jvm
+        // overhead. However, we do precise accounting for heap memory above. In contrast to other
+        // memory pools, there are no fractional variants for heap memory. Setting the absolute heap
+        // memory options could cause invalid configuration states when users adapt the total amount
+        // of memory. We also need to take care to remove any user-provided overrides for those.
+        tuningConfig.addRemoval(TaskManagerOptions.TASK_HEAP_MEMORY);
+        // Set default to zero because we already account for heap via task heap.
+        tuningConfig.addOverride(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, MemorySize.ZERO);
 
-        // All memory options which can be configured via fractions need to be set to their
-        // absolute values or, if there is no absolute setting, the fractions need to be
-        // re-calculated.
-        MemorySize managedMemory = memSpecs.getFlinkMemory().getManaged();
-        if (shouldTransferHeapToManagedMemory(config, heapDiffBytes)) {
-            // If RocksDB is configured, give back the heap memory as managed memory to RocksDB
-            MemorySize newManagedMemory =
-                    new MemorySize(managedMemory.getBytes() + Math.abs(heapDiffBytes));
-            LOG.info(
-                    "Increasing managed memory size from {} to {}",
-                    managedMemory,
-                    newManagedMemory);
-            tuningConfig.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, newManagedMemory);
-        } else {
-            tuningConfig.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, managedMemory);
-        }
+        MemorySize flinkMemorySize =
+                new MemorySize(
+                        memSpecs.getTotalFlinkMemorySize().getBytes() + flinkMemoryDiffBytes);
 
-        tuningConfig.set(
+        // All memory options which can be configured via fractions need to be re-calculated.
+        tuningConfig.addOverride(
+                TaskManagerOptions.MANAGED_MEMORY_FRACTION,
+                getFraction(newManagedSize, flinkMemorySize));
+        tuningConfig.addRemoval(TaskManagerOptions.MANAGED_MEMORY_SIZE);
+
+        tuningConfig.addOverride(
                 TaskManagerOptions.NETWORK_MEMORY_FRACTION,
-                getFraction(
-                        memSpecs.getFlinkMemory().getNetwork(),
-                        new MemorySize(
-                                memSpecs.getTotalFlinkMemorySize().getBytes() + heapDiffBytes)));
-        tuningConfig.set(
+                getFraction(newNetworkSize, flinkMemorySize));
+
+        tuningConfig.addOverride(
                 TaskManagerOptions.JVM_OVERHEAD_FRACTION,
                 getFraction(memSpecs.getJvmOverheadSize(), totalMemory));
+
+        tuningConfig.addOverride(TaskManagerOptions.JVM_METASPACE, newMetaspaceSize);
 
         eventHandler.handleEvent(
                 context,
@@ -151,40 +192,33 @@ public class MemoryTuning {
         return tuningConfig;
     }
 
-    private static MemorySize determineNewHeapSize(
-            EvaluatedMetrics evaluatedMetrics, Configuration config, MemorySize maxHeapSize) {
+    private static MemorySize determineNewSize(
+            ScalingMetric scalingMetric,
+            Map<ScalingMetric, EvaluatedScalingMetric> globalMetrics,
+            Configuration config,
+            MemoryBudget memoryBudget) {
 
-        double overheadFactor = 1 + config.get(AutoScalerOptions.MEMORY_TUNING_HEAP_OVERHEAD);
-        long heapTargetSizeBytes =
-                (long) (getHeapUsed(evaluatedMetrics).getBytes() * overheadFactor);
+        double overheadFactor = 1 + config.get(AutoScalerOptions.MEMORY_TUNING_OVERHEAD);
+        long targetSizeBytes =
+                (long) (getMemorySize(scalingMetric, globalMetrics).getBytes() * overheadFactor);
 
-        // Apply min/max heap size limits
-        heapTargetSizeBytes =
-                Math.min(
-                        Math.max(
-                                // Lower limit is the minimum configured heap size
-                                config.get(AutoScalerOptions.MEMORY_TUNING_MIN_HEAP).getBytes(),
-                                heapTargetSizeBytes),
-                        // Upper limit is the original max heap size in the spec
-                        maxHeapSize.getBytes());
+        // Lower limit is the minimum configured memory size
+        targetSizeBytes =
+                Math.max(
+                        config.get(AutoScalerOptions.MEMORY_TUNING_MIN).getBytes(),
+                        targetSizeBytes);
 
-        return new MemorySize(heapTargetSizeBytes);
+        // Upper limit is the available memory budget
+        targetSizeBytes = memoryBudget.budget(targetSizeBytes);
+
+        return new MemorySize(targetSizeBytes);
     }
 
-    private static MemorySize getHeapUsed(EvaluatedMetrics evaluatedMetrics) {
-        var globalMetrics = evaluatedMetrics.getGlobalMetrics();
-        MemorySize heapUsed =
-                new MemorySize(
-                        (long) globalMetrics.get(ScalingMetric.HEAP_MEMORY_USED).getAverage());
-        LOG.info("TM heap used size: {}", heapUsed);
+    private static MemorySize getMemorySize(
+            ScalingMetric scalingMetric, Map<ScalingMetric, EvaluatedScalingMetric> globalMetrics) {
+        MemorySize heapUsed = new MemorySize((long) globalMetrics.get(scalingMetric).getAverage());
+        LOG.info("{}: {}", scalingMetric, heapUsed);
         return heapUsed;
-    }
-
-    private static boolean shouldTransferHeapToManagedMemory(
-            Configuration config, long heapDiffBytes) {
-        return config.get(AutoScalerOptions.MEMORY_TUNING_TRANSFER_HEAP_TO_MANAGED)
-                && heapDiffBytes < 0
-                && "rocksdb".equalsIgnoreCase(config.get(StateBackendOptions.STATE_BACKEND));
     }
 
     public static MemorySize getTotalMemory(Configuration config, JobAutoScalerContext<?> ctx) {
@@ -195,20 +229,15 @@ public class MemoryTuning {
         return ctx.getTaskManagerMemory().orElse(MemorySize.ZERO);
     }
 
-    private static MemorySize adjustTotalTmMemory(JobAutoScalerContext<?> ctx, long heapDiffBytes) {
-
+    private static MemorySize adjustTotalTmMemory(
+            JobAutoScalerContext<?> ctx, long totalDiffBytes) {
         var specTaskManagerMemory = ctx.getTaskManagerMemory().orElse(MemorySize.ZERO);
         if (specTaskManagerMemory.compareTo(MemorySize.ZERO) <= 0) {
             LOG.warn("Spec TaskManager memory size could not be determined.");
             return MemorySize.ZERO;
         }
 
-        if (shouldTransferHeapToManagedMemory(ctx.getConfiguration(), heapDiffBytes)) {
-            // Total size does not change
-            return specTaskManagerMemory;
-        }
-
-        long newTotalMemBytes = specTaskManagerMemory.getBytes() + heapDiffBytes;
+        long newTotalMemBytes = specTaskManagerMemory.getBytes() + totalDiffBytes;
         // TM container memory can never grow beyond the user-specified max memory
         newTotalMemBytes = Math.min(newTotalMemBytes, specTaskManagerMemory.getBytes());
 
@@ -239,13 +268,26 @@ public class MemoryTuning {
     }
 
     /** Format config such that it can be directly used as a Flink configuration. */
-    private static String formatConfig(Configuration config) {
+    private static String formatConfig(ConfigChanges config) {
         var sb = new StringBuilder();
-        for (Map.Entry<String, String> entry : config.toMap().entrySet()) {
+        for (Map.Entry<String, String> entry : config.getOverrides().entrySet()) {
             sb.append(entry.getKey())
                     .append(": ")
                     .append(entry.getValue())
                     .append(System.lineSeparator());
+        }
+        if (!config.getRemovals().isEmpty()) {
+            sb.append("Remove the following config entries if present: [");
+            boolean first = true;
+            for (String toRemove : config.getRemovals()) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                sb.append(toRemove);
+            }
+            sb.append("]");
         }
         return sb.toString();
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
@@ -30,9 +30,8 @@ import org.apache.flink.autoscaler.state.AutoScalerStateStore;
 import org.apache.flink.autoscaler.state.InMemoryAutoScalerStateStore;
 import org.apache.flink.autoscaler.topology.JobTopology;
 import org.apache.flink.autoscaler.topology.VertexInfo;
+import org.apache.flink.autoscaler.tuning.ConfigChanges;
 import org.apache.flink.client.program.rest.RestClusterClient;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.metrics.Gauge;
@@ -302,23 +301,27 @@ public class JobAutoScalerImplTest {
                         null, null, null, eventCollector, scalingRealizer, stateStore);
 
         // Initially we should return empty overrides, do not crate any state
-        assertThat(stateStore.getConfigOverrides(context).toMap()).isEmpty();
+        assertThat(stateStore.getConfigChanges(context).getOverrides()).isEmpty();
 
-        var config = new Configuration();
-        config.set(TaskManagerOptions.TASK_HEAP_MEMORY, new MemorySize(42));
-        stateStore.storeConfigOverrides(context, config);
+        ConfigChanges config = new ConfigChanges();
+        config.addOverride(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 0.42f);
+        config.addRemoval(TaskManagerOptions.TASK_HEAP_MEMORY);
+        stateStore.storeConfigChanges(context, config);
         stateStore.flush(context);
 
         autoscaler.applyConfigOverrides(context);
-        assertThat(getEvent().getConfigOverrides().toMap())
-                .containsExactly(entry(TaskManagerOptions.TASK_HEAP_MEMORY.key(), "42 bytes"));
-        assertThat(stateStore.getConfigOverrides(context)).isEqualTo(config);
+        var event = getEvent();
+        assertThat(event.getConfigChanges().getOverrides())
+                .containsExactly(entry(TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(), "0.42"));
+        assertThat(event.getConfigChanges().getRemovals())
+                .containsExactly(TaskManagerOptions.TASK_HEAP_MEMORY.key());
+        assertThat(stateStore.getConfigChanges(context)).isEqualTo(config);
 
         // Disabling autoscaler should clear overrides
         context.getConfiguration().setString(AUTOSCALER_ENABLED.key(), "false");
         autoscaler.scale(context);
         autoscaler.applyConfigOverrides(context);
-        assertThat(getEvent().getConfigOverrides().toMap()).isEmpty();
+        assertThat(getEvent().getConfigChanges().getOverrides()).isEmpty();
     }
 
     @Test
@@ -362,17 +365,6 @@ public class JobAutoScalerImplTest {
         }
         assertThat(scalingEvent).isNotNull();
         assertEquals(expectedOverrides, scalingEvent.getParallelismOverrides());
-    }
-
-    @Nullable
-    private TestingScalingRealizer.Event<JobID, JobAutoScalerContext<JobID>> getEvent(
-            Map<String, String> expectedOverrides) {
-        var scalingEvent = getEvent();
-        if (expectedOverrides == null) {
-            assertThat(scalingEvent).isNull();
-            return null;
-        }
-        return scalingEvent;
     }
 
     @Nullable

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
@@ -237,7 +237,11 @@ public class RestApiMetricsCollectorTest {
         metricValues.put(HEAP_USED_NAME, heapUsed);
 
         assertMetricsEquals(
-                Map.of(FlinkMetric.HEAP_MAX, heapMax, FlinkMetric.HEAP_USED, heapUsed),
+                Map.of(
+                        FlinkMetric.HEAP_MEMORY_MAX,
+                        heapMax,
+                        FlinkMetric.HEAP_MEMORY_USED,
+                        heapUsed),
                 collector.queryTmMetrics(context));
         collector.cleanup(context.getJobKey());
 
@@ -247,9 +251,9 @@ public class RestApiMetricsCollectorTest {
 
         assertMetricsEquals(
                 Map.of(
-                        FlinkMetric.HEAP_MAX,
+                        FlinkMetric.HEAP_MEMORY_MAX,
                         heapMax,
-                        FlinkMetric.HEAP_USED,
+                        FlinkMetric.HEAP_MEMORY_USED,
                         heapUsed,
                         FlinkMetric.TOTAL_GC_TIME_PER_SEC,
                         gcTime),

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
@@ -60,6 +60,9 @@ public class RestApiMetricsCollectorTest {
     private static final String GC_METRIC_NAME = "Status.JVM.GarbageCollector.All.TimeMsPerSecond";
     private static final String HEAP_MAX_NAME = "Status.JVM.Memory.Heap.Max";
     private static final String HEAP_USED_NAME = "Status.JVM.Memory.Heap.Used";
+    private static final String MANAGED_MEMORY_NAME = "Status.Flink.Memory.Managed.Used";
+    private static final String NETWORK_MEMORY_NAME = "Status.Shuffle.Netty.UsedMemory";
+    private static final String METASPACE_MEMORY_NAME = "Status.JVM.Memory.Metaspace.Used";
 
     @Test
     public void testAggregateMultiplePendingRecordsMetricsPerSource() throws Exception {
@@ -233,15 +236,27 @@ public class RestApiMetricsCollectorTest {
         // Test only heap metrics available
         var heapMax = new AggregatedMetric(HEAP_MAX_NAME, null, 100., null, null);
         var heapUsed = new AggregatedMetric(HEAP_USED_NAME, null, 50., null, null);
+        var managedUsed = new AggregatedMetric(MANAGED_MEMORY_NAME, null, 42., null, null);
+        var networkUsed = new AggregatedMetric(NETWORK_MEMORY_NAME, null, 23., null, null);
+        var metaspaceUsed = new AggregatedMetric(METASPACE_MEMORY_NAME, null, 11., null, null);
         metricValues.put(HEAP_MAX_NAME, heapMax);
         metricValues.put(HEAP_USED_NAME, heapUsed);
+        metricValues.put(MANAGED_MEMORY_NAME, managedUsed);
+        metricValues.put(NETWORK_MEMORY_NAME, networkUsed);
+        metricValues.put(METASPACE_MEMORY_NAME, metaspaceUsed);
 
         assertMetricsEquals(
                 Map.of(
                         FlinkMetric.HEAP_MEMORY_MAX,
                         heapMax,
                         FlinkMetric.HEAP_MEMORY_USED,
-                        heapUsed),
+                        heapUsed,
+                        FlinkMetric.MANAGED_MEMORY_USED,
+                        managedUsed,
+                        FlinkMetric.METASPACE_MEMORY_USED,
+                        metaspaceUsed,
+                        FlinkMetric.NETWORK_MEMORY_USED,
+                        networkUsed),
                 collector.queryTmMetrics(context));
         collector.cleanup(context.getJobKey());
 
@@ -255,6 +270,12 @@ public class RestApiMetricsCollectorTest {
                         heapMax,
                         FlinkMetric.HEAP_MEMORY_USED,
                         heapUsed,
+                        FlinkMetric.MANAGED_MEMORY_USED,
+                        managedUsed,
+                        FlinkMetric.NETWORK_MEMORY_USED,
+                        networkUsed,
+                        FlinkMetric.METASPACE_MEMORY_USED,
+                        metaspaceUsed,
                         FlinkMetric.TOTAL_GC_TIME_PER_SEC,
                         gcTime),
                 collector.queryTmMetrics(context));

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -275,6 +275,12 @@ public class ScalingExecutorTest {
                         EvaluatedScalingMetric.of(9),
                         ScalingMetric.HEAP_MEMORY_USED,
                         EvaluatedScalingMetric.avg(MemorySize.parse("5 Gb").getBytes()),
+                        ScalingMetric.MANAGED_MEMORY_USED,
+                        EvaluatedScalingMetric.avg(MemorySize.parse("2 Gb").getBytes()),
+                        ScalingMetric.NETWORK_MEMORY_USED,
+                        EvaluatedScalingMetric.avg(MemorySize.parse("512 mb").getBytes()),
+                        ScalingMetric.METASPACE_MEMORY_USED,
+                        EvaluatedScalingMetric.avg(MemorySize.parse("300 mb").getBytes()),
                         ScalingMetric.HEAP_MAX_USAGE_RATIO,
                         EvaluatedScalingMetric.of(Double.NaN),
                         ScalingMetric.GC_PRESSURE,
@@ -286,12 +292,21 @@ public class ScalingExecutorTest {
         assertTrue(
                 scalingDecisionExecutor.scaleResource(
                         context, metrics, new HashMap<>(), new ScalingTracking(), now));
-        assertEquals(
-                "6.000gb (6442450944 bytes)",
-                stateStore
-                        .getConfigOverrides(context)
-                        .get(TaskManagerOptions.TASK_HEAP_MEMORY)
-                        .toHumanReadableString());
+        assertThat(stateStore.getConfigChanges(context).getOverrides())
+                .containsExactlyInAnyOrderEntriesOf(
+                        Map.of(
+                                TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(),
+                                "0.263",
+                                TaskManagerOptions.NETWORK_MEMORY_FRACTION.key(),
+                                "0.066",
+                                TaskManagerOptions.JVM_METASPACE.key(),
+                                "360 mb",
+                                TaskManagerOptions.JVM_OVERHEAD_FRACTION.key(),
+                                "0.095",
+                                TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(),
+                                "0 bytes",
+                                TaskManagerOptions.TOTAL_PROCESS_MEMORY.key(),
+                                "11249123327 bytes"));
     }
 
     @ParameterizedTest

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -273,7 +273,7 @@ public class ScalingExecutorTest {
                 Map.of(
                         ScalingMetric.NUM_TASK_SLOTS_USED,
                         EvaluatedScalingMetric.of(9),
-                        ScalingMetric.HEAP_USED,
+                        ScalingMetric.HEAP_MEMORY_USED,
                         EvaluatedScalingMetric.avg(MemorySize.parse("5 Gb").getBytes()),
                         ScalingMetric.HEAP_MAX_USAGE_RATIO,
                         EvaluatedScalingMetric.of(Double.NaN),

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -582,6 +582,12 @@ public class ScalingMetricEvaluatorTest {
                         EvaluatedScalingMetric.of(Double.NaN),
                         ScalingMetric.HEAP_MEMORY_USED,
                         EvaluatedScalingMetric.of(Double.NaN),
+                        ScalingMetric.MANAGED_MEMORY_USED,
+                        EvaluatedScalingMetric.of(Double.NaN),
+                        ScalingMetric.NETWORK_MEMORY_USED,
+                        EvaluatedScalingMetric.of(Double.NaN),
+                        ScalingMetric.METASPACE_MEMORY_USED,
+                        EvaluatedScalingMetric.of(Double.NaN),
                         ScalingMetric.NUM_TASK_SLOTS_USED,
                         EvaluatedScalingMetric.of(Double.NaN)),
                 ScalingMetricEvaluator.evaluateGlobalMetrics(globalMetrics));
@@ -597,7 +603,13 @@ public class ScalingMetricEvaluatorTest {
                                 ScalingMetric.GC_PRESSURE,
                                 0.6,
                                 ScalingMetric.HEAP_MEMORY_USED,
-                                512.)));
+                                512.,
+                                ScalingMetric.MANAGED_MEMORY_USED,
+                                420.,
+                                ScalingMetric.NETWORK_MEMORY_USED,
+                                230.,
+                                ScalingMetric.METASPACE_MEMORY_USED,
+                                110.)));
         assertEquals(
                 Map.of(
                         ScalingMetric.HEAP_MAX_USAGE_RATIO,
@@ -606,6 +618,12 @@ public class ScalingMetricEvaluatorTest {
                         EvaluatedScalingMetric.of(0.6),
                         ScalingMetric.HEAP_MEMORY_USED,
                         new EvaluatedScalingMetric(512, 512),
+                        ScalingMetric.MANAGED_MEMORY_USED,
+                        new EvaluatedScalingMetric(420, 420),
+                        ScalingMetric.NETWORK_MEMORY_USED,
+                        new EvaluatedScalingMetric(230, 230),
+                        ScalingMetric.METASPACE_MEMORY_USED,
+                        new EvaluatedScalingMetric(110, 110),
                         ScalingMetric.NUM_TASK_SLOTS_USED,
                         EvaluatedScalingMetric.of(Double.NaN)),
                 ScalingMetricEvaluator.evaluateGlobalMetrics(globalMetrics));
@@ -622,6 +640,12 @@ public class ScalingMetricEvaluatorTest {
                                 0.8,
                                 ScalingMetric.HEAP_MEMORY_USED,
                                 1024.,
+                                ScalingMetric.MANAGED_MEMORY_USED,
+                                840.,
+                                ScalingMetric.NETWORK_MEMORY_USED,
+                                460.,
+                                ScalingMetric.METASPACE_MEMORY_USED,
+                                220.,
                                 ScalingMetric.NUM_TASK_SLOTS_USED,
                                 42.)));
         assertEquals(
@@ -632,6 +656,12 @@ public class ScalingMetricEvaluatorTest {
                         EvaluatedScalingMetric.of(0.8),
                         ScalingMetric.HEAP_MEMORY_USED,
                         new EvaluatedScalingMetric(1024., 768.),
+                        ScalingMetric.MANAGED_MEMORY_USED,
+                        new EvaluatedScalingMetric(840., 630.),
+                        ScalingMetric.NETWORK_MEMORY_USED,
+                        new EvaluatedScalingMetric(460., 345.),
+                        ScalingMetric.METASPACE_MEMORY_USED,
+                        new EvaluatedScalingMetric(220., 165.),
                         ScalingMetric.NUM_TASK_SLOTS_USED,
                         EvaluatedScalingMetric.of(42.)),
                 ScalingMetricEvaluator.evaluateGlobalMetrics(globalMetrics));

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -580,7 +580,7 @@ public class ScalingMetricEvaluatorTest {
                         EvaluatedScalingMetric.of(Double.NaN),
                         ScalingMetric.GC_PRESSURE,
                         EvaluatedScalingMetric.of(Double.NaN),
-                        ScalingMetric.HEAP_USED,
+                        ScalingMetric.HEAP_MEMORY_USED,
                         EvaluatedScalingMetric.of(Double.NaN),
                         ScalingMetric.NUM_TASK_SLOTS_USED,
                         EvaluatedScalingMetric.of(Double.NaN)),
@@ -596,7 +596,7 @@ public class ScalingMetricEvaluatorTest {
                                 0.5,
                                 ScalingMetric.GC_PRESSURE,
                                 0.6,
-                                ScalingMetric.HEAP_USED,
+                                ScalingMetric.HEAP_MEMORY_USED,
                                 512.)));
         assertEquals(
                 Map.of(
@@ -604,7 +604,7 @@ public class ScalingMetricEvaluatorTest {
                         new EvaluatedScalingMetric(0.5, 0.5),
                         ScalingMetric.GC_PRESSURE,
                         EvaluatedScalingMetric.of(0.6),
-                        ScalingMetric.HEAP_USED,
+                        ScalingMetric.HEAP_MEMORY_USED,
                         new EvaluatedScalingMetric(512, 512),
                         ScalingMetric.NUM_TASK_SLOTS_USED,
                         EvaluatedScalingMetric.of(Double.NaN)),
@@ -620,7 +620,7 @@ public class ScalingMetricEvaluatorTest {
                                 0.7,
                                 ScalingMetric.GC_PRESSURE,
                                 0.8,
-                                ScalingMetric.HEAP_USED,
+                                ScalingMetric.HEAP_MEMORY_USED,
                                 1024.,
                                 ScalingMetric.NUM_TASK_SLOTS_USED,
                                 42.)));
@@ -630,7 +630,7 @@ public class ScalingMetricEvaluatorTest {
                         new EvaluatedScalingMetric(0.7, 0.6),
                         ScalingMetric.GC_PRESSURE,
                         EvaluatedScalingMetric.of(0.8),
-                        ScalingMetric.HEAP_USED,
+                        ScalingMetric.HEAP_MEMORY_USED,
                         new EvaluatedScalingMetric(1024., 768.),
                         ScalingMetric.NUM_TASK_SLOTS_USED,
                         EvaluatedScalingMetric.of(42.)),

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
@@ -484,7 +484,7 @@ public class ScalingMetricsTest {
     @Test
     public void testGlobalMetrics() {
         Configuration conf = new Configuration();
-        conf.set(AutoScalerOptions.MEMORY_TUNING_HEAP_TARGET, MemoryTuning.HeapUsageTarget.AVG);
+        conf.set(AutoScalerOptions.MEMORY_TUNING_TARGET, MemoryTuning.UsageTarget.AVG);
         assertEquals(Map.of(), ScalingMetrics.computeGlobalMetrics(Map.of(), Map.of(), conf));
         assertEquals(
                 Map.of(),
@@ -497,30 +497,54 @@ public class ScalingMetricsTest {
                         ScalingMetric.GC_PRESSURE,
                         0.25,
                         ScalingMetric.HEAP_MEMORY_USED,
-                        75.),
+                        75.,
+                        ScalingMetric.MANAGED_MEMORY_USED,
+                        128.,
+                        ScalingMetric.NETWORK_MEMORY_USED,
+                        42.,
+                        ScalingMetric.METASPACE_MEMORY_USED,
+                        11.),
                 ScalingMetrics.computeGlobalMetrics(
                         Map.of(),
                         Map.of(
                                 FlinkMetric.HEAP_MEMORY_USED,
                                 aggAvgMax(75, 100),
+                                FlinkMetric.MANAGED_MEMORY_USED,
+                                aggAvgMax(128, 133),
+                                FlinkMetric.NETWORK_MEMORY_USED,
+                                aggAvgMax(42, 48),
+                                FlinkMetric.METASPACE_MEMORY_USED,
+                                aggAvgMax(11, 22),
                                 FlinkMetric.HEAP_MEMORY_MAX,
                                 aggMax(200.),
                                 FlinkMetric.TOTAL_GC_TIME_PER_SEC,
                                 aggMax(250.)),
                         conf));
 
-        conf.set(AutoScalerOptions.MEMORY_TUNING_HEAP_TARGET, MemoryTuning.HeapUsageTarget.MAX);
+        conf.set(AutoScalerOptions.MEMORY_TUNING_TARGET, MemoryTuning.UsageTarget.MAX);
         assertEquals(
                 Map.of(
                         ScalingMetric.HEAP_MAX_USAGE_RATIO,
                         0.5,
                         ScalingMetric.HEAP_MEMORY_USED,
-                        100.),
+                        100.,
+                        ScalingMetric.MANAGED_MEMORY_USED,
+                        133.,
+                        ScalingMetric.NETWORK_MEMORY_USED,
+                        48.,
+                        ScalingMetric.METASPACE_MEMORY_USED,
+                        22.),
                 ScalingMetrics.computeGlobalMetrics(
                         Map.of(),
                         Map.of(
                                 FlinkMetric.HEAP_MEMORY_USED,
                                 aggAvgMax(75, 100),
+                                FlinkMetric.MANAGED_MEMORY_USED,
+                                aggAvgMax(128, 133),
+                                FlinkMetric.NETWORK_MEMORY_USED,
+                                aggAvgMax(42, 48),
+                                FlinkMetric.METASPACE_MEMORY_USED,
+                                aggAvgMax(11, 22),
                                 FlinkMetric.HEAP_MEMORY_MAX,
                                 aggMax(200.)),
                         conf));

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
@@ -489,21 +489,21 @@ public class ScalingMetricsTest {
         assertEquals(
                 Map.of(),
                 ScalingMetrics.computeGlobalMetrics(
-                        Map.of(), Map.of(FlinkMetric.HEAP_USED, aggMax(100)), conf));
+                        Map.of(), Map.of(FlinkMetric.HEAP_MEMORY_USED, aggMax(100)), conf));
         assertEquals(
                 Map.of(
                         ScalingMetric.HEAP_MAX_USAGE_RATIO,
                         0.5,
                         ScalingMetric.GC_PRESSURE,
                         0.25,
-                        ScalingMetric.HEAP_USED,
+                        ScalingMetric.HEAP_MEMORY_USED,
                         75.),
                 ScalingMetrics.computeGlobalMetrics(
                         Map.of(),
                         Map.of(
-                                FlinkMetric.HEAP_USED,
+                                FlinkMetric.HEAP_MEMORY_USED,
                                 aggAvgMax(75, 100),
-                                FlinkMetric.HEAP_MAX,
+                                FlinkMetric.HEAP_MEMORY_MAX,
                                 aggMax(200.),
                                 FlinkMetric.TOTAL_GC_TIME_PER_SEC,
                                 aggMax(250.)),
@@ -511,13 +511,17 @@ public class ScalingMetricsTest {
 
         conf.set(AutoScalerOptions.MEMORY_TUNING_HEAP_TARGET, MemoryTuning.HeapUsageTarget.MAX);
         assertEquals(
-                Map.of(ScalingMetric.HEAP_MAX_USAGE_RATIO, 0.5, ScalingMetric.HEAP_USED, 100.),
+                Map.of(
+                        ScalingMetric.HEAP_MAX_USAGE_RATIO,
+                        0.5,
+                        ScalingMetric.HEAP_MEMORY_USED,
+                        100.),
                 ScalingMetrics.computeGlobalMetrics(
                         Map.of(),
                         Map.of(
-                                FlinkMetric.HEAP_USED,
+                                FlinkMetric.HEAP_MEMORY_USED,
                                 aggAvgMax(75, 100),
-                                FlinkMetric.HEAP_MAX,
+                                FlinkMetric.HEAP_MEMORY_MAX,
                                 aggMax(200.)),
                         conf));
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/realizer/TestingScalingRealizer.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/realizer/TestingScalingRealizer.java
@@ -18,7 +18,7 @@
 package org.apache.flink.autoscaler.realizer;
 
 import org.apache.flink.autoscaler.JobAutoScalerContext;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.autoscaler.tuning.ConfigChanges;
 
 import lombok.Getter;
 
@@ -38,8 +38,8 @@ public class TestingScalingRealizer<KEY, Context extends JobAutoScalerContext<KE
     }
 
     @Override
-    public void realizeConfigOverrides(Context context, Configuration configOverrides) {
-        events.add(new Event<>(context, configOverrides));
+    public void realizeConfigOverrides(Context context, ConfigChanges configChanges) {
+        events.add(new Event<>(context, configChanges));
     }
 
     /** The collected event. */
@@ -49,16 +49,16 @@ public class TestingScalingRealizer<KEY, Context extends JobAutoScalerContext<KE
 
         @Getter private Map<String, String> parallelismOverrides;
 
-        @Getter private Configuration configOverrides;
+        @Getter private ConfigChanges configChanges;
 
         public Event(Context context, Map<String, String> parallelismOverrides) {
             this.context = context;
             this.parallelismOverrides = parallelismOverrides;
         }
 
-        public Event(Context context, Configuration configOverrides) {
+        public Event(Context context, ConfigChanges configChanges) {
             this.context = context;
-            this.configOverrides = configOverrides;
+            this.configChanges = configChanges;
         }
 
         @Override
@@ -69,7 +69,7 @@ public class TestingScalingRealizer<KEY, Context extends JobAutoScalerContext<KE
                     + ", parallelismOverrides="
                     + parallelismOverrides
                     + ", configOverrides="
-                    + configOverrides
+                    + configChanges
                     + '}';
         }
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/state/AbstractAutoScalerStateStoreTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/state/AbstractAutoScalerStateStoreTest.java
@@ -21,7 +21,7 @@ import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.ScalingSummary;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.metrics.CollectedMetrics;
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.autoscaler.tuning.ConfigChanges;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import org.junit.jupiter.api.Assertions;
@@ -184,26 +184,26 @@ public abstract class AbstractAutoScalerStateStoreTest<
                         new JobVertexID(),
                         new TreeMap<>(Map.of(Instant.now(), new ScalingSummary()))));
         stateStore.storeParallelismOverrides(ctx, Map.of(new JobVertexID().toHexString(), "23"));
-        stateStore.storeConfigOverrides(
-                ctx, Configuration.fromMap(Map.of("config.value", "value")));
+        stateStore.storeConfigChanges(
+                ctx, new ConfigChanges().addOverride("config.value", "value"));
 
         assertThat(stateStore.getCollectedMetrics(ctx)).isNotEmpty();
         assertThat(stateStore.getScalingHistory(ctx)).isNotEmpty();
         assertThat(stateStore.getParallelismOverrides(ctx)).isNotEmpty();
-        assertThat(stateStore.getConfigOverrides(ctx).toMap()).isNotEmpty();
+        assertThat(stateStore.getConfigChanges(ctx).getOverrides()).isNotEmpty();
 
         stateStore.flush(ctx);
 
         assertThat(stateStore.getCollectedMetrics(ctx)).isNotEmpty();
         assertThat(stateStore.getScalingHistory(ctx)).isNotEmpty();
         assertThat(stateStore.getParallelismOverrides(ctx)).isNotEmpty();
-        assertThat(stateStore.getConfigOverrides(ctx).toMap()).isNotEmpty();
+        assertThat(stateStore.getConfigChanges(ctx).getOverrides()).isNotEmpty();
 
         stateStore.clearAll(ctx);
 
         assertThat(stateStore.getCollectedMetrics(ctx)).isEmpty();
         assertThat(stateStore.getScalingHistory(ctx)).isEmpty();
         assertThat(stateStore.getParallelismOverrides(ctx)).isEmpty();
-        assertThat(stateStore.getConfigOverrides(ctx).toMap()).isEmpty();
+        assertThat(stateStore.getConfigChanges(ctx).getOverrides()).isEmpty();
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/utils/MemoryTuningTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/utils/MemoryTuningTest.java
@@ -25,9 +25,9 @@ import org.apache.flink.autoscaler.event.TestingEventCollector;
 import org.apache.flink.autoscaler.metrics.EvaluatedMetrics;
 import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.autoscaler.tuning.ConfigChanges;
 import org.apache.flink.autoscaler.tuning.MemoryTuning;
 import org.apache.flink.configuration.MemorySize;
-import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
@@ -76,52 +76,44 @@ public class MemoryTuningTest {
         var globalMetrics =
                 Map.of(
                         ScalingMetric.HEAP_MEMORY_USED,
-                        EvaluatedScalingMetric.avg(MemorySize.ofMebiBytes(5096).getBytes()));
+                        EvaluatedScalingMetric.avg(MemorySize.ofMebiBytes(5096).getBytes()),
+                        ScalingMetric.MANAGED_MEMORY_USED,
+                        EvaluatedScalingMetric.avg(MemorySize.ofMebiBytes(10000).getBytes()),
+                        ScalingMetric.NETWORK_MEMORY_USED,
+                        EvaluatedScalingMetric.avg(MemorySize.ofMebiBytes(300).getBytes()),
+                        ScalingMetric.METASPACE_MEMORY_USED,
+                        EvaluatedScalingMetric.avg(MemorySize.ofMebiBytes(100).getBytes()));
 
         var metrics = new EvaluatedMetrics(vertexMetrics, globalMetrics);
 
-        Map<String, String> overrides =
-                MemoryTuning.tuneTaskManagerHeapMemory(context, metrics, eventHandler).toMap();
+        ConfigChanges configChanges =
+                MemoryTuning.tuneTaskManagerHeapMemory(context, metrics, eventHandler);
         // Test reducing overall memory
-        assertThat(overrides)
+        assertThat(configChanges.getOverrides())
                 .containsExactlyInAnyOrderEntriesOf(
                         Map.of(
-                                TaskManagerOptions.TASK_HEAP_MEMORY.key(),
-                                "6412251955 bytes",
+                                TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(),
+                                "0.645",
+                                TaskManagerOptions.NETWORK_MEMORY_FRACTION.key(),
+                                "0.019",
+                                TaskManagerOptions.JVM_METASPACE.key(),
+                                config.get(AutoScalerOptions.MEMORY_TUNING_MIN).toString(),
+                                TaskManagerOptions.JVM_OVERHEAD_FRACTION.key(),
+                                "0.052",
                                 TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(),
                                 "0 bytes",
-                                TaskManagerOptions.MANAGED_MEMORY_SIZE.key(),
-                                "12348031160 bytes",
-                                TaskManagerOptions.JVM_OVERHEAD_FRACTION.key(),
-                                "0.046",
-                                TaskManagerOptions.NETWORK_MEMORY_FRACTION.key(),
-                                "0.14",
                                 TaskManagerOptions.TOTAL_PROCESS_MEMORY.key(),
-                                "23323685913 bytes"));
+                                "20849046323 bytes"));
 
-        assertThat(eventHandler.events.poll().getMessage())
-                .startsWith(
-                        "Memory tuning recommends the following configuration (automatic tuning is enabled):");
-
-        // Test giving back memory to RocksDB
-        config.set(AutoScalerOptions.MEMORY_TUNING_TRANSFER_HEAP_TO_MANAGED, true);
-        config.set(StateBackendOptions.STATE_BACKEND, "rocksdb");
-        overrides = MemoryTuning.tuneTaskManagerHeapMemory(context, metrics, eventHandler).toMap();
-        assertThat(overrides)
-                .containsExactlyInAnyOrderEntriesOf(
-                        Map.of(
-                                TaskManagerOptions.TASK_HEAP_MEMORY.key(),
-                                "6412251955 bytes",
-                                TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(),
-                                "0 bytes",
-                                TaskManagerOptions.MANAGED_MEMORY_SIZE.key(),
-                                "21236599967 bytes",
-                                TaskManagerOptions.JVM_OVERHEAD_FRACTION.key(),
-                                "0.033",
-                                TaskManagerOptions.NETWORK_MEMORY_FRACTION.key(),
-                                "0.14",
-                                TaskManagerOptions.TOTAL_PROCESS_MEMORY.key(),
-                                totalMemory.toString()));
+        assertThat(configChanges.getRemovals())
+                .containsExactlyInAnyOrder(
+                        TaskManagerOptions.TASK_HEAP_MEMORY.key(),
+                        TaskManagerOptions.MANAGED_MEMORY_SIZE.key(),
+                        TaskManagerOptions.MANAGED_MEMORY_SIZE
+                                .fallbackKeys()
+                                .iterator()
+                                .next()
+                                .getKey());
 
         assertThat(eventHandler.events.poll().getMessage())
                 .startsWith(
@@ -129,7 +121,9 @@ public class MemoryTuningTest {
 
         // Test tuning disabled
         config.set(AutoScalerOptions.MEMORY_TUNING_ENABLED, false);
-        assertThat(MemoryTuning.tuneTaskManagerHeapMemory(context, metrics, eventHandler).toMap())
+        assertThat(
+                        MemoryTuning.tuneTaskManagerHeapMemory(context, metrics, eventHandler)
+                                .getOverrides())
                 .isEmpty();
 
         assertThat(eventHandler.events.poll().getMessage())

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/utils/MemoryTuningTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/utils/MemoryTuningTest.java
@@ -75,7 +75,7 @@ public class MemoryTuningTest {
 
         var globalMetrics =
                 Map.of(
-                        ScalingMetric.HEAP_USED,
+                        ScalingMetric.HEAP_MEMORY_USED,
                         EvaluatedScalingMetric.avg(MemorySize.ofMebiBytes(5096).getBytes()));
 
         var metrics = new EvaluatedMetrics(vertexMetrics, globalMetrics);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.autoscaler;
 
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.autoscaler.tuning.ConfigChanges;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -68,9 +68,9 @@ public class KubernetesScalingRealizerTest {
         KubernetesJobAutoScalerContext ctx =
                 TestingKubernetesAutoscalerUtils.createContext("test", null);
 
-        var overrides = new Configuration();
+        ConfigChanges overrides = new ConfigChanges();
         MemorySize memoryOverride = MemorySize.ofMebiBytes(4096);
-        overrides.set(TaskManagerOptions.TOTAL_PROCESS_MEMORY, memoryOverride);
+        overrides.addOverride(TaskManagerOptions.TOTAL_PROCESS_MEMORY, memoryOverride);
         new KubernetesScalingRealizer().realizeConfigOverrides(ctx, overrides);
 
         assertThat(ctx.getResource()).isInstanceOf(FlinkDeployment.class);


### PR DESCRIPTION
This is the generalized version of #762 in which we tune all directly observable Flink memory pools: heap, managed memory, network, and metaspace. 

Notable changes:

- New metrics to measure managed memory, network, and metaspace usage in addition to heap usage have been added
- All memory pools are tuned, i.e. their size is increased or decreased according to their usage.
- Max memory size of a pool is no longer limited by the original configured limit for that pool. The only cap is the max TM memory in the spec.
- Memory can be freely moved between the pools
- The feature to "give back" memory to RocksDB has been removed. The reason is that the new version does that automatically. The available memory is distributed across the memory pools based on their usage. Managed memory is assigned last. In the case of a streaming job without RocksDB, this should result in very low managed memory usage and hence reduce the managed and total memory. However, when RocksDB is used, the managed memory is allowed to grow until the max available memory assigned in the spec.
- We assign a minimum of 256Mb (configurable) per memory pool

The changes have been verified with an actual Kubernetes deployment.