### PR TITLE
Fix ingress example in docs

### DIFF
--- a/docs/content/docs/operations/ingress.md
+++ b/docs/content/docs/operations/ingress.md
@@ -80,7 +80,7 @@ Beyond the example above the Operator understands other template formats too:
 **Simple domain based routing:**
 ```yaml
 ingress:
-  template: "{{name}}.{{namespace}}.flink.k8s.io"
+  template: "{{name}}.{{namespace}}.flink.k8s.io/"
 ```
 This example requires that anything `*.flink.k8s.io` must be routed to the Ingress Controller with a wildcard DNS entry:
 ```shell


### PR DESCRIPTION
In the "Simple domain based routing" example, there's no `/` so the ingress doesn't work by default