### PR TITLE
[hotfix] Minor autoscaler event and metric improvements

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -235,19 +235,10 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
                 AutoScalerEventHandler.Type.Normal,
                 INEFFECTIVE_SCALING,
                 message,
-                null,
+                "ineffective" + vertex + expectedIncrease,
                 conf.get(SCALING_EVENT_INTERVAL));
 
-        if (blockIneffectiveScalings) {
-            LOG.warn(
-                    "Ineffective scaling detected for {}, expected increase {}, actual {}",
-                    vertex,
-                    expectedIncrease,
-                    actualIncrease);
-            return true;
-        } else {
-            return false;
-        }
+        return blockIneffectiveScalings;
     }
 
     /**

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -546,6 +546,11 @@ public class JobVertexScalerTest {
         assertEquals(1, event.getCount());
 
         // Repeat ineffective scale with default interval, no event is triggered
+        // We slightly modify the computed tpr to simulate changing metrics
+        var tpr = evaluated.get(ScalingMetric.TRUE_PROCESSING_RATE);
+        evaluated.put(
+                ScalingMetric.TRUE_PROCESSING_RATE,
+                EvaluatedScalingMetric.avg(tpr.getAverage() + 0.01));
         assertEquals(
                 20,
                 vertexScaler.computeScaleTargetParallelism(
@@ -557,6 +562,9 @@ public class JobVertexScalerTest {
                         restartTime));
         assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         assertEquals(0, eventCollector.events.size());
+
+        // reset tpr
+        evaluated.put(ScalingMetric.TRUE_PROCESSING_RATE, tpr);
 
         // Repeat ineffective scale with postive interval, no event is triggered
         conf.set(AutoScalerOptions.SCALING_EVENT_INTERVAL, Duration.ofSeconds(1800));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/IOMetricsInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/job/metrics/IOMetricsInfo.java
@@ -140,15 +140,15 @@ public final class IOMetricsInfo {
     }
 
     public long getAccumulatedBackpressured() {
-        return accumulatedBackpressured;
+        return accumulatedBackpressured != null ? accumulatedBackpressured : 0;
     }
 
     public double getAccumulatedBusy() {
-        return accumulatedBusy;
+        return accumulatedBusy != null ? accumulatedBusy : Double.NaN;
     }
 
     public long getAccumulatedIdle() {
-        return accumulatedIdle;
+        return accumulatedIdle != null ? accumulatedIdle : 0;
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/runtime/rest/messages/job/metrics/IOMetricsInfoTest.java
+++ b/flink-kubernetes-operator/src/test/java/runtime/rest/messages/job/metrics/IOMetricsInfoTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package runtime.rest.messages.job.metrics;
+
+import org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for {@link org.apache.flink.runtime.rest.messages.job.metrics.IOMetricsInfo}. */
+public class IOMetricsInfoTest {
+
+    @Test
+    void testNullableAggregatedMetrics() {
+        var info1 = new IOMetricsInfo(0, false, 0, false, 0, false, 0, false, 1L, 2L, 3.4);
+        assertEquals(1, info1.getAccumulatedBackpressured());
+        assertEquals(2, info1.getAccumulatedIdle());
+        assertEquals(3.4, info1.getAccumulatedBusy());
+        var info2 = new IOMetricsInfo(0, false, 0, false, 0, false, 0, false, null, null, null);
+        assertEquals(0, info2.getAccumulatedBackpressured());
+        assertEquals(0, info2.getAccumulatedIdle());
+        assertEquals(Double.NaN, info2.getAccumulatedBusy());
+    }
+}


### PR DESCRIPTION
## Brief change log

  - *Set the proper key for ineffective event triggering to avoid spamming the user with events*
  - *Handle missing aggregated busy metrics gracefully in IOMetricsInfo for Flink 1.15*

## Verifying this change

Unit tests added

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
