### PR TITLE
[FLINK-35471] Bump flink version to 1.19.1 for flink-kubernetes-operator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ under the License.
         <lombok.version>1.18.30</lombok.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-io.version>2.11.0</commons-io.version>
-        <flink.version>1.18.1</flink.version>
+        <flink.version>1.19.1</flink.version>
 
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.1</log4j.version>


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-35471] Bump flink version to 1.19.1 for flink-kubernetes-operator


## Brief change log

[FLINK-35471] Bump flink version to 1.19.1 for flink-kubernetes-operator

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no

