### PR TITLE
[FLINK-34566] Pass a FixedThreadPool to set reconciliation parallelism correctly

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -137,7 +137,7 @@ public class FlinkOperator {
             overrider.withExecutorService(Executors.newCachedThreadPool());
         } else {
             LOG.info("Configuring operator with {} reconciliation threads.", parallelism);
-            overrider.withConcurrentReconciliationThreads(parallelism);
+            overrider.withExecutorService(Executors.newFixedThreadPool(parallelism));
         }
 
         if (operatorConf.isJosdkMetricsEnabled()) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
@@ -70,10 +70,21 @@ public class FlinkOperatorTest {
 
         var configService = testOperator.getOperator().getConfigurationService();
 
-        // Test parallelism being passed
+        // Test parallelism being passed expectedly
         var executorService = configService.getExecutorService();
         Assertions.assertInstanceOf(ThreadPoolExecutor.class, executorService);
         ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executorService;
+        for (int i = 0; i < testParallelism * 2; i++) {
+            threadPoolExecutor.execute(
+                    () -> {
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    });
+        }
+        Assertions.assertEquals(threadPoolExecutor.getPoolSize(), testParallelism);
         Assertions.assertEquals(threadPoolExecutor.getMaximumPoolSize(), testParallelism);
 
         // Test label selector being passed


### PR DESCRIPTION
## What is the purpose of the change

This pull request pass a fixed size thread pool to JOSDK, so that we can set a large reconciliation parallelism as we except .

## Brief change log

- set a fixed size thread pool as reconciliation executor in  JOSDK configuration

## Verifying this change

This change added tests and can be verified as follows:

*org.apache.flink.kubernetes.operator.FlinkOperatorTest#testConfigurationPassedToJOSDK:*
  - *Extended check logic about reconciliation thread pool creation *


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: ( no)
  - Core observer or reconciler logic that is regularly executed: ( yes)

## Documentation

  - Does this pull request introduce a new feature? ( no)