### PR TITLE
[FLINK-34504][autoscaler] Avoid the parallelism adjustment when the upstream shuffle type doesn't have keyBy

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -289,7 +289,8 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
                 // underflow.
                 (int) Math.min(Math.ceil(scaleFactor * currentParallelism), Integer.MAX_VALUE);
 
-        // Cap parallelism at either number of key groups or parallelism limit
+        // Cap parallelism at either maxParallelism(number of key groups or source partitions) or
+        // parallelism upper limit
         final int upperBound = Math.min(maxParallelism, parallelismUpperLimit);
 
         // Apply min/max parallelism
@@ -299,16 +300,16 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
             return newParallelism;
         }
 
-        // When the shuffle type of vertex data source contains keyBy, we try to adjust the
-        // parallelism such that it divides the number of key groups without a remainder =>
-        // data is evenly spread across subtasks
+        // When the shuffle type of vertex inputs contains keyBy or vertex is a source, we try to
+        // adjust the parallelism such that it divides the number of key groups without a remainder
+        // => data is evenly spread across subtasks
         for (int p = newParallelism; p <= maxParallelism / 2 && p <= upperBound; p++) {
             if (maxParallelism % p == 0) {
                 return p;
             }
         }
 
-        // If key group adjustment fails, use originally computed parallelism
+        // If parallelism adjustment fails, use originally computed parallelism
         return newParallelism;
     }
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -283,14 +283,16 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
         // Apply min/max parallelism
         newParallelism = Math.min(Math.max(minParallelism, newParallelism), upperBound);
 
+        if (!hasKeyBy) {
+            return newParallelism;
+        }
+
         // When the shuffle type of vertex data source contains keyBy, we try to adjust the
         // parallelism such that it divides the number of key groups without a remainder =>
         // data is evenly spread across subtasks
