### PR TITLE
[FLINK-34537] Autoscaler JDBC Support HikariPool

### DIFF
--- a/flink-autoscaler-standalone/pom.xml
+++ b/flink-autoscaler-standalone/pom.xml
@@ -133,6 +133,12 @@ under the License.
             <version>${log4j.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikari.version}</version>
+        </dependency>
+
         <!-- Test -->
 
         <dependency>
@@ -161,12 +167,6 @@ under the License.
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
             <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <version>${hikari.version}</version>
         </dependency>
 
         <!-- Derby tests -->

--- a/flink-autoscaler-standalone/pom.xml
+++ b/flink-autoscaler-standalone/pom.xml
@@ -133,12 +133,6 @@ under the License.
             <version>${log4j.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <version>${hikari.version}</version>
-        </dependency>
-
         <!-- Test -->
 
         <dependency>

--- a/flink-autoscaler-standalone/pom.xml
+++ b/flink-autoscaler-standalone/pom.xml
@@ -163,6 +163,12 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikari.version}</version>
+        </dependency>
+
         <!-- Derby tests -->
         <dependency>
             <groupId>org.apache.derby</groupId>

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactory.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactory.java
@@ -72,7 +72,7 @@ public class AutoscalerEventHandlerFactory {
     private static <KEY, Context extends JobAutoScalerContext<KEY>>
             AutoScalerEventHandler<KEY, Context> createJdbcEventHandler(Configuration conf)
                     throws Exception {
-        var conn = HikariJDBCUtil.getConnection(conf, "%s is required for jdbc event handler.");
+        var conn = HikariJDBCUtil.getConnection(conf);
         return new JdbcAutoScalerEventHandler<>(new JdbcEventInteractor(conn));
     }
 }

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactory.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactory.java
@@ -22,20 +22,15 @@ import org.apache.flink.autoscaler.event.AutoScalerEventHandler;
 import org.apache.flink.autoscaler.event.LoggingEventHandler;
 import org.apache.flink.autoscaler.jdbc.event.JdbcAutoScalerEventHandler;
 import org.apache.flink.autoscaler.jdbc.event.JdbcEventInteractor;
+import org.apache.flink.autoscaler.standalone.utils.HikariJDBCUtil;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.description.InlineElement;
 
-import java.sql.DriverManager;
-
 import static org.apache.flink.autoscaler.standalone.AutoscalerEventHandlerFactory.EventHandlerType.JDBC;
 import static org.apache.flink.autoscaler.standalone.AutoscalerEventHandlerFactory.EventHandlerType.LOGGING;
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.EVENT_HANDLER_TYPE;
-import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_PASSWORD_ENV_VARIABLE;
-import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_URL;
-import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_USERNAME;
 import static org.apache.flink.configuration.description.TextElement.text;
