### PR TITLE
[FLINK-35489][Autoscaler] Ensure METASPACE size is computed before the heap

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/tuning/MemoryTuning.java
@@ -125,10 +125,12 @@ public class MemoryTuning {
                                 scalingSummaries, evaluatedMetrics.getVertexMetrics()),
                         config,
                         memBudget);
-        MemorySize newHeapSize =
-                determineNewSize(getUsage(HEAP_MEMORY_USED, globalMetrics), config, memBudget);
+        // Assign memory to the METASPACE before the HEAP to ensure all needed memory is provided
+        // to the METASPACE
         MemorySize newMetaspaceSize =
                 determineNewSize(getUsage(METASPACE_MEMORY_USED, globalMetrics), config, memBudget);
+        MemorySize newHeapSize =
+                determineNewSize(getUsage(HEAP_MEMORY_USED, globalMetrics), config, memBudget);
         MemorySize newManagedSize =
                 adjustManagedMemory(
                         getUsage(MANAGED_MEMORY_USED, globalMetrics),


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

If the heap usage with overhead leads to remaining memory to be assigned to the HEAP no memory will be assigned to the METASPACE leading to JVM failure at startup
By setting this before the HEAP we ensure the JVM can start with appropriate amount of METASPACE memory

## Brief change log

*(for example:)*
  - *Compute METASPACE size to set before the HEAP size*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change added tests and can be verified as follows:
- Extended tests to validate that despite a big HEAP usage that would lead to the whole memory being used by it, the METASPACE has been well set with all appropriate memory

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