-        if (hasKeyBy) {
-            for (int p = newParallelism; p <= numKeyGroups / 2 && p <= upperBound; p++) {
-                if (numKeyGroups % p == 0) {
-                    return p;
-                }
+        for (int p = newParallelism; p <= numKeyGroups / 2 && p <= upperBound; p++) {
+            if (numKeyGroups % p == 0) {
+                return p;
             }
         }
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -229,13 +229,14 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                                 var currentParallelism =
                                         (int) metrics.get(ScalingMetric.PARALLELISM).getCurrent();
 
-                                final boolean hasKeyBy =
-                                        jobTopology.get(v).getInputs().containsValue(HASH);
+                                var inputs = jobTopology.get(v).getInputs();
+                                var adjustByMaxParallelism =
+                                        inputs.isEmpty() || inputs.containsValue(HASH);
                                 var newParallelism =
                                         jobVertexScaler.computeScaleTargetParallelism(
                                                 context,
                                                 v,
-                                                hasKeyBy,
+                                                adjustByMaxParallelism,
                                                 metrics,
                                                 scalingHistory.getOrDefault(
                                                         v, Collections.emptySortedMap()),

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -232,7 +232,7 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                                         jobVertexScaler.computeScaleTargetParallelism(
                                                 context,
                                                 v,
-                                                jobTopology.get(v).getInputs(),
+                                                jobTopology.get(v).getInputs().values(),
                                                 metrics,
                                                 scalingHistory.getOrDefault(
                                                         v, Collections.emptySortedMap()),

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -57,6 +57,7 @@ import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.addToScali
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.SCALE_DOWN_RATE_THRESHOLD;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.SCALE_UP_RATE_THRESHOLD;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_RATE;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.HASH;
 
 /** Class responsible for executing scaling decisions. */
 public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
@@ -229,7 +230,7 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                                         (int) metrics.get(ScalingMetric.PARALLELISM).getCurrent();
 
                                 final boolean hasKeyBy =
-                                        jobTopology.get(v).getInputs().containsValue("HASH");
+                                        jobTopology.get(v).getInputs().containsValue(HASH);
                                 var newParallelism =
                                         jobVertexScaler.computeScaleTargetParallelism(
                                                 context,

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -57,7 +57,6 @@ import static org.apache.flink.autoscaler.metrics.ScalingHistoryUtils.addToScali
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.SCALE_DOWN_RATE_THRESHOLD;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.SCALE_UP_RATE_THRESHOLD;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_RATE;
-import static org.apache.flink.autoscaler.topology.ShipStrategy.HASH;
 
 /** Class responsible for executing scaling decisions. */
 public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
@@ -229,14 +228,11 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                                 var currentParallelism =
                                         (int) metrics.get(ScalingMetric.PARALLELISM).getCurrent();
 
-                                var inputs = jobTopology.get(v).getInputs();
-                                var adjustByMaxParallelism =
-                                        inputs.isEmpty() || inputs.containsValue(HASH);
                                 var newParallelism =
                                         jobVertexScaler.computeScaleTargetParallelism(
                                                 context,
                                                 v,
-                                                adjustByMaxParallelism,
+                                                jobTopology.get(v).getInputs(),
                                                 metrics,
                                                 scalingHistory.getOrDefault(
                                                         v, Collections.emptySortedMap()),

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -102,7 +102,8 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
         var restartTime = scalingTracking.getMaxRestartTimeOrDefault(conf);
 
         var scalingSummaries =
-                computeScalingSummary(context, evaluatedMetrics, scalingHistory, restartTime);
+                computeScalingSummary(
+                        context, evaluatedMetrics, scalingHistory, restartTime, jobTopology);
 
         if (scalingSummaries.isEmpty()) {
             LOG.info("All job vertices are currently running at their target parallelism.");
@@ -203,7 +204,8 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
             Context context,
             EvaluatedMetrics evaluatedMetrics,
             Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory,
-            Duration restartTime) {
+            Duration restartTime,
+            JobTopology jobTopology) {
         LOG.debug("Restart time used in scaling summary computation: {}", restartTime);
 
         if (isJobUnderMemoryPressure(context, evaluatedMetrics.getGlobalMetrics())) {
@@ -225,10 +227,14 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                             } else {
                                 var currentParallelism =
                                         (int) metrics.get(ScalingMetric.PARALLELISM).getCurrent();
+
+                                final boolean hasKeyBy =
+                                        jobTopology.get(v).getInputs().containsValue("HASH");
                                 var newParallelism =
                                         jobVertexScaler.computeScaleTargetParallelism(
                                                 context,
                                                 v,
+                                                hasKeyBy,
                                                 metrics,
                                                 scalingHistory.getOrDefault(
                                                         v, Collections.emptySortedMap()),

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/JobTopology.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/JobTopology.java
@@ -61,7 +61,7 @@ public class JobTopology {
 
     public JobTopology(Set<VertexInfo> vertexInfo) {
 
-        Map<JobVertexID, Map<JobVertexID, String>> vertexOutputs = new HashMap<>();
+        Map<JobVertexID, Map<JobVertexID, ShipStrategy>> vertexOutputs = new HashMap<>();
         vertexInfos =
                 ImmutableMap.copyOf(
                         vertexInfo.stream().collect(Collectors.toMap(VertexInfo::getId, v -> v)));
@@ -145,7 +145,7 @@ public class JobTopology {
 
         for (JsonNode node : nodes) {
             var vertexId = JobVertexID.fromHexString(node.get("id").asText());
-            var inputs = new HashMap<JobVertexID, String>();
+            var inputs = new HashMap<JobVertexID, ShipStrategy>();
             var ioMetrics = metrics.get(vertexId);
             var finished = finishedVertices.contains(vertexId);
             vertexInfo.add(
@@ -160,7 +160,7 @@ public class JobTopology {
                 for (JsonNode input : node.get("inputs")) {
                     inputs.put(
                             JobVertexID.fromHexString(input.get("id").asText()),
-                            input.get("ship_strategy").asText());
+                            ShipStrategy.of(input.get("ship_strategy").asText()));
                 }
             }
         }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/ShipStrategy.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/ShipStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.topology;
+
+import javax.annotation.Nonnull;
+
+/** The ship strategy between 2 JobVertices. */
+public enum ShipStrategy {
+    HASH,
+
+    REBALANCE,
+
+    RESCALE,
+
+    FORWARD,
+
+    CUSTOM,
+
+    BROADCAST,
+
+    GLOBAL,
+
+    SHUFFLE,
+
+    UNKNOWN;
+
+    /**
+     * Generates a ShipStrategy from a string, or returns {@link #UNKNOWN} if the value cannot match
+     * any ShipStrategy.
+     */
+    @Nonnull
+    public static ShipStrategy of(String value) {
+        for (ShipStrategy shipStrategy : ShipStrategy.values()) {
+            if (shipStrategy.toString().equalsIgnoreCase(value)) {
+                return shipStrategy;
+            }
+        }
+        return UNKNOWN;
+    }
+}

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/VertexInfo.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/VertexInfo.java
@@ -31,10 +31,10 @@ public class VertexInfo {
     private final JobVertexID id;
 
     // All input vertices and the ship_strategy
-    private final Map<JobVertexID, String> inputs;
+    private final Map<JobVertexID, ShipStrategy> inputs;
 
     // All output vertices and the ship_strategy
-    private Map<JobVertexID, String> outputs;
+    private Map<JobVertexID, ShipStrategy> outputs;
 
     private final int parallelism;
 
@@ -48,7 +48,7 @@ public class VertexInfo {
 
     public VertexInfo(
             JobVertexID id,
-            Map<JobVertexID, String> inputs,
+            Map<JobVertexID, ShipStrategy> inputs,
             int parallelism,
             int maxParallelism,
             boolean finished,
@@ -65,7 +65,7 @@ public class VertexInfo {
     @VisibleForTesting
     public VertexInfo(
             JobVertexID id,
-            Map<JobVertexID, String> inputs,
+            Map<JobVertexID, ShipStrategy> inputs,
             int parallelism,
             int maxParallelism,
             IOMetrics ioMetrics) {
@@ -74,7 +74,10 @@ public class VertexInfo {
 
     @VisibleForTesting
     public VertexInfo(
-            JobVertexID id, Map<JobVertexID, String> inputs, int parallelism, int maxParallelism) {
+            JobVertexID id,
+            Map<JobVertexID, ShipStrategy> inputs,
+            int parallelism,
+            int maxParallelism) {
         this(id, inputs, parallelism, maxParallelism, null);
     }
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
@@ -45,6 +45,7 @@ import java.util.SortedMap;
 
 import static org.apache.flink.autoscaler.JobAutoScalerImpl.AUTOSCALER_ERROR;
 import static org.apache.flink.autoscaler.TestingAutoscalerUtils.createDefaultJobAutoScalerContext;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.REBALANCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -81,7 +82,7 @@ public class BacklogBasedScalingTest {
                                 new VertexInfo(source1, Map.of(), 1, 720, new IOMetrics(0, 0, 0)),
                                 new VertexInfo(
                                         sink,
-                                        Map.of(source1, "REBALANCE"),
+                                        Map.of(source1, REBALANCE),
                                         1,
                                         720,
                                         new IOMetrics(0, 0, 0))));
@@ -157,7 +158,7 @@ public class BacklogBasedScalingTest {
         metricsCollector.setJobTopology(
                 new JobTopology(
                         new VertexInfo(source1, Map.of(), 4, 24),
-                        new VertexInfo(sink, Map.of(source1, "REBALANCE"), 4, 720)));
+                        new VertexInfo(sink, Map.of(source1, REBALANCE), 4, 720)));
 
         metricsCollector.updateMetrics(
                 source1,
@@ -239,7 +240,7 @@ public class BacklogBasedScalingTest {
         metricsCollector.setJobTopology(
                 new JobTopology(
                         new VertexInfo(source1, Map.of(), 2, 24),
-                        new VertexInfo(sink, Map.of(source1, "REBALANCE"), 2, 720)));
+                        new VertexInfo(sink, Map.of(source1, REBALANCE), 2, 720)));
 
         /* Test stability while processing backlog. */
 
@@ -361,7 +362,7 @@ public class BacklogBasedScalingTest {
         metricsCollector.setJobTopology(
                 new JobTopology(
                         new VertexInfo(source1, Map.of(), 4, 720),
-                        new VertexInfo(sink, Map.of(source1, "REBALANCE"), 4, 720)));
+                        new VertexInfo(sink, Map.of(source1, REBALANCE), 4, 720)));
 
         var expectedEndTime = Instant.ofEpochMilli(10);
         metricsCollector.setJobUpdateTs(expectedEndTime);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -85,6 +85,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(10, 50, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -95,6 +96,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(10, 50, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -105,6 +107,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(10, 80, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -115,6 +118,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(10, 60, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -124,6 +128,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(10, 59, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -134,6 +139,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(2, 100, 40),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -144,6 +150,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(2, 100, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -155,6 +162,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(10, 10, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -165,6 +173,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(10, 10, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -176,6 +185,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(10, 200, 10),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -186,6 +196,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
+                        true,
                         evaluated(10, 200, 10),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -195,26 +206,44 @@ public class JobVertexScalerTest {
     public void testParallelismComputation() {
         final int minParallelism = 1;
         final int maxParallelism = Integer.MAX_VALUE;
-        assertEquals(1, JobVertexScaler.scale(1, 720, 0.0001, minParallelism, maxParallelism));
-        assertEquals(1, JobVertexScaler.scale(2, 720, 0.1, minParallelism, maxParallelism));
-        assertEquals(5, JobVertexScaler.scale(6, 720, 0.8, minParallelism, maxParallelism));
-        assertEquals(32, JobVertexScaler.scale(16, 128, 1.5, minParallelism, maxParallelism));
-        assertEquals(400, JobVertexScaler.scale(200, 720, 2, minParallelism, maxParallelism));
+        assertEquals(
+                1, JobVertexScaler.scale(1, 720, 0.0001, minParallelism, maxParallelism, false));
+        assertEquals(1, JobVertexScaler.scale(2, 720, 0.1, minParallelism, maxParallelism, false));
+        assertEquals(5, JobVertexScaler.scale(6, 720, 0.8, minParallelism, maxParallelism, false));
+        assertEquals(
+                24, JobVertexScaler.scale(16, 128, 1.5, minParallelism, maxParallelism, false));
+        assertEquals(
+                400, JobVertexScaler.scale(200, 720, 2, minParallelism, maxParallelism, false));
         assertEquals(
                 720,
-                JobVertexScaler.scale(200, 720, Integer.MAX_VALUE, minParallelism, maxParallelism));
+                JobVertexScaler.scale(
+                        200, 720, Integer.MAX_VALUE, minParallelism, maxParallelism, false));
+    }
+
+    @Test
+    public void testParallelismComputationWithKeyedOperator() {
+        final int minParallelism = 1;
+        final int maxParallelism = Integer.MAX_VALUE;
+        assertEquals(6, JobVertexScaler.scale(6, 36, 0.8, minParallelism, maxParallelism, true));
+        assertEquals(32, JobVertexScaler.scale(16, 128, 1.5, minParallelism, maxParallelism, true));
+        assertEquals(
+                360, JobVertexScaler.scale(200, 720, 1.3, minParallelism, maxParallelism, true));
+        assertEquals(
+                720,
+                JobVertexScaler.scale(
+                        200, 720, Integer.MAX_VALUE, minParallelism, maxParallelism, true));
     }
 
     @Test
     public void testParallelismComputationWithLimit() {
-        assertEquals(5, JobVertexScaler.scale(6, 720, 0.8, 1, 700));
-        assertEquals(8, JobVertexScaler.scale(8, 720, 0.8, 8, 700));
+        assertEquals(5, JobVertexScaler.scale(6, 720, 0.8, 1, 700, true));
+        assertEquals(8, JobVertexScaler.scale(8, 720, 0.8, 8, 700, true));
 
-        assertEquals(32, JobVertexScaler.scale(16, 128, 1.5, 1, Integer.MAX_VALUE));
-        assertEquals(64, JobVertexScaler.scale(16, 128, 1.5, 60, Integer.MAX_VALUE));
+        assertEquals(32, JobVertexScaler.scale(16, 128, 1.5, 1, Integer.MAX_VALUE, true));
+        assertEquals(64, JobVertexScaler.scale(16, 128, 1.5, 60, Integer.MAX_VALUE, true));
 
-        assertEquals(300, JobVertexScaler.scale(200, 720, 2, 1, 300));
-        assertEquals(600, JobVertexScaler.scale(200, 720, Integer.MAX_VALUE, 1, 600));
+        assertEquals(300, JobVertexScaler.scale(200, 720, 2, 1, 300, true));
+        assertEquals(600, JobVertexScaler.scale(200, 720, Integer.MAX_VALUE, 1, 600, true));
     }
 
     @Test
@@ -225,7 +254,7 @@ public class JobVertexScalerTest {
                                 assertEquals(
                                         600,
                                         JobVertexScaler.scale(
-                                                200, 720, Integer.MAX_VALUE, 500, 499)));
+                                                200, 720, Integer.MAX_VALUE, 500, 499, true)));
     }
 
     @Test
@@ -236,6 +265,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
+                        true,
                         evaluated(10, 100, 500),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -246,6 +276,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
+                        true,
                         evaluated(4, 100, 500),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -260,6 +291,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
+                        true,
                         evaluated(10, 500, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -270,6 +302,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
+                        true,
                         evaluated(12, 500, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -288,7 +321,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
 
         history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
 
@@ -297,7 +330,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
 
         // Pass some time...
         clock = Clock.offset(Clock.systemDefaultZone(), Duration.ofSeconds(61));
@@ -306,7 +339,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 5,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
         history.put(clock.instant(), new ScalingSummary(10, 5, evaluated));
 
         // Allow immediate scale up
@@ -314,7 +347,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
         history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
     }
 
@@ -330,7 +363,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
@@ -339,7 +372,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
 
@@ -349,7 +382,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Still considered ineffective (less than <10%)
@@ -357,7 +390,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Allow scale up if current parallelism doesnt match last (user rescaled manually)
@@ -365,14 +398,14 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
 
         // Over 10%, effective
         evaluated = evaluated(20, 180, 100);
         assertEquals(
                 36,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Ineffective but detection is turned off
@@ -381,7 +414,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 40,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
 
@@ -390,7 +423,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, evaluated, history, restartTime));
+                        context, op, true, evaluated, history, restartTime));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
     }
 
@@ -406,7 +439,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTime));
+                        context, jobVertexID, true, evaluated, history, restartTime));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
@@ -415,7 +448,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTime));
+                        context, jobVertexID, true, evaluated, history, restartTime));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
         assertEquals(0, eventCollector.events.size());
@@ -425,7 +458,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTime));
+                        context, jobVertexID, true, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(1, eventCollector.events.size());
         var event = eventCollector.events.poll();
@@ -441,7 +474,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTime));
+                        context, jobVertexID, true, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(0, eventCollector.events.size());
 
@@ -450,7 +483,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTime));
+                        context, jobVertexID, true, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(0, eventCollector.events.size());
 
@@ -459,7 +492,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTime));
+                        context, jobVertexID, true, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(1, eventCollector.events.size());
         event = eventCollector.events.poll();
