### PR TITLE
[FLINK-34152] Add an option to scale memory when downscaling

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -81,7 +81,7 @@
             <td>Overhead to add to tuning decisions (0-1). This ensures spare capacity and allows the memory to grow beyond the dynamically computed limits, but never beyond the original memory limits.</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.memory.tuning.scaling.enabled</h5></td>
+            <td><h5>job.autoscaler.memory.tuning.scale-down-compensation.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>If this option is enabled and memory tuning is enabled, TaskManager memory will be increased when scaling down. This ensures that after applying memory tuning there is sufficient memory when running with fewer TaskManagers.</td>

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -84,7 +84,7 @@
             <td><h5>job.autoscaler.memory.tuning.scaling.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>If this option is enabled and memory tuning is enabled, TaskManager heap and managed memory will be increased when scaling down. This ensures that after applying memory tuning there is sufficient memory when running with fewer TaskManagers.</td>
+            <td>If this option is enabled and memory tuning is enabled, TaskManager memory will be increased when scaling down. This ensures that after applying memory tuning there is sufficient memory when running with fewer TaskManagers.</td>
         </tr>
         <tr>
             <td><h5>job.autoscaler.metrics.busy-time.aggregator</h5></td>

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -81,6 +81,12 @@
             <td>Overhead to add to tuning decisions (0-1). This ensures spare capacity and allows the memory to grow beyond the dynamically computed limits, but never beyond the original memory limits.</td>
         </tr>
         <tr>
+            <td><h5>job.autoscaler.memory.tuning.scaling.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>If this option is enabled and memory tuning is enabled, TaskManager heap and managed memory will be increased when scaling down. This ensures that after applying memory tuning there is sufficient memory when running with fewer TaskManagers.</td>
+        </tr>
+        <tr>
             <td><h5>job.autoscaler.metrics.busy-time.aggregator</h5></td>
             <td style="word-wrap: break-word;">MAX</td>
             <td><p>Enum</p></td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -122,7 +122,7 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
         }
 
         var configOverrides =
