### PR TITLE
[FLINK-35662] Use maven batch mode in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Build with Maven
         run: |
-          set -o pipefail; mvn clean install javadoc:javadoc -Pgenerate-docs | tee ./mvn.log; set +o pipefail
+          set -o pipefail; mvn -B clean install javadoc:javadoc -Pgenerate-docs | tee ./mvn.log; set +o pipefail
           if [[ $(cat ./mvn.log | grep -E -v '(flink-runtime-.*.jar, flink-kubernetes-operator-.*.jar)|(flink-kubernetes-operator-.*.jar, flink-runtime-.*.jar) define 3 overlapping classes' | grep -E -v '(flink-runtime-.*.jar, flink-autoscaler-.*.jar)|(flink-autoscaler-.*.jar, flink-runtime-.*.jar) define 1|2 overlapping classes' | grep -c "overlapping classes" -) -gt 0 ]];then
             echo "Found overlapping classes: "
             cat ./mvn.log | grep "overlapping classes"
@@ -63,17 +63,17 @@ jobs:
       - name: Tests in flink-kubernetes-operator
         run: |
           cd flink-kubernetes-operator
-          mvn verify -Dit.skip=false
+          mvn -B verify -Dit.skip=false
           cd ..
       - name: Tests in flink-kubernetes-webhook
         run: |
           cd flink-kubernetes-webhook
-          mvn verify -Dit.skip=false
+          mvn -B verify -Dit.skip=false
           cd ..
       - name: Tests in flink-autoscaler-plugin-jdbc
         run: |
           cd flink-autoscaler-plugin-jdbc
-          mvn verify -Dit.skip=false
+          mvn -B verify -Dit.skip=false
           cd ..
   e2e_ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -54,6 +54,6 @@ jobs:
           echo "<password>$ASF_PASSWORD</password>" >> $tmp_settings
           echo "</server></servers></settings>" >> $tmp_settings
           
-          mvn --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release
+          mvn -B --settings $tmp_settings clean deploy -Dgpg.skip -Drat.skip -DskipTests -Papache-release
           
           rm $tmp_settings


### PR DESCRIPTION
## What is the purpose of the change

Use maven batch mode in GH CI workflows, so the produced logs are not polluted with `Progress ...` lines coming from maven interactive mode.

## Brief change log
- Add `-B` to every relevant `mvn` call.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.