@@ -476,7 +509,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 40,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, evaluated, history, restartTime));
+                        context, jobVertexID, true, evaluated, history, restartTime));
         assertEquals(1, eventCollector.events.size());
         event = eventCollector.events.poll();
         assertThat(event).isNotNull();

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -23,18 +23,22 @@ import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.event.TestingEventCollector;
 import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.autoscaler.topology.ShipStrategy;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -49,11 +53,31 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /** Test for vertex parallelism scaler logic. */
 public class JobVertexScalerTest {
 
+    private static final Map<JobVertexID, ShipStrategy> NOT_ADJUST_INPUTS =
+            Map.of(
+                    new JobVertexID(),
+                    ShipStrategy.REBALANCE,
+                    new JobVertexID(),
+                    ShipStrategy.RESCALE);
+
     private TestingEventCollector<JobID, JobAutoScalerContext<JobID>> eventCollector;
     private JobVertexScaler<JobID, JobAutoScalerContext<JobID>> vertexScaler;
     private JobAutoScalerContext<JobID> context;
     private Configuration conf;
     private Duration restartTime;
+
+    private static List<Map<JobVertexID, ShipStrategy>> adjustmentInputsProvider() {
+        return List.of(
+                Map.of(),
+                Map.of(new JobVertexID(), ShipStrategy.HASH),
+                Map.of(
+                        new JobVertexID(),
+                        ShipStrategy.REBALANCE,
+                        new JobVertexID(),
+                        ShipStrategy.HASH,
+                        new JobVertexID(),
+                        ShipStrategy.RESCALE));
+    }
 
     @BeforeEach
     public void setup() {
@@ -75,8 +99,9 @@ public class JobVertexScalerTest {
         restartTime = conf.get(AutoScalerOptions.RESTART_TIME);
     }
 
-    @Test
-    public void testParallelismScaling() {
+    @ParameterizedTest
+    @MethodSource("adjustmentInputsProvider")
+    public void testParallelismScaling(Map<JobVertexID, ShipStrategy> inputs) {
         var op = new JobVertexID();
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
 
@@ -85,7 +110,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(10, 50, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -96,7 +121,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(10, 50, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -107,7 +132,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(10, 80, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -118,7 +143,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(10, 60, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -128,7 +153,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(10, 59, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -139,7 +164,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(2, 100, 40),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -150,7 +175,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(2, 100, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -162,7 +187,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(10, 10, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -173,7 +198,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(10, 10, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -185,7 +210,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(10, 200, 10),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -196,7 +221,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
-                        true,
+                        inputs,
                         evaluated(10, 200, 10),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -207,43 +232,63 @@ public class JobVertexScalerTest {
         final int minParallelism = 1;
         final int maxParallelism = Integer.MAX_VALUE;
         assertEquals(
-                1, JobVertexScaler.scale(1, 720, 0.0001, minParallelism, maxParallelism, false));
-        assertEquals(1, JobVertexScaler.scale(2, 720, 0.1, minParallelism, maxParallelism, false));
-        assertEquals(5, JobVertexScaler.scale(6, 720, 0.8, minParallelism, maxParallelism, false));
+                1,
+                JobVertexScaler.scale(
+                        1, NOT_ADJUST_INPUTS, 720, 0.0001, minParallelism, maxParallelism));
         assertEquals(
-                24, JobVertexScaler.scale(16, 128, 1.5, minParallelism, maxParallelism, false));
+                1,
+                JobVertexScaler.scale(
+                        2, NOT_ADJUST_INPUTS, 720, 0.1, minParallelism, maxParallelism));
         assertEquals(
-                400, JobVertexScaler.scale(200, 720, 2, minParallelism, maxParallelism, false));
+                5,
+                JobVertexScaler.scale(
+                        6, NOT_ADJUST_INPUTS, 720, 0.8, minParallelism, maxParallelism));
+        assertEquals(
+                24,
+                JobVertexScaler.scale(
+                        16, NOT_ADJUST_INPUTS, 128, 1.5, minParallelism, maxParallelism));
+        assertEquals(
+                400,
+                JobVertexScaler.scale(
+                        200, NOT_ADJUST_INPUTS, 720, 2, minParallelism, maxParallelism));
         assertEquals(
                 720,
                 JobVertexScaler.scale(
-                        200, 720, Integer.MAX_VALUE, minParallelism, maxParallelism, false));
+                        200,
+                        NOT_ADJUST_INPUTS,
+                        720,
+                        Integer.MAX_VALUE,
+                        minParallelism,
+                        maxParallelism));
     }
 
-    @Test
-    public void testParallelismComputationWithKeyedOperator() {
+    @ParameterizedTest
+    @MethodSource("adjustmentInputsProvider")
+    public void testParallelismComputationWithAdjustment(Map<JobVertexID, ShipStrategy> inputs) {
         final int minParallelism = 1;
         final int maxParallelism = Integer.MAX_VALUE;
-        assertEquals(6, JobVertexScaler.scale(6, 36, 0.8, minParallelism, maxParallelism, true));
-        assertEquals(32, JobVertexScaler.scale(16, 128, 1.5, minParallelism, maxParallelism, true));
+        assertEquals(6, JobVertexScaler.scale(6, inputs, 36, 0.8, minParallelism, maxParallelism));
         assertEquals(
-                360, JobVertexScaler.scale(200, 720, 1.3, minParallelism, maxParallelism, true));
+                32, JobVertexScaler.scale(16, inputs, 128, 1.5, minParallelism, maxParallelism));
+        assertEquals(
+                360, JobVertexScaler.scale(200, inputs, 720, 1.3, minParallelism, maxParallelism));
         assertEquals(
                 720,
                 JobVertexScaler.scale(
-                        200, 720, Integer.MAX_VALUE, minParallelism, maxParallelism, true));
+                        200, inputs, 720, Integer.MAX_VALUE, minParallelism, maxParallelism));
     }
 
-    @Test
-    public void testParallelismComputationWithLimit() {
-        assertEquals(5, JobVertexScaler.scale(6, 720, 0.8, 1, 700, true));
-        assertEquals(8, JobVertexScaler.scale(8, 720, 0.8, 8, 700, true));
+    @ParameterizedTest
+    @MethodSource("adjustmentInputsProvider")
+    public void testParallelismComputationWithLimit(Map<JobVertexID, ShipStrategy> inputs) {
+        assertEquals(5, JobVertexScaler.scale(6, inputs, 720, 0.8, 1, 700));
+        assertEquals(8, JobVertexScaler.scale(8, inputs, 720, 0.8, 8, 700));
 
-        assertEquals(32, JobVertexScaler.scale(16, 128, 1.5, 1, Integer.MAX_VALUE, true));
-        assertEquals(64, JobVertexScaler.scale(16, 128, 1.5, 60, Integer.MAX_VALUE, true));
+        assertEquals(32, JobVertexScaler.scale(16, inputs, 128, 1.5, 1, Integer.MAX_VALUE));
+        assertEquals(64, JobVertexScaler.scale(16, inputs, 128, 1.5, 60, Integer.MAX_VALUE));
 
-        assertEquals(300, JobVertexScaler.scale(200, 720, 2, 1, 300, true));
-        assertEquals(600, JobVertexScaler.scale(200, 720, Integer.MAX_VALUE, 1, 600, true));
+        assertEquals(300, JobVertexScaler.scale(200, inputs, 720, 2, 1, 300));
+        assertEquals(600, JobVertexScaler.scale(200, inputs, 720, Integer.MAX_VALUE, 1, 600));
     }
 
     @Test
@@ -254,7 +299,12 @@ public class JobVertexScalerTest {
                                 assertEquals(
                                         600,
                                         JobVertexScaler.scale(
-                                                200, 720, Integer.MAX_VALUE, 500, 499, true)));
+                                                200,
+                                                NOT_ADJUST_INPUTS,
+                                                720,
+                                                Integer.MAX_VALUE,
+                                                500,
+                                                499)));
     }
 
     @Test
@@ -265,7 +315,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
-                        true,
+                        NOT_ADJUST_INPUTS,
                         evaluated(10, 100, 500),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -276,7 +326,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
-                        true,
+                        NOT_ADJUST_INPUTS,
                         evaluated(4, 100, 500),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -291,7 +341,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
-                        true,
+                        NOT_ADJUST_INPUTS,
                         evaluated(10, 500, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -302,7 +352,7 @@ public class JobVertexScalerTest {
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
-                        true,
+                        NOT_ADJUST_INPUTS,
                         evaluated(12, 500, 100),
                         Collections.emptySortedMap(),
                         restartTime));
@@ -321,7 +371,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
 
         history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
 
@@ -330,7 +380,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
 
         // Pass some time...
         clock = Clock.offset(Clock.systemDefaultZone(), Duration.ofSeconds(61));
@@ -339,7 +389,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 5,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
         history.put(clock.instant(), new ScalingSummary(10, 5, evaluated));
 
         // Allow immediate scale up
@@ -347,7 +397,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
         history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
     }
 
@@ -363,7 +413,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
@@ -372,7 +422,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
 
@@ -382,7 +432,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Still considered ineffective (less than <10%)
@@ -390,7 +440,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Allow scale up if current parallelism doesnt match last (user rescaled manually)
@@ -398,14 +448,14 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
 
         // Over 10%, effective
         evaluated = evaluated(20, 180, 100);
         assertEquals(
                 36,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Ineffective but detection is turned off
@@ -414,7 +464,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 40,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
 
@@ -423,12 +473,13 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, true, evaluated, history, restartTime));
+                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
     }
 
