### PR TITLE
[FLINK-35052] Reject unsupported versions in the webhook validator

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -30,6 +30,7 @@ import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkSessionJobSpec;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.spec.IngressSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobManagerSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
@@ -133,8 +134,14 @@ public class DefaultValidator implements FlinkResourceValidator {
 
     private Optional<String> validateFlinkVersion(FlinkDeployment deployment) {
         var spec = deployment.getSpec();
-        if (spec.getFlinkVersion() == null) {
+        var version = spec.getFlinkVersion();
+        if (version == null) {
             return Optional.of("Flink Version must be defined.");
+        }
+
+        if (!FlinkVersion.isSupported(version)) {
+            return Optional.of(
+                    "Flink version " + version + " is not supported by this operator version");
         }
 
         var lastReconciledSpec =

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -483,6 +483,12 @@ public class DefaultValidatorTest {
 
         testError(dep -> dep.getSpec().setFlinkVersion(null), "Flink Version must be defined.");
 
+        testError(
+                dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_14),
+                "Flink version "
+                        + FlinkVersion.v1_14
+                        + " is not supported by this operator version");
+
         testSuccess(dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_15));
 
         testError(


### PR DESCRIPTION
## What is the purpose of the change

The admission webhook currently does not verify if FlinkDeployment CR utilizes Flink versions that are not supported by the Operator. This causes the CR to be accepted and the failure to be postponed until the reconciliation phase. We should instead fail fast and provide users direct feedback.

## Brief change log

Adds a Flink version check to the validator

## Verifying this change
Added a test case to the existing test suite

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / **no**)
  - Core observer or reconciler logic that is regularly executed: (yes / **no**)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