-                MemoryTuning.tuneTaskManagerHeapMemory(
+                MemoryTuning.tuneTaskManagerMemory(
                         context,
                         evaluatedMetrics,
                         jobTopology,
@@ -130,7 +130,7 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                         autoScalerEventHandler);
 
         if (scalingWouldExceedClusterResources(
-                configOverrides.applyOverrides(conf),
+                configOverrides.newConfigWithOverrides(conf),
                 evaluatedMetrics,
                 scalingSummaries,
                 context)) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -264,7 +264,7 @@ public class AutoScalerOptions {
                     .defaultValue(true)
                     .withFallbackKeys(oldOperatorConfigKey("memory.tuning.scaling.enabled"))
                     .withDescription(
-                            "If this option is enabled and memory tuning is enabled, TaskManager heap and managed memory will be increased when scaling down. This ensures that after applying memory tuning there is sufficient memory when running with fewer TaskManagers.");
+                            "If this option is enabled and memory tuning is enabled, TaskManager memory will be increased when scaling down. This ensures that after applying memory tuning there is sufficient memory when running with fewer TaskManagers.");
 
     public static final ConfigOption<Double> MEMORY_TUNING_OVERHEAD =
             autoScalerConfig("memory.tuning.overhead")

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -258,6 +258,14 @@ public class AutoScalerOptions {
                     .withDescription(
                             "If enabled, the initial amount of memory specified for TaskManagers will be reduced/increased according to the observed needs.");
 
+    public static final ConfigOption<Boolean> MEMORY_SCALING_ENABLED =
+            autoScalerConfig("memory.tuning.scaling.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withFallbackKeys(oldOperatorConfigKey("memory.tuning.scaling.enabled"))
+                    .withDescription(
+                            "If this option is enabled and memory tuning is enabled, TaskManager heap and managed memory will be increased when scaling down. This ensures that after applying memory tuning there is sufficient memory when running with fewer TaskManagers.");
+
     public static final ConfigOption<Double> MEMORY_TUNING_OVERHEAD =
             autoScalerConfig("memory.tuning.overhead")
                     .doubleType()

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -259,10 +259,11 @@ public class AutoScalerOptions {
                             "If enabled, the initial amount of memory specified for TaskManagers will be reduced/increased according to the observed needs.");
 
     public static final ConfigOption<Boolean> MEMORY_SCALING_ENABLED =
-            autoScalerConfig("memory.tuning.scaling.enabled")
+            autoScalerConfig("memory.tuning.scale-down-compensation.enabled")
                     .booleanType()
                     .defaultValue(true)
-                    .withFallbackKeys(oldOperatorConfigKey("memory.tuning.scaling.enabled"))
+                    .withFallbackKeys(
+                            oldOperatorConfigKey("memory.tuning.scale-down-compensation.enabled"))
                     .withDescription(
                             "If this option is enabled and memory tuning is enabled, TaskManager memory will be increased when scaling down. This ensures that after applying memory tuning there is sufficient memory when running with fewer TaskManagers.");
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/ConfigChanges.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/ConfigChanges.java
@@ -56,7 +56,7 @@ public class ConfigChanges {
         return this;
     }
 
-    public Configuration applyOverrides(Configuration existingConfig) {
+    public Configuration newConfigWithOverrides(Configuration existingConfig) {
         Configuration config = new Configuration(existingConfig);
         for (String key : removals) {
             config.removeKey(key);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryScaling.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryScaling.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.tuning;
+
+import org.apache.flink.autoscaler.JobAutoScalerContext;
+import org.apache.flink.autoscaler.ScalingSummary;
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.autoscaler.metrics.EvaluatedMetrics;
+import org.apache.flink.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.autoscaler.utils.ResourceCheckUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Memory scaling ensures that memory is scaled alongside with the number of available TaskManagers.
+ *
+ * <p>When scaling down, TaskManagers are removed which can drastically limit the amount of
+ * available memory. To mitigate this issue, we keep the total cluster memory constant, until we can
+ * measure the actual needed memory usage.
+ *
+ * <p>When scaling up, i.e. adding more TaskManagers, we don't remove memory to ensure that we do
+ * not run into memory-constrained scenarios. However, MemoryTuning will still be applied which can
+ * result in a lower TaskManager memory baseline.
+ */
+public class MemoryScaling {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MemoryScaling.class);
+
+    /**
+     * Scales the amount of memory per TaskManager proportionally to the number of TaskManagers
+     * removed/added.
+     */
+    public static MemorySize applyMemoryScaling(
+            MemorySize currentTotalMemory,
+            MemorySize maxMemoryBySpec,
+            JobAutoScalerContext<?> context,
+            Map<JobVertexID, ScalingSummary> scalingSummaries,
+            EvaluatedMetrics evaluatedMetrics) {
+
+        if (!context.getConfiguration().get(AutoScalerOptions.MEMORY_SCALING_ENABLED)) {
+            return currentTotalMemory;
+        }
+
+        double memScalingFactor =
+                getMemoryScalingFactor(
+                        evaluatedMetrics, scalingSummaries, context.getConfiguration());
+        MemorySize scaledTotalMemory =
+                new MemorySize(
+                        Math.min(
+                                (long) (memScalingFactor * currentTotalMemory.getBytes()),
+                                maxMemoryBySpec.getBytes()));
+
+        LOG.info(
+                "Scaling factor: {}, Adjusting total memory from {} to {}.",
+                memScalingFactor,
+                currentTotalMemory,
+                scaledTotalMemory);
+
+        return scaledTotalMemory;
+    }
+
+    /**
+     * Returns a factor for scaling the total amount of process memory when the number of
+     * TaskManagers change.
+     */
+    private static double getMemoryScalingFactor(
+            EvaluatedMetrics evaluatedMetrics,
+            Map<JobVertexID, ScalingSummary> scalingSummaries,
+            Configuration config) {
+        int numTaskSlotsUsed =
+                (int)
+                        evaluatedMetrics
+                                .getGlobalMetrics()
+                                .get(ScalingMetric.NUM_TASK_SLOTS_USED)
+                                .getCurrent();
+        int numTaskSlotsAfterRescale =
+                ResourceCheckUtils.estimateNumTaskSlotsAfterRescale(
+                        evaluatedMetrics.getVertexMetrics(), scalingSummaries, numTaskSlotsUsed);
+
+        int numTaskSlotsPerTM = config.get(TaskManagerOptions.NUM_TASK_SLOTS);
+
+        int numTMsBeforeRescale = (int) Math.ceil(numTaskSlotsUsed / (double) numTaskSlotsPerTM);
+        int numTMsAfterRescale =
+                (int) Math.ceil(numTaskSlotsAfterRescale / (double) numTaskSlotsPerTM);
+
+        // Only add memory, don't remove any
+        return Math.max(1, numTMsBeforeRescale / (double) numTMsAfterRescale);
+    }
+}

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
@@ -169,6 +169,7 @@ public class MemoryTuning {
         // memory pools, there are no fractional variants for heap memory. Setting the absolute heap
         // memory options could cause invalid configuration states when users adapt the total amount
         // of memory. We also need to take care to remove any user-provided overrides for those.
+        tuningConfig.addRemoval(TaskManagerOptions.TOTAL_FLINK_MEMORY);
         tuningConfig.addRemoval(TaskManagerOptions.TASK_HEAP_MEMORY);
         // Set default to zero because we already account for heap via task heap.
         tuningConfig.addOverride(TaskManagerOptions.FRAMEWORK_HEAP_MEMORY, MemorySize.ZERO);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
@@ -108,9 +108,9 @@ public class MemoryTuning {
             LOG.warn("Spec TaskManager memory size could not be determined.");
             return EMPTY_CONFIG;
         }
-        MemoryBudget memBudget = new MemoryBudget(maxMemoryBySpec.getBytes());
 
-        // Add these current settings from the budget
+        MemoryBudget memBudget = new MemoryBudget(maxMemoryBySpec.getBytes());
+        // Budget the original spec's memory settings which we do not modify
         memBudget.budget(memSpecs.getFlinkMemory().getFrameworkOffHeap().getBytes());
         memBudget.budget(memSpecs.getFlinkMemory().getTaskOffHeap().getBytes());
         memBudget.budget(memSpecs.getJvmOverheadSize().getBytes());
@@ -135,6 +135,7 @@ public class MemoryTuning {
                         specManagedSize,
                         config,
                         memBudget);
+        // Rescale heap according to scaling decision after distributing all memory pools
         newHeapSize =
                 MemoryScaling.applyMemoryScaling(
                         newHeapSize, memBudget, context, scalingSummaries, evaluatedMetrics);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
@@ -238,7 +238,8 @@ public class MemoryTuning {
             long maxManagedMemorySize = memBudget.budget(Long.MAX_VALUE);
             return new MemorySize(maxManagedMemorySize);
         } else {
-            return managedMemoryConfigured;
+            long managedMemorySize = memBudget.budget(managedMemoryConfigured.getBytes());
+            return new MemorySize(managedMemorySize);
         }
     }
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -362,11 +362,11 @@ public class ScalingExecutorTest {
                                 TaskManagerOptions.JVM_METASPACE.key(),
                                 "360 mb",
                                 TaskManagerOptions.JVM_OVERHEAD_FRACTION.key(),
-                                "0.134",
+                                "0.053",
                                 TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(),
                                 "0 bytes",
                                 TaskManagerOptions.TOTAL_PROCESS_MEMORY.key(),
-                                "7864064 kb"));
+                                "20400832696 bytes"));
     }
 
     @ParameterizedTest

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryScalingTest.java
@@ -49,7 +49,7 @@ class MemoryScalingTest {
         int currentParallelism = 20;
         int rescaleParallelism = 10;
         MemorySize currentMemory = MemorySize.parse("10 gb");
-        MemorySize maxMemory = MemorySize.parse("30 gb");
+        MemoryBudget memoryBudget = new MemoryBudget(MemorySize.parse("30 gb").getBytes());
 
         assertThat(
                         runMemoryScaling(
@@ -57,7 +57,7 @@ class MemoryScalingTest {
                                 rescaleParallelism,
                                 context,
                                 currentMemory,
-                                maxMemory))
+                                memoryBudget))
                 .isEqualTo(MemorySize.parse("20 gb"));
     }
 