-    @Test
-    public void testSendingIneffectiveScalingEvents() {
+    @ParameterizedTest
+    @MethodSource("adjustmentInputsProvider")
+    public void testSendingIneffectiveScalingEvents(Map<JobVertexID, ShipStrategy> inputs) {
         var jobVertexID = new JobVertexID();
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.0);
@@ -439,7 +490,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 10,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, true, evaluated, history, restartTime));
+                        context, jobVertexID, inputs, evaluated, history, restartTime));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
@@ -448,7 +499,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, true, evaluated, history, restartTime));
+                        context, jobVertexID, inputs, evaluated, history, restartTime));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
         assertEquals(0, eventCollector.events.size());
@@ -458,7 +509,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, true, evaluated, history, restartTime));
+                        context, jobVertexID, inputs, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(1, eventCollector.events.size());
         var event = eventCollector.events.poll();
@@ -474,7 +525,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, true, evaluated, history, restartTime));
+                        context, jobVertexID, inputs, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(0, eventCollector.events.size());
 
@@ -483,7 +534,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, true, evaluated, history, restartTime));
+                        context, jobVertexID, inputs, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(0, eventCollector.events.size());
 
@@ -492,7 +543,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, true, evaluated, history, restartTime));
+                        context, jobVertexID, inputs, evaluated, history, restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(1, eventCollector.events.size());
         event = eventCollector.events.poll();
