### PR TITLE
[FLINK-35192] support jemalloc in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,14 @@ ARG SKIP_OS_UPDATE=true
 RUN if [ "$SKIP_OS_UPDATE" = "false" ]; then apt-get update; fi
 RUN if [ "$SKIP_OS_UPDATE" = "false" ]; then apt-get upgrade -y; fi
 
+ARG DISABLE_JEMALLOC=false
+# Install jemalloc
+RUN if [ "$DISABLE_JEMALLOC" = "false" ]; then \
+  apt-get update; \
+  apt-get -y install libjemalloc-dev; \
+  rm -rf /var/lib/apt/lists/*; \
+  fi
+
 USER flink
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["help"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,6 +22,27 @@ args=("$@")
 
 cd /flink-kubernetes-operator || exit
 
+maybe_enable_jemalloc() {
+    if [ "${DISABLE_JEMALLOC:-false}" == "false" ]; then
+        JEMALLOC_PATH="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so"
+        JEMALLOC_FALLBACK="/usr/lib/x86_64-linux-gnu/libjemalloc.so"
+        if [ -f "$JEMALLOC_PATH" ]; then
+            export LD_PRELOAD=$LD_PRELOAD:$JEMALLOC_PATH
+        elif [ -f "$JEMALLOC_FALLBACK" ]; then
+            export LD_PRELOAD=$LD_PRELOAD:$JEMALLOC_FALLBACK
+        else
+            if [ "$JEMALLOC_PATH" = "$JEMALLOC_FALLBACK" ]; then
+                MSG_PATH=$JEMALLOC_PATH
+            else
+                MSG_PATH="$JEMALLOC_PATH and $JEMALLOC_FALLBACK"
+            fi
+            echo "WARNING: attempted to load jemalloc from $MSG_PATH but the library couldn't be found. glibc will be used instead."
+        fi
+    fi
+}
+
+maybe_enable_jemalloc
+
 if [ "$1" = "help" ]; then
     printf "Usage: $(basename "$0") (operator|webhook)\n"
     printf "    Or $(basename "$0") help\n\n"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,7 +23,7 @@ args=("$@")
 cd /flink-kubernetes-operator || exit
 
 maybe_enable_jemalloc() {
-    if [ "${DISABLE_JEMALLOC:-false}" == "false" ]; then
+    if [ "${DISABLE_JEMALLOC:-false}" = "false" ]; then
         JEMALLOC_PATH="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so"
         JEMALLOC_FALLBACK="/usr/lib/x86_64-linux-gnu/libjemalloc.so"
         if [ -f "$JEMALLOC_PATH" ]; then


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

According to [FLINK-35192](https://issues.apache.org/jira/browse/FLINK-35192), the current operator image uses glibc as the memory allocator, which may cause memory leaks due to memory fragmentation.

This pr introduces jemalloc as a memory allocator for the operator's image.

## Brief change log

Introducing the `DISABLE_JEMALLOC` parameter to control whether the operator's image uses jemalloc as the memory allocator


## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->


This change is already covered by existing  ci-tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  not documented
