### PR TITLE
[FLINK-35278] Fix occasional NPE on getting latest resource for status replace

### DIFF
--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
@@ -74,11 +74,7 @@ public class StatusRecorderTest {
         assertThatThrownBy(
                         () ->
                                 statusRecorder.handleLockingError(
-                                        resource,
-                                        null,
-                                        kubernetesClient,
-                                        0,
-                                        cause))
+                                        resource, null, kubernetesClient, 0, cause))
                 .isInstanceOf(KubernetesClientException.class)
                 .hasMessage("Failed to retrieve latest resource")
                 .hasCause(cause);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/StatusRecorderTest.java
@@ -24,11 +24,13 @@ import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.metrics.MetricManager;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link StatusRecorder}. */
 @EnableKubernetesMockClient(crud = true)
@@ -47,17 +49,38 @@ public class StatusRecorderTest {
         var lastRequest = mockServer.getLastRequest();
 
         helper.patchAndCacheStatus(deployment, kubernetesClient);
-        assertTrue(mockServer.getLastRequest() != lastRequest);
+        assertThat(lastRequest).isNotSameAs(mockServer.getLastRequest());
         lastRequest = mockServer.getLastRequest();
         deployment.getStatus().getReconciliationStatus().setState(ReconciliationState.ROLLING_BACK);
         helper.patchAndCacheStatus(deployment, kubernetesClient);
 
         // We intentionally compare references
-        assertTrue(mockServer.getLastRequest() != lastRequest);
+        assertThat(lastRequest).isNotSameAs(mockServer.getLastRequest());
         lastRequest = mockServer.getLastRequest();
 
         // No update
         helper.patchAndCacheStatus(deployment, kubernetesClient);
-        assertTrue(mockServer.getLastRequest() == lastRequest);
+        assertThat(lastRequest).isSameAs(mockServer.getLastRequest());
+    }
+
+    @Test
+    public void testNullLatestResource() {
+        var statusRecorder =
+                new StatusRecorder<FlinkDeployment, FlinkDeploymentStatus>(
+                        new MetricManager<>(), (e, s) -> {});
+
+        var resource = TestUtils.buildApplicationCluster();
+        var cause = new KubernetesClientException("dummy");
+        assertThatThrownBy(
+                        () ->
+                                statusRecorder.handleLockingError(
+                                        resource,
+                                        null,
+                                        kubernetesClient,
+                                        0,
+                                        cause))
+                .isInstanceOf(KubernetesClientException.class)
+                .hasMessage("Failed to retrieve latest resource")
+                .hasCause(cause);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix occasional NPE on getting latest resource for status replace.

## Brief change log

- Added a `null`-check for `latest` and `latest.getMetadata()` and throw ex. to retry with delay.
- Separated error handling to a new method to make it testable.

## Verifying this change
- Added unit test to verify the `null`-check and the thrown ex.
