### PR TITLE
[FLINK-34502][autoscaler] Support calculating network memory for forward and rescale edge

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -338,7 +338,7 @@ public class ScalingMetricEvaluator {
             }
             out.put(CATCH_UP_DATA_RATE, EvaluatedScalingMetric.of(catchUpInputRate));
         } else {
-            var inputs = topology.get(vertex).getInputs();
+            var inputs = topology.get(vertex).getInputs().keySet();
             double sumAvgTargetRate = 0;
             double sumCatchUpDataRate = 0;
             for (var inputVertex : inputs) {
@@ -531,7 +531,7 @@ public class ScalingMetricEvaluator {
             JobVertexID from,
             JobVertexID to) {
 
-        var toVertexInputs = topology.get(to).getInputs();
+        var toVertexInputs = topology.get(to).getInputs().keySet();
         // Case 1: Downstream vertex has single input (from) so we can use the most reliable num
         // records in
         if (toVertexInputs.size() == 1) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/VertexInfo.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/VertexInfo.java
@@ -22,7 +22,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import lombok.Data;
 
-import java.util.Set;
+import java.util.Map;
 
 /** Job vertex information. */
 @Data
@@ -30,9 +30,11 @@ public class VertexInfo {
 
     private final JobVertexID id;
 
-    private final Set<JobVertexID> inputs;
+    // All input vertices and the ship_strategy
+    private final Map<JobVertexID, String> inputs;
 
-    private Set<JobVertexID> outputs;
+    // All output vertices and the ship_strategy
+    private Map<JobVertexID, String> outputs;
 
     private final int parallelism;
 
@@ -46,7 +48,7 @@ public class VertexInfo {
 
     public VertexInfo(
             JobVertexID id,
-            Set<JobVertexID> inputs,
+            Map<JobVertexID, String> inputs,
             int parallelism,
             int maxParallelism,
             boolean finished,
@@ -63,7 +65,7 @@ public class VertexInfo {
     @VisibleForTesting
     public VertexInfo(
             JobVertexID id,
-            Set<JobVertexID> inputs,
+            Map<JobVertexID, String> inputs,
             int parallelism,
             int maxParallelism,
             IOMetrics ioMetrics) {
@@ -72,7 +74,7 @@ public class VertexInfo {
 
     @VisibleForTesting
     public VertexInfo(
-            JobVertexID id, Set<JobVertexID> inputs, int parallelism, int maxParallelism) {
+            JobVertexID id, Map<JobVertexID, String> inputs, int parallelism, int maxParallelism) {
         this(id, inputs, parallelism, maxParallelism, null);
     }
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
@@ -40,7 +40,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Set;
+import java.util.Map;
 import java.util.SortedMap;
 
 import static org.apache.flink.autoscaler.JobAutoScalerImpl.AUTOSCALER_ERROR;
@@ -78,9 +78,13 @@ public class BacklogBasedScalingTest {
         metricsCollector =
                 new TestingMetricsCollector<>(
                         new JobTopology(
-                                new VertexInfo(source1, Set.of(), 1, 720, new IOMetrics(0, 0, 0)),
+                                new VertexInfo(source1, Map.of(), 1, 720, new IOMetrics(0, 0, 0)),
                                 new VertexInfo(
-                                        sink, Set.of(source1), 1, 720, new IOMetrics(0, 0, 0))));
+                                        sink,
+                                        Map.of(source1, "REBALANCE"),
+                                        1,
+                                        720,
+                                        new IOMetrics(0, 0, 0))));
 
         var defaultConf = context.getConfiguration();
         defaultConf.set(AutoScalerOptions.AUTOSCALER_ENABLED, true);
@@ -152,8 +156,8 @@ public class BacklogBasedScalingTest {
         // Update topology to reflect updated parallelisms
         metricsCollector.setJobTopology(
                 new JobTopology(
-                        new VertexInfo(source1, Set.of(), 4, 24),
-                        new VertexInfo(sink, Set.of(source1), 4, 720)));
+                        new VertexInfo(source1, Map.of(), 4, 24),
+                        new VertexInfo(sink, Map.of(source1, "REBALANCE"), 4, 720)));
 
         metricsCollector.updateMetrics(
                 source1,
@@ -234,8 +238,8 @@ public class BacklogBasedScalingTest {
         metricsCollector.setJobUpdateTs(now);
         metricsCollector.setJobTopology(
                 new JobTopology(
-                        new VertexInfo(source1, Set.of(), 2, 24),
-                        new VertexInfo(sink, Set.of(source1), 2, 720)));
+                        new VertexInfo(source1, Map.of(), 2, 24),
+                        new VertexInfo(sink, Map.of(source1, "REBALANCE"), 2, 720)));
 
         /* Test stability while processing backlog. */
 
@@ -356,8 +360,8 @@ public class BacklogBasedScalingTest {
         context = context.toBuilder().jobStatus(JobStatus.RUNNING).build();
         metricsCollector.setJobTopology(
                 new JobTopology(
-                        new VertexInfo(source1, Set.of(), 4, 720),
-                        new VertexInfo(sink, Set.of(source1), 4, 720)));
+                        new VertexInfo(source1, Map.of(), 4, 720),
+                        new VertexInfo(sink, Map.of(source1, "REBALANCE"), 4, 720)));
 
         var expectedEndTime = Instant.ofEpochMilli(10);
         metricsCollector.setJobUpdateTs(expectedEndTime);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
@@ -53,7 +53,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import static java.util.Map.entry;
@@ -87,7 +86,7 @@ public class JobAutoScalerImplTest {
     @Test
     void testMetricReporting() throws Exception {
         JobVertexID jobVertexID = new JobVertexID();
-        JobTopology jobTopology = new JobTopology(new VertexInfo(jobVertexID, Set.of(), 1, 10));
+        JobTopology jobTopology = new JobTopology(new VertexInfo(jobVertexID, Map.of(), 1, 10));
 
         var metricsCollector =
                 new TestingMetricsCollector<JobID, JobAutoScalerContext<JobID>>(jobTopology);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -47,7 +47,6 @@ import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import static org.apache.flink.autoscaler.TestingAutoscalerUtils.createDefaultJobAutoScalerContext;
@@ -89,11 +88,16 @@ public class MetricsCollectionAndEvaluationTest {
 
         topology =
                 new JobTopology(
-                        new VertexInfo(source1, Set.of(), 2, 720, new IOMetrics(0, 0, 0)),
-                        new VertexInfo(source2, Set.of(), 2, 720, new IOMetrics(0, 0, 0)),
+                        new VertexInfo(source1, Map.of(), 2, 720, new IOMetrics(0, 0, 0)),
+                        new VertexInfo(source2, Map.of(), 2, 720, new IOMetrics(0, 0, 0)),
                         new VertexInfo(
-                                map, Set.of(source1, source2), 12, 720, new IOMetrics(0, 0, 0)),
-                        new VertexInfo(sink, Set.of(map), 8, 24, new IOMetrics(0, 0, 0)));
+                                map,
+                                Map.of(source1, "REBALANCE", source2, "REBALANCE"),
+                                12,
+                                720,
+                                new IOMetrics(0, 0, 0)),
+                        new VertexInfo(
+                                sink, Map.of(map, "REBALANCE"), 8, 24, new IOMetrics(0, 0, 0)));
 
         metricsCollector = new TestingMetricsCollector<>(topology);
 
@@ -335,7 +339,7 @@ public class MetricsCollectionAndEvaluationTest {
 
     @Test
     public void testTolerateAbsenceOfPendingRecordsMetric() throws Exception {
-        var topology = new JobTopology(new VertexInfo(source1, Set.of(), 5, 720));
+        var topology = new JobTopology(new VertexInfo(source1, Map.of(), 5, 720));
 
         metricsCollector = new TestingMetricsCollector(topology);
         metricsCollector.setJobUpdateTs(startTime);
@@ -408,9 +412,9 @@ public class MetricsCollectionAndEvaluationTest {
         var finished = new JobVertexID();
         var topology =
                 new JobTopology(
-                        new VertexInfo(s1, Set.of(), 10, 720),
+                        new VertexInfo(s1, Map.of(), 10, 720),
                         new VertexInfo(
-                                finished, Set.of(), 10, 720, true, IOMetrics.FINISHED_METRICS));
+                                finished, Map.of(), 10, 720, true, IOMetrics.FINISHED_METRICS));
 
         metricsCollector = new TestingMetricsCollector(topology);
         metricsCollector.setJobUpdateTs(startTime);
@@ -445,7 +449,7 @@ public class MetricsCollectionAndEvaluationTest {
     @Test
     public void testObservedTprCollection() throws Exception {
         var source = new JobVertexID();
-        var topology = new JobTopology(new VertexInfo(source, Set.of(), 10, 720));
+        var topology = new JobTopology(new VertexInfo(source, Map.of(), 10, 720));
 
         metricsCollector = new TestingMetricsCollector(topology);
         metricsCollector.setJobUpdateTs(startTime);
@@ -521,7 +525,7 @@ public class MetricsCollectionAndEvaluationTest {
     @Test
     public void testMetricCollectionDuringStabilization() throws Exception {
         var source = new JobVertexID();
-        var topology = new JobTopology(new VertexInfo(source, Set.of(), 10, 720));
+        var topology = new JobTopology(new VertexInfo(source, Map.of(), 10, 720));
 
         metricsCollector = new TestingMetricsCollector(topology);
         metricsCollector.setJobUpdateTs(startTime);
@@ -596,7 +600,7 @@ public class MetricsCollectionAndEvaluationTest {
 
     @Test
     public void testScaleDownWithZeroProcessingRate() throws Exception {
-        var topology = new JobTopology(new VertexInfo(source1, Set.of(), 2, 720));
+        var topology = new JobTopology(new VertexInfo(source1, Map.of(), 2, 720));
 
         metricsCollector = new TestingMetricsCollector<>(topology);
         metricsCollector.setJobUpdateTs(startTime);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
@@ -37,7 +37,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Set;
+import java.util.Map;
 
 import static org.apache.flink.autoscaler.TestingAutoscalerUtils.createDefaultJobAutoScalerContext;
 import static org.apache.flink.autoscaler.TestingAutoscalerUtils.getRestClusterClientSupplier;
@@ -74,8 +74,8 @@ public class RecommendedParallelismTest {
         metricsCollector =
                 new TestingMetricsCollector<>(
                         new JobTopology(
-                                new VertexInfo(source, Set.of(), 1, 720),
-                                new VertexInfo(sink, Set.of(source), 1, 720)));
+                                new VertexInfo(source, Map.of(), 1, 720),
+                                new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 720)));
 
         var defaultConf = context.getConfiguration();
         defaultConf.set(AutoScalerOptions.AUTOSCALER_ENABLED, true);
@@ -198,8 +198,8 @@ public class RecommendedParallelismTest {
         // updating the topology to reflect the scale
         metricsCollector.setJobTopology(
                 new JobTopology(
-                        new VertexInfo(source, Set.of(), 4, 24),
-                        new VertexInfo(sink, Set.of(source), 4, 720)));
+                        new VertexInfo(source, Map.of(), 4, 24),
+                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 4, 720)));
 
         now = now.plus(Duration.ofSeconds(10));
         setClocksTo(now);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -45,7 +45,6 @@ import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.autoscaler.TestingAutoscalerUtils.createDefaultJobAutoScalerContext;
@@ -318,8 +317,8 @@ public class ScalingExecutorTest {
 
         JobTopology jobTopology =
                 new JobTopology(
-                        new VertexInfo(source, Set.of(), 10, 1000, false, null),
-                        new VertexInfo(sink, Set.of(source), 10, 1000, false, null));
+                        new VertexInfo(source, Map.of(), 10, 1000, false, null),
+                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 10, 1000, false, null));
 
         assertTrue(
                 scalingDecisionExecutor.scaleResource(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
@@ -217,10 +217,15 @@ public class ScalingMetricCollectorTest {
         var sourceId = JobVertexID.fromHexString("bc764cd8ddf7a0cff126f51c16239658");
         var sinkId = JobVertexID.fromHexString("20ba6b65f97481d5570070de90e4e791");
 
-        var source = new VertexInfo(sourceId, Set.of(), 2, 128, true, IOMetrics.FINISHED_METRICS);
+        var source = new VertexInfo(sourceId, Map.of(), 2, 128, true, IOMetrics.FINISHED_METRICS);
         var sink =
                 new VertexInfo(
-                        sinkId, Set.of(sourceId), 2, 128, false, new IOMetrics(291532, 1, 2));
+                        sinkId,
+                        Map.of(sourceId, "HASH"),
+                        2,
+                        128,
+                        false,
+                        new IOMetrics(291532, 1, 2));
 
         assertEquals(
                 new JobTopology(source, sink), metricsCollector.getJobTopology(jobDetailsInfo));
@@ -269,13 +274,13 @@ public class ScalingMetricCollectorTest {
 
         var t1 =
                 new JobTopology(
-                        new VertexInfo(source, Set.of(), 1, 1),
-                        new VertexInfo(sink, Set.of(source), 1, 1));
+                        new VertexInfo(source, Map.of(), 1, 1),
+                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 1));
 
         var t2 =
                 new JobTopology(
-                        new VertexInfo(source2, Set.of(), 1, 1),
-                        new VertexInfo(sink, Set.of(source2), 1, 1));
+                        new VertexInfo(source2, Map.of(), 1, 1),
+                        new VertexInfo(sink, Map.of(source2, "REBALANCE"), 1, 1));
 
         collector.queryFilteredMetricNames(context, t1);
         assertEquals(1, metricNameQueryCounter.get(source));
@@ -303,8 +308,8 @@ public class ScalingMetricCollectorTest {
         // Mark source finished, should not be queried again
         t2 =
                 new JobTopology(
-                        new VertexInfo(source2, Set.of(), 1, 1, true, null),
-                        new VertexInfo(sink, Set.of(source2), 1, 1));
+                        new VertexInfo(source2, Map.of(), 1, 1, true, null),
+                        new VertexInfo(sink, Map.of(source2, "REBALANCE"), 1, 1));
         collector.queryFilteredMetricNames(context, t2);
         assertEquals(3, metricNameQueryCounter.get(source));
         assertEquals(2, metricNameQueryCounter.get(source2));
@@ -327,8 +332,8 @@ public class ScalingMetricCollectorTest {
         var sink = new JobVertexID();
         var topology =
                 new JobTopology(
-                        new VertexInfo(source, Set.of(), 1, 1),
-                        new VertexInfo(sink, Set.of(source), 1, 1));
+                        new VertexInfo(source, Map.of(), 1, 1),
+                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 1));
 
         testRequiredMetrics(
                 metricList, getSourceRequiredMetrics(), testCollector, source, topology);
@@ -404,8 +409,8 @@ public class ScalingMetricCollectorTest {
         var sink = new JobVertexID();
         var topology =
                 new JobTopology(
-                        new VertexInfo(source, Set.of(), 1, 1),
-                        new VertexInfo(sink, Set.of(source), 1, 1));
+                        new VertexInfo(source, Map.of(), 1, 1),
+                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 1));
 
         var metricCollector = new TestingMetricsCollector<>(topology);
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -36,7 +36,6 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.CATCH_UP_DURATION;
@@ -60,8 +59,8 @@ public class ScalingMetricEvaluatorTest {
 
         var topology =
                 new JobTopology(
-                        new VertexInfo(source, Collections.emptySet(), 1, 1, null),
-                        new VertexInfo(sink, Set.of(source), 1, 1, null));
+                        new VertexInfo(source, Collections.emptyMap(), 1, 1, null),
+                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 1, null));
 
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
 
@@ -324,8 +323,8 @@ public class ScalingMetricEvaluatorTest {
 
         var topology =
                 new JobTopology(
-                        new VertexInfo(source, Collections.emptySet(), 1, 1),
-                        new VertexInfo(sink, Set.of(source), 1, 1));
+                        new VertexInfo(source, Collections.emptyMap(), 1, 1),
+                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 1));
 
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
 
@@ -660,10 +659,11 @@ public class ScalingMetricEvaluatorTest {
 
         var topology =
                 new JobTopology(
-                        new VertexInfo(source1, Collections.emptySet(), 1, 1),
-                        new VertexInfo(source2, Collections.emptySet(), 1, 1),
-                        new VertexInfo(op1, Set.of(source1, source2), 1, 1),
-                        new VertexInfo(sink1, Set.of(op1), 1, 1));
+                        new VertexInfo(source1, Collections.emptyMap(), 1, 1),
+                        new VertexInfo(source2, Collections.emptyMap(), 1, 1),
+                        new VertexInfo(
+                                op1, Map.of(source1, "REBALANCE", source2, "REBALANCE"), 1, 1),
+                        new VertexInfo(sink1, Map.of(op1, "REBALANCE"), 1, 1));
 
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
 
@@ -726,10 +726,12 @@ public class ScalingMetricEvaluatorTest {
 
         var topology =
                 new JobTopology(
-                        new VertexInfo(source1, Collections.emptySet(), 1, 1),
-                        new VertexInfo(source2, Collections.emptySet(), 1, 1),
-                        new VertexInfo(op1, Set.of(source1, source2), 1, 1),
-                        new VertexInfo(op2, Set.of(source1, source2), 1, 1));
+                        new VertexInfo(source1, Collections.emptyMap(), 1, 1),
+                        new VertexInfo(source2, Collections.emptyMap(), 1, 1),
+                        new VertexInfo(
+                                op1, Map.of(source1, "REBALANCE", source2, "REBALANCE"), 1, 1),
+                        new VertexInfo(
+                                op2, Map.of(source1, "REBALANCE", source2, "REBALANCE"), 1, 1));
 
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingTrackingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingTrackingTest.java
@@ -209,8 +209,7 @@ class ScalingTrackingTest {
         Set<VertexInfo> vertexInfos = new HashSet<>();
         for (Map.Entry<JobVertexID, Integer> entry : parallelisms.entrySet()) {
             vertexInfos.add(
-                    new VertexInfo(
-                            entry.getKey(), new HashSet<>(), entry.getValue(), entry.getValue()));
+                    new VertexInfo(entry.getKey(), Map.of(), entry.getValue(), entry.getValue()));
         }
         return vertexInfos;
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,8 +51,9 @@ public class ScalingMetricsTest {
         var topology =
                 new JobTopology(
                         new VertexInfo(
-                                source, Collections.emptySet(), 1, 1, new IOMetrics(1, 2, 3)),
-                        new VertexInfo(op, Set.of(source), 1, 1, new IOMetrics(1, 2, 3)));
+                                source, Collections.emptyMap(), 1, 1, new IOMetrics(1, 2, 3)),
+                        new VertexInfo(
+                                op, Map.of(source, "REBALANCE"), 1, 1, new IOMetrics(1, 2, 3)));
 
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
         ScalingMetrics.computeDataRateMetrics(
@@ -221,8 +221,9 @@ public class ScalingMetricsTest {
         var topology =
                 new JobTopology(
                         new VertexInfo(
-                                SOURCE, Collections.emptySet(), 1, 1, new IOMetrics(0, 0, 0)),
-                        new VertexInfo(sink, Set.of(SOURCE), 1, 1, new IOMetrics(0, 0, 0)));
+                                SOURCE, Collections.emptyMap(), 1, 1, new IOMetrics(0, 0, 0)),
+                        new VertexInfo(
+                                sink, Map.of(SOURCE, "REBALANCE"), 1, 1, new IOMetrics(0, 0, 0)));
 
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
         scalingMetrics.put(ScalingMetric.LAG, lag);


### PR DESCRIPTION
## What is the purpose of the change

This is follow up Jira of [FLINK-34471](https://issues.apache.org/jira/browse/FLINK-34471) #781 . [FLINK-34471](https://issues.apache.org/jira/browse/FLINK-34471) assuming all connections type are ALL_TO_ALL. This Jira will optimize it to save some network memory for forward and rescale connection.

Following is the optimization logic:

- When the connection type is FORWARD and the parallelism of 2 tasks are same. We calculate network memory based on FORWARD connection.
- When the connection type is FORWARD and the parallelism of 2 tasks are not same. We calculate network memory based on RESCALE connection.
- When the connection type is RESCALE. We calculate network memory based on RESCALE connection.


## Brief change log

[FLINK-34502][autoscaler] Support calculating network memory for forward and rescale edge

- Add the ship_strategy to JobTopology
- Improve the network memory calculating logic for forward and rescale connections.

## Verifying this change

- MemoryTuningTest#testCalculateNetworkSegmentNumber
- JobTopologyTest#testTopologyFromJson check the ship_strategy

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no

