### PR TITLE
[FLINK-33803] Remove deprecated `lastReconciledSpec` meta generation in favour of `observedGeneration`

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/reconciler/ReconciliationMetadata.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/reconciler/ReconciliationMetadata.java
@@ -21,7 +21,6 @@ import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -35,19 +34,15 @@ public class ReconciliationMetadata {
 
     private String apiVersion;
 
-    private ObjectMeta metadata;
-
     private boolean firstDeployment;
 
     public static ReconciliationMetadata from(AbstractFlinkResource<?, ?> resource) {
-        ObjectMeta metadata = new ObjectMeta();
-        metadata.setGeneration(resource.getMetadata().getGeneration());
 
         var firstDeploy =
                 resource.getStatus().getReconciliationStatus().isBeforeFirstDeployment()
                         || isFirstDeployment(resource);
 
-        return new ReconciliationMetadata(resource.getApiVersion(), metadata, firstDeploy);
+        return new ReconciliationMetadata(resource.getApiVersion(), firstDeploy);
     }
 
     private static boolean isFirstDeployment(AbstractFlinkResource<?, ?> resource) {

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/utils/SpecUtils.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/utils/SpecUtils.java
@@ -50,12 +50,12 @@ public class SpecUtils {
         try {
             ObjectNode wrapper = (ObjectNode) objectMapper.readTree(specWithMetaString);
             ObjectNode internalMeta = (ObjectNode) wrapper.remove(INTERNAL_METADATA_JSON_KEY);
-
             if (internalMeta == null) {
                 // migrating from old format
                 wrapper.remove("apiVersion");
                 return new SpecWithMeta<>(objectMapper.treeToValue(wrapper, specClass), null);
             } else {
+                internalMeta.remove("metadata");
                 return new SpecWithMeta<>(
                         objectMapper.treeToValue(wrapper.get("spec"), specClass),
                         objectMapper.convertValue(internalMeta, ReconciliationMetadata.class));

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -842,7 +842,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
                 status.getJobManagerDeploymentStatus());
 
         var specWithMeta = status.getReconciliationStatus().deserializeLastReconciledSpecWithMeta();
-        assertEquals(321L, specWithMeta.getMeta().getMetadata().getGeneration());
+        assertEquals(321L, status.getObservedGeneration());
         assertEquals(JobState.RUNNING, specWithMeta.getSpec().getJob().getState());
         assertEquals(5, specWithMeta.getSpec().getJob().getParallelism());
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -152,7 +152,7 @@ public class SessionObserverTest extends OperatorTestBase {
                 status.getJobManagerDeploymentStatus());
 
         var specWithMeta = status.getReconciliationStatus().deserializeLastReconciledSpecWithMeta();
-        assertEquals(321L, specWithMeta.getMeta().getMetadata().getGeneration());
+        assertEquals(321L, status.getObservedGeneration());
         assertEquals("1", specWithMeta.getSpec().getFlinkConfiguration().get("k"));
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -1124,30 +1124,18 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
         reconciler.reconcile(deployment, context);
         verifyAndSetRunningJobsToStatus(deployment, flinkService.listJobs());
 
-        assertEquals(
-                1L,
-                deployment
-                        .getStatus()
-                        .getReconciliationStatus()
-                        .deserializeLastReconciledSpecWithMeta()
-                        .getMeta()
-                        .getMetadata()
-                        .getGeneration());
+        assertEquals(1L, deployment.getStatus().getObservedGeneration());
 
         // Submit no-op upgrade
         deployment.getSpec().getFlinkConfiguration().put("kubernetes.operator.test", "value");
         deployment.getMetadata().setGeneration(2L);
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
 
         reconciler.reconcile(deployment, context);
-        assertEquals(
-                2L,
-                deployment
-                        .getStatus()
-                        .getReconciliationStatus()
-                        .deserializeLastReconciledSpecWithMeta()
-                        .getMeta()
-                        .getMetadata()
-                        .getGeneration());
+        assertEquals(2L, deployment.getStatus().getObservedGeneration());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What is the purpose of the change
Followup to https://issues.apache.org/jira/browse/FLINK-33803 (https://github.com/apache/flink-kubernetes-operator/pull/755)

> The `observedGeneration` field in the `FlinkDeployment` CRD status is used to persist the generation that was last acted on by the operator. At the end of a successful reconciliation, the operator sets the `observedGeneration` field to the current `generation` number (from the CRD metadata).

This PR removes internal usages of the `lastReconciledSpec` metadata (and generation) that were kept in the initial PR to avoid downstream breakage. `observedGeneration` replaces this semantically. Removing the deprecated fields is to end up with a cleaner codebase.

Note: the removed fields were nested within the `lastReconciledSpec` `String`, thus there is no documentation to be updated (please advise if I missed something).
 
## Brief change log
- There is no more `ObjectMeta` `metadata` attribute (containing `generation`) within the `ReconciliationMetadata` class
  - that field will not exist to the operator within `FlinkDeploymentStatus` w.r.t. reconciliation
- removed the `metadata` field (from the CRD metadata) during deserialization before passing the content into a `ReconciliationMetadata` instance such that its constructor does not mutate the resources
  - if not, Jackson throws a `JsonMappingException`: `Unrecognized field 'metadata' (class org.apache.flink.kubernetes.operator.api.reconciler.ReconciliationMetadata), not marked as ignorable`, causing pods to fail.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change added tests and can be verified as follows:

  - Modified existing tests that checked for `specWithMeta.getMeta().getMetadata().getGeneration()` to assert against `status.getObservedGeneration()` instead (tests pass)
  - Manually verified the change by running a cluster with  a `FlinkDeployment` custom resource that depends on the operator (with 2 JobManagers & 2 TaskManagers), and checking its CRD, verifying that fields are mapped accordingly.
<details> <summary> Logs </summary>

Before:
```yaml
k get flinkdeployment flink --context=<context> -n <ns>  -o yaml | yq .status.reconciliationStatus.lastReconciledSpec | jq .resource_metadata
{
  "apiVersion": "flink.apache.org/v1beta1",
  "metadata": {
    "generation": 5
  },
  "firstDeployment": false
}
```
```yaml
k get flinkdeployment flink --context=<context> -n <ns>  -o yaml | yq .status.observedGeneration
5
```
After:
```yaml
k get flinkdeployment flink --context=<context> -n <ns>  -o yaml | yq .status.reconciliationStatus.lastReconciledSpec | jq .resource_metadata                                                                                                                                                      
{
  "apiVersion": "flink.apache.org/v1beta1",
  "firstDeployment": true
}
```
```yaml
k get flinkdeployment flink --context=<context> -n <ns>  -o yaml | yq .status.observedGeneration
5
```
</details>

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  not applicable
