### PR TITLE
[FLINK-34957][autoscaler] Event handler records the exception stack trace when exception message is null

### DIFF
--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
@@ -141,13 +141,7 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
             autoScaler.scale(jobContext);
         } catch (Throwable e) {
             LOG.error("Error while scaling job", e);
-            eventHandler.handleEvent(
-                    jobContext,
-                    AutoScalerEventHandler.Type.Warning,
-                    AUTOSCALER_ERROR,
-                    e.getMessage(),
-                    null,
-                    null);
+            eventHandler.handleException(jobContext, AUTOSCALER_ERROR, e);
         } finally {
             MDC.clear();
         }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -228,13 +228,7 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
     private void onError(Context ctx, AutoscalerFlinkMetrics autoscalerMetrics, Throwable e) {
         LOG.error("Error while scaling job", e);
         autoscalerMetrics.incrementError();
-        eventHandler.handleEvent(
-                ctx,
-                AutoScalerEventHandler.Type.Warning,
-                AUTOSCALER_ERROR,
-                e.getMessage(),
-                null,
-                null);
+        eventHandler.handleException(ctx, AUTOSCALER_ERROR, e);
     }
 
     private AutoscalerFlinkMetrics getOrInitAutoscalerFlinkMetrics(Context ctx) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoScalerEventHandler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoScalerEventHandler.java
@@ -22,6 +22,9 @@ import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.ScalingSummary;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+
 import javax.annotation.Nullable;
 
 import java.time.Duration;
@@ -62,6 +65,17 @@ public interface AutoScalerEventHandler<KEY, Context extends JobAutoScalerContex
             String message,
             @Nullable String messageKey,
             @Nullable Duration interval);
+
+    /**
+     * Handle exception, and the exception event is warning type and don't deduplicate by default.
+     */
+    default void handleException(Context context, String reason, Throwable e) {
+        var message = e.getMessage();
+        if (message == null) {
+            message = StringUtils.abbreviate(ExceptionUtils.getStackTrace(e), 2048);
+        }
+        handleEvent(context, Type.Warning, reason, message, null, null);
+    }
 
     /**
      * Handle scaling reports.


### PR DESCRIPTION
## What is the purpose of the change

JDBC Autoscaler event handler doesn't allow the event message is null, but the message may be null when we handle the exception.

We consider the exception message as the event message, but the exception message may be null, such as: TimeoutException. (It has been shown in following picture.)

Also, recording a event without any message is meaningless. It doesn't have any benefit for troubleshooting.



## Brief change log

- [FLINK-34957][autoscaler] Event handler records the exception stack trace when exception message is null
  - Consider the exception message as the event message when exception message isn't null
  - The whole Exception as the event message if exception message is null.

## Verifying this change

Test manually, it works well. We can see the detailed exception from the `LoggingEventHandler`.

<img width="1630" alt="image" src="https://github.com/apache/flink-kubernetes-operator/assets/38427477/ff4ed621-241e-43f5-a4a2-b4fb322f07ea">


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no

