### PR TITLE
[FLINK-34619] Do not wait for scaling completion in UPGRADE state with in-place scaling

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/ReconciliationStatus.java
@@ -101,7 +101,15 @@ public abstract class ReconciliationStatus<SPEC extends AbstractFlinkSpec> {
         return lastReconciledSpec == null;
     }
 
+    /**
+     * This method is only here for backward compatibility reasons. The current version of the
+     * operator does not leave the resources in UPGRADING state during in-place scaling therefore
+     * this method will always return false.
+     *
+     * @return True if in-place scaling is in progress.
+     */
     @JsonIgnore
+    @Deprecated
     public boolean scalingInProgress() {
         if (isBeforeFirstDeployment() || state != ReconciliationState.UPGRADING) {
             return false;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
@@ -78,9 +78,8 @@ public abstract class AbstractFlinkResourceObserver<CR extends AbstractFlinkReso
             // We must check if the upgrade went through without the status upgrade for some reason
 
             if (reconciliationStatus.scalingInProgress()) {
-                if (ctx.getFlinkService().scalingCompleted(ctx)) {
-                    reconciliationStatus.setState(ReconciliationState.DEPLOYED);
-                }
+                // Keep this for backward compatibility
+                reconciliationStatus.setState(ReconciliationState.DEPLOYED);
             } else if (checkIfAlreadyUpgraded(ctx)) {
                 ReconciliationUtils.updateStatusForAlreadyUpgraded(resource);
             } else {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -39,7 +39,6 @@ import org.apache.flink.kubernetes.operator.api.utils.SpecUtils;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.exception.ValidationException;
-import org.apache.flink.kubernetes.operator.service.FlinkService;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
@@ -111,7 +110,8 @@ public class ReconciliationUtils {
         updateStatusBeforeDeploymentAttempt(target, conf, Clock.systemDefaultZone());
     }
 
-    private static <SPEC extends AbstractFlinkSpec> void updateStatusForSpecReconciliation(
+    @VisibleForTesting
+    public static <SPEC extends AbstractFlinkSpec> void updateStatusForSpecReconciliation(
             AbstractFlinkResource<SPEC, ?> target,
             JobState stateAfterReconcile,
             Configuration conf,
@@ -179,24 +179,6 @@ public class ReconciliationUtils {
                 reconciliationStatus.serializeAndSetLastReconciledSpec(clonedSpec, target);
             }
         }
-    }
-
-    public static <SPEC extends AbstractFlinkSpec> void updateAfterScaleUp(
-            AbstractFlinkResource<SPEC, ?> target,
-            Configuration deployConfig,
-            Clock clock,
-            FlinkService.ScalingResult scalingResult) {
-
-        var reconState = target.getStatus().getReconciliationStatus().getState();
-        // We mark the spec reconciled, and set state upgrading only if it was already upgrading or
-        // we actually triggered a new scale up
-        ReconciliationUtils.updateStatusForSpecReconciliation(
-                target,
-                JobState.RUNNING,
-                deployConfig,
-                reconState == ReconciliationState.UPGRADING
-                        || scalingResult == FlinkService.ScalingResult.SCALING_TRIGGERED,
-                clock);
     }
 
     public static <SPEC extends AbstractFlinkSpec> void updateLastReconciledSnapshotTriggerNonce(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -69,7 +69,6 @@ import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointStatusHeader
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointStatusMessageParameters;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointTriggerHeaders;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointTriggerRequestBody;
-import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.metrics.JobMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalRequest;
 import org.apache.flink.runtime.rest.messages.job.savepoints.SavepointDisposalTriggerHeaders;
@@ -884,16 +883,6 @@ public abstract class AbstractFlinkService implements FlinkService {
                     .get(operatorConfig.getFlinkClientTimeout().toSeconds(), TimeUnit.SECONDS);
         } catch (Exception e) {
             LOG.error("Failed to delete the jar: {}.", jarId, e);
-        }
-    }
-
-    @Override
-    public JobDetailsInfo getJobDetailsInfo(JobID jobID, Configuration conf) throws Exception {
-
-        try (var restClient = getClusterClient(conf)) {
-            return restClient
-                    .getJobDetails(jobID)
-                    .get(operatorConfig.getFlinkClientTimeout().toSeconds(), TimeUnit.SECONDS);
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -36,7 +36,6 @@ import org.apache.flink.kubernetes.operator.observer.CheckpointFetchResult;
 import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.jobmaster.JobResult;
-import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -118,25 +117,11 @@ public interface FlinkService {
 
     PodList getJmPodList(FlinkDeployment deployment, Configuration conf);
 
-    ScalingResult scale(FlinkResourceContext<?> resourceContext, Configuration deployConfig)
+    boolean scale(FlinkResourceContext<?> resourceContext, Configuration deployConfig)
             throws Exception;
-
-    boolean scalingCompleted(FlinkResourceContext<?> resourceContext);
 
     Map<String, String> getMetrics(Configuration conf, String jobId, List<String> metricNames)
             throws Exception;
 
     RestClusterClient<String> getClusterClient(Configuration conf) throws Exception;
-
-    JobDetailsInfo getJobDetailsInfo(JobID jobID, Configuration conf) throws Exception;
-
-    /** Result of an in-place scaling operation. */
-    enum ScalingResult {
-        // Scaling triggered by the operation
-        SCALING_TRIGGERED,
-        // Job already scaled to target previously
-        ALREADY_SCALED,
-        // Cannot execute scaling, full upgrade required
-        CANNOT_SCALE;
-    }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -50,7 +50,6 @@ import org.apache.flink.kubernetes.operator.observer.CheckpointFetchResult;
 import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
 import org.apache.flink.kubernetes.operator.service.AbstractFlinkService;
 import org.apache.flink.kubernetes.operator.service.CheckpointHistoryWrapper;
-import org.apache.flink.kubernetes.operator.service.NativeFlinkServiceTest;
 import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfigOptionsInternal;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.execution.ExecutionState;
@@ -65,7 +64,6 @@ import org.apache.flink.runtime.messages.webmonitor.MultipleJobsDetails;
 import org.apache.flink.runtime.rest.messages.DashboardConfiguration;
 import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
 import org.apache.flink.runtime.rest.messages.JobsOverviewHeaders;
-import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetric;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetricsResponseBody;
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedSubtaskMetricsHeaders;
@@ -147,8 +145,6 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     @Setter
     private Collection<AggregatedMetric> aggregatedMetricsResponse = Collections.emptyList();
-
-    @Setter private boolean scalingCompleted;
 
     public TestingFlinkService() {
         this(null);
@@ -599,7 +595,7 @@ public class TestingFlinkService extends AbstractFlinkService {
     }
 
     @Override
-    public ScalingResult scale(FlinkResourceContext<?> ctx, Configuration deployConfig) {
+    public boolean scale(FlinkResourceContext<?> ctx, Configuration deployConfig) {
         boolean standalone = ctx.getDeploymentMode() == KubernetesDeploymentMode.STANDALONE;
         boolean session = ctx.getResource().getSpec().getJob() == null;
         boolean reactive =
@@ -612,15 +608,10 @@ public class TestingFlinkService extends AbstractFlinkService {
                             .get(
                                     StandaloneKubernetesConfigOptionsInternal
                                             .KUBERNETES_TASKMANAGER_REPLICAS);
-            return ScalingResult.SCALING_TRIGGERED;
+            return true;
         }
 
-        return ScalingResult.CANNOT_SCALE;
-    }
-
-    @Override
-    public boolean scalingCompleted(FlinkResourceContext<?> resourceContext) {
-        return scalingCompleted;
+        return false;
     }
 
     public void setMetricValue(String name, String value) {
@@ -631,10 +622,5 @@ public class TestingFlinkService extends AbstractFlinkService {
     public Map<String, String> getMetrics(
             Configuration conf, String jobId, List<String> metricNames) {
         return metricsValues;
-    }
-
-    @Override
-    public JobDetailsInfo getJobDetailsInfo(JobID jobID, Configuration conf) {
-        return NativeFlinkServiceTest.createJobDetailsFor(List.of());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -1278,12 +1278,7 @@ public class AbstractFlinkServiceTest {
         }
 
         @Override
-        public ScalingResult scale(FlinkResourceContext<?> resourceContext, Configuration conf) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean scalingCompleted(FlinkResourceContext<?> resourceContext) {
+        public boolean scale(FlinkResourceContext<?> resourceContext, Configuration conf) {
             throw new UnsupportedOperationException();
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkServiceTest.java
@@ -150,8 +150,7 @@ public class StandaloneFlinkServiceTest {
                                 TestUtils.createTestMetricGroup(new Configuration()),
                                 null)
                         .getResourceContext(flinkDeployment, TestUtils.createEmptyContext());
-        assertEquals(
-                FlinkService.ScalingResult.SCALING_TRIGGERED,
+        assertTrue(
                 flinkStandaloneService.scale(ctx, ctx.getDeployConfig(flinkDeployment.getSpec())));
         assertEquals(
                 5,
@@ -181,8 +180,7 @@ public class StandaloneFlinkServiceTest {
 
         // Add replicas and verify that the scaling is not honoured as reactive mode not enabled
         flinkDeployment.getSpec().getTaskManager().setReplicas(10);
-        assertEquals(
-                FlinkService.ScalingResult.CANNOT_SCALE,
+        assertFalse(
                 flinkStandaloneService.scale(ctx, ctx.getDeployConfig(flinkDeployment.getSpec())));
     }
 
@@ -210,8 +208,7 @@ public class StandaloneFlinkServiceTest {
                                 TestUtils.createTestMetricGroup(new Configuration()),
                                 null)
                         .getResourceContext(flinkDeployment, TestUtils.createEmptyContext());
-        assertEquals(
-                FlinkService.ScalingResult.SCALING_TRIGGERED,
+        assertTrue(
                 flinkStandaloneService.scale(ctx, ctx.getDeployConfig(flinkDeployment.getSpec())));
 
         assertEquals(
@@ -228,8 +225,7 @@ public class StandaloneFlinkServiceTest {
         // Scale the replica count of the task managers
         flinkDeployment.getSpec().getTaskManager().setReplicas(10);
         createDeployments(flinkDeployment);
-        assertEquals(
-                FlinkService.ScalingResult.SCALING_TRIGGERED,
+        assertTrue(
                 flinkStandaloneService.scale(ctx, ctx.getDeployConfig(flinkDeployment.getSpec())));
 
         assertEquals(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -24,12 +24,9 @@ import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
-import org.apache.flink.kubernetes.operator.service.FlinkService;
 
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import org.junit.jupiter.api.Test;
-
-import java.time.Clock;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -66,24 +63,6 @@ public class ReconciliationUtilsTest {
         assertFalse(updateControl.isUpdateResource());
         assertFalse(updateControl.isUpdateStatus());
         assertNotEquals(0, updateControl.getScheduleDelay().get());
-    }
-
-    @Test
-    public void testRescheduleDuringScaling() {
-        FlinkDeployment app = BaseTestUtils.buildApplicationCluster();
-        app.getSpec().getJob().setState(JobState.RUNNING);
-        app.getStatus().getReconciliationStatus().setState(ReconciliationState.DEPLOYED);
-        var previous = ReconciliationUtils.clone(app);
-        ReconciliationUtils.updateAfterScaleUp(
-                app,
-                new Configuration(),
-                Clock.systemDefaultZone(),
-                FlinkService.ScalingResult.SCALING_TRIGGERED);
-
-        var updateControl =
-                ReconciliationUtils.toUpdateControl(operatorConfiguration, app, previous, true);
-
-        assertTrue(updateControl.getScheduleDelay().get() > 0);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

The operator currently puts the resource into upgrading state after triggering in-place scaling and keeps observing until the desired parallelism is reached before moving to deployed / stable. 

However this means that due to how the adaptive scheduler works this parallelism may never be reached and this is expected.

We should simplify the logic to consider scaling "done" once the resource requirements have been set correctly and then leave the rest to the adaptive scheduler

## Brief change log

  - *Remove complex logic around in-place, triggering and UPGRADING state*
  - *Remove observing logic for in progress scaling*
  - *Make sure we are backward compatible*

## Verifying this change

Unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