@@ -66,7 +66,7 @@ class MemoryScalingTest {
         int currentParallelism = 10;
         int rescaleParallelism = 20;
         MemorySize currentMemory = MemorySize.parse("10 gb");
-        MemorySize maxMemory = MemorySize.parse("30 gb");
+        MemoryBudget memoryBudget = new MemoryBudget(MemorySize.parse("30 gb").getBytes());
 
         assertThat(
                         runMemoryScaling(
@@ -74,7 +74,7 @@ class MemoryScalingTest {
                                 rescaleParallelism,
                                 context,
                                 currentMemory,
-                                maxMemory))
+                                memoryBudget))
                 .isEqualTo(MemorySize.parse("10 gb"));
     }
 
@@ -82,11 +82,11 @@ class MemoryScalingTest {
     void testMemoryScalingDisabled() {
         context.getConfiguration().set(AutoScalerOptions.MEMORY_SCALING_ENABLED, false);
         MemorySize currentMemory = MemorySize.parse("10 gb");
-        MemorySize maxMemory = MemorySize.parse("30 gb");
+        MemoryBudget memoryBudget = new MemoryBudget(MemorySize.parse("30 gb").getBytes());
 
         assertThat(
                         MemoryScaling.applyMemoryScaling(
-                                currentMemory, maxMemory, context, Map.of(), null))
+                                currentMemory, memoryBudget, context, Map.of(), null))
                 .isEqualTo(currentMemory);
     }
 
