### PR TITLE
[hotfix][docs] Fix typo in Log Example Given on upgrade.md File

### DIFF
--- a/docs/content/docs/operations/upgrade.md
+++ b/docs/content/docs/operations/upgrade.md
@@ -164,7 +164,7 @@ Here is a reference example of upgrading a `basic-checkpoint-ha-example` deploym
     ```
    Finally, verify that `deploy/basic-checkpoint-ha-example` log has:
     ```
-    Starting job 00000000000000000000000000000000 from savepoint /flink-data/savepoints/savepoint-000000-2f40a9c8e4b9/_metadata
+    Starting job 00000000000000000000000000000000 from savepoint /flink-data/savepoints/savepoint-000000-aec3dd08e76d/_metadata
     ```
 
 ### 3. Changes of default values of FlinkDeployment


### PR DESCRIPTION
The ID in the savepoint folder name that is passed as a parameter, and the ID in the folder name that is given as the log example do NOT match. 

Expected ID in log example: `aec3dd08e76d`
Actual ID given in the log example: `2f40a9c8e4b9`