### PR TITLE
[FLINK-34152][autoscaler] Refactor the MemoryTuning to avoid the huge method

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/TuningSimpleMemorySpec.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/TuningSimpleMemorySpec.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.tuning;
+
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.util.config.memory.CommonProcessMemorySpec;
+import org.apache.flink.runtime.util.config.memory.taskmanager.TaskExecutorFlinkMemory;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/** The task manager memory spec for memory tuning. */
+@AllArgsConstructor
+@Getter
+public class TuningSimpleMemorySpec {
+
+    private final MemorySize heapSize;
+    private final MemorySize managedSize;
+    private final MemorySize networkSize;
+    private final MemorySize metaspaceSize;
+
+    public TuningSimpleMemorySpec(CommonProcessMemorySpec<TaskExecutorFlinkMemory> memSpecs) {
+        this(
+                memSpecs.getFlinkMemory().getJvmHeapMemorySize(),
+                memSpecs.getFlinkMemory().getManaged(),
+                memSpecs.getFlinkMemory().getNetwork(),
+                memSpecs.getJvmMetaspaceSize());
+    }
+
+    @Override
+    public String toString() {
+        return "TuningSimpleMemorySpec {"
+                + "heap="
+                + heapSize.toHumanReadableString()
+                + ", managed="
+                + managedSize.toHumanReadableString()
+                + ", network="
+                + networkSize.toHumanReadableString()
+                + ", metaspace="
+                + metaspaceSize.toHumanReadableString()
+                + '}';
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

MemoryTuning#tuneTaskManagerMemory method is too long, the code line number is  135.

https://github.com/apache/flink-kubernetes-operator/blob/726e484c6a9b4121563829bc094b3eebeb8ddcf3/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java#L80


## Brief change log

- [FLINK-34152][autoscaler] Refactor the MemoryTuning to avoid the huge method
  - Extracted some detailed implementations to the separate method.

After refactor, the code line number is changed from 135 to 53.