@@ -95,7 +95,7 @@ class MemoryScalingTest {
             int rescaleParallelism,
             JobAutoScalerContext<JobID> context,
             MemorySize currentMemory,
-            MemorySize maxMemory) {
+            MemoryBudget memoryBudget) {
         var globalMetrics =
                 Map.of(
                         ScalingMetric.NUM_TASK_SLOTS_USED,
@@ -124,6 +124,6 @@ class MemoryScalingTest {
                                         currentParallelism, rescaleParallelism, Map.of()));
 
         return MemoryScaling.applyMemoryScaling(
-                currentMemory, maxMemory, context, scalingSummaries, metrics);
+                currentMemory, memoryBudget, context, scalingSummaries, metrics);
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryScalingTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.tuning;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.autoscaler.JobAutoScalerContext;
+import org.apache.flink.autoscaler.ScalingSummary;
+import org.apache.flink.autoscaler.TestingAutoscalerUtils;
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.autoscaler.metrics.EvaluatedMetrics;
+import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
+import org.apache.flink.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemoryScalingTest {
+
+    JobAutoScalerContext<JobID> context = TestingAutoscalerUtils.createResourceAwareContext();
+
+    @BeforeEach
+    void setup() {
+        context.getConfiguration().set(AutoScalerOptions.MEMORY_TUNING_ENABLED, true);
+    }
+
+    @Test
+    void testMemoryScalingDownscaling() {
+        int currentParallelism = 20;
+        int rescaleParallelism = 10;
+        MemorySize currentMemory = MemorySize.parse("10 gb");
+        MemorySize maxMemory = MemorySize.parse("30 gb");
+
+        assertThat(
+                        runMemoryScaling(
+                                currentParallelism,
+                                rescaleParallelism,
+                                context,
+                                currentMemory,
+                                maxMemory))
+                .isEqualTo(MemorySize.parse("20 gb"));
+    }
+
+    @Test
+    void testMemoryScalingUpscaling() {
+        int currentParallelism = 10;
+        int rescaleParallelism = 20;
+        MemorySize currentMemory = MemorySize.parse("10 gb");
+        MemorySize maxMemory = MemorySize.parse("30 gb");
+
+        assertThat(
+                        runMemoryScaling(
+                                currentParallelism,
+                                rescaleParallelism,
+                                context,
+                                currentMemory,
+                                maxMemory))
+                .isEqualTo(MemorySize.parse("10 gb"));
+    }
+
+    @Test
+    void testMemoryScalingDisabled() {
+        context.getConfiguration().set(AutoScalerOptions.MEMORY_SCALING_ENABLED, false);
+        MemorySize currentMemory = MemorySize.parse("10 gb");
+        MemorySize maxMemory = MemorySize.parse("30 gb");
+
+        assertThat(
+                        MemoryScaling.applyMemoryScaling(
+                                currentMemory, maxMemory, context, Map.of(), null))
+                .isEqualTo(currentMemory);
+    }
+
+    private static MemorySize runMemoryScaling(
+            int currentParallelism,
+            int rescaleParallelism,
+            JobAutoScalerContext<JobID> context,
+            MemorySize currentMemory,
+            MemorySize maxMemory) {
+        var globalMetrics =
+                Map.of(
+                        ScalingMetric.NUM_TASK_SLOTS_USED,
+                        EvaluatedScalingMetric.of(currentParallelism));
+        var jobVertex1 = new JobVertexID();
+        var jobVertex2 = new JobVertexID();
+        var vertexMetrics =
+                Map.of(
+                        jobVertex1,
+                                Map.of(
+                                        ScalingMetric.PARALLELISM,
+                                        EvaluatedScalingMetric.of(currentParallelism)),
+                        jobVertex2,
+                                Map.of(
+                                        ScalingMetric.PARALLELISM,
+                                        EvaluatedScalingMetric.of(currentParallelism)));
+        var metrics = new EvaluatedMetrics(vertexMetrics, globalMetrics);
+
+        Map<JobVertexID, ScalingSummary> scalingSummaries =
+                Map.of(
+                        jobVertex1,
+                                new ScalingSummary(
+                                        currentParallelism, rescaleParallelism, Map.of()),
+                        jobVertex2,
+                                new ScalingSummary(
+                                        currentParallelism, rescaleParallelism, Map.of()));
+
+        return MemoryScaling.applyMemoryScaling(
+                currentMemory, maxMemory, context, scalingSummaries, metrics);
+    }
+}

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryTuningTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryTuningTest.java
@@ -202,11 +202,11 @@ public class MemoryTuningTest {
                                 TaskManagerOptions.JVM_METASPACE.key(),
                                 "120 mb",
                                 TaskManagerOptions.JVM_OVERHEAD_FRACTION.key(),
-                                "0.07",
+                                "0.076",
                                 TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(),
                                 "0 bytes",
                                 TaskManagerOptions.TOTAL_PROCESS_MEMORY.key(),
-                                "15520261734 bytes"));
+                                "14172382822 bytes"));
 
         // Test tuning disabled
         config.set(AutoScalerOptions.MEMORY_TUNING_ENABLED, false);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryTuningTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryTuningTest.java
