### PR TITLE
[FLINK-35593][Kubernetes Operator] Add Apache 2 License to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ COPY --chown=flink:flink --from=build /app/flink-kubernetes-standalone/target/$K
 COPY --chown=flink:flink --from=build /app/flink-kubernetes-operator/target/plugins $FLINK_HOME/plugins
 COPY --chown=flink:flink --from=build /app/tools/license/licenses-output/NOTICE .
 COPY --chown=flink:flink --from=build /app/tools/license/licenses-output/licenses ./licenses
+COPY --chown=flink:flink --from=build /app/LICENSE ./LICENSE
 COPY --chown=flink:flink docker-entrypoint.sh /
 
 ARG SKIP_OS_UPDATE=true


### PR DESCRIPTION
## What is the purpose of the change
Adds Apache 2 LICENSE to Apache Kubernetes Operator Docker image

## Brief change log
- Adds LICENSE file to docker stage image


## Verifying this change
- Run `mvn clean verify -T1C -DskipTests` 
- `docker build  . -t apache/flink-kubernetes-operator:latest`
- From folder where apache-kubernetes-operator code is checked out, verified checksum
   ```
   ❯ docker run -it apache/flink-kubernetes-operator:latest cksum LICENSE
   3425401509 11357 LICENSE
  ❯ cksum LICENSE
  3425401509 11357 LICENSE 
   ```


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
