### PR TITLE
[FLINK-35105][autoscaler] Support setting default Autoscaler options at autoscaler standalone level

### DIFF
--- a/docs/content.zh/docs/custom-resource/autoscaler.md
+++ b/docs/content.zh/docs/custom-resource/autoscaler.md
@@ -275,6 +275,13 @@ org.apache.flink.autoscaler.standalone.StandaloneAutoscalerEntrypoint \
 Updating the `autoscaler.standalone.fetcher.flink-cluster.host` and `autoscaler.standalone.fetcher.flink-cluster.port`
 based on your flink cluster. In general, the host and port are the same as Flink WebUI.
 
+All autoscaler related options can be set at autoscaler standalone level, and the configuration at job-level can
+override the default value provided in the autoscaler standalone, such as: 
+
+- job.autoscaler.enabled
+- job.autoscaler.metrics.window
+- etc
+
 ### Using the JDBC Autoscaler State Store & Event Handler
 
 A driver dependency is required to connect to a specified database. Here are drivers currently supported,

--- a/docs/content/docs/custom-resource/autoscaler.md
+++ b/docs/content/docs/custom-resource/autoscaler.md
@@ -275,6 +275,13 @@ org.apache.flink.autoscaler.standalone.StandaloneAutoscalerEntrypoint \
 Updating the `autoscaler.standalone.fetcher.flink-cluster.host` and `autoscaler.standalone.fetcher.flink-cluster.port`
 based on your flink cluster. In general, the host and port are the same as Flink WebUI.
 
+All autoscaler related options can be set at autoscaler standalone level, and the configuration at job-level can 
+override the default value provided in the autoscaler standalone, such as:
+
+- job.autoscaler.enabled
+- job.autoscaler.metrics.window
+- etc
+
 ### Using the JDBC Autoscaler State Store & Event Handler
 
 A driver dependency is required to connect to a specified database. Here are drivers currently supported,

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/JobListFetcher.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/JobListFetcher.java
@@ -19,6 +19,7 @@ package org.apache.flink.autoscaler.standalone;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.autoscaler.JobAutoScalerContext;
+import org.apache.flink.configuration.Configuration;
 
 import java.util.Collection;
 
@@ -26,5 +27,11 @@ import java.util.Collection;
 @Experimental
 public interface JobListFetcher<KEY, Context extends JobAutoScalerContext<KEY>> {
 
-    Collection<Context> fetch() throws Exception;
+    /**
+     * Fetch the job context.
+     *
+     * @param baseConf The basic configuration for standalone autoscaler. The basic configuration
+     *     can be overridden by the configuration at job-level.
+     */
+    Collection<Context> fetch(Configuration baseConf) throws Exception;
 }

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
@@ -22,6 +22,7 @@ import org.apache.flink.autoscaler.JobAutoScaler;
 import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.event.AutoScalerEventHandler;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.UnmodifiableConfiguration;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import org.apache.flink.shaded.guava31.com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -60,6 +61,7 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
     private final JobAutoScaler<KEY, Context> autoScaler;
     private final ScheduledExecutorService scheduledExecutorService;
     private final ExecutorService scalingThreadPool;
+    private final UnmodifiableConfiguration baseConf;
 
     /**
      * Maintain a set of job keys that during scaling, it should be updated at {@link
@@ -88,6 +90,7 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
                 Executors.newFixedThreadPool(
                         parallelism, new ExecutorThreadFactory("autoscaler-standalone-scaling"));
         this.scalingJobKeys = new HashSet<>();
+        this.baseConf = new UnmodifiableConfiguration(conf);
     }
 
     public void start() {
@@ -107,7 +110,7 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
         LOG.info("Standalone autoscaler starts scaling.");
         Collection<Context> jobList;
         try {
-            jobList = jobListFetcher.fetch();
+            jobList = jobListFetcher.fetch(baseConf);
         } catch (Throwable e) {
             LOG.error("Error while fetch job list.", e);
             return;

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutorTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutorTest.java
@@ -84,7 +84,7 @@ class StandaloneAutoscalerExecutorTest {
 
         try (var autoscalerExecutor =
                 new StandaloneAutoscalerExecutor<>(
-                        conf, () -> jobList, eventCollector, jobAutoScaler) {
+                        conf, baseConf -> jobList, eventCollector, jobAutoScaler) {
                     @Override
                     protected void scalingSingleJob(JobAutoScalerContext<JobID> jobContext) {
                         super.scalingSingleJob(jobContext);
@@ -112,7 +112,7 @@ class StandaloneAutoscalerExecutorTest {
         try (var autoscalerExecutor =
                 new StandaloneAutoscalerExecutor<>(
                         new Configuration(),
-                        () -> {
+                        baseConf -> {
                             throw new RuntimeException("Excepted exception.");
                         },
                         eventCollector,
@@ -149,7 +149,7 @@ class StandaloneAutoscalerExecutorTest {
         try (var autoscalerExecutor =
                 new StandaloneAutoscalerExecutor<>(
                         conf,
-                        () -> jobList,
+                        baseConf -> jobList,
                         new TestingEventCollector<>(),
                         new JobAutoScaler<>() {
                             @Override
@@ -197,7 +197,7 @@ class StandaloneAutoscalerExecutorTest {
         try (var autoscalerExecutor =
                 new StandaloneAutoscalerExecutor<>(
                         conf,
-                        jobContextWithIndex::keySet,
+                        baseConf -> jobContextWithIndex.keySet(),
                         new TestingEventCollector<>(),
                         new JobAutoScaler<>() {
                             @Override


### PR DESCRIPTION
## What is the purpose of the change

Currently, autoscaler standalone doesn't support set [autoscaler options](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-release-1.8/docs/operations/configuration/#autoscaler-configuration). We must set them at job level when we use autoscaler standalone. It's not convenient if platform administrator wanna change the default value for some autoscaler options, such as:

- job.autoscaler.enabled
- job.autoscaler.metrics.window
- etc

## Brief change log

- [FLINK-35105][autoscaler] Support setting default Autoscaler options at autoscaler standalone level
  - This Jira supports setting Autoscaler options at autoscaler standalone level, it's similar with flink kubernetes operator.
  - The  autoscaler options of autoscaler standalone will be as the base configuration, and the configuration at job-level can override the default value provided in the autoscaler standalone.

## Verifying this change

- Improved the `FlinkClusterJobListFetcherTest#testFetchJobListAndConfigurationInfo` to check baseConf is empty and not empty.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
