### PR TITLE
[FLINK-34961] Use dedicated CI name for Kubernetes Operator to differentiate it in infra-reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@
 # limitations under the License.
 ################################################################################
 
-name: CI
+
+# We need to specify repo related information here since Apache INFRA doesn't differentiate
+# between several workflows with the same names while preparing a report for GHA usage
+# https://infra-reports.apache.org/#ghactions
+name: Flink Kubernetes Operator CI
 on:
   push:
   pull_request:


### PR DESCRIPTION
## What is the purpose of the change

The problem with current GHA ci is that it has `CI` name which is the same across multiple Flink projects and Apache INFRA doesn't differentiate it in it's  GHA usage report https://infra-reports.apache.org/#ghactions . The idea is to use different names to cope with this

## Brief change log

changed name for gha ci

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: ( no)
  - Core observer or reconciler logic that is regularly executed: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
