### PR TITLE
[FLINK-34524] Scale down JM deployment to 0 before deletion

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -106,7 +106,7 @@ public class FlinkDeploymentController
         var ctx = ctxFactory.getResourceContext(flinkApp, josdkContext);
         try {
             observerFactory.getOrCreate(flinkApp).observe(ctx);
-        } catch (DeploymentFailedException dfe) {
+        } catch (Exception err) {
             // ignore during cleanup
         }
         statusRecorder.removeCachedStatus(flinkApp);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -139,8 +139,7 @@ public class ApplicationReconciler
         deployment.getStatus().getJobStatus().setState(JobStatus.FAILED.name());
         flinkService.deleteClusterDeployment(
                 deployment.getMetadata(), deployment.getStatus(), deployConfig, false);
-        flinkService.waitForClusterShutdown(deployConfig);
-        LOG.info("Deleted jobmanager deployment that never started.");
+        LOG.info("Deleted application cluster that never started.");
     }
 
     @Override
@@ -170,10 +169,9 @@ public class ApplicationReconciler
 
         if (status.getJobManagerDeploymentStatus() != JobManagerDeploymentStatus.MISSING) {
             Preconditions.checkArgument(ReconciliationUtils.isJobInTerminalState(status));
-            LOG.info("Deleting deployment with terminated application before new deployment");
+            LOG.info("Deleting cluster with terminated application before new deployment");
             flinkService.deleteClusterDeployment(
                     relatedResource.getMetadata(), status, deployConfig, !requireHaMetadata);
-            flinkService.waitForClusterShutdown(deployConfig);
             statusRecorder.patchAndCacheStatus(relatedResource, ctx.getKubernetesClient());
         }
 
@@ -238,7 +236,6 @@ public class ApplicationReconciler
         var conf = ctx.getDeployConfig(ctx.getResource().getSpec());
         flinkService.deleteClusterDeployment(
                 ctx.getResource().getMetadata(), ctx.getResource().getStatus(), conf, false);
-        flinkService.waitForClusterShutdown(conf);
     }
 
     // Workaround for https://issues.apache.org/jira/browse/FLINK-27569

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -85,7 +85,6 @@ public class SessionReconciler
         ctx.getFlinkService()
                 .deleteClusterDeployment(
                         deployment.getMetadata(), deployment.getStatus(), conf, false);
-        ctx.getFlinkService().waitForClusterShutdown(ctx.getObserveConfig());
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -118,8 +118,6 @@ public interface FlinkService {
 
     PodList getJmPodList(FlinkDeployment deployment, Configuration conf);
 
-    void waitForClusterShutdown(Configuration conf);
-
     ScalingResult scale(FlinkResourceContext<?> resourceContext, Configuration deployConfig)
             throws Exception;
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -76,13 +76,16 @@ import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import lombok.Getter;
 import lombok.Setter;
 
 import javax.annotation.Nullable;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -484,16 +487,22 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     @Override
     protected void deleteClusterInternal(
-            ObjectMeta meta,
+            String namespace,
+            String clusterId,
             Configuration conf,
-            boolean deleteHaMeta,
             DeletionPropagation deletionPropagation) {
         jobs.clear();
-        sessions.remove(meta.getName());
+        sessions.remove(clusterId);
     }
 
     @Override
-    public void waitForClusterShutdown(Configuration conf) {}
+    protected Duration deleteDeploymentBlocking(
+            String name,
+            Resource<Deployment> deployment,
+            DeletionPropagation propagation,
+            Duration timeout) {
+        return timeout;
+    }
 
     @Override
     public void disposeSavepoint(String savepointPath, Configuration conf) {
@@ -627,10 +636,5 @@ public class TestingFlinkService extends AbstractFlinkService {
     @Override
     public JobDetailsInfo getJobDetailsInfo(JobID jobID, Configuration conf) {
         return NativeFlinkServiceTest.createJobDetailsFor(List.of());
-    }
-
-    @Override
-    protected List<String> getDeploymentNames(String namespace, String clusterId) {
-        return List.of(clusterId + "-deployment");
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -74,7 +74,6 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.JobVertexResourceRequirements;
 import org.apache.flink.util.concurrent.Executors;
 
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -1027,12 +1026,9 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
         flinkService =
                 new TestingFlinkService() {
                     @Override
-                    protected void deleteClusterInternal(
-                            ObjectMeta meta,
-                            Configuration conf,
-                            boolean deleteHaMeta,
-                            DeletionPropagation deletionPropagation) {
-                        deleted.set(deleteHaMeta);
+                    protected void deleteHAData(
+                            String namespace, String clusterId, Configuration conf) {
+                        deleted.set(true);
                     }
                 };
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -97,7 +97,8 @@ public class StandaloneFlinkServiceTest {
                 new Configuration(),
                 false);
 
-        assertEquals(2, mockServer.getRequestCount() - requestsBeforeDelete);
+        assertEquals(4, mockServer.getRequestCount() - requestsBeforeDelete);
+
         assertTrue(mockServer.getLastRequest().getPath().contains("taskmanager"));
 
         deployments = kubernetesClient.apps().deployments().list().getItems();
@@ -118,9 +119,6 @@ public class StandaloneFlinkServiceTest {
                 flinkDeployment.getStatus(),
                 new Configuration(),
                 true);
-
-        // How many times were getDeploymentNames() called
-        assertEquals(1, service.nbCall);
 
         deployments = kubernetesClient.apps().deployments().list().getItems();
 
@@ -269,7 +267,6 @@ public class StandaloneFlinkServiceTest {
 
     class TestingStandaloneFlinkService extends StandaloneFlinkService {
         Configuration runtimeConfig;
-        int nbCall = 0;
 
         public TestingStandaloneFlinkService(StandaloneFlinkService service) {
             super(
@@ -286,12 +283,6 @@ public class StandaloneFlinkServiceTest {
         @Override
         protected void submitClusterInternal(Configuration conf, Mode mode) {
             this.runtimeConfig = conf;
-        }
-
-        @Override
-        protected List<String> getDeploymentNames(String namespace, String clusterId) {
-            nbCall++;
-            return List.of(clusterId);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

We recently improved the JM deployment deletion mechanism, however it seems like task manager pod deletion can get stuck sometimes for a couple of minutes in native mode if we simply try to delete everything at once.

It speeds up the process and leads to cleaner shutdown if we scale down the JM deployment to 0 (shutting down the JM pods first) and then perform the deletion.

## Verifying this change

 - Manually verified in local Kube env
 - E2Es
 - Unit tests 
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no