### PR TITLE
[FLINK-34934] Translation Flink-Kubernetes-Operator document framework construction

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -70,3 +70,14 @@ pygmentsUseClasses = true
 [markup]
 [markup.goldmark.renderer]
   unsafe = true
+
+[languages]
+[languages.en]
+languageName = 'English'
+contentDir = 'content'
+weight = 1
+
+[languages.zh]
+languageName = '中文版'
+contentDir = 'content.zh'
+weight = 2

--- a/docs/content.zh/_index.md
+++ b/docs/content.zh/_index.md
@@ -1,0 +1,57 @@
+---
+title: Apache Flink Kubernetes Operator
+type: docs
+bookToc: false
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Flink Kubernetes Operator
+
+The [Flink Kubernetes Operator](https://github.com/apache/flink-kubernetes-operator) extends the [Kubernetes](https://kubernetes.io/) API with the ability to manage and operate
+Flink Deployments. The operator features the following amongst others:
+- Deploy and monitor Flink Application and Session deployments
+- Upgrade, suspend and delete deployments
+- Full logging and metrics integration
+- Flexible deployments and native integration with Kubernetes tooling
+- Flink Job Autoscaler
+
+{{< img src="/img/overview.svg" alt="Flink Kubernetes Operator Overview" >}}
+
+For an overview and brief demo of the Flink Kubernetes Operator you can check out our initial meetup talk [recording](https://www.youtube.com/watch?v=bedzs9jBUfc&t=2121s).
+
+{{< columns >}}
+## Try the Flink Kubernetes Operator
+
+If you’re interested in playing around with the operator, check out our [quickstart]({{< ref "docs/try-flink-kubernetes-operator/quick-start" >}}). It provides a step by
+step introduction to deploying the operator and an example job.
+
+<--->
+
+## Get Help with the Flink Kubernetes Operator
+
+If you get stuck, check out our [community support
+resources](https://flink.apache.org/community.html). In particular, Apache
+Flink’s user mailing list is consistently ranked as one of the most active of
+any Apache project, and is a great way to get help quickly.
+
+{{< /columns >}}
+
+The Flink Kubernetes Operator is developed under the umbrella of [Apache
+Flink](https://flink.apache.org/).

--- a/docs/content.zh/docs/concepts/_index.md
+++ b/docs/content.zh/docs/concepts/_index.md
@@ -1,0 +1,25 @@
+---
+title: Concepts
+icon: <i class="fa fa-map-o title appetizer" aria-hidden="true"></i>
+bold: true
+bookCollapseSection: true
+weight: 2
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/content.zh/docs/concepts/architecture.md
+++ b/docs/content.zh/docs/concepts/architecture.md
@@ -1,0 +1,80 @@
+---
+title: "Architecture"
+weight: 2
+type: docs
+aliases:
+- /concepts/architecture.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Architecture
+
+Flink Kubernetes Operator (Operator) acts as a control plane to manage the complete deployment lifecycle of Apache Flink applications. The Operator can be installed on a Kubernetes cluster using [Helm](https://helm.sh). In most production environments it is typically deployed in a designated namespace and controls Flink deployments in one or more managed namespaces. The custom resource definition (CRD) that describes the schema of a `FlinkDeployment` is a cluster wide resource. For a CRD, the declaration must be registered before any resources of that CRDs kind(s) can be used, and the registration process sometimes takes a few seconds.
+
+{{< img src="/img/concepts/architecture.svg" alt="Flink Kubernetes Operator Architecture" >}}
+> Note: There is no support at this time for [upgrading or deleting CRDs using Helm](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/).
+
+## Control Loop
+The Operator follow the Kubernetes principles, notably the [control loop](https://kubernetes.io/docs/concepts/architecture/controller/):
+
+{{< img src="/img/concepts/control_loop.svg" alt="Control Loop" >}}
+
+Users can interact with the operator using the Kubernetes command-line tool, [kubectl](https://kubernetes.io/docs/tasks/tools/). The Operator continuously tracks cluster events relating to the `FlinkDeployment` and `FlinkSessionJob` custom resources. When the operator receives a new resource update, it will take action to adjust the Kubernetes cluster to the desired state as part of its reconciliation loop. The initial loop consists of the following high-level steps:
+
+1. User submits a `FlinkDeployment`/`FlinkSessionJob` custom resource(CR) using `kubectl`
+2. Operator observes the current status of the Flink resource (if previously deployed)
+3. Operator validates the submitted resource change
+4. Operator reconciles any required changes and executes upgrades
+
+The CR can be (re)applied on the cluster any time. The Operator makes continuous adjustments to imitate the desired state until the current state becomes the desired state. All lifecycle management operations are realized using this very simple principle in the Operator.
+
+The Operator is built with the [Java Operator SDK](https://github.com/java-operator-sdk/java-operator-sdk) and uses the [Native Kubernetes Integration](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/native_kubernetes/) for launching Flink deployments and submitting jobs under the hood. The Java Operator SDK is a higher level framework and related tooling to support writing Kubernetes Operators in Java. Both the Java Operator SDK and Flink's native kubernetes integration itself is using the [Fabric8 Kubernetes Client](https://github.com/fabric8io/kubernetes-client) to interact with the Kubernetes API Server.
+
+## Flink Resource Lifecycle
+
+The Operator manages the lifecycle of Flink resources. The following chart illustrates the different possible states and transitions:
+
+{{< img src="/img/concepts/resource_lifecycle.svg" alt="Flink Resource Lifecycle" >}}
+
+**We can distinguish the following states:**
+
+  - CREATED : The resource was created in Kubernetes but not yet handled by the operator
+  - SUSPENDED : The (job) resource has been suspended
+  - UPGRADING : The resource is suspended before upgrading to a new spec
+  - DEPLOYED : The resource is deployed/submitted to Kubernetes, but it's not yet considered to be stable and might be rolled back in the future
+  - STABLE : The resource deployment is considered to be stable and won't be rolled back
+  - ROLLING_BACK : The resource is being rolled back to the last stable spec
+  - ROLLED_BACK : The resource is deployed with the last stable spec
+  - FAILED : The job terminally failed
+
+## Admission Control
+
+In addition to compiled-in admission plugins, a custom admission plugin named Flink Kubernetes Operator Webhook (Webhook)
+can be started as extension and run as webhook.
+
+The Webhook follow the Kubernetes principles, notably the [dynamic admission control](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/).
+
+It's deployed by default when the Operator is installed on a Kubernetes cluster using [Helm](https://helm.sh).
+Please see further details how to deploy the Operator/Webhook [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/try-flink-kubernetes-operator/quick-start/#deploying-the-operator).
+
+The Webhook is using TLS protocol for communication by default. It automatically loads/re-loads keystore file when the file
+has changed and provides the following endpoints:
+
+{{< img src="/img/concepts/webhook.svg" alt="Webhook" >}}

--- a/docs/content.zh/docs/concepts/controller-flow.md
+++ b/docs/content.zh/docs/concepts/controller-flow.md
@@ -1,0 +1,162 @@
+---
+title: "Controller Flow"
+weight: 3
+type: docs
+aliases:
+- /concepts/controller-flow.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Flink Operator Controller Flow
+
+The goal of this page is to provide a deep introduction to the Flink operator logic and provide enough details about the control flow design so that new developers can get started.
+
+We will assume a good level of Flink Kubernetes and general operational experience for different cluster and job types. For Flink related concepts please refer to https://flink.apache.org/.
+
+We will also assume a deep user-level understanding of the Flink Kubernetes Operator itself.
+
+This document is mostly concerned about the ***Why?*** and ***How?*** of the operator mechanism, the user facing ***What?*** is already documented elsewhere.
+
+The core operator controller flow (as implemented in `FlinkDeploymentController` and `FlinkSessionJobController`) contains the following logical phases:
+
+1. Observe the status of the currently deployed resource
+2. Validate the new resource spec
+3. Reconcile any required changes based on the new spec and the observed status
+4. Rinse and repeat
+
+It is very important to note that all these steps are executed every time. Observe and reconciliation is always executed regardless of the output of the validation, but validation might affect the target of reconciliation as we will see in the next sections.
+
+## Observation phase
+
+In the observation phase the Observer module is responsible for observing the current (point-in-time) status of any deployed Flink resources (already submitted clusters, jobs) and updated the CR Status fields based on that.
+
+The observer will always work using the previously deployed configuration to ensure that it can access the Flink clusters through the rest api. User configuration can affect the rest clients (port configs etc.) so we must always use the config that is running on the cluster. This is the main reason why the `FlinkConfigManager` and the operator in general distinguishes observe & deploy configuration throughout the implementation.
+
+The observer should never take actions to change or submit new resources, these actions are the responsibility of the Reconciler module as we will see later. The main reason for this separation is that the required actions not only depend on the current cluster state but also on any new spec changes the user might have submitted in the meantime.
+
+**Observer class hierarchy:**
+
+{{< img src="/img/concepts/observer_classes.svg" alt="Observer Class Hierarchy" >}}
+
+### Observer Steps
+
+1. If no resource is deployed we skip observing
+2. If we are in `ReconciliationState.UPGRADING` state, we check whether the upgrade already went through.
+    Normally the reconciler upgrades the state to `DEPLOYED` after a successful submission, but a transient error could prevent this status update. Therefore we use resource specific logic to check if the resource on the cluster already matches the target upgrade spec (annotations, deterministic job ids).
+3. For FlinkDeployments we next observe the status of the cluster Kubernetes resources, JM Deployment and Pods. We do this once after an upgrade or any time we cannot access the Job Rest endpoints. The status is recorded in the `jobManagerDeploymentStatus` field.
+
+    It’s important to note here that trying to observe Jobs or anything through the Flink rest API only makes sense if the JobManager Kubernetes resources are seemingly healthy. Any errors with the JM deployment automatically translate into an error state and should clear out any previously observed running JobStatus. A Job cannot be in running state without a healthy jobmanager.
+4. If the cluster is seemingly healthy, we proceed to observing the `JobStatus` (for Application and SessionJob resources). In this phase we query the information using the Jobmanager rest api about the current job state and pending savepoint progress.
+
+    The current state of the job determines what can be observed. For terminal job states (`FAILED, FINISHED`) we also record the last available savepoint information to be used during last-state upgrades. We can only do this in terminal states because otherwise there is no guarantee that by the time of the upgrade a new checkpoint won’t be created.
+
+    If the Job cannot be accessed, we have to check the status of the cluster again (see step 3), or if we cannot find the job on the cluster, the next step will depend on the resource type and config and will either trigger an error or we simply need to wait. When the job’s status cannot be determined we use the `RECONCILING` state.
+5. Last step in the observe flow is some administration based on the observed status. If everything is healthy and running, we clear previously recorded errors on the resource status. If the job is not running anymore we clear previous savepoint trigger information so that it may be retriggered in the reconcile phase later.
+6. At the end of the observer phase the operator sends the updated resource status to Kubernetes. This is a very important step to avoid losing critical information during the later phases. One example of such state loss: You have a failed/completed job and the observer records the latest savepoint info. The reconciler might decide to delete this cluster for an upgrade, but if at this point the operator should fail, the observer would not be able to record the last savepoint again as it cannot be observed on the deleted cluster anymore. Recording the status before any cluster actions are taken is a critical part of the logic.
+
+### Observing the SavepointInfo
+
+Savepoint information is part of the JobStatus and tracks both pending (either manual or periodic savepoint trigger info) and the savepoint history according to the config. Savepoint info is only updated for running and terminal jobs as seen in the observe steps. If a job is failing, restarting etc that means that the savepoint failed and needs to be retriggered.
+
+We observe pending savepoints using the triggerId and if they were completed we record them to the history. If the history reaches the configured size limit we dispose savepoint through the running job rest api, allowing us to do so without any user storage credentials. If the job is not running or unhealthy, we clear pending savepoint trigger info which essentially aborts the savepoint from the operator’s perspective.
+
+## Validation phase
+
+After the resource was successfully observed and the status updated, we next validate the incoming resource spec field.
+
+If the new spec validation fails, we trigger an error event to the user and we reset the last successfully submitted spec in the resource (we don’t update it in Kubernetes, only locally for the purpose of reconciliation).
+
+This step is very important to ensure that reconciliation runs even if the user submits an incorrect specification, thus allowing the operator to stabilize the previously desired state if any errors happened to the deployed resources in the meantime.
+
+## Reconciliation phase
+
+Last step is the reconciliation phase which will execute any required cluster actions to bring the resource to the last desired (valid) spec. In some cases the desired spec is reached in a single reconcile loop, in others we might need multiple passes as we will see.
+
+It’s very important to understand that the Observer phase records a point-in-time view of the cluster and resources into the status. In most cases this can change at any future time (a running job can fail at any time), in some rare cases it is stable (a terminally failed or completed job will stay that way). Therefore the reconciler logic must always take into account the possibility that the cluster status has already drifted from what is in the status (most of the complications arise from this need).
+
+{{< img src="/img/concepts/reconciler_classes.svg" alt="Reconciler Class Hierarchy" >}}
+
+### Base reconciler steps
+
+The `AbstractFlinkResourceReconciler` encapsulates the core reconciliation flow for all Flink resource types. Let’s take a look at the high level flow before we go into specifics for session, application and session job resources.
+
+1. Check if the resource is ready for reconciliation or if there are any pending operations that should not be interrupted (manual savepoints for example)
+2. If this is the first deployment attempt for the resource, we simply deploy it. It’s important to note here that this is the only deploy operation where we use the `initialSavepointPath` provided in the spec.
+3. Next we determine if the desired spec changed and the type of change: `IGNORE, SCALE, UPGRADE`. Only for scale and upgrade type changes do we need to execute further reconciliation logic.
+4. If we have upgrade/scale spec changes we execute the upgrade logic specific for the resource type
+5. If we did not receive any spec change we still have to ensure that the currently deployed resources are fully reconciled:
+    1. We check if any previously deployed resources have failed / not stabilized and we have to perform a rollback operation.
+    2. We apply any further reconciliation steps specific to the individual resources (trigger savepoints, recover deployments, restart unhealthy clusters etc.)
+
+### A note on deploy operations
+
+We have to take special care around deployment operations as they start clusters and jobs which might immediately start producing data and checkpoints. Therefore it’s critical to be able to recognize when a deployment has succeeded / failed. At the same time, the operator process can fail at any point in time making it difficult to always record the correct status.
+
+To ensure we can always recover the deployment status and what is running on the cluster, the to-be-deployed spec is always written to the status with the `UPGRADING` state before we attempt the deployment. Furthermore an annotation is added to the deployed Kubernetes Deployment resources to be able to distinguish the exact deployment attempt (we use the CR generation for this). For session jobs as we cannot add annotations we use a special way of generating the jobid to contain the same information.
+
+### Base job reconciler
+
+The AbstractJobReconciler is responsible for executing the shared logic for Flink resources that also manage jobs (Application and SessionJob clusters). Here the core part of the logic deals with managing job state and executing stateful job updates in a safe manner.
+
+Depending on the type of Spec change SCALE/UPGRADE the job reconciler has slightly different codepaths. For scale operations, if standalone mode and reactive scaling is enabled, we only need to rescale the taskmanagers. In the future we might also add more efficient rescaling here for other cluster types (such as using the rescale API once implemented in upstream Flink)
+
+If an UPGRADE type change is detected in the spec we execute the job upgrade flow:
+
+1. If the job is currently running, suspend according to the desired (available upgrade mode), more on this later
+2. Mark upgrading state in status, and trigger a new reconciliation loop (this allows us to pick up new spec changes mid upgrade as the suspend can take a while)
+3. Restore job according to the new spec from either HA metadata or savepoint info recorded in status, or empty state (depending on upgrade mode setting)
+
+#### UpgradeMode and suspend/cancel behaviour
+
+The operator must always respect the upgrade mode setting when it comes to stateful upgrades to avoid data loss. There is however some flexibility in the mechanism to account for unhealthy jobs and to provide extra safeguards during version upgrades. The **getAvailableUpgradeMode** method is an important corner stone in the upgrade logic, and it is used to decide what actualy upgrade mode should be used given the request from the user and current cluster state.
+
+In normal healthy cases, the available upgrade mode will be the same as what the user has in the spec. However, there are some cases where we have to change between savepoint and last-state upgrade mode. Savepoint upgrade mode can only be used if the job is healthy and running, for failing, restarting or otherwise unhealthy deployments, we are allowed to use last-state upgrade mode as long as HA metadata is available (and not explicitly configured otherwise). This allows us to have a robust upgrade flow even if a job failed, while keeping state consistency.
+
+Last-state upgrade mode refers to upgrading using the checkpoint information stored in the HA metadata. HA metadata format may not be compatible when upgrading between Flink minor versions therefore a version change must force savepoint upgrade mode and require a healthy running job.
+
+It is very important to note that we NEVER change from last-state/savepoint upgrade mode to stateless as that would compromise the upgrade logic and lead to state loss.
+
+### Application reconciler
+
+Application clusters have a few more extra config steps compared to session jobs that we need to take care of during deployment/upgrade/cancel operations. Here are some important things that the operator does to ensure robust behaviour:
+
+**setRandomJobResultStorePath**: In order to avoid terminated applications being restarted on JM failover, we have to disable Job result cleanup. This forces us to create a random job result store path for each application deployment as described here: https://issues.apache.org/jira/browse/FLINK-27569 . Users need to manually clean up the jobresultstore later.
+
+**setJobIdIfNecessary**: Flink by default generates deterministic jobids based on the clusterId (which is the CR name in our case). This causes checkpoint path conflicts if the job is ever restarted from an empty state (stateless upgrade). We therefore generate a random jobid to avoid this.
+
+**cleanupTerminalJmAfterTtl**: Flink 1.15 and above we do not automatically terminate jobmanager processes after shutdown/failure to get a robust observer behaviour. However once the terminal state is observed we can clean up the JM process/deployment.
+
+## Custom Flink Resource Status update mechanism
+
+The JOSDK provides built in ways to update resource spec and status for the reconciler implementations however the Flink Operator does not use this and has a custom status update mechanism due to the following reasons.
+
+When using the JOSDK, the status of a CR can only be updated at the end of the reconciliation method. In our case we often need to trigger status updates in the middle of the reconciliation flow to provide maximum robustness. One example of such case is recording the deployment information in the status before executing the deploy action.
+
+Another way to look at it is that the Flink Operator uses the resource status as a write ahead log for many actions to guarantee robustness in case of operator failures.
+
+The status update mechanism is implemented in the StatusRecorder class, which serves both as a cache for the latest status and the updater logic. We need to always update our CR status from the cache in the beginning of the controller flow as we are bypassing the JOSDK update-mechanism/caches which can cause old status instances to be returned. For the actual status update we use a modified optimistic locking mechanism which only updates the status if the status has not been externally modified in the meantime.
+
+Under normal circumstances this assumption holds as the operator is the sole owner/updater of the status. Exceptions here might indicate that the user tampered with the status or another operator instance might be running at the same time managing the same resources, which can lead to serious issues.
+
+## JOSDK vs Operator interface naming conflicts
+
+In JOSDK world the Reconciler interface represents the whole control/reconciliation flow. In our case we call these classes controllers and reserve our own Reconciler interface to a specific part of this controller flow.
+
+Historically the JOSDK also called Reconciler interface Controller.

--- a/docs/content.zh/docs/concepts/overview.md
+++ b/docs/content.zh/docs/concepts/overview.md
@@ -1,0 +1,109 @@
+---
+title: "Overview"
+weight: 1
+type: docs
+aliases:
+- /concepts/overview.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Overview
+Flink Kubernetes Operator acts as a control plane to manage the complete deployment lifecycle of Apache Flink applications. Although Flink’s native Kubernetes integration already allows you to directly deploy Flink applications on a running Kubernetes(k8s) cluster, [custom resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) and the [operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) have also become central to a Kubernetes native deployment experience.
+
+Flink Kubernetes Operator aims to capture the responsibilities of a human operator who is managing Flink deployments. Human operators have deep knowledge of how Flink deployments ought to behave, how to start clusters, how to deploy jobs, how to upgrade them and how to react if there are problems. The main goal of the operator is the automation of these activities, which cannot be achieved through the Flink native integration alone.
+
+## Features
+### Core
+- Fully-automated [Job Lifecycle Management]({{< ref "docs/custom-resource/job-management" >}})
+  - Running, suspending and deleting applications
+  - Stateful and stateless application upgrades
+  - Triggering and managing savepoints
+  - Handling errors, rolling-back broken upgrades
+- Multiple Flink version support: v1.15, v1.16, v1.17, v1.18
+- [Deployment Modes]({{< ref "docs/custom-resource/overview#application-deployments" >}}):
+  - Application cluster
+  - Session cluster
+  - Session job
+- Built-in [High Availability](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/kubernetes_ha/)   
+- Extensible framework
+  - [Custom validators]({{< ref "docs/operations/plugins#custom-flink-resource-validators" >}})
+  - [Custom resource listeners]({{< ref "docs/operations/plugins#custom-flink-resource-listeners" >}})  
+- Advanced [Configuration]({{< ref "docs/operations/configuration" >}}) management
+  - Default configurations with dynamic updates
+  - Per job configuration
+  - Environment variables
+- POD augmentation via [Pod Templates]({{< ref "docs/custom-resource/pod-template" >}})
+  - Native Kubernetes POD definitions
+  - Layering (Base/JobManager/TaskManager overrides)
+- [Job Autoscaler]({{< ref "docs/custom-resource/autoscaler" >}})
+  - Collect lag and utilization metrics
+  - Scale job vertices to the ideal parallelism
+  - Scale up and down as the load changes
+### Operations
+- Operator [Metrics]({{< ref "docs/operations/metrics-logging#metrics" >}})
+  - Utilizes the well-established [Flink Metric System](https://nightlies.apache.org/flink/flink-docs-master/docs/ops/metrics)
+  - Pluggable metrics reporters
+  - Detailed resources and kubernetes api access metrics
+- Fully-customizable [Logging]({{< ref "docs/operations/metrics-logging#logging" >}})
+  - Default log configuration
+  - Per job log configuration
+  - Sidecar based log forwarders
+- Flink Web UI and REST Endpoint Access
+  - Fully supported Flink Native Kubernetes [service expose types](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/native_kubernetes/#accessing-flinks-web-ui)
+  - Dynamic [Ingress templates]({{< ref "docs/operations/ingress" >}})
+- [Helm based installation]({{< ref "docs/operations/helm" >}})
+  - Automated [RBAC configuration]({{< ref "docs/operations/rbac" >}})
+  - Advanced customization techniques
+- Up-to-date public repositories
+  - GitHub Container Registry [ghcr.io/apache/flink-kubernetes-operator](http://ghcr.io/apache/flink-kubernetes-operator)
+  - DockerHub [https://hub.docker.com/r/apache/flink-kubernetes-operator](https://hub.docker.com/r/apache/flink-kubernetes-operator)
+
+## Built-in Examples
+
+The operator project comes with a wide variety of built in examples to show you how to use the operator functionality.
+The examples are maintained as part of the operator repo and can be found [here](https://github.com/apache/flink-kubernetes-operator/tree/main/examples).
+
+**What is covered:**
+
+ - Application, Session and SessionJob submission
+ - Checkpointing and HA configuration
+ - Java, SQL and Python Flink jobs
+ - Ingress, logging and metrics configuration
+ - Advanced operator deployment techniques using Kustomize
+ - And some more...
+
+## Known Issues & Limitations
+
+### JobManager High-availability
+The Operator supports both [Kubernetes HA Services](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/kubernetes_ha/) and [Zookeeper HA Services](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/zookeeper_ha/) for providing High-availability for Flink jobs. The HA solution can benefit form using additional [Standby replicas](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/ha/overview/), it will result in a faster recovery time, but Flink jobs will still restart when the Leader JobManager goes down.
+
+### JobResultStore Resource Leak
+To mitigate the impact of [FLINK-27569](https://issues.apache.org/jira/browse/FLINK-27569) the operator introduced a workaround [FLINK-27573](https://issues.apache.org/jira/browse/FLINK-27573) by setting `job-result-store.delete-on-commit=false` and a unique value for `job-result-store.storage-path` for every cluster launch. The storage path for older runs must be cleaned up manually, keeping the latest directory always:
+```shell
+ls -lth /tmp/flink/ha/job-result-store/basic-checkpoint-ha-example/
+total 0
+drwxr-xr-x 2 9999 9999 40 May 12 09:51 119e0203-c3a9-4121-9a60-d58839576f01 <- must be retained
+drwxr-xr-x 2 9999 9999 60 May 12 09:46 a6031ec7-ab3e-4b30-ba77-6498e58e6b7f
+drwxr-xr-x 2 9999 9999 60 May 11 15:11 b6fb2a9c-d1cd-4e65-a9a1-e825c4b47543
+```
+
+### AuditUtils can log sensitive information present in the custom resources
+As reported in [FLINK-30306](https://issues.apache.org/jira/browse/FLINK-30306) when Flink custom resources change the operator logs the change, which could include sensitive information. We suggest ingesting secrets to Flink containers during runtime to mitigate this.
+Also note that anyone who has access to the custom resources already had access to the potentially sensitive information in question, but folks who only have access to the logs could also see them now. We are planning to introduce redaction rules to AuditUtils to improve this in a later release.

--- a/docs/content.zh/docs/custom-resource/_index.md
+++ b/docs/content.zh/docs/custom-resource/_index.md
@@ -1,0 +1,25 @@
+---
+title: Custom Resource
+icon: <i class="fa fa-code title maindish" aria-hidden="true"></i>
+bold: true
+bookCollapseSection: true
+weight: 3
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/content.zh/docs/custom-resource/autoscaler.md
+++ b/docs/content.zh/docs/custom-resource/autoscaler.md
@@ -1,0 +1,335 @@
+---
+title: "Autoscaler"
+weight: 4
+type: docs
+aliases:
+- /custom-resource/autoscaler.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Autoscaler
+
+The operator provides a job autoscaler functionality that collects various metrics from running Flink jobs and automatically scales individual job vertexes (chained operator groups) to eliminate backpressure and satisfy the utilization target set by the user.
+By adjusting parallelism on a job vertex level (in contrast to job parallelism) we can efficiently autoscale complex and heterogeneous streaming applications.
+
+Key benefits to the user:
+ - Better cluster resource utilization and lower operating costs
+ - Automatic parallelism tuning for even complex streaming pipelines
+ - Automatic adaptation to changing load patterns
+ - Detailed utilization metrics for performance debugging
+
+## Overview
+
+The autoscaler relies on the metrics exposed by the Flink metric system for the individual tasks. The metrics are queried directly from the Flink job.
+
+Collected metrics:
+ - Backlog information at each source
+ - Incoming data rate at the sources (e.g. records/sec written into the Kafka topic)
+ - Record processing rate at each job vertex
+ - Busy and backpressured time at each job vertex
+
+{{< hint info >}}
+Please note that we are not using any container memory / CPU utilization metrics directly here. High utilization will be reflected in the processing rate and busy time metrics of the individual job vertexes.
+{{< /hint >}}
+
+The algorithm starts from the sources and recursively computes the required processing capacity (target data rate) for each operator in the pipeline. At the source vertices, target data rate is equal to incoming data rate (from the Kafka topic).
+
+For downstream operators we compute the target data rate as the sum of the input (upstream) operators output data rate along the given edge in the processing graph.
+
+{{< img src="/img/custom-resource/autoscaler_fig1.png" alt="Computing Target Data Rates" >}}
+
+Users configure the target utilization percentage of the operators in the pipeline, e.g. keep the all operators between 60% - 80% busy. The autoscaler then finds a parallelism configuration such that the output rates of all operators match the input rates of all their downstream operators at the targeted utilization.
+
+In this example we see an upscale operation:
+
+{{< img src="/img/custom-resource/autoscaler_fig2.png" alt="Scaling Up" >}}
+
+Similarly as load decreases, the autoscaler adjusts individual operator parallelism levels to match the current rate over time.
+
+{{< img src="/img/custom-resource/autoscaler_fig3.png" alt="Scaling Down" >}}
+
+The autoscaler approach is based on [Three steps is all you need: fast, accurate, automatic scaling decisions for distributed streaming dataflows](https://www.usenix.org/system/files/osdi18-kalavri.pdf) by Kalavri et al.
+
+## Executing rescaling operations
+
+By default, the autoscaler uses the built-in job upgrade mechanism from the operator to perform the rescaling as detailed in [Job Management and Stateful upgrades]({{< ref "docs/custom-resource/job-management" >}}).
+
+### Flink 1.18 and in-place scaling support
+
+The upcoming Flink 1.18 release brings very significant improvements to the speed of scaling operations through the new resource requirements rest endpoint.
+This allows the autoscaler to scale vertices in-place without performing a full job upgrade cycle.
+
+To try this experimental feature, please use the currently available Flink 1.18 snapshot base image to build you application docker image.
+Furthermore make sure you set Flink version to `v1_18` in your FlinkDeployment yaml and enable the adaptive scheduler which is required for this feature.
+
+```
+jobmanager.scheduler: adaptive
+```
+
+## Job Requirements and Limitations
+
+### Requirements
+
+The autoscaler currently only works with [Flink 1.17](https://hub.docker.com/_/flink) and later flink images, or after backporting the following fixes to your 1.15/1.16 Flink images:
+
+ - Job vertex parallelism overrides (must have)
+   - [Add option to override job vertex parallelisms during job submission](https://github.com/apache/flink/commit/23ce2281a0bb4047c64def9af7ddd5f19d88e2a9)
+   - [Change ForwardPartitioner to RebalancePartitioner on parallelism changes](https://github.com/apache/flink/pull/21443) (consists of 5 commits)
+   - [Fix logic for determining downstream subtasks for partitioner replacement](https://github.com/apache/flink/commit/fb482fe39844efda33a4c05858903f5b64e158a3)
+ - [Support timespan for busyTime metrics](https://github.com/apache/flink/commit/a7fdab8b23cddf568fa32ee7eb804d7c3eb23a35) (good to have)
+
+For session job auto-scaling, a latest custom build of Flink 1.19 or 1.18 is required that contains the fix for [FLINK-33534](https://issues.apache.org/jira/browse/FLINK-33534).
+
+### Limitations
+
+By default, the autoscaler can work for all job vertices in the processing graph.
+
+However, source scaling requires that the sources:
+
+   - Use the new [Source API](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface) that exposes the busy time metric (must have, most common connectors already do)
+   - Expose the [standardized connector metrics](https://cwiki.apache.org/confluence/display/FLINK/FLIP-33%3A+Standardize+Connector+Metrics) for accessing backlog information (good to have, extra capacity will be added for catching up with backlog)
+
+In the current state the autoscaler works best with Kafka sources, as they expose all the standardized metrics. It also comes with some additional benefits when using Kafka such as automatically detecting and limiting source max parallelism to the number of Kafka partitions.
+
+
+## Configuration guide
+
+Depending on your environment and job characteristics there are a few very important configurations that will affect how well the autoscaler works.
+
+Key configuration areas:
+ - Job and per operator max parallelism
+ - Stabilization and metrics collection intervals
+ - Target utilization and flexible boundaries
+ - Target catch-up duration and restart time
+
+The defaults might work reasonably well for many applications, but some tuning may be required in this early stage of the autoscaler module.
+
+{{< hint info >}}
+The autoscaler also supports a passive/metrics-only mode where it only collects and evaluates scaling related performance metrics but does not trigger any job upgrades.
+This can be used to gain confidence in the module without any impact on the running applications.
+
+To disable scaling actions, set: `job.autoscaler.scaling.enabled: "false"`
+{{< /hint >}}
+
+### Job and per operator max parallelism
+
+When computing the scaled parallelism, the autoscaler always considers the max parallelism settings for each job vertex to ensure that it doesn't introduce unnecessary data skew.
+The computed parallelism will always be a divisor of the max parallelism number.
+
+To ensure flexible scaling it is therefore recommended to choose max parallelism settings that have a [lot of divisors](https://en.wikipedia.org/wiki/Highly_composite_number) instead of relying on the Flink provided defaults.
+You can then use the `pipeline.max-parallelism` to configure this for your pipeline.
+
+Some good numbers for max-parallelism are: 120, 180, 240, 360, 720 etc.
+
+It is also possible to set maxParallelism on a per operator level, which can be useful if we want to avoid scaling some sources/sinks beyond a certain number.
+
+### Stabilization and metrics collection intervals
+
+The autoscaler always looks at average metrics in the collection time window defined by `job.autoscaler.metrics.window`.
+The size of this window determines how small fluctuations will affect the autoscaler. The larger the window, the more smoothing and stability we get, but we may be slower to react to sudden load changes.
+We suggest you experiment with setting this anywhere between 3-60 minutes for best experience.
+
+To allow jobs to stabilize after recovery users can configure a stabilization window by setting `job.autoscaler.stabilization.interval`.
+During this time period no metrics will be collected and no scaling actions will be taken.
+
+### Target utilization and flexible boundaries
+
+In order to provide stable job performance and some buffer for load fluctuations, the autoscaler allows users to set a target utilization level for the job (`job.autoscaler.target.utilization`).
+A target of `0.6` means we are targeting 60% utilization/load for the job vertexes.
+
+In general, it's not recommended to set target utilization close to 100% as performance usually degrades as we reach capacity limits in most real world systems.
+
+In addition to the utilization target we can set a utilization boundary, that serves as extra buffer to avoid immediate scaling on load fluctuations.
+Setting `job.autoscaler.target.utilization.boundary: "0.2"` means that we allow 20% deviation from the target utilization before triggering a scaling action.
+
+### Target catch-up duration and restart time
+
+When taking scaling decisions the operator need to account for the extra capacity required to catch up the backlog created during scaling operations.
+The amount of extra capacity is determined automatically by the following 3 configs:
+
+ - `job.autoscaler.catch-up.duration` : Time to job is expected to catch up after scaling
+ - `job.autoscaler.restart.time` : Time it usually takes to restart the application
+ - `job.autoscaler.restart.time-tracking.enabled` : Whether to use the actual observed rescaling restart times instead of the fixed 'job.autoscaler.restart.time' configuration. It's disabled by default.
+
+The maximum restart duration over a number of samples will be used when `job.autoscaler.restart.time-tracking.enabled` is set to true, 
+but the target catch-up duration depends on the users SLO.
+
+By lowering the catch-up duration the autoscaler will have to reserve more extra capacity for the scaling actions.
+We suggest setting this based on your actual objective, such us 10,30,60 minutes etc.
+
+### Basic configuration example
+```yaml
+...
+flinkVersion: v1_17
+flinkConfiguration:
+    job.autoscaler.enabled: "true"
+    job.autoscaler.stabilization.interval: 1m
+    job.autoscaler.metrics.window: 5m
+    job.autoscaler.target.utilization: "0.6"
+    job.autoscaler.target.utilization.boundary: "0.2"
+    job.autoscaler.restart.time: 2m
+    job.autoscaler.catch-up.duration: 5m
+    pipeline.max-parallelism: "720"
+```
+
+### Advanced config parameters
+
+The autoscaler also exposes various more advanced config parameters that affect scaling actions:
+
+ - Minimum time before scaling down after scaling up a vertex
+ - Maximum parallelism change when scaling down
+ - Min/max parallelism
+
+The list of options will likely grow to cover more complex scaling scenarios.
+
+For a detailed config reference check the [general configuration page]({{< ref "docs/operations/configuration#autoscaler-configuration" >}})
+
+## Extensibility of Autoscaler
+
+The Autoscaler exposes a set of interfaces for storing autoscaler state, handling autoscaling events,
+and executing scaling decisions. How these are implemented is specific to the orchestration framework
+used (e.g. Kubernetes), but the interfaces are designed to be as generic as possible. The following
+are the introduction of these generic interfaces:
+
+- **AutoScalerEventHandler** : Handling autoscaler events, such as: ScalingReport,
+  AutoscalerError, etc. `LoggingEventHandler` is the default implementation, it logs events.
+- **AutoScalerStateStore** : Storing all state during scaling. `InMemoryAutoScalerStateStore` is
+  the default implementation, it's based on the Java Heap, so the state will be discarded after
+  process restarts. We will implement persistent State Store in the future, such as : `JdbcAutoScalerStateStore`.
+- **ScalingRealizer** : Applying scaling actions.
+- **JobAutoScalerContext** : Including all details related to the current job.
+
+## Autoscaler Standalone
+
+**Flink Autoscaler Standalone** is an implementation of **Flink Autoscaler**, it runs as a separate java
+process. It computes the reasonable parallelism of all job vertices by monitoring the metrics, such as:
+processing rate, busy time, etc.
+
+Flink Autoscaler Standalone rescales flink job in-place by rest api of
+[Externalized Declarative Resource Management](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/elastic_scaling/#externalized-declarative-resource-management).
+`RescaleApiScalingRealizer` is the default implementation of `ScalingRealizer`, it uses the Rescale API
+to apply parallelism changes.
+
+Kubernetes Operator is well integrated with Autoscaler, we strongly recommend using Kubernetes Operator
+directly for the kubernetes flink jobs, and only flink jobs in non-kubernetes environments use Autoscaler
+Standalone.
+
+### How To Use Autoscaler Standalone
+
+Currently, `Flink Autoscaler Standalone` only supports a single Flink cluster. It can be any type of
+Flink cluster, includes:
+
+- Flink Standalone Cluster
+- MiniCluster
+- Flink yarn session cluster
+- Flink yarn application cluster
+- Flink kubernetes session cluster
+- Flink kubernetes application cluster
+- etc
+
+You can start a Flink Streaming job with the following ConfigOptions.
+
+```
+# Enable Adaptvie scheduler to play the in-place rescaling.
+jobmanager.scheduler : adaptive
+
+# Enable autoscale and scaling
+job.autoscaler.enabled : true
+job.autoscaler.scaling.enabled : true
+job.autoscaler.stabilization.interval : 1m
+job.autoscaler.metrics.window : 3m
+```
+
+> Note: In-place rescaling is only supported since Flink 1.18. Flink jobs before version
+> 1.18 cannot be scaled automatically, but you can view the `ScalingReport` in Log.
+> `ScalingReport` will show the recommended parallelism for each vertex.
+
+After the flink job starts, please start the StandaloneAutoscaler process by the
+following command. Please download released autoscaler-standalone jar from
+[here](https://repo.maven.apache.org/maven2/org/apache/flink/flink-autoscaler-standalone/) first.
+
+```
+java -cp flink-autoscaler-standalone-{{< version >}}.jar \
+org.apache.flink.autoscaler.standalone.StandaloneAutoscalerEntrypoint \
+--autoscaler.standalone.fetcher.flink-cluster.host localhost \
+--autoscaler.standalone.fetcher.flink-cluster.port 8081
+```
+
+Updating the `autoscaler.standalone.fetcher.flink-cluster.host` and `autoscaler.standalone.fetcher.flink-cluster.port`
+based on your flink cluster. In general, the host and port are the same as Flink WebUI.
+
+### Using the JDBC Autoscaler State Store & Event Handler
+
+A driver dependency is required to connect to a specified database. Here are drivers currently supported,
+please download JDBC driver and initialize database and table first.
+
+| Driver     | Group Id                   | Artifact Id            | JAR                                                                             | Schema                  |
+|:-----------|:---------------------------|:-----------------------|:--------------------------------------------------------------------------------|-------------------------|
+| MySQL      | `mysql`                    | `mysql-connector-java` | [Download](https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/)    | [Table DDL](https://github.com/apache/flink-kubernetes-operator/blob/main/flink-autoscaler-plugin-jdbc/src/main/resources/schema/mysql_schema.sql)     |
+| PostgreSQL | `org.postgresql`           | `postgresql`           | [Download](https://jdbc.postgresql.org/download/)                               | [Table DDL](https://github.com/apache/flink-kubernetes-operator/blob/main/flink-autoscaler-plugin-jdbc/src/main/resources/schema/postgres_schema.sql)  |
+| Derby      | `org.apache.derby`         | `derby`                | [Download](http://db.apache.org/derby/derby_downloads.html)                     | [Table DDL](https://github.com/apache/flink-kubernetes-operator/blob/main/flink-autoscaler-plugin-jdbc/src/main/resources/schema/derby_schema.sql)     |
+
+```
+JDBC_DRIVER_JAR=./mysql-connector-java-8.0.30.jar
+# export the password of jdbc state store & jdbc event handler
+export JDBC_PWD=123456
+
+java -cp flink-autoscaler-standalone-{{< version >}}.jar:${JDBC_DRIVER_JAR} \
+org.apache.flink.autoscaler.standalone.StandaloneAutoscalerEntrypoint \
+--autoscaler.standalone.fetcher.flink-cluster.host localhost \
+--autoscaler.standalone.fetcher.flink-cluster.port 8081 \
+--autoscaler.standalone.state-store.type jdbc \
+--autoscaler.standalone.event-handler.type jdbc \
+--autoscaler.standalone.jdbc.url jdbc:mysql://localhost:3306/flink_autoscaler \
+--autoscaler.standalone.jdbc.username root
+```
+
+All supported options for autoscaler standalone can be viewed
+[here]({{< ref "docs/operations/configuration#autoscaler-standalone-configuration" >}}).
+
+### Extensibility of autoscaler standalone
+
+Please click [here]({{< ref "docs/custom-resource/autoscaler#extensibility-of-autoscaler" >}})
+to check out extensibility of generic autoscaler.
+
+`Autoscaler Standalone` isn't responsible for job management, so it doesn't have job information.
+`Autoscaler Standalone` defines the `JobListFetcher` interface in order to get the
+`JobAutoScalerContext` of the job. It has a control loop that periodically calls
+`JobListFetcher#fetch` to fetch the job list and scale these jobs.
+
+Currently `FlinkClusterJobListFetcher` is the only implementation of the `JobListFetcher`
+interface, that's why `Flink Autoscaler Standalone` only supports a single Flink cluster so far.
+We will implement `YarnJobListFetcher` in the future, `Flink Autoscaler Standalone` will call
+`YarnJobListFetcher#fetch` to fetch job list from yarn cluster periodically.
+
+## Metrics
+
+The operator reports detailed jobvertex level metrics about the evaluated Flink job metrics that are collected and used in the scaling decision.
+
+This includes:
+ - Utilization, input rate, target rate metrics
+ - Scaling thresholds
+ - Parallelism and max parallelism changes over time
+
+These metrics are reported under the Kubernetes Operator Resource metric group:
+
+```
+[resource_prefix].Autoscaler.[jobVertexID].[ScalingMetric].Current/Average
+```

--- a/docs/content.zh/docs/custom-resource/autotuning.md
+++ b/docs/content.zh/docs/custom-resource/autotuning.md
@@ -1,0 +1,127 @@
+---
+title: "Autotuning"
+weight: 4
+type: docs
+aliases:
+- /custom-resource/autotuning.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Flink Autotuning
+
+Flink Autotuning aims at fully automating the configuration of Apache Flink.
+
+One of the biggest challenges with deploying new Flink pipelines is to write an adequate Flink configuration. The most
+important configuration values are:
+
+- memory configuration (heap memory, network memory, managed memory, JVM off-heap, etc.)
+- number of task slots
+
+## Memory Autotuning
+
+As a first step, we have tackled the memory configuration which, according to users, is the most frustrating part of
+the configuration process. The most important aspect of the memory configuration is the right-sizing of the
+various [Flink memory pools](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/memory/mem_tuning/).
+These memory pools include: heap memory, network memory, managed memory, and JVM off-heap memory settings. Non-optimal
+configuration of these pools can cause application crashes, or block large amounts of memory which remain unused.
+
+### How It Works
+
+With Flink Autoscaling and Flink Autotuning, all users need to do is set a max memory size for the TaskManagers, just
+like they would normally configure TaskManager memory. Flink Autotuning then automatically adjusts the various memory
+pools and brings down the total container memory size. It does that by observing the actual max memory usage on the
+TaskMangers or by calculating the exact number of network buffers required for the job topology. The adjustments are
+made together with Flink Autoscaling, so there is no extra downtime involved.
+
+It is important to note that adjusting the container memory only works on Kubernetes and that the initially provided
+memory settings represent the maximum amount of memory Flink Autotuning will use. You may want to be more conservative
+than usual when initially assigning memory with Autotuning. We never go beyond the initial limits to ensure we can
+safely create TaskManagers without running into pod memory quotas or limits.
+
+### Getting Started
+
+#### Dry-run Mode
+
+As soon as Flink Autoscaling is enabled, Flink Autotuning will provide recommendations via events
+(e.g. Kubernetes events):
+```
+# Autoscaling needs to be enabled
+job.autoscaler.enabled: true
+# Disable automatic memory tuning (only get recommendations)
+job.autoscaler.memory.tuning.enabled: false
+```
+
+#### Automatic Mode
+
+Automatic memory tuning via can be enabled by setting:
+
+```
+# Autoscaling needs to be enabled
+job.autoscaler.enabled: true
+# Turn on Autotuning and apply memory config changes
+job.autoscaler.memory.tuning.enabled: true
+```
+
+### Advanced Options
+
+#### Maximize Managed Memory
+
+Enabling the following option allows to return all saved memory as managed memory. This is beneficial
+when running with RocksDB to maximize its performance.
+
+```
+job.autoscaler.memory.tuning.maximize-managed-memory: true
+```
+
+#### Setting Memory Overhead
+
+Memory Autotuning uses a constant amount of memory overhead for heap and metaspace to allow the memory to grow beyond
+the determined maximum size. The default of 20% can be changed to 50% by setting:
+
+```
+job.autoscaler.memory.tuning.overhead: 0.5
+```
+
+## Future Work
+
+### Task Slots Autotuning
+
+The number of task slots are partially taken care by Flink Autoscaling which adjusts the task parallelism and hence
+changes the total number of slots and the number of TaskManagers.
+
+In future versions of Flink Autotuning, we will try to further optimize the number of task slots depending on the
+number of tasks running inside a task slot.
+
+### JobManager Memory Tuning
+
+Currently, only TaskManager memory is adjusted.
+
+### RocksDB Memory Tuning
+
+Currently, if no managed memory is used, e.g. the heap-based state backend is used, managed memory will be set to
+zero by Flink Autotuning which helps save a lot of memory. However, if managed memory is used, e.g. via RocksDB, the
+configured managed memory will be kept constant because Flink currently lacks metrics to accurately measure the usage of
+managed memory.
+
+Nevertheless, users already benefit from the resource savings and optimizations for heap, metaspace, and
+network memory. RocksDB users can solely focus their attention on configuring managed memory.
+
+We already added an option to add all saved memory to the managed memory. This is beneficial when running with RocksDB
+to maximize the in-memory performance.

--- a/docs/content.zh/docs/custom-resource/job-management.md
+++ b/docs/content.zh/docs/custom-resource/job-management.md
@@ -1,0 +1,327 @@
+---
+title: "Job Management"
+weight: 2
+type: docs
+aliases:
+- /custom-resource/job-management.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Job Lifecycle Management
+
+The core responsibility of the Flink operator is to manage the full production lifecycle of Flink applications.
+
+What is covered:
+ - Running, suspending and deleting applications
+ - Stateful and stateless application upgrades
+ - Triggering and managing savepoints
+ - Handling errors, rolling-back broken upgrades
+
+The behaviour is always controlled by the respective configuration fields of the `JobSpec` object as introduced in the [FlinkDeployment/FlinkSessionJob overview]({{< ref "docs/custom-resource/overview" >}}).
+
+Let's take a look at these operations in detail.
+
+{{< hint info >}}
+The management features detailed in this section apply (in most part) to both `FlinkDeployment` (application clusters) and `FlinkSessionJob` (session job) deployments.
+{{< /hint >}}
+
+## Running, suspending and deleting applications
+
+By controlling the `state` field of the `JobSpec` users can define the desired state of the application.
+
+Supported application states:
+ - `running` : The job is expected to be running and processing data.
+ - `suspended` : Data processing should be temporarily suspended, with the intention of continuing later.
+
+**Job State transitions**
+
+There are 4 possible state change scenarios when updating the current FlinkDeployment.
+
+ - `running` -> `running` : Job upgrade operation. In practice, a suspend followed by a restore operation.
+ - `running` -> `suspended` : Suspend operation. Stops the job while maintaining state information for stateful applications.
+ - `suspended` -> `running` : Restore operation. Start the application from current state using the latest spec.
+ - `suspended` -> `suspended` : Update spec, job is not started.
+
+The way state is handled for suspend and restore operations is described in detail in the next section.
+
+**Cancelling/Deleting applications**
+
+As you can see there is no cancelled or deleted among the possible desired states. When users no longer wish to process data with a given FlinkDeployment they can delete the deployment object using the Kubernetes api:
+
+```
+kubectl delete flinkdeployment my-deployment
+```
+
+{{< hint danger >}}
+Deleting a deployment will remove all checkpoint and status information. Future deployments will start from an empty state unless manually overridden by the user.
+{{< /hint >}}
+
+## Stateful and stateless application upgrades
+
+When the spec changes for FlinkDeployment and FlinkSessionJob resources, the running application must be upgraded.
+In order to do this the operator will stop the currently running job (unless already suspended) and redeploy it using the latest spec and state carried over from the previous run for stateful applications.
+
+Users have full control on how state should be managed when stopping and restoring stateful applications using the `upgradeMode` setting of the JobSpec.
+
+Supported values: `stateless`, `savepoint`, `last-state`
+
+The `upgradeMode` setting controls both the stop and restore mechanisms as detailed in the following table:
+
+|                        | Stateless               | Last State                                 | Savepoint                              |
+|------------------------|-------------------------|--------------------------------------------|----------------------------------------|
+| Config Requirement     | None                    | Checkpointing & HA Enabled                 | Checkpoint/Savepoint directory defined |
+| Job Status Requirement | None                    | HA metadata available                      | Job Running*                           |
+| Suspend Mechanism      | Cancel / Delete         | Delete Flink deployment (keep HA metadata) | Cancel with savepoint                  |
+| Restore Mechanism      | Deploy from empty state | Recover last state using HA metadata       | Restore From savepoint                 |
+| Production Use         | Not recommended         | Recommended                                | Recommended                            |
+
+
+*\* When HA is enabled the `savepoint` upgrade mode may fall back to the `last-state` behaviour in cases where the job is in an unhealthy state.*
+
+The three upgrade modes are intended to support different scenarios:
+
+ 1. **stateless**: Stateless application upgrades from empty state
+ 2. **last-state**: Quick upgrades in any application state (even for failing jobs), does not require a healthy job as it always uses the latest checkpoint information. Manual recovery may be necessary if HA metadata is lost. To limit the time the job may fall back when picking up the latest checkpoint you can configure `kubernetes.operator.job.upgrade.last-state.max.allowed.checkpoint.age`. If the checkpoint is older than the configured value a savepoint will be taken instead for healthy jobs.
+ 3. **savepoint**: Use savepoint for upgrade, providing maximal safety and possibility to serve as backup/fork point. The savepoint will be created during the upgrade process. Note that the Flink job needs to be running to allow the savepoint to get created. If the job is in an unhealthy state, the last checkpoint will be used (unless `kubernetes.operator.job.upgrade.last-state-fallback.enabled` is set to `false`). If the last checkpoint is not available, the job upgrade will fail.
+
+During stateful upgrades there are always cases which might require user intervention to preserve the consistency of the application. Please see the [manual Recovery section](#manual-recovery) for details.
+
+Full example using the `last-state` strategy:
+
+```yaml
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: basic-checkpoint-ha-example
+spec:
+  image: flink:1.17
+  flinkVersion: v1_17
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "2"
+    state.savepoints.dir: file:///flink-data/savepoints
+    state.checkpoints.dir: file:///flink-data/checkpoints
+    high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
+    high-availability.storageDir: file:///flink-data/ha
+  serviceAccount: flink
+  jobManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  taskManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  podTemplate:
+    spec:
+      containers:
+        - name: flink-main-container
+          volumeMounts:
+            - mountPath: /flink-data
+              name: flink-volume
+      volumes:
+        - name: flink-volume
+          hostPath:
+            # directory location on host
+            path: /tmp/flink
+            # this field is optional
+            type: Directory
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+    parallelism: 2
+    upgradeMode: last-state
+    state: running
+```
+
+{{< hint warning >}}
+Last state upgrade mode is currently only supported for `FlinkDeployments`.
+{{< /hint >}}
+
+### Application restarts without spec change
+
+There are cases when users would like to restart the Flink deployments to deal with some transient problem.
+
+For this purpose you can use the `restartNonce` top level field in the spec. Set a different value to this field to trigger a restart.
+
+```yaml
+ spec:
+    ...
+    restartNonce: 123
+```
+
+Restarts work exactly the same way as other application upgrades and follow the semantics detailed in the previous section.
+
+## Savepoint management
+
+Savepoints are triggered automatically by the system during the upgrade process as we have seen in the previous sections.
+
+For backup, job forking and other purposes savepoints can be triggered manually or periodically by the operator, however generally speaking these will not be used during upgrades and are not required for the correct operation.
+
+### Manual Savepoint Triggering
+
+Users can trigger savepoints manually by defining a new (different/random) value to the variable `savepointTriggerNonce` in the job specification:
+
+```yaml
+ job:
+    ...
+    savepointTriggerNonce: 123
+```
+
+Changing the nonce value will trigger a new savepoint. Information about pending and last savepoint is stored in the resource status.
+
+### Periodic Savepoint Triggering
+
+The operator also supports periodic savepoint triggering through the following config option which can be configured on a per job level:
+
+```yaml
+ flinkConfiguration:
+    ...
+    kubernetes.operator.periodic.savepoint.interval: 6h
+```
+
+There is no guarantee on the timely execution of the periodic savepoints as they might be delayed by unhealthy job status or other interfering user operation.
+
+### Savepoint History
+
+The operator automatically keeps track of the savepoint history triggered by upgrade or manual savepoint operations.
+This is necessary so cleanup can be performed by the operator for old savepoints.
+
+Users can control the cleanup behaviour by specifying a maximum age and maximum count for the savepoints in the history.
+
+```
+kubernetes.operator.savepoint.history.max.age: 24 h
+kubernetes.operator.savepoint.history.max.count: 5
+```
+
+{{< hint info >}}
+Savepoint cleanup happens lazily and only when the application is running.
+It is therefore very likely that savepoints live beyond the max age configuration.  
+{{< /hint >}}
+
+To disable savepoint cleanup by the operator you can set `kubernetes.operator.savepoint.cleanup.enabled: false`.
+When savepoint cleanup is disabled the operator will still collect and populate the savepoint history but not perform any dispose operations.
+
+## Recovery of missing job deployments
+
+When HA is enabled, the operator can recover the Flink cluster deployments in cases when it was accidentally deleted
+by the user or some external process. Deployment recovery can be turned off in the configuration by setting `kubernetes.operator.jm-deployment-recovery.enabled` to `false`, however it is recommended to keep this setting on the default `true` value.
+
+This is not something that would usually happen during normal operation and can also indicate a deeper problem,
+therefore an Error event is also triggered by the system when it detects a missing deployment.
+
+One scenario which could lead to a loss of jobmanager deployment in Flink versions before 1.15 is the job entering a terminal state:
+ - Fatal job error
+ - Job Finished
+ - Loss of operator process after triggering savepoint shutdown but before recording the status
+
+In Flink version before 1.15 a terminal job state leads to a deployment shutdown, therefore it's impossible for the operator to know what happened.
+In these cases no recovery will be performed to avoid dataloss and an error will be thrown.
+
+Please check the [manual Recovery section](#manual-recovery) to understand how to recover from these situations.
+
+## Restart of unhealthy job deployments
+
+When HA is enabled, the operator can restart the Flink cluster deployments in cases when it was considered
+unhealthy. Unhealthy deployment restart can be turned on in the configuration by setting `kubernetes.operator.cluster.health-check.enabled` to `true` (default: `false`).  
+In order this feature to work one must enable [recovery of missing job deployments](#recovery-of-missing-job-deployments).
+
+At the moment deployment is considered unhealthy when:
+* Flink's restarts count reaches `kubernetes.operator.cluster.health-check.restarts.threshold` (default: `64`)
+within time window of `kubernetes.operator.cluster.health-check.restarts.window` (default: 2 minutes).
+* `cluster.health-check.checkpoint-progress.enabled` is turned on and Flink's successful checkpoints count is not
+changing within time window of within time window of `kubernetes.operator.cluster.health-check.checkpoint-progress.window` (default: 5 minutes).
+
+## Restart failed job deployments
+
+The operator can restart a failed Flink job. This could be useful in cases when the job main task is
+able to reconfigure the job to handle these failures.
+
+When `kubernetes.operator.job.restart.failed` is set to `true` then at the moment when the job status is
+set to `FAILED` the kubernetes operator will delete the current job and redeploy the job using the
+latest successful checkpoint.
+
+## Application upgrade rollbacks (Experimental)
+
+The operator supports upgrade rollbacks as an experimental feature.
+The rollback feature works based on the concept of stable deployments specs.
+
+When an application is upgraded, the new spec is initially considered unstable. Once the operator successfully observes the new job in a healthy running state, the spec is marked as stable.
+If a new upgrade is not marked stable within a certain configurable time period (`kubernetes.operator.deployment.readiness.timeout`) then a rollback operation will be performed, rolling back to the last stable spec.
+
+To enable rollbacks you need to set:
+```
+kubernetes.operator.deployment.rollback.enabled: true
+```
+
+HA is currently required for the rollback functionality.
+
+Applications are never rolled back to a previous running state if they were suspended before the upgrade.
+In these cases no rollback will be performed.
+
+Rollbacks exclusively affect the `FlinkDeployment`/`FlinkSession` CRDs.
+When releasing a new version of your Flink application that updates several Kubernetes resources (such as config maps and services), you must ensure backward compatibility. This means that your updates to non-FlinkDeployment/FlinkSession resources must be compatible with both old and new FlinkDeployment/FlinkSession resources.
+
+### Stability condition
+
+Currently, a new job is marked stable as soon as the operator could observe it running. This allows us to detect obvious errors, but it's not always enough to detect more complex issues.
+In the future we expect to introduce more sophisticated conditions.
+
+{{< hint warning >}}
+Rollback is currently only supported for `FlinkDeployments`.
+{{< /hint >}}
+
+## Manual Recovery
+
+There are cases when manual intervention is required from the user to recover a Flink application deployment or to restore to a user specified state.
+
+In most of these situations the main reason for this is that the deployment got into a state where the operator cannot determine the health of the application or the latest checkpoint information to be used for recovery.
+While these cases are not common, we need to be prepared to handle them.
+
+Users have two options to restore a job from a target savepoint / checkpoint
+
+### Redeploy using the savepointRedeployNonce
+
+It is possible to redeploy a `FlinkDeployment` or `FlinkSessionJob` resource from a target savepoint by using the combination of `savepointRedeployNonce` and `initialSavepointPath` in the job spec:
+
+```yaml
+ job:
+   initialSavepointPath: file://redeploy-target-savepoint
+   # If not set previously, set to 1, otherwise increment, e.g. 2
+   savepointRedeployNonce: 1
+```
+
+When changing the `savepointRedeployNonce` the operator will redeploy the job to the savepoint defined in the `initialSavepointPath`. The savepoint path must not be empty. 
+
+{{< hint warning >}}
+Rollbacks are not supported after redeployments.
+{{< /hint >}}
+
+### Delete and recreate the custom resource 
+ 
+Alternatively you can completely delete and recreate the custom resources to solve almost any issues. This will fully reset the status information to start from a clean slate.
+However, this also means that savepoint history is lost and the operator won't clean up past periodic savepoints taken before the deletion.
+
+ 1. Locate the latest checkpoint/savepoint metafile in your configured checkpoint/savepoint directory.
+ 2. Delete the `FlinkDeployment` resource for your application
+ 3. Check that you have the current savepoint, and that your `FlinkDeployment` is deleted completely
+ 4. Modify your `FlinkDeployment` JobSpec and set the `initialSavepointPath` to your last checkpoint location
+ 5. Recreate the deployment
+
+These steps ensure that the operator will start completely fresh from the user defined savepoint path and can hopefully fully recover.
+Keep an eye on your job to see what could have cause the problem in the first place.

--- a/docs/content.zh/docs/custom-resource/overview.md
+++ b/docs/content.zh/docs/custom-resource/overview.md
@@ -1,0 +1,224 @@
+---
+title: "Overview"
+weight: 1
+type: docs
+aliases:
+- /custom-resource/overview.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Overview
+
+The core user facing API of the Flink Kubernetes Operator is the FlinkDeployment and FlinkSessionJob Custom Resources (CR).
+
+Custom Resources are extensions of the Kubernetes API and define new object types. In our case the FlinkDeployment CR defines Flink Application and Session cluster deployments. The FlinkSessionJob CR defines the session job on the Session cluster and each Session cluster can run multiple FlinkSessionJob.
+
+Once the Flink Kubernetes Operator is installed and running in your Kubernetes environment, it will continuously watch FlinkDeployment and FlinkSessionJob objects submitted by the user to detect new CR and changes to existing ones. In case you haven't deployed the operator yet, please check out the [quickstart]({{< ref "docs/try-flink-kubernetes-operator/quick-start" >}}) for detailed instructions on how to get started.
+
+With these two Custom Resources, we can support two different operational models:
+
+- Flink application managed by the `FlinkDeployment`
+- Empty Flink session managed by the `FlinkDeployment` + multiple jobs managed by the `FlinkSessionJobs`. The operations on the session jobs are independent of each other.
+
+## FlinkDeployment
+
+FlinkDeployment objects are defined in YAML format by the user and must contain the following required fields:
+
+```
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  namespace: namespace-of-my-deployment
+  name: my-deployment
+spec:
+  // Deployment specs of your Flink Session/Application
+```
+
+The `apiVersion`, `kind` fields have fixed values while `metadata` and `spec` control the actual Flink deployment.
+
+The Flink operator will subsequently add status information to your FlinkDeployment object based on the observed deployment state:
+
+```
+kubectl get flinkdeployment my-deployment -o yaml
+```
+
+```yaml
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  ...
+spec:
+  ...
+status:
+  clusterInfo:
+    ...
+  jobManagerDeploymentStatus: READY
+  jobStatus:
+    ...
+  reconciliationStatus:
+    ...
+```
+
+While the status contains a lot of information that the operator tracks about the deployment, it is considered to be internal to the operator logic and users should only rely on it with care.
+
+## FlinkDeployment spec overview
+
+The `spec` is the most important part of the `FlinkDeployment` as it describes the desired Flink Application or Session cluster.
+The spec contains all the information the operator need to deploy and manage your Flink deployments, including docker images, configurations, desired state etc.
+
+Most deployments will define at least the following fields:
+ - `image` : Docker used to run Flink job and task manager processes
+ - `flinkVersion` : Flink version used in the image (`v1_15`, `v1_16`, `v1_17`, `v1_18`, ...)
+ - `serviceAccount` : Kubernetes service account used by the Flink pods
+ - `taskManager, jobManager` : Job and Task manager pod resource specs (cpu, memory, ephemeralStorage)
+ - `flinkConfiguration` : Map of Flink configuration overrides such as HA and checkpointing configs
+ - `job` : Job Spec for Application deployments
+
+The Flink Kubernetes Operator supports two main types of deployments: **Application** and **Session**
+
+Application deployments manage a single job deployment in Application mode while Session deployments manage Flink Session clusters without providing any job management for it. The type of cluster created depends on the `spec` provided by the user as we will see in the next sections.
+
+### Application Deployments
+
+To create an Application deployment users must define the `job` (JobSpec) field in their deployment spec.
+
+Required fields:
+ - `jarURI` : URI of the job jar
+ - `parallelism` : Parallelism of the job
+ - `upgradeMode` : Upgrade mode of the job (stateless/savepoint/last-state)
+ - `state` : Desired state of the job (running/suspended)
+
+Minimal example:
+
+```yaml
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  namespace: default
+  name: basic-example
+spec:
+  image: flink:1.17
+  flinkVersion: v1_17
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "2"
+  serviceAccount: flink
+  jobManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  taskManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+    parallelism: 2
+    upgradeMode: stateless
+    state: running
+```
+
+Once created FlinkDeployment yamls can be submitted through kubectl:
+
+```bash
+kubectl apply -f your-deployment.yaml
+```
+
+### Session Cluster Deployments
+
+Session clusters use a similar spec to application clusters with the only difference that `job` is not defined.
+
+For Session clusters the operator only provides very basic management and monitoring that cover:
+ - Start Session cluster
+ - Monitor overall cluster health
+ - Stop / Delete Session cluster
+
+### Cluster Deployment Modes
+On-top of the deployment types the Flink Kubernetes Operator also supports two modes of deployments: **Native** and **Standalone**
+
+Native cluster deployment is the default deployment mode and uses Flink's built in integration with Kubernetes when deploying the cluster. This integration means the Flink cluster communicates directly with Kubernetes and allows it to manage Kubernetes resources, e.g. dynamically allocate and de-allocate TaskManager pods.
+
+For standard Operator use running your own Flink Jobs Native mode is recommended.
+
+Standalone cluster deployment simply uses Kubernetes as an orchestration platform that the Flink cluster is running on. Flink is unaware that it is running on Kubernetes and therefore all Kubernetes resources need to be managed externally, by the Kubernetes Operator.
+
+In Standalone mode the Flink cluster doesn't have access to the Kubernetes cluster so this can increase security. If unknown or external code is being ran on the Flink cluster then Standalone mode adds another layer of security.
+
+The deployment mode can be set using the `mode` field in the deployment spec.
+
+```yaml
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+...
+spec:
+  ...
+  mode: standalone
+
+
+```
+
+## FlinkSessionJob
+
+The FlinkSessionJob have a similar structure to FlinkDeployment with the following required fields:
+
+```
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkSessionJob
+metadata:
+  name: basic-session-job-example
+spec:
+  deploymentName: basic-session-cluster
+  job:
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.16.1/flink-examples-streaming_2.12-1.16.1-TopSpeedWindowing.jar
+    parallelism: 4
+    upgradeMode: stateless
+```
+
+### FlinkSessionJob spec overview
+
+The spec contains the information to submit a session job to the session cluster. Mostly, it will define at least the following fields:
+
+ - deploymentName: The name of the target session cluster's CR
+ - job: The specification for the Session Job
+
+The job specification has the same structure in FlinkSessionJobs and FlinkDeployments, but in FlinkSessionJobs the jarUri can contain remote sources too.
+It leverages the [Flink filesystem](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/) mechanism to download the jar and submit to the session cluster.
+So the FlinkSessionJob must be run with an existing session cluster managed by the FlinkDeployment.
+
+To support jar from different filesystems, you should extend the base docker image as below, and put the related filesystem jar to the plugin dir and deploy the operator.
+For example, to support the hadoop fs resource:
+
+```shell script
+FROM apache/flink-kubernetes-operator
+ENV FLINK_PLUGINS_DIR=/opt/flink/plugins
+COPY flink-hadoop-fs-1.15-SNAPSHOT.jar $FLINK_PLUGINS_DIR/hadoop-fs/
+```
+
+Alternatively, if you use helm to install flink-kubernetes-operator, it allows you to specify a postStart hook to download the required plugins.
+
+### Limitations
+
+- Last-state upgradeMode is currently not supported for FlinkSessionJobs
+
+## Further information
+
+ - [Job Management and Stateful upgrades]({{< ref "docs/custom-resource/job-management" >}})
+ - [Deployment customization and pod templates]({{< ref "docs/custom-resource/pod-template" >}})
+ - [Full Reference]({{< ref "docs/custom-resource/reference" >}})
+ - [Examples](https://github.com/apache/flink-kubernetes-operator/tree/main/examples)

--- a/docs/content.zh/docs/custom-resource/pod-template.md
+++ b/docs/content.zh/docs/custom-resource/pod-template.md
@@ -1,0 +1,128 @@
+---
+title: "Pod Template"
+weight: 3
+type: docs
+aliases:
+- /custom-resource/pod-template.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Pod template
+
+The operator CRD is designed to have a minimal set of direct, short-hand CRD settings to express the most
+basic attributes of a deployment. For all other settings the CRD provides the `flinkConfiguration` and
+`podTemplate` fields.
+
+Pod templates permit customization of the Flink job and task manager pods, for example to specify
+volume mounts, ephemeral storage, sidecar containers etc.
+
+Pod templates can be layered, as shown in the example below.
+A common pod template may hold the settings that apply to both job and task manager,
+like `volumeMounts`. Another template under job or task manager can define additional settings that supplement or override those
+in the common template, such as a task manager sidecar.
+
+The operator is going to merge the common and specific templates for job and task manager respectively.
+
+Here the full example:
+
+```yaml
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  namespace: default
+  name: pod-template-example
+spec:
+  image: flink:1.17
+  flinkVersion: v1_17
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "2"
+  serviceAccount: flink
+  podTemplate:
+    spec:
+      containers:
+        # Do not change the main container name
+        - name: flink-main-container
+          volumeMounts:
+            - mountPath: /opt/flink/log
+              name: flink-logs
+        # Sample sidecar container
+        - name: fluentbit
+          image: fluent/fluent-bit:1.8.12-debug
+          command: [ 'sh','-c','/fluent-bit/bin/fluent-bit -i tail -p path=/flink-logs/*.log -p multiline.parser=java -o stdout' ]
+          volumeMounts:
+            - mountPath: /flink-logs
+              name: flink-logs
+      volumes:
+        - name: flink-logs
+          emptyDir: { }
+  jobManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  taskManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+    podTemplate:
+      spec:
+        initContainers:
+          # Sample sidecar container
+          - name: busybox
+            image: busybox:1.35.0
+            command: [ 'sh','-c','echo hello from task manager' ]
+  job:
+    jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
+    parallelism: 2
+```
+
+{{< hint info >}}
+When using the operator with Flink native Kubernetes integration, please refer to [pod template field precedence](
+https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/native_kubernetes/#fields-overwritten-by-flink).
+{{< /hint >}}
+
+## Array Merging Behaviour
+
+When layering pod templates (defining both a top level and jobmanager specific podtemplate for example) the corresponding yamls are merged together.
+
+The default behaviour of the pod template mechanism is to merge array arrays by merging the objects in the respective array positions.
+This requires that containers in the podTemplates are defined in the same order otherwise the results may be undefined.
+
+Default behaviour (merge by position):
+
+```
+arr1: [{name: a, p1: v1}, {name: b, p1: v1}]
+arr1: [{name: a, p2: v2}, {name: c, p2: v2}]
+
+merged: [{name: a, p1: v1, p2: v2}, {name: c, p1: v1, p2: v2}]
+```
+
+The operator supports an alternative array merging mechanism that can be enabled by the `kubernetes.operator.pod-template.merge-arrays-by-name` flag.
+When true, instead of the default positional merging, object array elements that have a `name` property defined will be merged by their name and the resulting array will be a union of the two input arrays.
+
+Merge by name:
+
+```
+arr1: [{name: a, p1: v1}, {name: b, p1: v1}]
+arr1: [{name: a, p2: v2}, {name: c, p2: v2}]
+
+merged: [{name: a, p1: v1, p2: v2}, {name: b, p1: v1}, {name: c, p2: v2}]
+```
+
+Merging by name can we be very convenient when merging container specs or when the base and override templates are not defined together.

--- a/docs/content.zh/docs/custom-resource/reference.md
+++ b/docs/content.zh/docs/custom-resource/reference.md
@@ -1,0 +1,377 @@
+---
+title: "Reference"
+weight: 4
+type: docs
+aliases:
+- /custom-resource/reference.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# FlinkDeployment Reference
+
+This page serves as a full reference for FlinkDeployment custom resource definition including all the possible configuration parameters.
+
+## FlinkDeployment
+**Class**: org.apache.flink.kubernetes.operator.crd.FlinkDeployment
+
+**Description**: Custom resource that represents both Application and Session deployments.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| spec | org.apache.flink.kubernetes.operator.crd.spec.FlinkDeploymentSpec | Spec that describes a Flink application or session cluster deployment. |
+| status | org.apache.flink.kubernetes.operator.crd.status.FlinkDeploymentStatus | Last observed status of the Flink deployment. |
+
+## Spec
+
+### FlinkDeploymentSpec
+**Class**: org.apache.flink.kubernetes.operator.api.spec.FlinkDeploymentSpec
+
+**Description**: Spec that describes a Flink application or session cluster deployment.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| job | org.apache.flink.kubernetes.operator.api.spec.JobSpec | Job specification for application deployments/session job. Null for session clusters. |
+| restartNonce | java.lang.Long | Nonce used to manually trigger restart for the cluster/session job. In order to trigger restart, change the number to a different non-null value. |
+| flinkConfiguration | java.util.Map<java.lang.String,java.lang.String> | Flink configuration overrides for the Flink deployment or Flink session job. |
+| image | java.lang.String | Flink docker image used to start the Job and TaskManager pods. |
+| imagePullPolicy | java.lang.String | Image pull policy of the Flink docker image. |
+| serviceAccount | java.lang.String | Kubernetes service used by the Flink deployment. |
+| flinkVersion | org.apache.flink.kubernetes.operator.api.spec.FlinkVersion | Flink image version. |
+| ingress | org.apache.flink.kubernetes.operator.api.spec.IngressSpec | Ingress specs. |
+| podTemplate | io.fabric8.kubernetes.api.model.PodTemplateSpec | Base pod template for job and task manager pods. Can be overridden by the jobManager and taskManager pod templates. |
+| jobManager | org.apache.flink.kubernetes.operator.api.spec.JobManagerSpec | JobManager specs. |
+| taskManager | org.apache.flink.kubernetes.operator.api.spec.TaskManagerSpec | TaskManager specs. |
+| logConfiguration | java.util.Map<java.lang.String,java.lang.String> | Log configuration overrides for the Flink deployment. Format logConfigFileName -> configContent. |
+| mode | org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode | Deployment mode of the Flink cluster, native or standalone. |
+
+### FlinkSessionJobSpec
+**Class**: org.apache.flink.kubernetes.operator.api.spec.FlinkSessionJobSpec
+
+**Description**: Spec that describes a Flink session job.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| job | org.apache.flink.kubernetes.operator.api.spec.JobSpec | Job specification for application deployments/session job. Null for session clusters. |
+| restartNonce | java.lang.Long | Nonce used to manually trigger restart for the cluster/session job. In order to trigger restart, change the number to a different non-null value. |
+| flinkConfiguration | java.util.Map<java.lang.String,java.lang.String> | Flink configuration overrides for the Flink deployment or Flink session job. |
+| deploymentName | java.lang.String | The name of the target session cluster deployment. |
+
+### FlinkVersion
+**Class**: org.apache.flink.kubernetes.operator.api.spec.FlinkVersion
+
+**Description**: Enumeration for supported Flink versions.
+
+| Value | Docs |
+| ----- | ---- |
+| v1_13 | No longer supported since 1.7 operator release. |
+| v1_14 | No longer supported since 1.7 operator release. |
+| v1_15 |  |
+| v1_16 |  |
+| v1_17 |  |
+| v1_18 |  |
+| v1_19 |  |
+
+### IngressSpec
+**Class**: org.apache.flink.kubernetes.operator.api.spec.IngressSpec
+
+**Description**: Ingress spec.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| template | java.lang.String | Ingress template for the JobManager service. |
+| className | java.lang.String | Ingress className for the Flink deployment. |
+| annotations | java.util.Map<java.lang.String,java.lang.String> | Ingress annotations. |
+| labels | java.util.Map<java.lang.String,java.lang.String> | Ingress labels. |
+| tls | java.util.List<io.fabric8.kubernetes.api.model.networking.v1.IngressTLS> | Ingress tls. |
+
+### JobManagerSpec
+**Class**: org.apache.flink.kubernetes.operator.api.spec.JobManagerSpec
+
+**Description**: JobManager spec.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| resource | org.apache.flink.kubernetes.operator.api.spec.Resource | Resource specification for the JobManager pods. |
+| replicas | int | Number of JobManager replicas. Must be 1 for non-HA deployments. |
+| podTemplate | io.fabric8.kubernetes.api.model.PodTemplateSpec | JobManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. |
+
+### JobSpec
+**Class**: org.apache.flink.kubernetes.operator.api.spec.JobSpec
+
+**Description**: Flink job spec.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| jarURI | java.lang.String | Optional URI of the job jar within the Flink docker container. For example: local:///opt/flink/examples/streaming/StateMachineExample.jar. If not specified the job jar should be available in the system classpath. |
+| parallelism | int | Parallelism of the Flink job. |
+| entryClass | java.lang.String | Fully qualified main class name of the Flink job. |
+| args | java.lang.String[] | Arguments for the Flink job main class. |
+| state | org.apache.flink.kubernetes.operator.api.spec.JobState | Desired state for the job. |
+| savepointTriggerNonce | java.lang.Long | Nonce used to manually trigger savepoint for the running job. In order to trigger a savepoint, change the number to a different non-null value. |
+| initialSavepointPath | java.lang.String | Savepoint path used by the job the first time it is deployed or during savepoint redeployments (triggered by changing the savepointRedeployNonce). |
+| checkpointTriggerNonce | java.lang.Long | Nonce used to manually trigger checkpoint for the running job. In order to trigger a checkpoint, change the number to a different non-null value. |
+| upgradeMode | org.apache.flink.kubernetes.operator.api.spec.UpgradeMode | Upgrade mode of the Flink job. |
+| allowNonRestoredState | java.lang.Boolean | Allow checkpoint state that cannot be mapped to any job vertex in tasks. |
+| savepointRedeployNonce | java.lang.Long | Nonce used to trigger a full redeployment of the job from the savepoint path specified in initialSavepointPath. In order to trigger redeployment, change the number to a different non-null value. Rollback is not possible after redeployment. |
+
+### JobState
+**Class**: org.apache.flink.kubernetes.operator.api.spec.JobState
+
+**Description**: Enum describing the desired job state.
+
+| Value | Docs |
+| ----- | ---- |
+| running | Job is expected to be processing data. |
+| suspended | Processing is suspended with the intention of continuing later. |
+
+### KubernetesDeploymentMode
+**Class**: org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode
+
+**Description**: Enum to control Flink deployment mode on Kubernetes.
+
+| Value | Docs |
+| ----- | ---- |
+| native | Deploys Flink using Flinks native Kubernetes support. Only supported for newer versions of Flink |
+| standalone | Deploys Flink on-top of kubernetes in standalone mode. |
+
+### Resource
+**Class**: org.apache.flink.kubernetes.operator.api.spec.Resource
+
+**Description**: Resource spec.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| cpu | java.lang.Double | Amount of CPU allocated to the pod. |
+| memory | java.lang.String | Amount of memory allocated to the pod. Example: 1024m, 1g |
+| ephemeralStorage | java.lang.String | Amount of ephemeral storage allocated to the pod. Example: 1024m, 2G |
+
+### TaskManagerSpec
+**Class**: org.apache.flink.kubernetes.operator.api.spec.TaskManagerSpec
+
+**Description**: TaskManager spec.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| resource | org.apache.flink.kubernetes.operator.api.spec.Resource | Resource specification for the TaskManager pods. |
+| replicas | java.lang.Integer | Number of TaskManager replicas. If defined, takes precedence over parallelism |
+| podTemplate | io.fabric8.kubernetes.api.model.PodTemplateSpec | TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. |
+
+### UpgradeMode
+**Class**: org.apache.flink.kubernetes.operator.api.spec.UpgradeMode
+
+**Description**: Enum to control Flink job upgrade behavior.
+
+| Value | Docs |
+| ----- | ---- |
+| savepoint | Job is upgraded by first taking a savepoint of the running job, shutting it down and restoring from the savepoint. |
+| last-state | Job is upgraded using any latest checkpoint or savepoint available. |
+| stateless | Job is upgraded with empty state. |
+
+## Status
+
+### Checkpoint
+**Class**: org.apache.flink.kubernetes.operator.api.status.Checkpoint
+
+**Description**: Represents information about a finished checkpoint.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| timeStamp | long | Millisecond timestamp at the start of the checkpoint operation. |
+| triggerType | org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType | Checkpoint trigger mechanism. |
+| formatType | org.apache.flink.kubernetes.operator.api.status.CheckpointType | Checkpoint format. |
+| triggerNonce | java.lang.Long | Nonce value used when the checkpoint was triggered manually {@link SnapshotTriggerType#MANUAL}, null for other types of checkpoint. |
+
+### CheckpointInfo
+**Class**: org.apache.flink.kubernetes.operator.api.status.CheckpointInfo
+
+**Description**: Stores checkpoint-related information.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| lastCheckpoint | org.apache.flink.kubernetes.operator.api.status.Checkpoint | Last completed checkpoint by the operator. |
+| triggerId | java.lang.String | Trigger id of a pending checkpoint operation. |
+| triggerTimestamp | java.lang.Long | Trigger timestamp of a pending checkpoint operation. |
+| triggerType | org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType | Checkpoint trigger mechanism. |
+| formatType | org.apache.flink.kubernetes.operator.api.status.CheckpointType | Checkpoint format. |
+| lastPeriodicCheckpointTimestamp | long | Trigger timestamp of last periodic checkpoint operation. |
+
+### CheckpointType
+**Class**: org.apache.flink.kubernetes.operator.api.status.CheckpointType
+
+**Description**: Checkpoint format type.
+
+| Value | Docs |
+| ----- | ---- |
+| FULL |  |
+| INCREMENTAL |  |
+| UNKNOWN | Checkpoint format unknown, if the checkpoint was not triggered by the operator. |
+| description | org.apache.flink.configuration.description.InlineElement |  |
+
+### FlinkDeploymentReconciliationStatus
+**Class**: org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentReconciliationStatus
+
+**Description**: Status of the last reconcile step for the flink deployment.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| reconciliationTimestamp | long | Epoch timestamp of the last successful reconcile operation. |
+| lastReconciledSpec | java.lang.String | Last reconciled deployment spec. Used to decide whether further reconciliation steps are necessary. |
+| lastStableSpec | java.lang.String | Last stable deployment spec according to the specified stability condition. If a rollback strategy is defined this will be the target to roll back to. |
+| state | org.apache.flink.kubernetes.operator.api.status.ReconciliationState | Deployment state of the last reconciled spec. |
+
+### FlinkDeploymentStatus
+**Class**: org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus
+
+**Description**: Last observed status of the Flink deployment.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| jobStatus | org.apache.flink.kubernetes.operator.api.status.JobStatus | Last observed status of the Flink job on Application/Session cluster. |
+| error | java.lang.String | Error information about the FlinkDeployment/FlinkSessionJob. |
+| observedGeneration | java.lang.Long | Last observed generation of the FlinkDeployment/FlinkSessionJob. |
+| lifecycleState | org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState | Lifecycle state of the Flink resource (including being rolled back, failed etc.). |
+| clusterInfo | java.util.Map<java.lang.String,java.lang.String> | Information from running clusters. |
+| jobManagerDeploymentStatus | org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus | Last observed status of the JobManager deployment. |
+| reconciliationStatus | org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentReconciliationStatus | Status of the last reconcile operation. |
+| taskManager | org.apache.flink.kubernetes.operator.api.status.TaskManagerInfo | Information about the TaskManagers for the scale subresource. |
+
+### FlinkSessionJobReconciliationStatus
+**Class**: org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobReconciliationStatus
+
+**Description**: Status of the last reconcile step for the flink sessionjob.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| reconciliationTimestamp | long | Epoch timestamp of the last successful reconcile operation. |
+| lastReconciledSpec | java.lang.String | Last reconciled deployment spec. Used to decide whether further reconciliation steps are necessary. |
+| lastStableSpec | java.lang.String | Last stable deployment spec according to the specified stability condition. If a rollback strategy is defined this will be the target to roll back to. |
+| state | org.apache.flink.kubernetes.operator.api.status.ReconciliationState | Deployment state of the last reconciled spec. |
+
+### FlinkSessionJobStatus
+**Class**: org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobStatus
+
+**Description**: Last observed status of the Flink Session job.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| jobStatus | org.apache.flink.kubernetes.operator.api.status.JobStatus | Last observed status of the Flink job on Application/Session cluster. |
+| error | java.lang.String | Error information about the FlinkDeployment/FlinkSessionJob. |
+| observedGeneration | java.lang.Long | Last observed generation of the FlinkDeployment/FlinkSessionJob. |
+| lifecycleState | org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState | Lifecycle state of the Flink resource (including being rolled back, failed etc.). |
+| reconciliationStatus | org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobReconciliationStatus | Status of the last reconcile operation. |
+
+### JobManagerDeploymentStatus
+**Class**: org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus
+
+**Description**: Status of the Flink JobManager Kubernetes deployment.
+
+| Value | Docs |
+| ----- | ---- |
+| READY | JobManager is running and ready to receive REST API calls. |
+| DEPLOYED_NOT_READY | JobManager is running but not ready yet to receive REST API calls. |
+| DEPLOYING | JobManager process is starting up. |
+| MISSING | JobManager deployment not found, probably not started or killed by user. |
+| ERROR | Deployment in terminal error, requires spec change for reconciliation to continue. |
+
+### JobStatus
+**Class**: org.apache.flink.kubernetes.operator.api.status.JobStatus
+
+**Description**: Last observed status of the Flink job within an application deployment.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| jobName | java.lang.String | Name of the job. |
+| jobId | java.lang.String | Flink JobId of the Job. |
+| state | java.lang.String | Last observed state of the job. |
+| startTime | java.lang.String | Start time of the job. |
+| updateTime | java.lang.String | Update time of the job. |
+| savepointInfo | org.apache.flink.kubernetes.operator.api.status.SavepointInfo | Information about pending and last savepoint for the job. |
+| checkpointInfo | org.apache.flink.kubernetes.operator.api.status.CheckpointInfo | Information about pending and last checkpoint for the job. |
+
+### ReconciliationState
+**Class**: org.apache.flink.kubernetes.operator.api.status.ReconciliationState
+
+**Description**: Current state of the reconciliation.
+
+| Value | Docs |
+| ----- | ---- |
+| DEPLOYED | The lastReconciledSpec is currently deployed. |
+| UPGRADING | The spec is being upgraded. |
+| ROLLING_BACK | In the process of rolling back to the lastStableSpec. |
+| ROLLED_BACK | Rolled back to the lastStableSpec. |
+
+### Savepoint
+**Class**: org.apache.flink.kubernetes.operator.api.status.Savepoint
+
+**Description**: Represents information about a finished savepoint.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| timeStamp | long | Millisecond timestamp at the start of the savepoint operation. |
+| location | java.lang.String | External pointer of the savepoint can be used to recover jobs. |
+| triggerType | org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType | Savepoint trigger mechanism. |
+| formatType | org.apache.flink.kubernetes.operator.api.status.SavepointFormatType | Savepoint format. |
+| triggerNonce | java.lang.Long | Nonce value used when the savepoint was triggered manually {@link SnapshotTriggerType#MANUAL}, null for other types of savepoints. |
+
+### SavepointFormatType
+**Class**: org.apache.flink.kubernetes.operator.api.status.SavepointFormatType
+
+**Description**: Savepoint format type.
+
+| Value | Docs |
+| ----- | ---- |
+| CANONICAL | A canonical, common for all state backends format. |
+| NATIVE | A format specific for the chosen state backend. |
+| UNKNOWN | Savepoint format unknown, if the savepoint was not triggered by the operator. |
+
+### SavepointInfo
+**Class**: org.apache.flink.kubernetes.operator.api.status.SavepointInfo
+
+**Description**: Stores savepoint related information.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| lastSavepoint | org.apache.flink.kubernetes.operator.api.status.Savepoint | Last completed savepoint by the operator. |
+| triggerId | java.lang.String | Trigger id of a pending savepoint operation. |
+| triggerTimestamp | java.lang.Long | Trigger timestamp of a pending savepoint operation. |
+| triggerType | org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType | Savepoint trigger mechanism. |
+| formatType | org.apache.flink.kubernetes.operator.api.status.SavepointFormatType | Savepoint format. |
+| savepointHistory | java.util.List<org.apache.flink.kubernetes.operator.api.status.Savepoint> | List of recent savepoints. |
+| lastPeriodicSavepointTimestamp | long | Trigger timestamp of last periodic savepoint operation. |
+
+### SnapshotTriggerType
+**Class**: org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType
+
+**Description**: Snapshot trigger mechanism.
+
+| Value | Docs |
+| ----- | ---- |
+| MANUAL | Snapshot manually triggered by changing a triggerNonce. |
+| PERIODIC | Snapshot periodically triggered by the operator. |
+| UPGRADE | Snapshot triggered during stateful upgrade. |
+| UNKNOWN | Snapshot trigger mechanism unknown, such as savepoint retrieved directly from Flink job. |
+
+### TaskManagerInfo
+**Class**: org.apache.flink.kubernetes.operator.api.status.TaskManagerInfo
+
+**Description**: Last observed status of the Flink job within an application deployment.
+
+| Parameter | Type | Docs |
+| ----------| ---- | ---- |
+| labelSelector | java.lang.String | TaskManager label selector. |
+| replicas | int | Number of TaskManager replicas if defined in the spec. |

--- a/docs/content.zh/docs/development/_index.md
+++ b/docs/content.zh/docs/development/_index.md
@@ -1,0 +1,31 @@
+---
+title: Development
+icon: <i class="fa fa-book title maindish" aria-hidden="true"></i>
+bold: true
+bookCollapseSection: true
+weight: 5
+---
+title: RoadMap
+icon: <i class="fa fa-book title maindish" aria-hidden="true"></i>
+bold: true
+bookCollapseSection: true
+weight: 5
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/content.zh/docs/development/guide.md
+++ b/docs/content.zh/docs/development/guide.md
@@ -1,0 +1,178 @@
+---
+title: "Guide"
+weight: 1
+type: docs
+aliases:
+- /development/guide.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Development Guide
+
+We gathered a set of best practices here to aid development.
+
+## Build from sources
+
+In order to build the operator you need to [clone the git repository]({{< github_repo >}}).
+
+```bash
+git clone {{< github_repo >}}
+```
+
+To build from the command line, it is necessary to have **Maven 3** and a **Java Development Kit** (JDK) installed. Please note that Flink Kubernetes Operator requires **Java 11**.
+
+To build the project, you can use the following command:
+
+```bash
+mvn clean install
+```
+
+To speed up the build you can:
+- skip the tests by using ' -DskipTests'
+- use Maven's parallel build feature, e.g., 'mvn package -T 1C' will attempt to build 1 module for each CPU core in parallel
+
+```bash
+mvn clean install -DskipTests -T 1C
+```
+
+## Local environment setup
+
+We recommend you install [Docker Desktop](https://www.docker.com/products/docker-desktop), [minikube](https://minikube.sigs.k8s.io/docs/start/)
+and [helm](https://helm.sh/docs/intro/quickstart/) on your local machine. For the setup please refer to our
+[quickstart]({{< ref "docs/try-flink-kubernetes-operator/quick-start" >}}#prerequisites).
+
+### Building docker images
+You can build your own flavor of image as follows via specifying your `<repo>`:
+```bash
+docker build . -t <repo>/flink-kubernetes-operator:latest
+docker push <repo>/flink-kubernetes-operator:latest
+```
+
+If you are using minikube you might want to load the image directly instead of pushing it to a registry:
+
+```bash
+minikube image load <repo>/flink-kubernetes-operator:latest
+```
+
+You can cut a corner via using the docker daemon of your minikube installation directly as follows:
+```bash
+eval $(minikube docker-env)
+DOCKER_BUILDKIT=1 docker build . -t <repo>/flink-kubernetes-operator:latest
+```
+
+When you want to reset your environment to the defaults you can do the following:
+```bash
+eval $(minikube docker-env --unset)
+```
+
+The most useful insight when it comes to minikube that it is just a docker container on your local machine and you can
+ssh to it with the following command in case you needed to hack something there (like adding a hostpath mount or modifying docker images).
+
+```bash
+minikube ssh
+Last login: Wed Mar 9 10:01:21 2022 from 192.168.49.1
+docker@minikube:~$ docker images
+REPOSITORY                                             TAG                IMAGE ID       CREATED         SIZE
+flink-kubernetes-operator                              latest             cf7856d9ef59   23 hours ago    578MB
+docker@minikube:~$ exit
+```
+
+### Installing the operator locally
+
+```bash
+helm install flink-kubernetes-operator helm/flink-kubernetes-operator --set image.repository=<repo>/flink-kubernetes-operator --set image.tag=latest
+```
+
+To uninstall you can simply call:
+
+```bash
+helm uninstall flink-kubernetes-operator
+```
+
+### Running the operator from the IDE
+
+You can run or debug the `FlinkOperator` from your preferred IDE. The operator itself is accessing the deployed Flink clusters through the REST interface. When running locally the `rest.port`, `rest.address` and `kubernetes.rest-service.exposed.type` Flink configuration parameters must be modified.
+
+When using `minikube tunnel` the rest service is exposed on `localhost:8081`
+```bash
+> minikube tunnel
+
+> kubectl get services
+NAME                         TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)             AGE
+basic-session-example        ClusterIP      None           <none>        6123/TCP,6124/TCP   14h
+basic-session-example-rest   LoadBalancer   10.96.36.250   127.0.0.1     8081:30572/TCP      14h
+```
+The operator picks up the default log and flink configurations from `/opt/flink/conf`. You can put the rest configuration parameters here:
+```bash
+cat /opt/flink/conf/flink-conf.yaml
+rest.port: 8081
+rest.address: localhost
+kubernetes.rest-service.exposed.type: LoadBalancer
+```
+
+Due to fabric8 conflicts between core Flink and the operator, the `flink-kubernetes-operator` module depends on the shaded `flink-kubernetes-standalone` jar which contains the relocated version of the old fabric8 Kubernetes client. Unfortunately IntelliJ is not great at handling dependencies with classifiers so you might get the following error when trying to run `FlinkOperator#main`:
+
+```
+java.lang.NoSuchMethodError: 'java.lang.Object io.fabric8.kubernetes.client.dsl.ServiceResource.fromServer()'
+```
+
+There are two solutions to this problem, both requires you to first build the project.
+
+First:
+
+```bash
+mvn clean install
+```
+
+Then either:
+
+ 1. Import the `flink-kubernetes-operator` submodule as a separate IntelliJ project. This will resolve the classifier dependency correctly from your local maven cache.
+ 2. If you want to keep a single multi-module project, you need to add the `flink-kubernetes-standalone-XX-shaded.jar` on the classpath manually when running the main method:
+ `Edit Run Configuration/Modify Options/Modify Classpath`
+
+### Generating and Upgrading the CRD
+
+By default, the CRD is generated by the [Fabric8 CRDGenerator](https://github.com/fabric8io/kubernetes-client/blob/master/doc/CRD-generator.md), when building from source.
+When installing flink-kubernetes-operator for the first time, the CRD will be applied to the kubernetes cluster automatically. But it will not be removed or upgraded when re-installing the flink-kubernetes-operator, as described in the relevant helm [documentation](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/).
+So if the CRD is changed, you have to delete the CRD resource manually, and re-install the flink-kubernetes-operator.
+
+```bash
+kubectl delete crd flinkdeployments.flink.apache.org
+```
+
+### Mounts
+
+The operator supports to specify the volume mounts. The default mounts to hostPath can be activated by the following command. You can change the default mounts in the `helm/flink-kubernetes-operator/values.yaml`
+
+```bash
+helm install flink-operator helm/flink-operator --set operatorVolumeMounts.create=true --set operatorVolumes.create=true
+```
+
+
+## CI/CD
+
+We use [GitHub Actions](https://help.github.com/en/actions/getting-started-with-github-actions/about-github-actions) to help you automate your software development workflows in the same place you store code and collaborate on pull requests and issues.
+You can write individual tasks, called actions, and combine them to create a custom workflow.
+Workflows are custom automated processes that you can set up in your repository to build, test, package, release, or deploy any code project on GitHub.
+
+Considering the cost of running the builds, the stability, and the maintainability, flink-kubernetes-operator chose GitHub Actions and build the whole CI/CD solution on it.
+All the unit tests, integration tests, and the end-to-end tests will be triggered for each PR.
+
+Note: Please make sure the CI passed before merging.

--- a/docs/content.zh/docs/development/roadmap.md
+++ b/docs/content.zh/docs/development/roadmap.md
@@ -1,0 +1,36 @@
+---
+title: "Roadmap"
+weight: 1
+type: docs
+aliases:
+- /development/roadmap.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Flink Operator Roadmap
+
+This page is intended to present an overview of the general direction of the Flink Kubernetes Operator project, and the larger new features on our radar.
+It's not a comprehensive list and might be slightly outdated at any given time. Please check JIRA for the actual work items and the Flink mailing lists for feature planning and discussion.
+
+## What’s Next?
+
+- Improved rollback mechanism and stability conditions
+- Autoscaler hardening and improvements
+- Support for in-place job rescaling with Flink 1.18

--- a/docs/content.zh/docs/operations/_index.md
+++ b/docs/content.zh/docs/operations/_index.md
@@ -1,0 +1,25 @@
+---
+title: Operations
+icon: <i class="fa fa-cogs title maindish" aria-hidden="true"></i>
+bold: true
+bookCollapseSection: true
+weight: 4
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/content.zh/docs/operations/compatibility.md
+++ b/docs/content.zh/docs/operations/compatibility.md
@@ -1,0 +1,63 @@
+---
+title: "Compatibility Guarantees"
+weight: 4
+type: docs
+aliases:
+- /operations/compatibility.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Compatibility Guarantees
+
+It is very important for users to clearly understand the compatibility guarantees the operator provides when upgrading to new versions.
+
+## Custom Resource backward compatibility
+
+The main user facing api of the operator are the Flink [custom resources]({{< ref "docs/custom-resource/overview" >}}).
+
+Starting from `v1beta1` (operator version 1.0.0) we aim to provide backward compatibility for the already deployed Flink custom resources (`FlinkDeployment`, `FlinkSessionJob`).
+
+This means that if you have Flink resources deployed (and Flink applications running), you can still safely upgrade to newer versions of the operator and CRD without any problems.
+This should ensure a smooth operational experience where you can always benefit from the latest fixes and improvements without risking current deployments.
+
+{{< hint warning >}}
+We do not guarantee that you will always be able to deploy new resources using old API versions.
+For example when in the future we upgrade from `v1beta1 -> v1`, while it is guaranteed that your current jobs won't fail, you might need to upgrade to `v1` before you can submit new resources.
+{{< /hint >}}
+
+## Contents of the resource status
+
+Currently, the `FlinkDeployment` and `FlinkSessionJob` resources contain a very detailed status information that contains everything necessary for the operator to manage the resources.
+Most of this information should be considered ***internal*** to operator logic and is subject to change/disappear in the future.
+
+In general, we are aiming to slim down the status to only contain information that is relevant to users/client for the next major CRD version (`v1`).
+
+## Java API compatibility
+
+While it is very important for us to provide [backward compatibility for the custom resources](#custom-resource-backward-compatibility), at this time we cannot provide the same guarantee for Java API.
+
+The operator related java interfaces, such as Validators should be considered experimental/evolving and can possibly break between releases.
+
+## Helm chart compatibility
+
+The Helm chart included in the operator repo provides a convenient way to deploy and manage the operator in complex environments.
+We are constantly working on improving the configuration parameters and features to cover all the different scenarios.
+
+At this time we do not provide backward compatibility for the Helm chart configuration / components. Please verify your custom settings before upgrading to a new version.

--- a/docs/content.zh/docs/operations/configuration.md
+++ b/docs/content.zh/docs/operations/configuration.md
@@ -1,0 +1,161 @@
+---
+title: "Configuration"
+weight: 2
+type: docs
+aliases:
+- /operations/configuration.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Configuration
+
+## Specifying Operator Configuration
+
+The operator allows users to specify default configuration that will be shared by the Flink operator itself and the Flink deployments.
+
+These configuration files are mounted externally via ConfigMaps. The [Configuration files](https://github.com/apache/flink-kubernetes-operator/tree/main/helm/flink-kubernetes-operator/conf) with default values are shipped in the Helm chart. It is recommended to review and adjust them if needed in the `values.yaml` file before deploying the Operator in production environments.
+
+To append to the default configuration, define the `flink-conf.yaml` key in the `defaultConfiguration` section of the Helm `values.yaml` file:
+
+```
+defaultConfiguration:
+  create: true
+  # Set append to false to replace configuration files
+  append: true
+  flink-conf.yaml: |+
+    # Flink Config Overrides
+    kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory
+    kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE
+
+    kubernetes.operator.reconcile.interval: 15 s
+    kubernetes.operator.observer.progress-check.interval: 5 s
+```
+
+To learn more about metrics and logging configuration please refer to the dedicated [docs page]({{< ref "docs/operations/metrics-logging" >}}).
+
+### Flink Version and Namespace specific defaults
+
+The operator also supports default configuration overrides for selected Flink versions and namespaces. This can be important if some behaviour changed across Flink versions or we want to treat certain namespaces differently (such as reconcile it more or less frequently etc).
+
+```
+# Flink Version specific defaults 
+kubernetes.operator.default-configuration.flink-version.v1_17.k1: v1
+kubernetes.operator.default-configuration.flink-version.v1_17.k2: v2
+kubernetes.operator.default-configuration.flink-version.v1_17.k3: v3
+
+# Namespace specific defaults
+kubernetes.operator.default-configuration.namespace.ns1.k1: v1
+kubernetes.operator.default-configuration.namespace.ns1.k2: v2
+kubernetes.operator.default-configuration.namespace.ns2.k1: v1
+```
+
+Flink version specific defaults will have a higher precedence so namespace defaults would be overridden by the same key.
+
+## Dynamic Operator Configuration
+
+The Kubernetes operator supports dynamic config changes through the operator ConfigMaps. Dynamic operator configuration is enabled by default, and can be disabled by setting `kubernetes.operator.dynamic.config.enabled` to false. Time interval for checking dynamic config changes is specified by `kubernetes.operator.dynamic.config.check.interval` of which default value is 5 minutes.
+
+Verify whether dynamic operator configuration updates is enabled via the `deploy/flink-kubernetes-operator` log has:
+
+```
+2022-05-28 13:08:29,222 o.a.f.k.o.c.FlinkConfigManager [INFO ] Enabled dynamic config updates, checking config changes every PT5M
+```
+
+To change config values dynamically the ConfigMap can be directly edited via `kubectl patch` or `kubectl edit` command. For example to change the reschedule interval you can override `kubernetes.operator.reconcile.interval`.
+
+Verify whether the config value of `kubernetes.operator.reconcile.interval` is updated to 30 seconds via the `deploy/flink-kubernetes-operator` log has:
+
+```text
+2022-05-28 13:08:30,115 o.a.f.k.o.c.FlinkConfigManager [INFO ] Updating default configuration to {kubernetes.operator.reconcile.interval=PT30S}
+```
+
+## Leader Election and High Availability
+
+The operator supports high availability through leader election and standby operator instances. To enable leader election you need to add the following two mandatory operator configuration parameters.
+
+```yaml
+kubernetes.operator.leader-election.enabled: true
+kubernetes.operator.leader-election.lease-name: flink-operator-lease
+```
+
+Lease name must be unique in the current lease namespace. For other more advanced config parameters please refer to the configuration reference.
+
+Once you enabled leader election you can increase the `replicas` for the operator Deployment using the Helm chart to enable high availability.
+
+If `replicas` value is greater than 1, you can define [topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+via `operatorPod.topologySpreadConstraints`.
+
+
+## Environment variables
+The operator exposes several environment variables which can be used for custom plugins.
+
+| Name     | Description                           | FieldRef      |
+|----------|---------------------------------------|---------------|
+| HOST_IP  | The host which the pod is deployed on | status.hostIP |
+| POD_IP   | Pod IP                                | status.podIP  |
+| POD_NAME | Pod Name                              | metadata.name |
+
+## Operator Configuration Reference
+
+### System Configuration
+
+General operator system configuration. Cannot be overridden on a per-resource basis.
+
+{{< generated/system_section >}}
+
+### Resource/User Configuration
+
+These options can be configured on both an operator and a per-resource level. When set under `spec.flinkConfiguration` for the Flink resources it will override the default value provided in the operator default configuration (`flink-conf.yaml`).
+
+{{< generated/dynamic_section >}}
+
+### Autoscaler Configuration
+
+Like other resource options these can be configured on both an operator and a per-resource level. When set under `spec.flinkConfiguration` for the Flink resources it will override the default value provided in the operator default configuration (`flink-conf.yaml`).
+
+> Note: The option prefix `kubernetes.operator.` was removed in FLIP-334, because the autoscaler module was decoupled from flink-kubernetes-operator.
+
+{{< generated/auto_scaler_configuration >}}
+
+### Autoscaler Standalone Configuration
+
+Unlike other resource options, these options only work with autoscaler standalone process.
+
+{{< generated/autoscaler_standalone_configuration >}}
+
+### System Metrics Configuration
+
+Operator system metrics configuration. Cannot be overridden on a per-resource basis.
+
+{{< generated/kubernetes_operator_metric_configuration >}}
+
+### Advanced System Configuration
+
+Advanced operator system configuration. Cannot be overridden on a per-resource basis.
+
+{{< generated/system_advanced_section >}}
+
+### IPV6 Configuration
+
+If you run Flink Operator in IPV6 environment, the [host name verification error](https://issues.apache.org/jira/browse/FLINK-32777) will be triggered
+due to a known bug in Okhttp client. As a workaround before new Okhttp 5.0.0 release, the environment variable below needs to be set 
+for both Flink Operator and Flink Deployment Configuration.
+
+KUBERNETES_DISABLE_HOSTNAME_VERIFICATION=true

--- a/docs/content.zh/docs/operations/health.md
+++ b/docs/content.zh/docs/operations/health.md
@@ -1,0 +1,69 @@
+---
+title: "Operator Health Monitoring"
+weight: 3
+type: docs
+aliases:
+- /operations/health.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Operator Health Monitoring
+
+## Health Probe
+
+The Flink Kubernetes Operator provides a built in health endpoint that serves as the information source for Kubernetes liveness and startup probes.
+
+The liveness and startup probes are enabled by default in the Helm chart:
+
+```
+operatorHealth:
+  port: 8085
+  livenessProbe:
+    periodSeconds: 10
+    initialDelaySeconds: 30
+  startupProbe:
+    failureThreshold: 30
+    periodSeconds: 10
+```
+
+The health endpoint catches startup and informer errors that are exposed by the JOSDK framework. By default if one of the watched namespaces becomes inaccessible the health endpoint will report an error and the operator will restart.
+
+In some cases it is desirable to keep the operator running even if some namespaces are inaccessible. To allow the operator to start even if some namespaces cannot be watched, you can disable the `kubernetes.operator.startup.stop-on-informer-error` flag.
+
+## Canary Resources
+
+The canary resource feature allows users to deploy special dummy resources (canaries) into selected namespaces. The operator health probe will then monitor that these resources are reconciled in a timely manner. This allows the operator health probe to catch any slowdowns, and other general reconciliation issues not covered otherwise.
+
+Canary deployments are identified by a special label: `"flink.apache.org/canary": "true"`. These resources do not need to define a spec and they will not start any pods or consume other cluster resources and are purely there to assert the operator reconciliation functionality.
+
+Canary FlinkDeployment:
+
+```
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: canary
+  labels:
+    "flink.apache.org/canary": "true"
+```
+
+The default timeout for reconciling the canary resources is 1 minute and it is controlled by `kubernetes.operator.health.canary.resource.timeout`. If the operator cannot reconcile the canaries within this time limit the operator is marked unhealthy and will be automatically restarted.
+
+Canaries can be deployed into multiple namespaces.

--- a/docs/content.zh/docs/operations/helm.md
+++ b/docs/content.zh/docs/operations/helm.md
@@ -1,0 +1,288 @@
+---
+title: "Helm"
+weight: 1
+type: docs
+aliases:
+- /operations/helm.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Helm installation
+
+The operator installation is managed by a helm chart. To install with the chart bundled in the source code run:
+
+```
+helm install flink-kubernetes-operator helm/flink-kubernetes-operator
+```
+
+To install from our Helm Chart Reporsitory run:
+
+```
+helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-<OPERATOR-VERSION>/
+helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator
+```
+
+Alternatively to install the operator (and also the helm chart) to a specific namespace add the arguments `--namespace` and `--create-namespace` ex:
+
+```
+helm install flink-kubernetes-operator helm/flink-kubernetes-operator --namespace flink --create-namespace
+```
+
+Note that in this case you will need to update the namespace in the examples accordingly or the `default`
+namespace to the [watched namespaces](#watching-only-specific-namespaces).
+
+## Overriding configuration parameters during Helm install
+
+Helm provides different ways to override the default installation parameters (contained in `values.yaml`) for the Helm chart.
+
+To override single parameters you can use `--set`, for example:
+```
+helm install --set image.repository=apache/flink-kubernetes-operator --set image.tag={{< stable >}}{{< version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}} flink-kubernetes-operator helm/flink-kubernetes-operator
+```
+
+You can also provide your custom values file by using the `-f` flag:
+```
+helm install -f myvalues.yaml flink-kubernetes-operator helm/flink-kubernetes-operator
+```
+
+The configurable parameters of the Helm chart and which default values as detailed in the following table:
+
+| Parameters                                     | Description                                                                                                                                                    | Default Value                                                                                                                                                                                                                                                                                  |
+|------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| watchNamespaces                                | List of kubernetes namespaces to watch for FlinkDeployment changes, empty means all namespaces.                                                                |                                                                                                                                                                                                                                                                                                |
+| image.repository                               | The image repository of flink-kubernetes-operator.                                                                                                             | ghcr.io/apache/flink-kubernetes-operator                                                                                                                                                                                                                                                       |
+| image.pullPolicy                               | The image pull policy of flink-kubernetes-operator.                                                                                                            | IfNotPresent                                                                                                                                                                                                                                                                                   |
+| image.tag                                      | The image tag of flink-kubernetes-operator.                                                                                                                    | latest                                                                                                                                                                                                                                                                                         |
+| image.digest                                   | The image tag of flink-kubernetes-operator. If set then it takes precedence and the image tag will be ignored.                                                 |                                                                                                                                                                                                                                                                                                |
+| replicas                                       | Operator replica count. Must be 1 unless leader election is configured.                                                                                        | 1                                                                                                                                                                                                                                                                                              |
+| strategy.type                                  | Operator pod upgrade strategy. Must be Recreate unless leader election is configured.                                                                          | Recreate                                                                                                                                                                                                                                                                                       |
+| rbac.create                                    | Whether to enable RBAC to create for said namespaces.                                                                                                          | true                                                                                                                                                                                                                                                                                           |
+| rbac.nodesRule.create                          | Whether to add RBAC rule to list nodes which is needed for rest-service exposed as NodePort type.                                                              | false                                                                                                                                                                                                                                                                                          |
+| operatorPod.annotations                        | Custom annotations to be added to the operator pod (but not the deployment).                                                                                   |                                                                                                                                                                                                                                                                                                |
+| operatorPod.labels                             | Custom labels to be added to the operator pod (but not the deployment).                                                                                        |                                                                                                                                                                                                                                                                                                |
+| operatorPod.env                                | Custom env to be added to the operator pod.                                                                                                                    |                                                                                                                                                                                                                                                                                                |
+| operatorPod.envFrom                            | Custom envFrom settings to be added to the operator pod.                                                                                                       |                                                                                                                                                                                                                                                                                                |
+| operatorPod.dnsPolicy                          | DNS policy to be used by the operator pod.                                                                                                                     |                                                                                                                                                                                                                                                                                                |
+| operatorPod.dnsConfig                          | DNS configuration to be used by the operator pod.                                                                                                              |                                                                                                                                                                                                                                                                                                |
+| operatorPod.nodeSelector                       | Custom nodeSelector to be added to the operator pod.                                                                                                           |                                                                                                                                                                                                                                                                                                |
+| operatorPod.topologySpreadConstraints          | Custom topologySpreadConstraints to be added to the operator pod.                                                                                              |                                                                                                                                                                                                                                                                                                |
+| operatorPod.resources                          | Custom resources block to be added to the operator pod on main container.                                                                                      |                                                                                                                                                                                                                                                                                                |
+| operatorPod.webhook.resources                  | Custom resources block to be added to the operator pod on flink-webhook container.                                                                             |                                                                                                                                                                                                                                                                                                |
+| operatorPod.tolerations                        | Custom tolerations to be added to the operator pod.                                                                                                            |                                                                                                                                                                                                                                                                                                |
+| operatorServiceAccount.create                  | Whether to enable operator service account to create for flink-kubernetes-operator.                                                                            | true                                                                                                                                                                                                                                                                                           |
+| operatorServiceAccount.annotations             | The annotations of operator service account.                                                                                                                   |                                                                                                                                                                                                                                                                                                |
+| operatorServiceAccount.name                    | The name of operator service account.                                                                                                                          | flink-operator                                                                                                                                                                                                                                                                                 |
+| jobServiceAccount.create                       | Whether to enable job service account to create for flink jobmanager/taskmanager pods.                                                                         | true                                                                                                                                                                                                                                                                                           |
+| jobServiceAccount.annotations                  | The annotations of job service account.                                                                                                                        | "helm.sh/resource-policy": keep                                                                                                                                                                                                                                                                |
+| jobServiceAccount.name                         | The name of job service account.                                                                                                                               | flink                                                                                                                                                                                                                                                                                          |
+| operatorVolumeMounts.create                    | Whether to enable operator volume mounts to create for flink-kubernetes-operator.                                                                              | false                                                                                                                                                                                                                                                                                          |
+| operatorVolumeMounts.data                      | List of mount paths of operator volume mounts.                                                                                                                 | - name: flink-artifacts<br/>&nbsp;&nbsp;mountPath: /opt/flink/artifacts                                                                                                                                                                                                                        |
+| operatorVolumes.create                         | Whether to enable operator volumes to create for flink-kubernetes-operator.                                                                                    | false                                                                                                                                                                                                                                                                                          |
+| operatorVolumes.data                           | The ConfigMap of operator volumes.                                                                                                                             | - name: flink-artifacts<br/>&nbsp;&nbsp;hostPath:<br/>&nbsp;&nbsp;&nbsp;&nbsp;path: /tmp/flink/artifacts<br/>&nbsp;&nbsp;&nbsp;&nbsp;type: DirectoryOrCreate                                                                                                                                   |
+| podSecurityContext                             | Defines privilege and access control settings for a pod or container for pod security context.                                                                 | runAsUser: 9999<br/>runAsGroup: 9999                                                                                                                                                                                                                                                           |
+| operatorSecurityContext                        | Defines privilege and access control settings for a pod or container for operator security context.                                                            |                                                                                                                                                                                                                                                                                                |
+| webhookSecurityContext                         | Defines privilege and access control settings for a pod or container for webhook security context.                                                             |                                                                                                                                                                                                                                                                                                |
+| webhook.create                                 | Whether to enable validating and mutating webhooks for flink-kubernetes-operator.                                                                              | true                                                                                                                                                                                                                                                                                           |
+| webhook.mutator.create                         | Enable or disable mutating webhook, overrides `webhook.create`                                                                                                 |                                                                                                                                                                                                                                                                                                |
+| webhook.validator.create                       | Enable or disable validating webhook, overrides `webhook.create`                                                                                               |                                                                                                                                                                                                                                                                                                |
+| webhook.keystore                               | The ConfigMap of webhook key store.                                                                                                                            | useDefaultPassword: true                                                                                                                                                                                                                                                                       |
+| defaultConfiguration.create                    | Whether to enable default configuration to create for flink-kubernetes-operator.                                                                               | true                                                                                                                                                                                                                                                                                           |
+| defaultConfiguration.append                    | Whether to append configuration files with configs.                                                                                                            | true                                                                                                                                                                                                                                                                                           |
+| defaultConfiguration.flink-conf.yaml           | The default configuration of flink-conf.yaml.                                                                                                                  | kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory<br/>kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE<br/>kubernetes.operator.reconcile.interval: 15 s<br/>kubernetes.operator.observer.progress-check.interval: 5 s |
+| defaultConfiguration.log4j-operator.properties | The default configuration of log4j-operator.properties.                                                                                                        |                                                                                                                                                                                                                                                                                                |
+| defaultConfiguration.log4j-console.properties  | The default configuration of log4j-console.properties.                                                                                                         |                                                                                                                                                                                                                                                                                                |
+| metrics.port                                   | The metrics port on the container for default configuration.                                                                                                   |                                                                                                                                                                                                                                                                                                |
+| imagePullSecrets                               | The image pull secrets of flink-kubernetes-operator.                                                                                                           |                                                                                                                                                                                                                                                                                                |
+| nameOverride                                   | Overrides the name with the specified name.                                                                                                                    |                                                                                                                                                                                                                                                                                                |
+| fullnameOverride                               | Overrides the fullname with the specified full name.                                                                                                           |                                                                                                                                                                                                                                                                                                |
+| jvmArgs.webhook                                | The JVM start up options for webhook.                                                                                                                          |                                                                                                                                                                                                                                                                                                |
+| jvmArgs.operator                               | The JVM start up options for operator.                                                                                                                         |                                                                                                                                                                                                                                                                                                |
+| operatorHealth.port                            | Operator health endpoint port to be used by the probes.                                                                                                        | 8085                                                                                                                                                                                                                                                                                           |
+| operatorHealth.livenessProbe                   | Liveness probe configuration for the operator using the health endpoint. Only time settings should be configured, endpoint is set automatically based on port. |                                                                                                                                                                                                                                                                                                |
+| operatorHealth.startupProbe                    | Startup probe configuration for the operator using the health endpoint. Only time settings should be configured, endpoint is set automatically based on port.  |                                                                                                                                                                                                                                                                                                |
+| postStart                                      | The postStart hook configuration for the main container.                                                                                                       |                                                                                                                                                                                                                                                                                                |
+| tls.create                                     | Whether to mount an optional secret containing a tls truststore for the flink-kubernetes-operator.                                                             | false                                                                                                                                                                                                                                                                                          |
+| tls.secretName                                 | The name of the tls secret                                                                                                                                     | flink-operator-cert                                                                                                                                                                                                                                                                            |
+| tls.secretKeyRef.name                 | The name of the secret containing the password for the java keystore/truststore                                                                                | operator-certificate-password                                                                                                                                                                                                                                                                  |
+| tls.secretKeyRef.key                  | The key that holds this password                                                                                                                               | password                                                                                                                                                                                                                                                                                       |
+
+For more information check the [Helm documentation](https://helm.sh/docs/helm/helm_install/).
+
+__Notice__: The pod resources should be set as your workload in different environments to archive a matched K8s pod QoS. See also [Pod Quality of Service Classes](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/#quality-of-service-classes).
+
+## Operator webhooks
+
+In order to use the webhooks in the operator, you must install the cert-manager on the Kubernetes cluster:
+```
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
+```
+
+The webhooks can be disabled during helm install by passing the `--set webhook.create=false` parameter or editing the `values.yaml` directly.
+
+## Watching only specific namespaces
+
+The operator supports watching a specific list of namespaces for FlinkDeployment resources. You can enable it by setting the `--set watchNamespaces={flink-test}` parameter.
+When this is enabled role-based access control is only created specifically for these namespaces for the operator and the jobmanagers, otherwise it defaults to cluster scope.
+
+<span class="label label-info">Note</span> When working with webhook in a specified namespace, users should pay attention to the definition of `namespaceSelector.matchExpressions` in `webhook.yaml`. Currently, the default implementation of webhook relies on the `kubernetes.io/metadata.name` label to filter the validation requests
+so that only validation requests from the specified namespace will be processed. The `kubernetes.io/metadata.name` label is automatically attached since k8s [1.21.1](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#v1211).
+
+As a result, for users who run the flink kubernetes operator with older k8s version, they may label the specified namespace by themselves before installing the operator with helm:
+
+```
+kubectl label namespace <target namespace name> kubernetes.io/metadata.name=<target namespace name>
+```
+
+Besides, users can define their own namespaceSelector to filter the requests due to customized requirements.
+
+For example, if users label their namespace with key-value pair {customized_namespace_key: &lt;target namespace name&gt; }
+the corresponding namespaceSelector that only accepts requests from this namespace could be:
+```yaml
+namespaceSelector:
+  matchExpressions:
+    - key: customized_namespace_key
+    operator: In
+    values: [{{- range .Values.watchNamespaces }}{{ . | quote }},{{- end}}]
+```
+Check out this [document](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) for more details.
+
+## Working with Argo CD
+
+If you are using [Argo CD](https://argoproj.github.io) to manage the operator,
+the simplest example could look like this.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: flink-kubernetes-operator
+spec:
+  source:
+    repoURL: https://github.com/apache/flink-kubernetes-operator
+    targetRevision: main
+    path: helm/flink-kubernetes-operator
+...
+```
+
+Check out [Argo CD documents](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/) for more details.
+
+## Advanced customization techniques
+The Helm chart does not aim to provide configuration options for all the possible deployment scenarios of the Operator. There are use cases for injecting common tools and/or sidecars in most enterprise environments that cannot be covered by public Helm charts.
+
+Fortunately, [post rendering](https://helm.sh/docs/topics/advanced/#post-rendering) in Helm gives you the ability to manually manipulate manifests before they are installed on a Kubernetes cluster. This allows users to use tools like [kustomize](https://kustomize.io) to apply configuration changes without the need to fork public charts.
+
+The GitHub repository for the Operator contains a simple [example](https://github.com/apache/flink-kubernetes-operator/tree/main/examples/kustomize) on how to augment the Operator Deployment with a [fluent-bit](https://docs.fluentbit.io/manual) sidecar container and adjust container resources using `kustomize`.
+
+The example demonstrates that we can still use a `values.yaml` file to override the default Helm values for changing the log configuration, for example:
+
+```yaml
+
+defaultConfiguration:
+  ...
+  log4j-operator.properties: |+
+    rootLogger.appenderRef.file.ref = LogFile
+    appender.file.name = LogFile
+    appender.file.type = File
+    appender.file.append = false
+    appender.file.fileName = ${sys:log.file}
+    appender.file.layout.type = PatternLayout
+    appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+jvmArgs:
+  webhook: "-Dlog.file=/opt/flink/log/webhook.log -Xms256m -Xmx256m"
+  operator: "-Dlog.file=/opt/flink/log/operator.log -Xms2048m -Xmx2048m"
+```
+
+But we cannot ingest our fluent-bit sidecar for example unless we patch the deployment using `kustomize`
+
+```yaml
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: not-important
+spec:
+  template:
+    spec:
+      containers:
+        - name: flink-kubernetes-operator
+          volumeMounts:
+            - name: flink-log
+              mountPath: /opt/flink/log
+          resources:
+            requests:
+              memory: "2.5Gi"
+              cpu: "1000m"
+            limits:
+              memory: "2.5Gi"
+              cpu: "2000m"
+        - name: flink-webhook
+          volumeMounts:
+            - name: flink-log
+              mountPath: /opt/flink/log
+          resources:
+            requests:
+              memory: "0.5Gi"
+              cpu: "200m"
+            limits:
+              memory: "0.5Gi"
+              cpu: "500m"
+        - name: fluentbit
+          image: fluent/fluent-bit:1.8.12
+          command: [ 'sh','-c','/fluent-bit/bin/fluent-bit -i tail -p path=/opt/flink/log/*.log -p multiline.parser=java -o stdout' ]
+          volumeMounts:
+            - name: flink-log
+              mountPath: /opt/flink/log
+      volumes:
+        - name: flink-log
+          emptyDir: { }
+```
+
+You can try out the example using the following command:
+```shell
+helm install flink-kubernetes-operator helm/flink-kubernetes-operator -f examples/kustomize/values.yaml --post-renderer examples/kustomize/render
+```
+
+By examining the sidecar output you should see that the logs from both containers are being processed from the shared folder:
+
+```shell
+[2022/04/06 10:04:36] [ info] [input:tail:tail.0] inotify_fs_add(): inode=3812411 watch_fd=1 name=/opt/flink/log/operator.log
+[2022/04/06 10:04:36] [ info] [input:tail:tail.0] inotify_fs_add(): inode=3812412 watch_fd=2 name=/opt/flink/log/webhook.log
+```
+
+Check out the [kustomize](https://github.com/kubernetes-sigs/kustomize/tree/master/examples) repo for more advanced examples.
+> Please note that post-render mechanism will always override the Helm template values.

--- a/docs/content.zh/docs/operations/ingress.md
+++ b/docs/content.zh/docs/operations/ingress.md
@@ -1,0 +1,109 @@
+---
+title: "Ingress"
+weight: 3
+type: docs
+aliases:
+- /operations/ingress.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Accessing Flink’s Web UI
+The Flink Kubernetes Operator, by default, does not change the way the native kubernetes integration [exposes](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/native_kubernetes/#accessing-flinks-web-ui) the Flink Web UI.
+
+## Ingress
+Beyond the native options, the Operator also supports creating [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) entries for external UI access. 
+Ingress generation can be turned on by defining the `ingress` field in the `FlinkDeployment`:
+```yaml
+metadata:
+  namespace: default
+  name: advanced-ingress
+spec:
+  image: flink:1.17
+  flinkVersion: v1_17
+  ingress:
+    template: "flink.k8s.io/{{namespace}}/{{name}}(/|$)(.*)"
+    className: "nginx"
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+```
+The `ingress` specification defines a mandatory `template` field and two optional fields `className` and `annotations`. 
+When the CR is submitted, the Operator substitutes the template variables from metadata and creates an Ingress entry on the Kubernetes cluster.  
+Given the example above the Flink UI could be accessed at https://flink.k8s.io/default/advanced-ingress/ and the generated Ingress entry would be:
+```yaml
+apiVersion: networking.k8s.io/v1
+  kind: Ingress
+  metadata:
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /$2
+    name: advanced-ingress
+    namespace: default
+  spec:
+    ingressClassName: nginx
+    rules:
+    - host: flink.k8s.io
+    - http:
+        paths:
+        - backend:
+            service:
+              name: advanced-ingress-rest
+              port:
+                number: 8081
+          path: /default/advanced-ingress(/|$)(.*)
+          pathType: ImplementationSpecific
+```
+
+>Note: Flink Web UI is built with the popular [Angular](https://angular.io) framework and uses relative path to load static resources, hence the endpoint URL must end with trailing a `/` when accessing it from browsers through a proxy otherwise the main page appears as blank. 
+> In order to support accessing base URLs without a trailing `/` the URLs can be [redirected](https://github.com/kubernetes/ingress-nginx/issues/4266). When using NGINX as ingress-controller this can be achieved by adding an extra annotation to the Ingress definition:
+```yaml
+nginx.ingress.kubernetes.io/configuration-snippet: |
+if ($uri = "/default/advanced-ingress") {rewrite .* $1/default/advanced-ingress/ permanent;}
+```
+Beyond the example above the Operator understands other template formats too:
+
+**Simple domain based routing:**
+```yaml
+ingress:
+  template: "{{name}}.{{namespace}}.flink.k8s.io"
+```
+This example requires that anything `*.flink.k8s.io` must be routed to the Ingress Controller with a wildcard DNS entry:
+```shell
+kubectl get ingress -A
+NAMESPACE   NAME             CLASS   HOSTS                                 ADDRESS        PORTS   AGE
+default     sample-job       nginx   sample-job.default.flink.k8s.io       192.168.49.2   80      30m
+```
+The Flink Web UI can be accessed at https://sample-job.default.flink.k8s.io
+
+**Simple path based routing:**
+```yaml
+ingress:
+  template: "/{{namespace}}/{{name}}(/|$)(.*)"
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: "/$2"
+```
+This example requires no DNS entries. 
+
+```shell
+kubectl get ingress -A
+NAMESPACE   NAME               CLASS   HOSTS          ADDRESS     PORTS   AGE
+default     sample-job         nginx   *              localhost   80      54m
+```
+The Flink Web UI can be accessed at https://localhost/default/sample-job/
+>Note: All the examples were created on a minikube cluster. Check the [description](https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/) for enabling the NGINX Ingress Controller on minikube.
+

--- a/docs/content.zh/docs/operations/metrics-logging.md
+++ b/docs/content.zh/docs/operations/metrics-logging.md
@@ -1,0 +1,234 @@
+---
+title: "Metrics and Logging"
+weight: 4
+type: docs
+aliases:
+- /operations/metrics-logging.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Metrics and Logging
+
+## Metrics
+
+The Flink Kubernetes Operator (Operator) extends the [Flink Metric System](https://nightlies.apache.org/flink/flink-docs-master/docs/ops/metrics/) that allows gathering and exposing metrics to centralized monitoring solutions.
+
+Different operator metrics can be turned on/off individually using the configuration. For details check the [metrics config reference]({{< ref "docs/operations/configuration#system-metrics-configuration" >}}).
+
+### Flink Resource Metrics
+The Operator gathers aggregates metrics about managed resources.
+
+| Scope              | Metrics                                                                                   | Description                                                                                                                                                                                        | Type      |
+|--------------------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| Namespace          | FlinkDeployment/FlinkSessionJob.Count                                                     | Number of managed resources per namespace                                                                                                                               | Gauge     |
+| Namespace          | FlinkDeployment.ResourceUsage.Cpu/Memory                                            | Total resources used per namespace                                                                                                                                                                | Gauge     |
+| Namespace          | FlinkDeployment.JmDeploymentStatus.&lt;Status&gt;.Count                                   | Number of managed FlinkDeployment resources per &lt;Status&gt; per namespace. &lt;Status&gt; can take values from: READY, DEPLOYED_NOT_READY, DEPLOYING, MISSING, ERROR                            | Gauge     |
+| Namespace          | FlinkDeployment.FlinkVersion.&lt;FlinkVersion&gt;.Count                               | Number of managed FlinkDeployment resources per &lt;FlinkVersion&gt; per namespace. &lt;FlinkVersion&gt; is retrieved via REST API from Flink JM.                                                  | Gauge     |
+| Namespace          | FlinkDeployment/FlinkSessionJob.Lifecycle.State.&lt;State&gt;.Count                       | Number of managed resources currently in state &lt;State&gt; per namespace. &lt;State&gt; can take values from: CREATED, SUSPENDED, UPGRADING, DEPLOYED, STABLE, ROLLING_BACK, ROLLED_BACK, FAILED | Gauge     |
+| System/Namespace   | FlinkDeployment/FlinkSessionJob.Lifecycle.State.&lt;State&gt;.TimeSeconds                 | Time spent in state &lt;State$gt for a given resource. &lt;State&gt; can take values from: CREATED, SUSPENDED, UPGRADING, DEPLOYED, STABLE, ROLLING_BACK, ROLLED_BACK, FAILED                      | Histogram |
+| System/Namespace   | FlinkDeployment/FlinkSessionJob.Lifecycle.Transition.&lt;Transition&gt;.TimeSeconds       | Time statistics for selected lifecycle state transitions. &lt;Transition&gt; can take values from: Resume, Upgrade, Suspend, Stabilization, Rollback, Submission                                   | Histogram |
+
+#### Lifecycle metrics
+
+Based on the resource status the operator monitors [resource lifecycle states]({{< ref "docs/concepts/architecture#flink-resource-lifecycle" >}}).
+
+The number of resources and time spend in each of these states at any given time is tracked by the `Lifecycle.<STATE>.Count` and `Lifecycle.<STATE>.TimeSeconds` metrics.
+
+In addition to the simple counts we further track a few selected state transitions:
+
+ - Upgrade : End-to-end resource upgrade time from stable to stable
+ - Resume : Time from suspended to stable
+ - Suspend : Time for any suspend operation
+ - Stabilization : Time from deployed to stable state
+ - Rollback : Time from deployed to rolled_back state if the resource was rolled back
+ - Submission: Flink resource submission time
+
+### Kubernetes Client Metrics
+
+The Operator gathers various metrics related to Kubernetes API server access.
+
+| Scope  | Metrics                                                   | Description                                                                                                                                                  | Type      |
+|--------|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| System | KubeClient.HttpRequest.Count                              | Number of HTTP request sent to the Kubernetes API Server                                                                                                     | Counter   |
+| System | KubeClient.HttpRequest.&lt;RequestMethod&gt;.Count        | Number of HTTP request sent to the Kubernetes API Server per request method. &lt;RequestMethod&gt; can take values from: GET, POST, PUT, PATCH, DELETE, etc. | Counter   |
+| System | KubeClient.HttpRequest.Failed.Count                       | Number of failed HTTP requests that has no response from the Kubernetes API Server                                                                           | Counter   |
+| System | KubeClient.HttpResponse.Count                             | Number of HTTP responses received from the Kubernetes API Server                                                                                             | Counter   |
+| System | KubeClient.HttpResponse.&lt;ResponseCode&gt;.Count        | Number of HTTP responses received from the Kubernetes API Server per response code. &lt;ResponseCode&gt; can take values from: 200, 404, 503, etc.           | Counter   |
+| System | KubeClient.HttpResponse.&lt;ResponseCode&gt;.NumPerSecond | Number of HTTP responses received from the Kubernetes API Server per response code per second. &lt;ResponseCode&gt; can take values from: 200, 404, 503, etc.| Meter     |
+| System | KubeClient.HttpRequest.NumPerSecond                       | Number of HTTP requests sent to the Kubernetes API Server per second                                                                                         | Meter     |
+| System | KubeClient.HttpRequest.Failed.NumPerSecond                | Number of failed HTTP requests sent to the Kubernetes API Server per second                                                                                  | Meter     |
+| System | KubeClient.HttpResponse.NumPerSecond                      | Number of HTTP responses received from the Kubernetes API Server per second                                                                                  | Meter     |
+| System | KubeClient.HttpResponse.TimeNanos                         | Latency statistics obtained from the HTTP responses received from the Kubernetes API Server                                                                  | Histogram |
+
+#### Kubernetes client metrics by Http Response Code
+
+It's possible to publish additional metrics by Http response code received from API server by setting `kubernetes.client.metrics.http.response.code.groups.enabled` to `true` .
+
+| Scope  | Metrics                                                   | Description                                                                                                                                                  | Type      |
+|--------|-----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|
+| System | KubeClient.HttpResponse.1xx.Count                         | Number of HTTP Code 1xx responses (informational) received from the Kubernetes API Server per response code.                                                 | Counter   |
+| System | KubeClient.HttpResponse.2xx.Count                         | Number of HTTP Code 2xx responses (success) received from the Kubernetes API Server per response code.                                                       | Counter   |
+| System | KubeClient.HttpResponse.3xx.Count                         | Number of HTTP Code 3xx responses (redirection) received from the Kubernetes API Server per response code.                                                   | Counter   |
+| System | KubeClient.HttpResponse.4xx.Count                         | Number of HTTP Code 4xx responses (client error) received from the Kubernetes API Server per response code.                                                  | Counter   |
+| System | KubeClient.HttpResponse.5xx.Count                         | Number of HTTP Code 5xx responses (server error) received from the Kubernetes API Server per response code.                                                  | Counter   |
+| System | KubeClient.HttpResponse.1xx.NumPerSecond                  | Number of HTTP Code 1xx responses (informational) received from the Kubernetes API Server per response code per second.                                      | Meter     |
+| System | KubeClient.HttpResponse.2xx.NumPerSecond                  | Number of HTTP Code 2xx responses (success) received from the Kubernetes API Server per response code per second.                                            | Meter     |
+| System | KubeClient.HttpResponse.3xx.NumPerSecond                  | Number of HTTP Code 3xx responses (redirection) received from the Kubernetes API Server per response code per second.                                        | Meter     |
+| System | KubeClient.HttpResponse.4xx.NumPerSecond                  | Number of HTTP Code 4xx responses (client error) received from the Kubernetes API Server per response code per second.                                       | Meter     |
+| System | KubeClient.HttpResponse.5xx.NumPerSecond                  | Number of HTTP Code 5xx responses (server error) received from the Kubernetes API Server per response code per second.                                       | Meter     |
+
+### JVM Metrics
+
+The Operator gathers metrics about the JVM process and exposes it similarly to core Flink [System metrics](https://nightlies.apache.org/flink/flink-docs-master/docs/ops/metrics/#system-metrics). The list of metrics are not repeated in this document.
+
+### JOSDK Metrics
+
+The Flink operator also forwards metrics created by the Java Operator SDK framework itself under the `JOSDK` metric name prefix.
+Some of these metrics are on system, namespace and resource level.
+
+## Metric Reporters
+
+The well known [Metric Reporters](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/metric_reporters) are shipped in the operator image and are ready to use.
+
+In order to specify metrics configuration for the operator, prefix them with `kubernetes.operator.`. This logic ensures that we can separate Flink job and operator metrics configuration.
+
+Let's look at a few examples.
+
+### Slf4j
+The default metrics reporter in the operator is Slf4j. It does not require any external monitoring systems, and it is enabled in the `values.yaml` file by default, mainly for demonstrating purposes.
+```yaml
+defaultConfiguration:
+  create: true
+  append: true
+  flink-conf.yaml: |+
+    kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory
+    kubernetes.operator.metrics.reporter.slf4j.interval: 5 MINUTE
+```
+To use a more robust production grade monitoring solution the configuration needs to be changed.
+
+### How to Enable Prometheus (Example)
+The following example shows how to enable the Prometheus metric reporter:
+```yaml
+defaultConfiguration:
+  create: true
+  append: true
+  flink-conf.yaml: |+
+    kubernetes.operator.metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+    kubernetes.operator.metrics.reporter.prom.port: 9999
+```
+Some metric reporters, including the Prometheus, need a port to be exposed on the container. This can be achieved be defining a value for the otherwise empty `metrics.port` variable.
+Either in the `values.yaml` file:
+```yaml
+metrics:
+  port: 9999
+```
+or using the option `--set metrics.port=9999` in the command line.
+
+#### Set up Prometheus locally
+The Prometheus Operator among other options provides an elegant, declarative way to specify how group of pods should be monitored using custom resources.
+
+To install the Prometheus operator via Helm run:
+
+```shell
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm install prometheus prometheus-community/kube-prometheus-stack
+```
+The Grafana dashboard can be accessed through port-forwarding:
+```shell
+kubectl port-forward deployment/prometheus-grafana 3000
+```
+The credentials for the dashboard can be retrieved by:
+```bash
+kubectl get secret prometheus-grafana -o jsonpath="{.data.admin-user}" | base64 --decode ; echo
+kubectl get secret prometheus-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
+```
+
+To enable the operator metrics in Prometheus create a `pod-monitor.yaml` file with the following content:
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: flink-kubernetes-operator
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: flink-kubernetes-operator
+  podMetricsEndpoints:
+      - port: metrics
+```
+and apply it on your Kubernetes environment:
+```shell
+kubectl create -f pod-monitor.yaml
+```
+Once the custom resource is created in the Kubernetes environment the operator metrics are ready to explore [http://localhost:3000/explore](http://localhost:3000/explore).
+
+## Logging
+The Operator controls the logging behaviour for Flink applications and the Operator itself using configuration files mounted externally via ConfigMaps. [Configuration files](https://github.com/apache/flink-kubernetes-operator/tree/main/helm/flink-kubernetes-operator/conf) with default values are shipped in the Helm chart. It is recommended to review and adjust them if needed in the `values.yaml` file before deploying the Operator in production environments.
+
+To append/override the default log configuration properties for the operator and Flink deployments define the `log4j-operator.properties` and `log4j-console.properties` keys respectively:
+
+```yaml
+defaultConfiguration:
+  create: true
+  append: true
+  log4j-operator.properties: |+
+    # Flink Operator Logging Overrides
+    # rootLogger.level = DEBUG
+  log4j-console.properties: |+
+    # Flink Deployment Logging Overrides
+    # rootLogger.level = DEBUG
+```
+
+{{< hint info >}}
+Logging in the operator is intentionally succinct and does not include contextual information such as namespace or name of the FlinkDeployment objects.
+We rely on the MDC provided by the operator-sdk to access this information and use it directly in the log layout.
+
+See the [Java Operator SDK docs](https://javaoperatorsdk.io/docs/features#contextual-info-for-logging-with-mdc) for more detail.
+{{< /hint >}}
+
+To learn more about accessing the job logs or changing the log level dynamically check the corresponding [section](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/native_kubernetes/#logging) of the core documentation.
+
+### FlinkDeployment Logging Configuration
+
+Users have the freedom to override the default `log4j-console.properties` settings on a per-deployment level by putting the entire log configuration into `spec.logConfiguration`:
+
+```yaml
+spec:
+  ...
+  logConfiguration:
+    log4j-console.properties: |+
+      rootLogger.level = DEBUG
+      rootLogger.appenderRef.file.ref = LogFile
+      ...
+```
+
+### FlinkDeployment Prometheus Configuration
+
+The following example shows how to enable the Prometheus metric reporter for the FlinkDeployment:
+
+```yaml
+spec:
+  ...
+  flinkConfiguration:
+    metrics.reporter.prom.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+    metrics.reporter.prom.port: 9249-9250
+```

--- a/docs/content.zh/docs/operations/plugins.md
+++ b/docs/content.zh/docs/operations/plugins.md
@@ -1,0 +1,190 @@
+---
+title: "Custom Operator Plugins"
+weight: 5
+type: docs
+aliases:
+- /operations/plugins.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Custom Operator Plugins
+
+The operator provides a customizable platform for Flink resource management. Users can develop plugins to tailor the operator behaviour to their own needs.
+
+## Custom Flink Resource Validators
+
+`FlinkResourceValidator`, an interface for validating the resources of `FlinkDeployment` and `FlinkSessionJob`,  is a pluggable component based on the [Plugins](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/plugins) mechanism. During development, we can customize the implementation of `FlinkResourceValidator` and make sure to retain the service definition in `META-INF/services`.
+The following steps demonstrate how to develop and use a custom validator.
+
+1. Implement `FlinkResourceValidator` interface:
+    ```java
+    package org.apache.flink.kubernetes.operator.validation;
+
+    import org.apache.flink.kubernetes.operator.crd.FlinkDeployment;
+    import org.apache.flink.kubernetes.operator.crd.FlinkSessionJob;
+
+    import java.util.Optional;
+
+    /** Custom validator implementation of {@link FlinkResourceValidator}. */
+    public class CustomValidator implements FlinkResourceValidator {
+
+        @Override
+        public Optional<String> validateDeployment(FlinkDeployment deployment) {
+            if (deployment.getSpec().getFlinkVersion() == null) {
+              return Optional.of("Flink Version must be defined.");
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> validateSessionJob(
+                 FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
+            if (sessionJob.getSpec().getJob() == null) {
+              return Optional.of("The job spec should not be empty");
+            }
+            return Optional.empty();
+        }
+    }
+    ```
+
+2. Create service definition file `org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator` in `META-INF/services`.   With custom `FlinkResourceValidator` implementation, the service definition describes as follows:
+    ```text
+    org.apache.flink.kubernetes.operator.validation.CustomValidator
+    ```
+
+3. Use the Maven tool to package the project and generate the custom validator JAR.
+
+4. Create Dockerfile to build a custom image from the `apache/flink-kubernetes-operator` official image and copy the generated JAR to custom validator plugin directory.
+    `/opt/flink/plugins` is the value of `FLINK_PLUGINS_DIR` environment variable in the flink-kubernetes-operator helm chart. The structure of custom validator directory under `/opt/flink/plugins` is as follows:
+    ```text
+    /opt/flink/plugins
+        ├── custom-validator
+        │   ├── custom-validator.jar
+        └── ...
+    ```
+
+    With the custom validator directory location, the Dockerfile is defined as follows:
+    ```shell script
+    FROM apache/flink-kubernetes-operator
+    ENV FLINK_PLUGINS_DIR=/opt/flink/plugins
+    ENV CUSTOM_VALIDATOR_DIR=custom-validator
+    RUN mkdir $FLINK_PLUGINS_DIR/$CUSTOM_VALIDATOR_DIR
+    COPY custom-validator.jar $FLINK_PLUGINS_DIR/$CUSTOM_VALIDATOR_DIR/
+    ```
+
+5. Install the flink-kubernetes-operator helm chart with the custom image and verify the `deploy/flink-kubernetes-operator` log has:
+    ```text
+    2022-05-04 14:01:46,551 o.a.f.k.o.u.FlinkUtils         [INFO ] Discovered resource validator from plugin directory[/opt/flink/plugins]: org.apache.flink.kubernetes.operator.validation.CustomValidator.
+    ```
+
+## Custom Flink Resource Listeners
+
+The Flink Kubernetes Operator allows users to listen to events and status updates triggered for the Flink Resources managed by the operator.
+This feature enables tighter integration with the user's own data platform.
+
+By implementing the `FlinkResourceListener` interface users can listen to both events and status updates per resource type (`FlinkDeployment` / `FlinkSessionJob`). These methods will be called after the respective events have been triggered by the system.
+Using the context provided on each listener method users can also get access to the related Flink resource and the `KubernetesClient` itself in order to trigger any further events etc on demand.
+
+Similar to custom validator implementations, resource listeners are loaded via the Flink [Plugins](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/plugins) mechanism.
+
+In order to enable your custom `FlinkResourceListener` you need to:
+
+ 1. Implement the interface
+ 2. Add your listener class to `org.apache.flink.kubernetes.operator.api.listener.FlinkResourceListener` in `META-INF/services`
+ 3. Package your JAR and add it to the plugins directory of your operator image (`/opt/flink/plugins`)
+
+
+## Additional Dependencies
+In some cases, users may need to add required dependencies onto the operator classpath.
+
+When building the custom image, The additional dependencies shall be copied to `/opt/flink/operator-lib` with the environment variable: `OPERATOR_LIB`
+That folder is added to classpath upon initialization.
+
+```shell script
+    FROM apache/flink-kubernetes-operator
+    ARG ARTIFACT1=custom-artifact1.jar
+    ARG ARTIFACT2=custom-artifact2.jar
+    COPY target/$ARTIFACT1 $OPERATOR_LIB
+    COPY target/$ARTIFACT2 $OPERATOR_LIB
+```
+
+## Custom Flink Resource Mutators
+
+`FlinkResourceMutator`, an interface for ,mutating the resources of `FlinkDeployment` and `FlinkSessionJob`,  is a pluggable component based on the [Plugins](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/plugins) mechanism. During development, we can customize the implementation of `FlinkResourceMutator` and make sure to retain the service definition in `META-INF/services`.
+The following steps demonstrate how to develop and use a custom mutator.
+
+1. Implement `FlinkResourceMutator` interface:
+    ```java
+    package org.apache.flink.mutator;
+
+   import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+   import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+   import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
+
+   import java.util.Optional;
+
+   /** Custom Flink Mutator. */
+   public class CustomFlinkMutator implements FlinkResourceMutator {
+
+    @Override
+    public FlinkDeployment mutateDeployment(FlinkDeployment deployment) {
+
+        return deployment;
+    }
+
+    @Override
+    public FlinkSessionJob mutateSessionJob(
+            FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
+
+        return sessionJob;
+    }
+}
+
+    ```
+
+2. Create service definition file `org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator` in `META-INF/services`.   With custom `FlinkResourceMutator` implementation, the service definition describes as follows:
+    ```text
+    org.apache.flink.mutator.CustomFlinkMutator
+    ```
+
+3. Use the Maven tool to package the project and generate the custom mutator JAR.
+
+4. Create Dockerfile to build a custom image from the `apache/flink-kubernetes-operator` official image and copy the generated JAR to custom mutator plugin directory.
+   `/opt/flink/plugins` is the value of `FLINK_PLUGINS_DIR` environment variable in the flink-kubernetes-operator helm chart. The structure of custom mutator directory under `/opt/flink/plugins` is as follows:
+    ```text
+    /opt/flink/plugins
+        ├── custom-mutator
+        │   ├── custom-mutator.jar
+        └── ...
+    ```
+
+   With the custom mutator directory location, the Dockerfile is defined as follows:
+    ```shell script
+    FROM apache/flink-kubernetes-operator
+    ENV FLINK_PLUGINS_DIR=/opt/flink/plugins
+    ENV CUSTOM_MUTATOR_DIR=custom-mutator
+    RUN mkdir $FLINK_PLUGINS_DIR/$CUSTOM_MUTATOR_DIR
+    COPY custom-mutator.jar $FLINK_PLUGINS_DIR/$CUSTOM_MUTATOR_DIR/
+    ```
+
+5. Install the flink-kubernetes-operator helm chart with the custom image and verify the `deploy/flink-kubernetes-operator` log has:
+    ```text
+    2023-12-12 06:26:56,667 o.a.f.k.o.u.MutatorUtils [INFO ] Discovered mutator from plugin directory[/opt/flink/plugins]: org.apache.flink.mutator.CustomFlinkMutator.
+    ```

--- a/docs/content.zh/docs/operations/rbac.md
+++ b/docs/content.zh/docs/operations/rbac.md
@@ -1,0 +1,110 @@
+---
+title: "RBAC model"
+weight: 2
+type: docs
+aliases:
+- /operations/rbac.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Role-based Access Control Model
+
+To be able to deploy the operator itself and Flink jobs, we define two separate Kubernetes
+[roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole).
+The former, called `flink-operator` role is used to manage the `flinkdeployments`, to create and manage the
+[JobManager](https://nightlies.apache.org/flink/flink-docs-master/docs/concepts/flink-architecture/#jobmanager) deployment
+for each Flink job and other resources like [services](https://kubernetes.io/docs/concepts/services-networking/service/).
+The latter, called the `flink` role is used by the JobManagers of the jobs to create and manage the
+[TaskManagers](https://nightlies.apache.org/flink/flink-docs-master/docs/concepts/flink-architecture/#taskmanagers) and
+[ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/) for the job.
+
+{{< img src="/img/operations/rbac.svg" alt="Flink Operator RBAC Model" >}}
+
+These service accounts and roles can be created via the operator Helm [chart]({{< ref "docs/operations/helm" >}}).
+By default the `flink-operator` role is cluster scoped (created as a `clusterrole`) and thus allowing a single operator
+instance to be responsible for all Flink deployments (jobs) in a Kubernetes cluster regardless of the namespace they are
+deployed to (with the additional [instruction](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/docs/operations/rbac/#cluster-scoped-flink-operator-with-jobs-running-in-other-namespaces) below). Certain environments are more restrictive and only allow namespaced roles, so we also support this option
+via [watchNamespaces]({{< ref "docs/operations/helm" >}}#watching-only-specific-namespaces).
+
+The `flink` role is always namespaced, by default it is created in the namespace of the operator. When
+[watchNamespaces]({{< ref "docs/operations/helm" >}}#watching-only-specific-namespaces) is enabled it is created for all
+watched namespaces individually.
+
+## Cluster Scoped Flink Operator With Jobs Running in Other Namespaces
+The steps described in the [quick-start](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-0.1/docs/try-flink-kubernetes-operator/quick-start/#deploying-the-operator) let users install Flink operator and run Flink jobs in the default namespace. To run Flink jobs in another namespace, users are responsible for creating a flink service account in that namespace. This is when users deploy cluster scoped Flink operator without using the `--set watchNamespaces={namespaces}` option and wish to create Flink jobs in other namespaces later.
+
+For each additional namespace that runs the Flink jobs, users need to do the following:
+1. Switch to the namespace by running:
+    ```sh
+    kubectl config set-context --current --namespace=CHANGEIT
+    ```
+2. Create the service account, role, and role binding in the namespace using the commands below:
+    ``` sh
+    kubectl apply -f - <<EOF
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/name: flink-kubernetes-operator
+        app.kubernetes.io/version: 1.0.1
+      name: flink
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/name: flink-kubernetes-operator
+        app.kubernetes.io/version: 1.0.1
+      name: flink
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - configmaps
+      verbs:
+      - '*'
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      verbs:
+      - '*'
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/name: flink-kubernetes-operator
+        app.kubernetes.io/version: 1.0.1
+      name: flink-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: flink
+    subjects:
+    - kind: ServiceAccount
+      name: flink
+    EOF
+    ```
+3. Optionally create an example Flink job in the namespace. Run the command from the root of the cloned flink-kuberntes-operator repo:
+    ```sh
+    kubectl -f example/basic.yaml
+    ```

--- a/docs/content.zh/docs/operations/upgrade.md
+++ b/docs/content.zh/docs/operations/upgrade.md
@@ -1,0 +1,174 @@
+---
+title: "Operator Upgrades"
+weight: 4
+type: docs
+aliases:
+- /operations/upgrade.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Operator Upgrade Process
+
+This page details the process of upgrading the operator to a new version.
+
+Please check the [compatibility page]({{< ref "docs/operations/compatibility" >}}) for the complete overview of the backward compatibility guarantees before upgrading to new versions.
+
+{{< hint danger >}}
+Upgrading from the preview/experimental `v1alpha1` release to `v1beta1` requires a one time manual process.
+Please check the [related section](#upgrading-from-v1alpha1---v1beta1).
+{{< /hint >}}
+
+## Normal Upgrade Process
+
+If you are upgrading from `kubernetes-operator-1.0.0` or later, please refer to the following two steps:
+1. Upgrading the CRDs
+2. Upgrading the Helm deployment
+
+We will cover these steps in detail in the next sections.
+
+### 1. Upgrading the Java client library
+
+If you use the Flink Kubernetes operator Java client library, you need to update it first to ensure that responses from
+the new operator version can be parsed properly. For minor releases, the new version of the Java library is
+backwards-compatible with the previous minor version of the operator.
+
+### 2. Upgrading the CRD
+
+The first step of the upgrade process is upgrading the CRDs for `FlinkDeployment` and `FlinkSessionJob` resources.
+This step must be completed manually and is not part of the helm installation logic.
+
+```sh
+kubectl replace -f helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+kubectl replace -f helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+```
+
+{{< hint danger >}}
+Please note that we are using the `replace` command here which ensures that running deployments are unaffected.
+{{< /hint >}}
+
+### 3. Upgrading the Helm deployment
+
+{{< hint danger >}}
+Before upgrading, please compare the version difference between the currently generated yaml and the running yaml, which will be used for backup and restore.
+{{< /hint >}}
+
+
+```sh
+helm template flink-kubernetes-operator <helm-repo>/flink-kubernetes-operator  <custom settings> | kubectl diff -f -
+```
+
+
+Once we have the new CRDs versions we can upgrade the Helm deployment:
+
+
+```sh
+helm upgrade flink-kubernetes-operator <helm-repo>/flink-kubernetes-operator <custom settings>
+```
+
+or
+
+```sh
+# Uninstall running Helm deployment and install new version
+helm uninstall flink-kubernetes-operator
+helm install flink-kubernetes-operator <helm-repo>/flink-kubernetes-operator <custom settings>
+```
+
+The exact installation/upgrade command depends on your current environment and settings. Please see the [helm page]({{< ref "docs/operations/helm" >}}) for details.
+
+## Upgrading from v1alpha1 -> v1beta1
+
+If you are upgrading from `kubernetes-operator-0.1.0` , please refer to the following steps. Because the first stable `v1beta1` release introduced some breaking changes on the operator side when upgrading from the preview (`v1alpha1`) release.
+These changes require a one time manual upgrade process for the running jobs.
+
+### 1. Upgrading without existing FlinkDeployments
+
+In an environment without any `FlinkDeployments` you need to uninstall the operator and delete the `v1alpha1` CRD.
+
+```sh
+# Uninstall helm deployment
+helm uninstall flink-kubernetes-operator
+
+# Delete CRD
+kubectl delete crd flinkdeployments.flink.apache.org
+
+# Now reinstall the operator with the new v1beta1 version
+helm install flink-kubernetes-operator <helm-repo>/flink-kubernetes-operator <custom settings>
+```
+
+### 2. Upgrading with existing FlinkDeployments
+
+The following steps demonstrate the CRD upgrade process from `v1alpha1` to `v1beta1` in an environment with an existing [stateful](https://github.com/apache/flink-kubernetes-operator/blob/main/examples/basic-checkpoint-ha.yaml) job with an old `v1alpha1` apiVersion. After the CRD upgrade, the job will resumed from the savepoint.
+Here is a reference example of upgrading a `basic-checkpoint-ha-example` deployment.
+1. Suspend the job and create savepoint:
+    ```sh
+    kubectl patch flinkdeployment/basic-checkpoint-ha-example --type=merge -p '{"spec": {"job": {"state": "suspended", "upgradeMode": "savepoint"}}}'
+    ```
+    Verify `deploy/basic-checkpoint-ha-example` has terminated and `flinkdeployment/basic-checkpoint-ha-example` has the Last Savepoint Location similar to `file:/flink-data/savepoints/savepoint-000000-aec3dd08e76d/_metadata`. This file will used to restore the job. See [stateful and stateless application upgrade]({{< ref "docs/custom-resource/job-management" >}})  for more detail.
+
+2. Delete the job:
+   ```sh
+   kubectl delete flinkdeployment/basic-checkpoint-ha-example
+   ```
+
+3. Uninstall flink-kubernetes-operator helm chart and the CRD with the old `v1alpha1` version:
+    ```sh
+    helm uninstall flink-kubernetes-operator
+    kubectl delete crd flinkdeployments.flink.apache.org
+    ```
+4. Reinstall the flink-kubernetes-operator helm chart with the `v1beta1` CRD
+    ```sh
+    helm repo update flink-operator-repo
+    helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator
+    ```
+    Verify the `deploy/flink-kubernetes-operator` log has:
+    ```
+    2022-04-13 06:09:40,761 i.j.o.Operator                 [INFO ] Registered reconciler: 'flinkdeploymentcontroller' for resource: 'class org.apache.flink.kubernetes.operator.crd.FlinkDeployment' for namespace(s): [all namespaces]
+    2022-04-13 06:09:40,943 i.f.k.c.i.VersionUsageUtils    [WARN ] The client is using resource type 'flinksessionjobs' with unstable version 'v1beta1'
+    2022-04-13 06:09:41,461 i.j.o.Operator                 [INFO ] Registered reconciler: 'flinksessionjobcontroller' for resource: 'class org.apache.flink.kubernetes.operator.crd.FlinkSessionJob' for namespace(s): [all namespaces]
+    2022-04-13 06:09:41,464 i.j.o.Operator                 [INFO ] Operator SDK 2.1.2 (commit: a3a81ef) built on 2022-03-15T09:59:42.000+0000 starting...
+    2022-04-13 06:09:41,464 i.j.o.Operator                 [INFO ] Client version: 5.12.1
+    2022-04-13 06:09:41,499 i.f.k.c.i.VersionUsageUtils    [WARN ] The client is using resource type 'flinkdeployments' with unstable version 'v1beta1'
+    ```
+5. Restore the job:
+
+   Deploy the previously deleted job using this [FlinkDeployemnt](https://raw.githubusercontent.com/apache/flink-kubernetes-operator/main/examples/basic-checkpoint-ha.yaml) with `v1beta1` and explicitly set the `job.initialSavepointPath` to the savepoint location obtained from the step 1.
+
+    ```
+    spec:
+      ...
+      job:
+        initialSavepointPath: /flink-data/savepoints/savepoint-000000-aec3dd08e76d/_metadata
+        upgradeMode: savepoint
+      ...
+    ```
+    Alternatively, we may use this command to edit and deploy the manifest:
+    ```sh
+    wget -qO - https://raw.githubusercontent.com/apache/flink-kubernetes-operator/main/examples/basic-checkpoint-ha.yaml| yq w - "spec.job.initialSavepointPath" "/flink-data/savepoints/savepoint-000000-aec3dd08e76d/_metadata"| kubectl apply -f -
+    ```
+   Finally, verify that `deploy/basic-checkpoint-ha-example` log has:
+    ```
+    Starting job 00000000000000000000000000000000 from savepoint /flink-data/savepoints/savepoint-000000-2f40a9c8e4b9/_metadata
+    ```
+
+### 3. Changes of default values of FlinkDeployment
+There are some changes or improvement of default values in the fields of the FlinkDeployment in `v1beta1`:
+1. Default value of `crd.spec.Resource#cpu` is `1.0`.
+2. Default value of `crd.spec.JobManagerSpec#replicas` is `1`.
+3. No default value of `crd.spec.FlinkDeploymentSpec#serviceAccount` and users must specify its value explicitly.

--- a/docs/content.zh/docs/try-flink-kubernetes-operator/_index.md
+++ b/docs/content.zh/docs/try-flink-kubernetes-operator/_index.md
@@ -1,0 +1,25 @@
+---
+title: Try the Flink Kubernetes Operator 
+icon: <i class="fa fa-rocket title appetizer" aria-hidden="true"></i>
+bold: true
+bookCollapseSection: true
+weight: 1
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->

--- a/docs/content.zh/docs/try-flink-kubernetes-operator/quick-start.md
+++ b/docs/content.zh/docs/try-flink-kubernetes-operator/quick-start.md
@@ -1,0 +1,132 @@
+---
+title: "Quick Start"
+weight: 1
+type: docs
+aliases:
+- /try-flink-kubernetes-operator/quick-start.html
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Quick Start
+
+This document provides a quick introduction to using the Flink Kubernetes Operator. Readers
+of this document will be able to deploy the Flink operator itself and an example Flink job to a local
+Kubernetes installation.
+
+## Prerequisites
+
+We assume that you have a local installations of the following:
+1. [docker](https://docs.docker.com/)
+2. [kubernetes](https://kubernetes.io/)
+3. [helm](https://helm.sh/docs/intro/quickstart/)
+
+So that the `kubectl` and `helm` commands are available on your local system.
+
+For docker we recommend that you have [Docker Desktop](https://www.docker.com/products/docker-desktop) installed
+and configured with at least 8GB of RAM.
+For kubernetes [minikube](https://minikube.sigs.k8s.io/docs/start/) is our choice, at the time of writing this we are
+using version v1.25.3 (end-to-end tests are using the same version). You can start a cluster with the following command:
+
+```bash
+minikube start --kubernetes-version=v1.25.3
+😄  minikube v1.28.0 on Darwin 13.0.1
+✨  Automatically selected the docker driver. Other choices: hyperkit, ssh
+📌  Using Docker Desktop driver with root privileges
+👍  Starting control plane node minikube in cluster minikube
+🚜  Pulling base image ...
+🔥  Creating docker container (CPUs=2, Memory=4000MB) ...
+🐳  Preparing Kubernetes v1.25.3 on Docker 20.10.20 ...
+    ▪ Generating certificates and keys ...
+    ▪ Booting up control plane ...
+    ▪ Configuring RBAC rules ...
+🔎  Verifying Kubernetes components...
+    ▪ Using image gcr.io/k8s-minikube/storage-provisioner:v5
+🌟  Enabled addons: default-storageclass, storage-provisioner
+🏄  Done! kubectl is now configured to use "minikube" cluster and "default" namespace by default
+```
+
+We also recommend [k9s](https://k9scli.io/) as GUI for kubernetes, but it is optional for this quickstart guide.
+
+## Deploying the operator
+
+Install the certificate manager on your Kubernetes cluster to enable adding the webhook component (only needed once per Kubernetes cluster):
+```bash
+kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
+```
+
+{{< hint info >}}
+In case the cert manager installation failed for any reason you can disable the webhook by passing `--set webhook.create=false` to the helm install command for the operator.
+{{< /hint >}}
+
+Now you can deploy the selected stable Flink Kubernetes Operator version using the included Helm chart:
+
+```bash
+helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-{{< stable >}}{{< version >}}{{< /stable >}}{{< unstable >}}&lt;OPERATOR-VERSION&gt;{{< /unstable >}}/
+helm install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator
+```
+
+To find the list of stable versions please visit https://flink.apache.org/downloads.html
+
+{{< hint info >}}
+The Helm chart by default points to the `ghcr.io/apache/flink-kubernetes-operator` image repository.
+If you have connectivity issues or prefer to use Dockerhub instead you can use `--set image.repository=apache/flink-kubernetes-operator` during installation.
+{{< /hint >}}
+
+You may verify your installation via `kubectl` and `helm`:
+```bash
+kubectl get pods
+NAME READY STATUS RESTARTS AGE
+flink-kubernetes-operator-fb5d46f94-ghd8b 2/2 Running 0 4m21s
+
+helm list
+NAME NAMESPACE REVISION UPDATED STATUS CHART APP VERSION
+flink-kubernetes-operator default 1 2022-03-09 17 (tel:12022030917):39:55.461359 +0100 CET deployed flink-kubernetes-operator-{{< version >}} {{< version >}}
+```
+
+## Submitting a Flink job
+
+Once the operator is running as seen in the previous step you are ready to submit a Flink job:
+```bash
+kubectl create -f https://raw.githubusercontent.com/apache/flink-kubernetes-operator/{{< stable_branch >}}/examples/basic.yaml
+```
+You may follow the logs of your job, after a successful startup (which can take on the order of a minute in a fresh environment, seconds afterwards) you can:
+
+```bash
+kubectl logs -f deploy/basic-example
+
+2022-03-11 21:46:04,458 INFO  org.apache.flink.runtime.checkpoint.CheckpointCoordinator    [] - Triggering checkpoint 206 (type=CHECKPOINT) @ 1647035164458 for job a12c04ac7f5d8418d8ab27931bf517b7.
+2022-03-11 21:46:04,465 INFO  org.apache.flink.runtime.checkpoint.CheckpointCoordinator    [] - Completed checkpoint 206 for job a12c04ac7f5d8418d8ab27931bf517b7 (28509 bytes, checkpointDuration=7 ms, finalizationTime=0 ms).
+2022-03-11 21:46:06,458 INFO  org.apache.flink.runtime.checkpoint.CheckpointCoordinator    [] - Triggering checkpoint 207 (type=CHECKPOINT) @ 1647035166458 for job a12c04ac7f5d8418d8ab27931bf517b7.
+2022-03-11 21:46:06,483 INFO  org.apache.flink.runtime.checkpoint.CheckpointCoordinator    [] - Completed checkpoint 207 for job a12c04ac7f5d8418d8ab27931bf517b7 (28725 bytes, checkpointDuration=25 ms, finalizationTime=0 ms).
+```
+
+To expose the Flink Dashboard you may add a port-forward rule or look the [ingress configuration options]({{< ref "docs/operations/ingress" >}}):
+
+```bash
+kubectl port-forward svc/basic-example-rest 8081
+```
+
+Now the Flink Dashboard is accessible at [localhost:8081](http://localhost:8081/).
+
+In order to stop your job and delete your FlinkDeployment you can:
+
+```bash
+kubectl delete flinkdeployment/basic-example
+```

--- a/docs/content.zh/versions.md
+++ b/docs/content.zh/versions.md
@@ -1,0 +1,29 @@
+---
+title: Versions 
+type: docs
+bookToc: false
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Versions
+
+An appendix of hosted documentation for all versions of Apache Flink Kubernetes Operator.
+
+{{< all_versions >}}


### PR DESCRIPTION
## What is the purpose of the change
https://issues.apache.org/jira/browse/FLINK-34934

Build the Flink-Kubernetes-Operator document translation framework, and subsequently translate English documents one by one.


## Brief change log

Copy all documentations to content.zh folder, and add the English and Chinese（中文版） button.