@@ -509,7 +560,7 @@ public class JobVertexScalerTest {
         assertEquals(
                 40,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, jobVertexID, true, evaluated, history, restartTime));
+                        context, jobVertexID, inputs, evaluated, history, restartTime));
         assertEquals(1, eventCollector.events.size());
         event = eventCollector.events.poll();
         assertThat(event).isNotNull();

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -183,7 +183,7 @@ public class MetricsCollectionAndEvaluationTest {
                 new HashMap<>(),
                 new ScalingTracking(),
                 clock.instant(),
-                new JobTopology());
+                topology);
 
         var scaledParallelism = ScalingExecutorTest.getScaledParallelism(stateStore, context);
         assertEquals(4, scaledParallelism.size());
@@ -401,7 +401,7 @@ public class MetricsCollectionAndEvaluationTest {
                 new HashMap<>(),
                 new ScalingTracking(),
                 clock.instant(),
-                new JobTopology());
+                topology);
         var scaledParallelism = ScalingExecutorTest.getScaledParallelism(stateStore, context);
         assertEquals(1, scaledParallelism.get(source1));
     }
@@ -652,7 +652,7 @@ public class MetricsCollectionAndEvaluationTest {
                 new HashMap<>(),
                 new ScalingTracking(),
                 clock.instant(),
-                new JobTopology());
+                topology);
         var scaledParallelism = ScalingExecutorTest.getScaledParallelism(stateStore, context);
         assertEquals(1, scaledParallelism.get(source1));
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -50,6 +50,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static org.apache.flink.autoscaler.TestingAutoscalerUtils.createDefaultJobAutoScalerContext;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.REBALANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -92,12 +93,12 @@ public class MetricsCollectionAndEvaluationTest {
                         new VertexInfo(source2, Map.of(), 2, 720, new IOMetrics(0, 0, 0)),
                         new VertexInfo(
                                 map,
-                                Map.of(source1, "REBALANCE", source2, "REBALANCE"),
+                                Map.of(source1, REBALANCE, source2, REBALANCE),
                                 12,
                                 720,
                                 new IOMetrics(0, 0, 0)),
                         new VertexInfo(
-                                sink, Map.of(map, "REBALANCE"), 8, 24, new IOMetrics(0, 0, 0)));
+                                sink, Map.of(map, REBALANCE), 8, 24, new IOMetrics(0, 0, 0)));
 
         metricsCollector = new TestingMetricsCollector<>(topology);
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
@@ -43,6 +43,7 @@ import static org.apache.flink.autoscaler.TestingAutoscalerUtils.createDefaultJo
 import static org.apache.flink.autoscaler.TestingAutoscalerUtils.getRestClusterClientSupplier;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.PARALLELISM;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.RECOMMENDED_PARALLELISM;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.REBALANCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -75,7 +76,7 @@ public class RecommendedParallelismTest {
                 new TestingMetricsCollector<>(
                         new JobTopology(
                                 new VertexInfo(source, Map.of(), 1, 720),
-                                new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 720)));
+                                new VertexInfo(sink, Map.of(source, REBALANCE), 1, 720)));
 
         var defaultConf = context.getConfiguration();
         defaultConf.set(AutoScalerOptions.AUTOSCALER_ENABLED, true);