@@ -55,6 +55,7 @@ public class MemoryTuningTest {
         var context = TestingAutoscalerUtils.createResourceAwareContext();
         var config = context.getConfiguration();
         config.set(AutoScalerOptions.MEMORY_TUNING_ENABLED, true);
+        config.set(AutoScalerOptions.MEMORY_SCALING_ENABLED, false);
         config.set(TaskManagerOptions.NUM_TASK_SLOTS, 5);
         config.set(AutoScalerOptions.SCALING_EVENT_INTERVAL, Duration.ZERO);
         MemorySize totalMemory = MemorySize.parse("30 gb");
@@ -82,7 +83,9 @@ public class MemoryTuningTest {
                         ScalingMetric.MANAGED_MEMORY_USED,
                         EvaluatedScalingMetric.avg(MemorySize.ofMebiBytes(10000).getBytes()),
                         ScalingMetric.METASPACE_MEMORY_USED,
-                        EvaluatedScalingMetric.avg(MemorySize.ofMebiBytes(100).getBytes()));
+                        EvaluatedScalingMetric.avg(MemorySize.ofMebiBytes(100).getBytes()),
+                        ScalingMetric.NUM_TASK_SLOTS_USED,
+                        EvaluatedScalingMetric.of(50));
 
         var metrics = new EvaluatedMetrics(vertexMetrics, globalMetrics);
 
@@ -98,7 +101,7 @@ public class MemoryTuningTest {
                         jobVertex2, new ScalingSummary(50, 10, Map.of()));
 
         ConfigChanges configChanges =
