### PR TITLE
[FLINK-34743][autoscaler] Memory tuning takes effect even if the parallelism isn't changed

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -214,11 +214,11 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
             return;
         }
 
-        var parallelismChanged =
+        var parallelismOrConfChanged =
                 scalingExecutor.scaleResource(
                         ctx, evaluatedMetrics, scalingHistory, scalingTracking, now, jobTopology);
 
-        if (parallelismChanged) {
+        if (parallelismOrConfChanged) {
             autoscalerMetrics.incrementScaling();
         } else {
             autoscalerMetrics.incrementBalanced();

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/ConfigChanges.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/ConfigChanges.java
@@ -27,6 +27,7 @@ import lombok.Getter;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /** Holds the configuration overrides and removals for a Flink Configuration. */
@@ -63,5 +64,22 @@ public class ConfigChanges {
         }
         config.addAll(Configuration.fromMap(overrides));
         return config;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConfigChanges that = (ConfigChanges) o;
+        return Objects.equals(overrides, that.overrides) && Objects.equals(removals, that.removals);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(overrides, removals);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, the memory tuning related logic is only called when the parallelism is changed.

See ScalingExecutor#scaleResource to get more details.

It's better to let the memory tuning takes effect even if the parallelism isn't changed. For example, one flink job runs with desired parallelisms, but it wastes memory.


## Brief change log

[FLINK-34743][autoscaler] Memory tuning takes effect even if the parallelism isn't changed

- Do scaling when parallelism or memory configuration is changed.

## Verifying this change

Manually test done.

The unit test is writing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed:  no

## Documentation

  - Does this pull request introduce a new feature? no