@@ -199,7 +200,7 @@ public class RecommendedParallelismTest {
         metricsCollector.setJobTopology(
                 new JobTopology(
                         new VertexInfo(source, Map.of(), 4, 24),
-                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 4, 720)));
+                        new VertexInfo(sink, Map.of(source, REBALANCE), 4, 720)));
 
         now = now.plus(Duration.ofSeconds(10));
         setClocksTo(now);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -354,9 +354,9 @@ public class ScalingExecutorTest {
                                 TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(),
                                 "0.652",
                                 TaskManagerOptions.NETWORK_MEMORY_MIN.key(),
-                                "23040 kb",
+                                "24320 kb",
                                 TaskManagerOptions.NETWORK_MEMORY_MAX.key(),
-                                "23040 kb",
+                                "24320 kb",
                                 TaskManagerOptions.JVM_METASPACE.key(),
                                 "360 mb",
                                 TaskManagerOptions.JVM_OVERHEAD_FRACTION.key(),
@@ -364,7 +364,7 @@ public class ScalingExecutorTest {
                                 TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(),
                                 "0 bytes",
                                 TaskManagerOptions.TOTAL_PROCESS_MEMORY.key(),
-                                "7862784 kb"));
+                                "7864064 kb"));
     }
 
     @ParameterizedTest

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -52,6 +52,8 @@ import static org.apache.flink.autoscaler.event.AutoScalerEventHandler.SCALING_R
 import static org.apache.flink.autoscaler.event.AutoScalerEventHandler.SCALING_SUMMARY_ENTRY;
 import static org.apache.flink.autoscaler.event.AutoScalerEventHandler.SCALING_SUMMARY_HEADER_SCALING_EXECUTION_DISABLED;
 import static org.apache.flink.autoscaler.event.AutoScalerEventHandler.SCALING_SUMMARY_HEADER_SCALING_EXECUTION_ENABLED;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.HASH;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.REBALANCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -154,10 +156,8 @@ public class ScalingExecutorTest {
         JobTopology jobTopology =
                 new JobTopology(
                         new VertexInfo(source, Map.of(), 10, 1000, false, null),
-                        new VertexInfo(
-                                filterOperator, Map.of(source, "HASH"), 10, 1000, false, null),
-                        new VertexInfo(
-                                sink, Map.of(filterOperator, "HASH"), 10, 1000, false, null));
+                        new VertexInfo(filterOperator, Map.of(source, HASH), 10, 1000, false, null),
+                        new VertexInfo(sink, Map.of(filterOperator, HASH), 10, 1000, false, null));
 
         var conf = context.getConfiguration();
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
@@ -204,7 +204,7 @@ public class ScalingExecutorTest {
         JobTopology jobTopology =
                 new JobTopology(
                         new VertexInfo(source, Map.of(), 10, 1000, false, null),
-                        new VertexInfo(sink, Map.of(source, "HASH"), 10, 1000, false, null));
+                        new VertexInfo(sink, Map.of(source, HASH), 10, 1000, false, null));
 
         var conf = context.getConfiguration();
         var now = Instant.now();