-import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** The factory of {@link AutoScalerEventHandler}. */
 public class AutoscalerEventHandlerFactory {
@@ -77,12 +72,7 @@ public class AutoscalerEventHandlerFactory {
     private static <KEY, Context extends JobAutoScalerContext<KEY>>
             AutoScalerEventHandler<KEY, Context> createJdbcEventHandler(Configuration conf)
                     throws Exception {
-        final var jdbcUrl = conf.get(JDBC_URL);
-        checkArgument(jdbcUrl != null, "%s is required for jdbc event handler.", JDBC_URL.key());
-        var user = conf.get(JDBC_USERNAME);
-        var password = System.getenv().get(conf.get(JDBC_PASSWORD_ENV_VARIABLE));
-
-        var conn = DriverManager.getConnection(jdbcUrl, user, password);
+        var conn = HikariJDBCUtil.getConnection(conf, "%s is required for jdbc event handler.");
         return new JdbcAutoScalerEventHandler<>(new JdbcEventInteractor(conn));
     }
 }

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactory.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactory.java
@@ -21,22 +21,17 @@ import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.jdbc.state.JdbcAutoScalerStateStore;
 import org.apache.flink.autoscaler.jdbc.state.JdbcStateInteractor;
 import org.apache.flink.autoscaler.jdbc.state.JdbcStateStore;
+import org.apache.flink.autoscaler.standalone.utils.HikariJDBCUtil;
 import org.apache.flink.autoscaler.state.AutoScalerStateStore;
 import org.apache.flink.autoscaler.state.InMemoryAutoScalerStateStore;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.description.InlineElement;
 
-import java.sql.DriverManager;
-
 import static org.apache.flink.autoscaler.standalone.AutoscalerStateStoreFactory.StateStoreType.JDBC;
 import static org.apache.flink.autoscaler.standalone.AutoscalerStateStoreFactory.StateStoreType.MEMORY;
-import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_PASSWORD_ENV_VARIABLE;
-import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_URL;
-import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_USERNAME;
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.STATE_STORE_TYPE;
 import static org.apache.flink.configuration.description.TextElement.text;
-import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** The factory of {@link AutoScalerStateStore}. */
 public class AutoscalerStateStoreFactory {
@@ -79,12 +74,7 @@ public class AutoscalerStateStoreFactory {
     private static <KEY, Context extends JobAutoScalerContext<KEY>>
             AutoScalerStateStore<KEY, Context> createJdbcStateStore(Configuration conf)
                     throws Exception {
-        final var jdbcUrl = conf.get(JDBC_URL);
-        checkArgument(jdbcUrl != null, "%s is required for jdbc state store.", JDBC_URL.key());
-        var user = conf.get(JDBC_USERNAME);
-        var password = System.getenv().get(conf.get(JDBC_PASSWORD_ENV_VARIABLE));
-
-        var conn = DriverManager.getConnection(jdbcUrl, user, password);
+        var conn = HikariJDBCUtil.getConnection(conf, "%s is required for jdbc state store.");
         return new JdbcAutoScalerStateStore<>(new JdbcStateStore(new JdbcStateInteractor(conn)));
     }
 }

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactory.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactory.java
@@ -74,7 +74,7 @@ public class AutoscalerStateStoreFactory {
     private static <KEY, Context extends JobAutoScalerContext<KEY>>
             AutoScalerStateStore<KEY, Context> createJdbcStateStore(Configuration conf)
                     throws Exception {
-        var conn = HikariJDBCUtil.getConnection(conf, "%s is required for jdbc state store.");
+        var conn = HikariJDBCUtil.getConnection(conf);
         return new JdbcAutoScalerStateStore<>(new JdbcStateStore(new JdbcStateInteractor(conn)));
     }
 }

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/utils/HikariJDBCUtil.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/utils/HikariJDBCUtil.java
@@ -33,9 +33,12 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 /** Hikari JDBC common util. */
 public class HikariJDBCUtil {
 
-    public static Connection getConnection(Configuration conf, String errMsg) throws SQLException {
+    public static Connection getConnection(Configuration conf) throws SQLException {
         final var jdbcUrl = conf.get(JDBC_URL);
-        checkArgument(jdbcUrl != null, errMsg, JDBC_URL.key());
+        checkArgument(
+                jdbcUrl != null,
+                "%s is required when jdbc state store or jdbc event handler is used.",
+                JDBC_URL.key());
         var user = conf.get(JDBC_USERNAME);
         var password = System.getenv().get(conf.get(JDBC_PASSWORD_ENV_VARIABLE));
         HikariConfig hikariConfig = new HikariConfig();

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/utils/HikariJDBCUtil.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/utils/HikariJDBCUtil.java
@@ -18,6 +18,7 @@
 package org.apache.flink.autoscaler.standalone.utils;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.StringUtils;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -33,12 +34,14 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 /** Hikari JDBC common util. */
 public class HikariJDBCUtil {
 
+    public static final String JDBC_URL_REQUIRED_HINT =
+            String.format(
+                    "%s is required when jdbc state store or jdbc event handler is used.",
+                    JDBC_URL.key());
+
     public static Connection getConnection(Configuration conf) throws SQLException {
         final var jdbcUrl = conf.get(JDBC_URL);
-        checkArgument(
-                jdbcUrl != null,
-                "%s is required when jdbc state store or jdbc event handler is used.",
-                JDBC_URL.key());
+        checkArgument(!StringUtils.isNullOrWhitespaceOnly(jdbcUrl), JDBC_URL_REQUIRED_HINT);
         var user = conf.get(JDBC_USERNAME);
         var password = System.getenv().get(conf.get(JDBC_PASSWORD_ENV_VARIABLE));
         HikariConfig hikariConfig = new HikariConfig();

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/utils/HikariJDBCUtil.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/utils/HikariJDBCUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.standalone.utils;
+
+import org.apache.flink.configuration.Configuration;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_PASSWORD_ENV_VARIABLE;
+import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_URL;
+import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_USERNAME;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** Hikari JDBC common util. */
+public class HikariJDBCUtil {
+
+    public static Connection getConnection(Configuration conf, String errMsg) throws SQLException {
+        final var jdbcUrl = conf.get(JDBC_URL);
+        checkArgument(jdbcUrl != null, errMsg, JDBC_URL.key());
+        var user = conf.get(JDBC_USERNAME);
+        var password = System.getenv().get(conf.get(JDBC_PASSWORD_ENV_VARIABLE));
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(jdbcUrl);
+        hikariConfig.setUsername(user);
+        hikariConfig.setPassword(password);
+        return new HikariDataSource(hikariConfig).getConnection();
+    }
+}

--- a/flink-autoscaler-standalone/src/main/resources/META-INF/NOTICE
+++ b/flink-autoscaler-standalone/src/main/resources/META-INF/NOTICE
@@ -20,6 +20,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.logging.log4j:log4j-api:2.17.1
 - org.apache.logging.log4j:log4j-core:2.17.1
 - org.apache.logging.log4j:log4j-1.2-api:2.17.1
+- com.zaxxer:HikariCP:5.1.0
 
 This project bundles the following dependencies under the BSD License.
 See bundled license files for details.

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactoryTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactoryTest.java
@@ -57,7 +57,9 @@ class AutoscalerEventHandlerFactoryTest {
         conf.set(EVENT_HANDLER_TYPE, JDBC);
         assertThatThrownBy(() -> AutoscalerEventHandlerFactory.create(conf))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("%s is required for jdbc event handler.", JDBC_URL.key());
+                .hasMessage(
+                        "%s is required when jdbc state store or jdbc event handler is used.",
+                        JDBC_URL.key());
     }
 
     @Test
@@ -67,14 +69,14 @@ class AutoscalerEventHandlerFactoryTest {
         final var conf = new Configuration();
         conf.set(EVENT_HANDLER_TYPE, JDBC);
         conf.set(JDBC_URL, String.format("%s;create=true", jdbcUrl));
-        HikariJDBCUtil.getConnection(conf, "testCreateJdbcEventHandler Failed").close();
+        HikariJDBCUtil.getConnection(conf).close();
 
         var eventHandler = AutoscalerEventHandlerFactory.create(conf);
         assertThat(eventHandler).isInstanceOf(JdbcAutoScalerEventHandler.class);
 
         try {
             conf.set(JDBC_URL, String.format("%s;shutdown=true", jdbcUrl));
-            HikariJDBCUtil.getConnection(conf, "testCreateJdbcEventHandler Failed").close();
+            HikariJDBCUtil.getConnection(conf).close();
         } catch (RuntimeException ignored) {
             // database shutdown ignored exception
         }

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactoryTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactoryTest.java
@@ -28,6 +28,7 @@ import static org.apache.flink.autoscaler.standalone.AutoscalerEventHandlerFacto
 import static org.apache.flink.autoscaler.standalone.AutoscalerEventHandlerFactory.EventHandlerType.LOGGING;
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.EVENT_HANDLER_TYPE;
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_URL;
+import static org.apache.flink.autoscaler.standalone.utils.HikariJDBCUtil.JDBC_URL_REQUIRED_HINT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -57,9 +58,7 @@ class AutoscalerEventHandlerFactoryTest {
         conf.set(EVENT_HANDLER_TYPE, JDBC);
         assertThatThrownBy(() -> AutoscalerEventHandlerFactory.create(conf))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "%s is required when jdbc state store or jdbc event handler is used.",
-                        JDBC_URL.key());
+                .hasMessage(JDBC_URL_REQUIRED_HINT);
     }
 
     @Test

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactoryTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactoryTest.java
@@ -56,7 +56,9 @@ class AutoscalerStateStoreFactoryTest {
         conf.set(STATE_STORE_TYPE, JDBC);
         assertThatThrownBy(() -> AutoscalerStateStoreFactory.create(conf))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("%s is required for jdbc state store.", JDBC_URL.key());
+                .hasMessage(
+                        "%s is required when jdbc state store or jdbc event handler is used.",
+                        JDBC_URL.key());
     }
 
     @Test
@@ -66,14 +68,14 @@ class AutoscalerStateStoreFactoryTest {
         final var conf = new Configuration();
         conf.set(STATE_STORE_TYPE, JDBC);
         conf.set(JDBC_URL, String.format("%s;create=true", jdbcUrl));
-        HikariJDBCUtil.getConnection(conf, "testCreateJdbcStateStore Failed").close();
+        HikariJDBCUtil.getConnection(conf).close();
 
         var stateStore = AutoscalerStateStoreFactory.create(conf);
         assertThat(stateStore).isInstanceOf(JdbcAutoScalerStateStore.class);
 
         try {
             conf.set(JDBC_URL, String.format("%s;shutdown=true", jdbcUrl));
-            HikariJDBCUtil.getConnection(conf, "testCreateJdbcStateStore Failed").close();
+            HikariJDBCUtil.getConnection(conf).close();
         } catch (RuntimeException ignored) {
             // database shutdown ignored exception
         }

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactoryTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactoryTest.java
@@ -28,6 +28,7 @@ import static org.apache.flink.autoscaler.standalone.AutoscalerStateStoreFactory
 import static org.apache.flink.autoscaler.standalone.AutoscalerStateStoreFactory.StateStoreType.MEMORY;
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_URL;
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.STATE_STORE_TYPE;
+import static org.apache.flink.autoscaler.standalone.utils.HikariJDBCUtil.JDBC_URL_REQUIRED_HINT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -56,9 +57,7 @@ class AutoscalerStateStoreFactoryTest {
         conf.set(STATE_STORE_TYPE, JDBC);
         assertThatThrownBy(() -> AutoscalerStateStoreFactory.create(conf))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "%s is required when jdbc state store or jdbc event handler is used.",
-                        JDBC_URL.key());
+                .hasMessage(JDBC_URL_REQUIRED_HINT);
     }
 
     @Test

--- a/flink-autoscaler/pom.xml
+++ b/flink-autoscaler/pom.xml
@@ -57,6 +57,18 @@ under the License.
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
             <version>${quartz.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>HikariCP-java7</artifactId>
+                    <groupId>com.zaxxer</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikari.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@ under the License.
         <assertj.version>3.21.0</assertj.version>
 
         <quartz.version>2.3.2</quartz.version>
+        <hikari.version>5.1.0</hikari.version>
 
         <flink-kubernetes-operator.surefire.baseArgLine>-XX:+IgnoreUnrecognizedVMOptions ${surefire.module.config}</flink-kubernetes-operator.surefire.baseArgLine>
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Autoscaler JDBC Support HikariPool to Replace JDBC DirverManager*


## Brief change log

  - *Add Autoscaler HikariPool Test*
  - *Replace JDBC DirverManager Wiht HikariPool DataSource*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

  - *Added HikariPool Connection Test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