-                MemoryTuning.tuneTaskManagerHeapMemory(
+                MemoryTuning.tuneTaskManagerMemory(
                         context, metrics, jobTopology, scalingSummaries, eventHandler);
         // Test reducing overall memory
         assertThat(configChanges.getOverrides())
@@ -136,7 +139,7 @@ public class MemoryTuningTest {
         // Test maximize managed memory
         config.set(AutoScalerOptions.MEMORY_TUNING_MAXIMIZE_MANAGED_MEMORY, true);
         configChanges =
-                MemoryTuning.tuneTaskManagerHeapMemory(
+                MemoryTuning.tuneTaskManagerMemory(
                         context, metrics, jobTopology, scalingSummaries, eventHandler);
         assertThat(configChanges.getOverrides())
                 .containsExactlyInAnyOrderEntriesOf(
@@ -161,7 +164,7 @@ public class MemoryTuningTest {
         metrics.getGlobalMetrics()
                 .put(ScalingMetric.MANAGED_MEMORY_USED, EvaluatedScalingMetric.avg(0));
         configChanges =
-                MemoryTuning.tuneTaskManagerHeapMemory(
+                MemoryTuning.tuneTaskManagerMemory(
                         context, metrics, jobTopology, scalingSummaries, eventHandler);
         assertThat(configChanges.getOverrides())
                 .containsExactlyInAnyOrderEntriesOf(
@@ -181,10 +184,33 @@ public class MemoryTuningTest {
                                 TaskManagerOptions.TOTAL_PROCESS_MEMORY.key(),
                                 "7760130867 bytes"));
 
+        // Test integration with MemoryScaling
+        config.set(AutoScalerOptions.MEMORY_SCALING_ENABLED, true);
+        configChanges =
+                MemoryTuning.tuneTaskManagerMemory(
+                        context, metrics, jobTopology, scalingSummaries, eventHandler);
+        assertThat(configChanges.getOverrides())
+                .containsExactlyInAnyOrderEntriesOf(
+                        Map.of(
+                                TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(),
+                                "0.0",
+                                TaskManagerOptions.NETWORK_MEMORY_MIN.key(),
+                                "13760 kb",
+                                TaskManagerOptions.NETWORK_MEMORY_MAX.key(),
+                                "13760 kb",
+                                TaskManagerOptions.JVM_METASPACE.key(),
+                                "120 mb",
+                                TaskManagerOptions.JVM_OVERHEAD_FRACTION.key(),
+                                "0.07",
+                                TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(),
+                                "0 bytes",
+                                TaskManagerOptions.TOTAL_PROCESS_MEMORY.key(),
+                                "15520261734 bytes"));
+
         // Test tuning disabled
         config.set(AutoScalerOptions.MEMORY_TUNING_ENABLED, false);
         assertThat(
-                        MemoryTuning.tuneTaskManagerHeapMemory(
+                        MemoryTuning.tuneTaskManagerMemory(
                                         context,
                                         metrics,
                                         jobTopology,

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryTuningTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryTuningTest.java
@@ -116,11 +116,11 @@ public class MemoryTuningTest {
                                 TaskManagerOptions.JVM_METASPACE.key(),
                                 "120 mb",
                                 TaskManagerOptions.JVM_OVERHEAD_FRACTION.key(),
-                                "0.139",
+                                "0.054",
                                 TaskManagerOptions.FRAMEWORK_HEAP_MEMORY.key(),
                                 "0 bytes",
                                 TaskManagerOptions.TOTAL_PROCESS_MEMORY.key(),
-                                "7760130867 bytes"));
+                                "20108162027 bytes"));
 
         assertThat(configChanges.getRemovals())
                 .containsExactlyInAnyOrder(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryTuningTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/tuning/MemoryTuningTest.java
@@ -124,6 +124,7 @@ public class MemoryTuningTest {
 
         assertThat(configChanges.getRemovals())
                 .containsExactlyInAnyOrder(
+                        TaskManagerOptions.TOTAL_FLINK_MEMORY.key(),
                         TaskManagerOptions.TASK_HEAP_MEMORY.key(),
                         TaskManagerOptions.MANAGED_MEMORY_SIZE.key(),
                         TaskManagerOptions.MANAGED_MEMORY_SIZE


### PR DESCRIPTION
This adds an option to increase heap and managed memory when removing TaskManagers. The scaling is applied after adjusting the memory pools (heap, metaspace, network, managed) and only affects heap memory.

The reason for adding this functionality is that the likelihood of running into memory constrained scenarios when downscaling is increased after applying memory tuning. As a precaution, we temporarily increase the total cluster
memory proportionally to the removed TaskManagers up to the maximum allowed TaskManager memory.