@@ -255,7 +255,7 @@ public class ScalingExecutorTest {
         JobTopology jobTopology =
                 new JobTopology(
                         new VertexInfo(source, Map.of(), 10, 1000, false, null),
-                        new VertexInfo(sink, Map.of(source, "HASH"), 10, 1000, false, null));
+                        new VertexInfo(sink, Map.of(source, HASH), 10, 1000, false, null));
 
         var now = Instant.now();
         var metrics =
@@ -338,7 +338,7 @@ public class ScalingExecutorTest {
         JobTopology jobTopology =
                 new JobTopology(
                         new VertexInfo(source, Map.of(), 10, 1000, false, null),
-                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 10, 1000, false, null));
+                        new VertexInfo(sink, Map.of(source, REBALANCE), 10, 1000, false, null));
 
         assertTrue(
                 scalingDecisionExecutor.scaleResource(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
@@ -53,6 +53,8 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.autoscaler.TestingAutoscalerUtils.createDefaultJobAutoScalerContext;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.HASH;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.REBALANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -220,12 +222,7 @@ public class ScalingMetricCollectorTest {
         var source = new VertexInfo(sourceId, Map.of(), 2, 128, true, IOMetrics.FINISHED_METRICS);
         var sink =
                 new VertexInfo(
-                        sinkId,
-                        Map.of(sourceId, "HASH"),
-                        2,
-                        128,
-                        false,
-                        new IOMetrics(291532, 1, 2));
+                        sinkId, Map.of(sourceId, HASH), 2, 128, false, new IOMetrics(291532, 1, 2));
 
         assertEquals(
                 new JobTopology(source, sink), metricsCollector.getJobTopology(jobDetailsInfo));
@@ -275,12 +272,12 @@ public class ScalingMetricCollectorTest {
         var t1 =
                 new JobTopology(
                         new VertexInfo(source, Map.of(), 1, 1),
-                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 1));
+                        new VertexInfo(sink, Map.of(source, REBALANCE), 1, 1));
 
         var t2 =
                 new JobTopology(
                         new VertexInfo(source2, Map.of(), 1, 1),
-                        new VertexInfo(sink, Map.of(source2, "REBALANCE"), 1, 1));
+                        new VertexInfo(sink, Map.of(source2, REBALANCE), 1, 1));
 
         collector.queryFilteredMetricNames(context, t1);
         assertEquals(1, metricNameQueryCounter.get(source));
@@ -309,7 +306,7 @@ public class ScalingMetricCollectorTest {
         t2 =
                 new JobTopology(
                         new VertexInfo(source2, Map.of(), 1, 1, true, null),
-                        new VertexInfo(sink, Map.of(source2, "REBALANCE"), 1, 1));
+                        new VertexInfo(sink, Map.of(source2, REBALANCE), 1, 1));
         collector.queryFilteredMetricNames(context, t2);
         assertEquals(3, metricNameQueryCounter.get(source));
         assertEquals(2, metricNameQueryCounter.get(source2));
@@ -333,7 +330,7 @@ public class ScalingMetricCollectorTest {
         var topology =
                 new JobTopology(
                         new VertexInfo(source, Map.of(), 1, 1),
-                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 1));
+                        new VertexInfo(sink, Map.of(source, REBALANCE), 1, 1));
 
         testRequiredMetrics(
                 metricList, getSourceRequiredMetrics(), testCollector, source, topology);
@@ -410,7 +407,7 @@ public class ScalingMetricCollectorTest {
         var topology =
                 new JobTopology(
                         new VertexInfo(source, Map.of(), 1, 1),
-                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 1));
+                        new VertexInfo(sink, Map.of(source, REBALANCE), 1, 1));
 
         var metricCollector = new TestingMetricsCollector<>(topology);
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -43,6 +43,7 @@ import static org.apache.flink.autoscaler.config.AutoScalerOptions.PREFER_TRACKE
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.RESTART_TIME;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.REBALANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,7 +61,7 @@ public class ScalingMetricEvaluatorTest {
         var topology =
                 new JobTopology(
                         new VertexInfo(source, Collections.emptyMap(), 1, 1, null),
-                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 1, null));
+                        new VertexInfo(sink, Map.of(source, REBALANCE), 1, 1, null));
 
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
 
@@ -324,7 +325,7 @@ public class ScalingMetricEvaluatorTest {
         var topology =
                 new JobTopology(
                         new VertexInfo(source, Collections.emptyMap(), 1, 1),
-                        new VertexInfo(sink, Map.of(source, "REBALANCE"), 1, 1));
+                        new VertexInfo(sink, Map.of(source, REBALANCE), 1, 1));
 
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
 
@@ -661,9 +662,8 @@ public class ScalingMetricEvaluatorTest {
                 new JobTopology(
                         new VertexInfo(source1, Collections.emptyMap(), 1, 1),
                         new VertexInfo(source2, Collections.emptyMap(), 1, 1),
-                        new VertexInfo(
-                                op1, Map.of(source1, "REBALANCE", source2, "REBALANCE"), 1, 1),
-                        new VertexInfo(sink1, Map.of(op1, "REBALANCE"), 1, 1));
+                        new VertexInfo(op1, Map.of(source1, REBALANCE, source2, REBALANCE), 1, 1),
+                        new VertexInfo(sink1, Map.of(op1, REBALANCE), 1, 1));
 
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
 
