### PR TITLE
[FLINK-34744][autoscaler] Fix the issue that autoscaling-dynamic cannot run

### DIFF
--- a/examples/autoscaling/autoscaling-dynamic.yaml
+++ b/examples/autoscaling/autoscaling-dynamic.yaml
@@ -50,7 +50,4 @@ spec:
     parallelism: 1
     upgradeMode: stateless
     args:
-    - --maxLoadPerTask
-    - "1;2;4;8;16;\n16;8;4;2;1\n8;4;16;1;2"
-    - --repeatsAfterMinutes
-    - "60"
+    - --maxLoadPerTask "1;2;4;8;16;\n16;8;4;2;1\n8;4;16;1;2" --repeatsAfterMinutes "60"


### PR DESCRIPTION
autoscaling-dynamic cannot run on my Local

I guess yaml cannot hanlde the `\n` properly with multiple lines. 

It works after changing them to one line.

<img width="1660" alt="image" src="https://github.com/apache/flink-kubernetes-operator/assets/38427477/2abe2602-3d16-478a-992d-49d7e536c48f">