@@ -728,10 +728,8 @@ public class ScalingMetricEvaluatorTest {
                 new JobTopology(
                         new VertexInfo(source1, Collections.emptyMap(), 1, 1),
                         new VertexInfo(source2, Collections.emptyMap(), 1, 1),
-                        new VertexInfo(
-                                op1, Map.of(source1, "REBALANCE", source2, "REBALANCE"), 1, 1),
-                        new VertexInfo(
-                                op2, Map.of(source1, "REBALANCE", source2, "REBALANCE"), 1, 1));
+                        new VertexInfo(op1, Map.of(source1, REBALANCE, source2, REBALANCE), 1, 1),
+                        new VertexInfo(op2, Map.of(source1, REBALANCE, source2, REBALANCE), 1, 1));
 
         var metricHistory = new TreeMap<Instant, CollectedMetrics>();
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.autoscaler.topology.ShipStrategy.REBALANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -53,7 +54,7 @@ public class ScalingMetricsTest {
                         new VertexInfo(
                                 source, Collections.emptyMap(), 1, 1, new IOMetrics(1, 2, 3)),
                         new VertexInfo(
-                                op, Map.of(source, "REBALANCE"), 1, 1, new IOMetrics(1, 2, 3)));
+                                op, Map.of(source, REBALANCE), 1, 1, new IOMetrics(1, 2, 3)));
 
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
         ScalingMetrics.computeDataRateMetrics(
@@ -223,7 +224,7 @@ public class ScalingMetricsTest {
                         new VertexInfo(
                                 SOURCE, Collections.emptyMap(), 1, 1, new IOMetrics(0, 0, 0)),
                         new VertexInfo(
-                                sink, Map.of(SOURCE, "REBALANCE"), 1, 1, new IOMetrics(0, 0, 0)));
+                                sink, Map.of(SOURCE, REBALANCE), 1, 1, new IOMetrics(0, 0, 0)));
 
         Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
         scalingMetrics.put(ScalingMetric.LAG, lag);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/topology/JobTopologyTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/topology/JobTopologyTest.java
@@ -31,6 +31,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.flink.autoscaler.topology.ShipStrategy.FORWARD;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.HASH;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.REBALANCE;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.RESCALE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -82,25 +86,25 @@ public class JobTopologyTest {
         assertTrue(jobTopology.get(vertices.get("Sink: sink3")).getOutputs().isEmpty());
 
         assertEquals(
-                Map.of(vertices.get("map1"), "HASH"),
+                Map.of(vertices.get("map1"), HASH),
                 jobTopology.get(vertices.get("Source: s1")).getOutputs());
         assertEquals(
-                Map.of(vertices.get("map1"), "HASH"),
+                Map.of(vertices.get("map1"), HASH),
                 jobTopology.get(vertices.get("Source: s2")).getOutputs());
         assertEquals(
-                Map.of(vertices.get("Sink: sink1"), "FORWARD"),
+                Map.of(vertices.get("Sink: sink1"), FORWARD),
                 jobTopology.get(vertices.get("map1")).getOutputs());
 
         assertEquals(
-                Map.of(vertices.get("map2"), "RESCALE"),
+                Map.of(vertices.get("map2"), RESCALE),
                 jobTopology.get(vertices.get("Source: s3")).getOutputs());
 
         assertEquals(
                 Map.of(
                         vertices.get("Sink: sink2"),
-                        "REBALANCE",
+                        REBALANCE,
                         vertices.get("Sink: sink3"),
-                        "REBALANCE"),
+                        REBALANCE),
                 jobTopology.get(vertices.get("map2")).getOutputs());
 
         assertEquals(2, jobTopology.get(vertices.get("map1")).getParallelism());

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryTuningTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryTuningTest.java
@@ -38,6 +38,10 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.flink.autoscaler.topology.ShipStrategy.FORWARD;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.REBALANCE;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.RESCALE;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.UNKNOWN;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 /** Tests for {@link MemoryTuning}. */
@@ -86,12 +90,7 @@ public class MemoryTuningTest {
                 new JobTopology(
                         new VertexInfo(jobVertex1, Map.of(), 50, 1000, false, null),
                         new VertexInfo(
-                                jobVertex2,
-                                Map.of(jobVertex1, "REBALANCE"),
-                                50,
-                                1000,
-                                false,
-                                null));
+                                jobVertex2, Map.of(jobVertex1, REBALANCE), 50, 1000, false, null));
 
         Map<JobVertexID, ScalingSummary> scalingSummaries =
                 Map.of(
@@ -202,23 +201,19 @@ public class MemoryTuningTest {
     @Test
     void testCalculateNetworkSegmentNumber() {
         // Test FORWARD
-        assertThat(MemoryTuning.calculateNetworkSegmentNumber(10, 10, "FORWARD", 2, 8))
-                .isEqualTo(10);
+        assertThat(MemoryTuning.calculateNetworkSegmentNumber(10, 10, FORWARD, 2, 8)).isEqualTo(10);
 
         // Test FORWARD is changed to RESCALE.
-        assertThat(MemoryTuning.calculateNetworkSegmentNumber(10, 15, "FORWARD", 2, 8))
-                .isEqualTo(12);
+        assertThat(MemoryTuning.calculateNetworkSegmentNumber(10, 15, FORWARD, 2, 8)).isEqualTo(12);
 
         // Test RESCALE.
-        assertThat(MemoryTuning.calculateNetworkSegmentNumber(10, 15, "RESCALE", 2, 8))
-                .isEqualTo(12);
+        assertThat(MemoryTuning.calculateNetworkSegmentNumber(10, 15, RESCALE, 2, 8)).isEqualTo(12);
 
         // Test REBALANCE.
-        assertThat(MemoryTuning.calculateNetworkSegmentNumber(10, 15, "REBALANCE", 2, 8))
+        assertThat(MemoryTuning.calculateNetworkSegmentNumber(10, 15, REBALANCE, 2, 8))
                 .isEqualTo(38);
 
-        // Test Unrecognizable.
-        assertThat(MemoryTuning.calculateNetworkSegmentNumber(10, 15, "Unrecognizable", 2, 8))
-                .isEqualTo(38);
+        // Test UNKNOWN.
+        assertThat(MemoryTuning.calculateNetworkSegmentNumber(10, 15, UNKNOWN, 2, 8)).isEqualTo(38);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

JobVertexScaler#scale has a optimization: Try to adjust the parallelism such that it divides the number of key groups without a remainder =>  data is evenly spread across subtasks.

It's only useful when the upstream shuffle type has keyBy. We should avoid this optimization when the upstream shuffle type doesn't have keyBy.

## Brief change log

[FLINK-34504][autoscaler] Avoid the parallelism adjustment when the upstream shuffle type doesn't have keyBy

## Verifying this change

- Improve `JobVertexScalerTest#testParallelismComputation`
- Add `JobVertexScalerTest#testParallelismComputationWithKeyedOperator`
- Add `ScalingExecutorTest#testAdjustByMaxParallelism`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no

