### PR TITLE
[FLINK-31215] [autoscaler] Backpropagate processing rate limits from non-scalable bottlenecks to upstream operators

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -117,6 +117,18 @@
             <td>Percentage threshold for switching to observed from busy time based true processing rate if the measurement is off by at least the configured fraction. For example 0.15 means we switch to observed if the busy time based computation is at least 15% higher during catchup.</td>
         </tr>
         <tr>
+            <td><h5>job.autoscaler.processing.rate.backpropagation.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Enable backpropagation of processing rate during autoscaling to reduce resources usage.</td>
+        </tr>
+        <tr>
+            <td><h5>job.autoscaler.processing.rate.backpropagation.impact</h5></td>
+            <td style="word-wrap: break-word;">0.0</td>
+            <td>Double</td>
+            <td>How strong should backpropagated values affect scaling. 0 - means no effect, 1 - use backpropagated values. It is not recommended to set this factor greater than 0.8</td>
+        </tr>
+        <tr>
             <td><h5>job.autoscaler.quota.cpu</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Double</td>
@@ -210,7 +222,7 @@
             <td><h5>job.autoscaler.vertex.exclude.ids</h5></td>
             <td style="word-wrap: break-word;"></td>
             <td>List&lt;String&gt;</td>
-            <td>A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling. Caution: For non-sink vertices this will still scale their downstream operators until https://issues.apache.org/jira/browse/FLINK-31215 is implemented.</td>
+            <td>A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling.</td>
         </tr>
         <tr>
             <td><h5>job.autoscaler.vertex.max-parallelism</h5></td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -20,8 +20,10 @@ package org.apache.flink.autoscaler;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.event.AutoScalerEventHandler;
+import org.apache.flink.autoscaler.metrics.EvaluatedMetrics;
 import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
 import org.apache.flink.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.autoscaler.topology.JobTopology;
 import org.apache.flink.autoscaler.topology.ShipStrategy;
 import org.apache.flink.autoscaler.utils.AutoScalerUtils;
 import org.apache.flink.configuration.Configuration;
@@ -37,6 +39,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.SortedMap;
@@ -52,8 +55,10 @@ import static org.apache.flink.autoscaler.metrics.ScalingMetric.EXPECTED_PROCESS
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.MAX_PARALLELISM;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.NUM_SOURCE_PARTITIONS;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.PARALLELISM;
+import static org.apache.flink.autoscaler.metrics.ScalingMetric.TARGET_DATA_RATE;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_RATE;
 import static org.apache.flink.autoscaler.topology.ShipStrategy.HASH;
+import static org.apache.flink.autoscaler.utils.AutoScalerUtils.getTargetDataRateFromUpstream;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Component responsible for computing vertex parallelism based on the scaling metrics. */
@@ -145,6 +150,67 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
 
         public static ParallelismChange noChange() {
             return NO_CHANGE;
+        }
+    }
+
+    public void backpropagateRate(
+            Configuration conf,
+            JobVertexID vertex,
+            JobTopology topology,
+            EvaluatedMetrics evaluatedMetrics,
+            Map<JobVertexID, Double> backpropagationRate,
+            List<String> excludedVertices) {
+
+        if (excludedVertices.contains(vertex.toHexString())) {
+            return;
+        }
+
+        var vertexMetrics = evaluatedMetrics.getVertexMetrics().get(vertex);
+
+        // vertex scale factor is limited by max scale factor
+        double scaleFactor = 1 + conf.get(MAX_SCALE_UP_FACTOR);
+
+        // vertex scale factor is limited by max parallelism scale factor
+        scaleFactor =
+                Math.min(
+                        scaleFactor,
+                        vertexMetrics.get(MAX_PARALLELISM).getCurrent()
+                                / vertexMetrics.get(PARALLELISM).getCurrent());
+
+        double maxProcessingRateAfterScale =
+                Math.min(
+                        vertexMetrics.get(TARGET_DATA_RATE).getAverage()
+                                * backpropagationRate.getOrDefault(vertex, 1.0),
+                        vertexMetrics.get(TRUE_PROCESSING_RATE).getAverage() * scaleFactor);
+
+        // evaluating partially updated target data rate from upstream
+        double targetDataRate =
+                getTargetDataRateFromUpstream(
+                        evaluatedMetrics, topology, vertex, backpropagationRate);
+
+        // if cannot derive finite value, then assume full processing
+        if (Double.isNaN(targetDataRate) || Double.isInfinite(targetDataRate)) {
+            return;
+        }
+
+        // if cannot derive finite value, then assume full processing
+        if (Double.isNaN(maxProcessingRateAfterScale)
+                || Double.isInfinite(maxProcessingRateAfterScale)) {
+            return;
+        }
+
+        // if all input stream can be processed, skip propagation
+        if (targetDataRate < maxProcessingRateAfterScale) {
+            return;
+        }
+
+        // propagation coefficient
+        double adjustmentRate = maxProcessingRateAfterScale / targetDataRate;
+
+        // update rate of direct upstream vertices
+        for (var v : topology.getVertexInfos().get(vertex).getInputs().keySet()) {
+            double vertexRate = backpropagationRate.getOrDefault(v, 1.0);
+            backpropagationRate.put(v, vertexRate * adjustmentRate);
         }
     }
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -352,6 +352,7 @@ public class ScalingMetricEvaluator {
                 var inputTargetRate = inputEvaluatedMetrics.get(TARGET_DATA_RATE);
                 var outputRatio =
                         computeEdgeOutputRatio(inputVertex, vertex, topology, metricsHistory);
+                topology.get(vertex).getInputRatios().put(inputVertex, outputRatio);
                 LOG.debug(
                         "Computed output ratio for edge ({} -> {}) : {}",
                         inputVertex,

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -58,6 +58,24 @@ public class AutoScalerOptions {
                     .withDescription(
                             "Enable vertex scaling execution by the autoscaler. If disabled, the autoscaler will only collect metrics and evaluate the suggested parallelism for each vertex but will not upgrade the jobs.");
 
+    public static final ConfigOption<Boolean> PROCESSING_RATE_BACKPROPAGATION_ENABLED =
+            autoScalerConfig("processing.rate.backpropagation.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withFallbackKeys(
+                            oldOperatorConfigKey("processing.rate.backpropagation.enabled"))
+                    .withDescription(
+                            "Enable backpropagation of processing rate during autoscaling to reduce resources usage.");
+
+    public static final ConfigOption<Double> PROCESSING_RATE_BACKPROPAGATION_IMPACT =
+            autoScalerConfig("processing.rate.backpropagation.impact")
+                    .doubleType()
+                    .defaultValue(0.0)
+                    .withFallbackKeys(
+                            oldOperatorConfigKey("processing.rate.backpropagation.impact"))
+                    .withDescription(
+                            "How strong should backpropagated values affect scaling. 0 - means no effect, 1 - use backpropagated values. It is not recommended to set this factor greater than 0.8");
+
     public static final ConfigOption<Duration> METRICS_WINDOW =
             autoScalerConfig("metrics.window")
                     .durationType()
@@ -320,7 +338,7 @@ public class AutoScalerOptions {
                     .defaultValues()
                     .withFallbackKeys(oldOperatorConfigKey("vertex.exclude.ids"))
                     .withDescription(
-                            "A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling. Caution: For non-sink vertices this will still scale their downstream operators until https://issues.apache.org/jira/browse/FLINK-31215 is implemented.");
+                            "A (semicolon-separated) list of vertex ids in hexstring for which to disable scaling.");
 
     public static final ConfigOption<Duration> SCALING_EVENT_INTERVAL =
             autoScalerConfig("scaling.event.interval")

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/VertexInfo.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/topology/VertexInfo.java
@@ -25,6 +25,7 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.Setter;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /** Job vertex information. */
@@ -32,6 +33,9 @@ import java.util.Map;
 public class VertexInfo {
 
     private final JobVertexID id;
+
+    // Output ratios from input vertices. Used for backpropagation
+    private final Map<JobVertexID, Double> inputRatios;
 
     // All input vertices and the ship_strategy
     private final Map<JobVertexID, ShipStrategy> inputs;
@@ -67,6 +71,7 @@ public class VertexInfo {
         this.maxParallelism = maxParallelism;
         this.finished = finished;
         this.ioMetrics = ioMetrics;
+        this.inputRatios = new HashMap<>();
     }
 
     @VisibleForTesting

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -181,6 +181,10 @@ public class MetricsCollectionAndEvaluationTest {
         assertTrue(collectedMetrics.isFullyCollected());
 
         var evaluation = evaluator.evaluate(conf, collectedMetrics, restartTime);
+        assertEquals(Map.of(map, 2.0), topology.getVertexInfos().get(sink).getInputRatios());
+        assertEquals(
+                Map.of(source1, 2.0, source2, 2.0),
+                topology.getVertexInfos().get(map).getInputRatios());
         scalingExecutor.scaleResource(
                 context,
                 evaluation,

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorBackpropagationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorBackpropagationTest.java
@@ -1,0 +1,578 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.autoscaler.event.TestingEventCollector;
+import org.apache.flink.autoscaler.metrics.EvaluatedMetrics;
+import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
+import org.apache.flink.autoscaler.metrics.ScalingMetric;
+import org.apache.flink.autoscaler.state.InMemoryAutoScalerStateStore;
+import org.apache.flink.autoscaler.topology.JobTopology;
+import org.apache.flink.autoscaler.topology.VertexInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.autoscaler.TestingAutoscalerUtils.createDefaultJobAutoScalerContext;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALE_DOWN_INTERVAL;
+import static org.apache.flink.autoscaler.topology.ShipStrategy.HASH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for backpropagation in {@link ScalingExecutor}. */
+public class ScalingExecutorBackpropagationTest {
+
+    private static final int MAX_PARALLELISM = 720;
+
+    private JobAutoScalerContext<JobID> context;
+    private TestingEventCollector<JobID, JobAutoScalerContext<JobID>> eventCollector;
+    private ScalingExecutor<JobID, JobAutoScalerContext<JobID>> scalingExecutor;
+
+    private InMemoryAutoScalerStateStore<JobID, JobAutoScalerContext<JobID>> stateStore;
+
+    private static final Map<ScalingMetric, EvaluatedScalingMetric> dummyGlobalMetrics =
+            Map.of(
+                    ScalingMetric.GC_PRESSURE, EvaluatedScalingMetric.of(Double.NaN),
+                    ScalingMetric.HEAP_MAX_USAGE_RATIO, EvaluatedScalingMetric.of(Double.NaN));
+
+    @BeforeEach
+    public void setup() {
+        eventCollector = new TestingEventCollector<>();
+        context = createDefaultJobAutoScalerContext();
+        stateStore = new InMemoryAutoScalerStateStore<>();
+
+        scalingExecutor =
+                new ScalingExecutor<>(eventCollector, stateStore) {
+                    @Override
+                    protected boolean scalingWouldExceedMaxResources(
+                            Configuration tunedConfig,
+                            JobTopology jobTopology,
+                            EvaluatedMetrics evaluatedMetrics,
+                            Map<JobVertexID, ScalingSummary> scalingSummaries,
+                            JobAutoScalerContext<JobID> ctx) {
+                        return super.scalingWouldExceedMaxResources(
+                                tunedConfig, jobTopology, evaluatedMetrics, scalingSummaries, ctx);
+                    }
+                };
+        Configuration conf = context.getConfiguration();
+        conf.set(AutoScalerOptions.STABILIZATION_INTERVAL, Duration.ZERO);
+        conf.set(AutoScalerOptions.SCALING_ENABLED, true);
+        conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 1.);
+        conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 1.0);
+        conf.set(AutoScalerOptions.CATCH_UP_DURATION, Duration.ZERO);
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.0);
+        conf.set(AutoScalerOptions.PROCESSING_RATE_BACKPROPAGATION_ENABLED, true);
+    }
+
+    @Test
+    public void testMetricsNotUpdateOnNoPropagation() throws Exception {
+        var sourceHexString = "0bfd135746ac8efb3cce668b12e16d3a";
+        var source = JobVertexID.fromHexString(sourceHexString);
+        var filterOperatorHexString = "869fb403873411306404e9f2e4438c0e";
+        var filterOperator = JobVertexID.fromHexString(filterOperatorHexString);
+        var sinkHexString = "a6b7102b8d3e3a9564998c1ffeb5e2b7";
+        var sink = JobVertexID.fromHexString(sinkHexString);
+
+        JobTopology jobTopology =
+                new JobTopology(
+                        new VertexInfo(source, Map.of(), 10, 20, false, null),
+                        new VertexInfo(filterOperator, Map.of(source, HASH), 10, 20, false, null),
+                        new VertexInfo(sink, Map.of(filterOperator, HASH), 10, 20, false, null));
+
+        jobTopology.get(filterOperator).getInputRatios().put(source, 1.0);
+        jobTopology.get(sink).getInputRatios().put(filterOperator, 1.0);
+
+        var conf = context.getConfiguration();
+        conf.set(SCALE_DOWN_INTERVAL, Duration.ofMillis(0));
+        var metrics =
+                new EvaluatedMetrics(
+                        Map.of(
+                                source,
+                                evaluated(10, 50, 100),
+                                filterOperator,
+                                evaluated(10, 50, 100),
+                                sink,
+                                evaluated(10, 50, 100)),
+                        dummyGlobalMetrics);
+
+        // there is no bottlenecks, so scaling should not change target data rate
+        var now = Instant.now();
+        assertTrue(
+                scalingExecutor.scaleResource(
+                        context,
+                        metrics,
+                        new HashMap<>(),
+                        new ScalingTracking(),
+                        now,
+                        jobTopology,
+                        new DelayedScaleDown()));
+        assertEquals(
+                50.0,
+                metrics.getVertexMetrics()
+                        .get(source)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                50.0,
+                metrics.getVertexMetrics()
+                        .get(filterOperator)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                50.0,
+                metrics.getVertexMetrics()
+                        .get(sink)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+
+        metrics =
+                new EvaluatedMetrics(
+                        Map.of(
+                                source,
+                                evaluated(10, 100, 100),
+                                filterOperator,
+                                evaluated(10, 200, 100),
+                                sink,
+                                evaluated(10, 400, 100)),
+                        dummyGlobalMetrics);
+        jobTopology.get(filterOperator).getInputRatios().put(source, 2.0);
+        jobTopology.get(sink).getInputRatios().put(filterOperator, 2.0);
+        assertTrue(
+                scalingExecutor.scaleResource(
+                        context,
+                        metrics,
+                        new HashMap<>(),
+                        new ScalingTracking(),
+                        now,
+                        jobTopology,
+                        new DelayedScaleDown()));
+        assertEquals(
+                100,
+                metrics.getVertexMetrics()
+                        .get(source)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                200.0,
+                metrics.getVertexMetrics()
+                        .get(filterOperator)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                400.0,
+                metrics.getVertexMetrics()
+                        .get(sink)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+    }
+
+    @Test
+    public void testMetricsUpdateOnPropagation() throws Exception {
+        var sourceHexString = "0bfd135746ac8efb3cce668b12e16d3a";
+        var source = JobVertexID.fromHexString(sourceHexString);
+        var filterOperatorHexString = "869fb403873411306404e9f2e4438c0e";
+        var filterOperator = JobVertexID.fromHexString(filterOperatorHexString);
+        var sinkHexString = "a6b7102b8d3e3a9564998c1ffeb5e2b7";
+        var sink = JobVertexID.fromHexString(sinkHexString);
+
+        JobTopology jobTopology =
+                new JobTopology(
+                        new VertexInfo(source, Map.of(), 10, 20, false, null),
+                        new VertexInfo(filterOperator, Map.of(source, HASH), 10, 20, false, null),
+                        new VertexInfo(sink, Map.of(filterOperator, HASH), 10, 20, false, null));
+
+        var conf = context.getConfiguration();
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.0);
+        conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 1.0);
+        var metrics =
+                new EvaluatedMetrics(
+                        Map.of(
+                                source,
+                                evaluated(10, 100, 100),
+                                filterOperator,
+                                evaluated(10, 400, 100),
+                                sink,
+                                evaluated(10, 400, 100)),
+                        dummyGlobalMetrics);
+        jobTopology.get(filterOperator).getInputRatios().put(source, 4.0);
+        jobTopology.get(sink).getInputRatios().put(filterOperator, 1.0);
+        conf.set(AutoScalerOptions.PROCESSING_RATE_BACKPROPAGATION_IMPACT, 1.0);
+        var now = Instant.now();
+        assertTrue(
+                scalingExecutor.scaleResource(
+                        context,
+                        metrics,
+                        new HashMap<>(),
+                        new ScalingTracking(),
+                        now,
+                        jobTopology,
+                        new DelayedScaleDown()));
+        assertEquals(
+                50.0,
+                metrics.getVertexMetrics()
+                        .get(source)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                200.0,
+                metrics.getVertexMetrics()
+                        .get(filterOperator)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                200.0,
+                metrics.getVertexMetrics()
+                        .get(sink)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+    }
+
+    @Test
+    public void testMetricsUpdateOnPropagationMaxParallelismLimit() throws Exception {
+        var sourceHexString = "0bfd135746ac8efb3cce668b12e16d3a";
+        var source = JobVertexID.fromHexString(sourceHexString);
+        var filterOperatorHexString = "869fb403873411306404e9f2e4438c0e";
+        var filterOperator = JobVertexID.fromHexString(filterOperatorHexString);
+        var sinkHexString = "a6b7102b8d3e3a9564998c1ffeb5e2b7";
+        var sink = JobVertexID.fromHexString(sinkHexString);
+
+        JobTopology jobTopology =
+                new JobTopology(
+                        new VertexInfo(source, Map.of(), 10, 20, false, null),
+                        new VertexInfo(filterOperator, Map.of(source, HASH), 10, 20, false, null),
+                        new VertexInfo(sink, Map.of(filterOperator, HASH), 10, 10, false, null));
+
+        var conf = context.getConfiguration();
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.0);
+        var metrics =
+                new EvaluatedMetrics(
+                        Map.of(
+                                source,
+                                evaluated(10, 100, 100),
+                                filterOperator,
+                                evaluated(10, 400, 100),
+                                sink,
+                                evaluated(10, 400, 100)),
+                        dummyGlobalMetrics);
+        jobTopology.get(filterOperator).getInputRatios().put(source, 4.0);
+        jobTopology.get(sink).getInputRatios().put(filterOperator, 1.0);
+        conf.set(AutoScalerOptions.PROCESSING_RATE_BACKPROPAGATION_IMPACT, 1.0);
+
+        metrics.getVertexMetrics()
+                .get(sink)
+                .put(ScalingMetric.MAX_PARALLELISM, EvaluatedScalingMetric.of(10));
+
+        var now = Instant.now();
+        assertFalse(
+                scalingExecutor.scaleResource(
+                        context,
+                        metrics,
+                        new HashMap<>(),
+                        new ScalingTracking(),
+                        now,
+                        jobTopology,
+                        new DelayedScaleDown()));
+        assertEquals(
+                25.0,
+                metrics.getVertexMetrics()
+                        .get(source)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                100.0,
+                metrics.getVertexMetrics()
+                        .get(filterOperator)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                100.0,
+                metrics.getVertexMetrics()
+                        .get(sink)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+    }
+
+    @Test
+    public void testMetricsUpdateOnPropagationExcludedVertices() throws Exception {
+        var sourceHexString = "0bfd135746ac8efb3cce668b12e16d3a";
+        var source = JobVertexID.fromHexString(sourceHexString);
+        var filterOperatorHexString = "869fb403873411306404e9f2e4438c0e";
+        var filterOperator = JobVertexID.fromHexString(filterOperatorHexString);
+        var sinkHexString = "a6b7102b8d3e3a9564998c1ffeb5e2b7";
+        var sink = JobVertexID.fromHexString(sinkHexString);
+
+        JobTopology jobTopology =
+                new JobTopology(
+                        new VertexInfo(source, Map.of(), 10, 20, false, null),
+                        new VertexInfo(filterOperator, Map.of(source, HASH), 10, 20, false, null),
+                        new VertexInfo(sink, Map.of(filterOperator, HASH), 10, 20, false, null));
+
+        var conf = context.getConfiguration();
+        conf.set(AutoScalerOptions.VERTEX_EXCLUDE_IDS, List.of(sinkHexString));
+        var metrics =
+                new EvaluatedMetrics(
+                        Map.of(
+                                source,
+                                evaluated(10, 100, 100),
+                                filterOperator,
+                                evaluated(10, 400, 100),
+                                sink,
+                                evaluated(10, 400, 100)),
+                        dummyGlobalMetrics);
+        jobTopology.get(filterOperator).getInputRatios().put(source, 4.0);
+        jobTopology.get(sink).getInputRatios().put(filterOperator, 1.0);
+        var now = Instant.now();
+        conf.set(AutoScalerOptions.PROCESSING_RATE_BACKPROPAGATION_IMPACT, 1.0);
+        assertTrue(
+                scalingExecutor.scaleResource(
+                        context,
+                        metrics,
+                        new HashMap<>(),
+                        new ScalingTracking(),
+                        now,
+                        jobTopology,
+                        new DelayedScaleDown()));
+        assertEquals(
+                50.0,
+                metrics.getVertexMetrics()
+                        .get(source)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                200.0,
+                metrics.getVertexMetrics()
+                        .get(filterOperator)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                200.0,
+                metrics.getVertexMetrics()
+                        .get(sink)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+    }
+
+    @Test
+    public void testDisconnectedJobMetricsUpdate() throws Exception {
+        var source1HexString = "0bfd135746ac8efb3cce668b12e16d3a";
+        var source1 = JobVertexID.fromHexString(source1HexString);
+        var sink1HexString = "a6b7102b8d3e3a9564998c1ffeb5e2b7";
+        var sink1 = JobVertexID.fromHexString(sink1HexString);
+        var source2HexString = "74b8b4bd0762e2177f8d71481f79f07c";
+        var source2 = JobVertexID.fromHexString(source2HexString);
+        var sink2HexString = "c044d7d1304e32489deb16b4e0b080ef";
+        var sink2 = JobVertexID.fromHexString(sink2HexString);
+
+        JobTopology jobTopology =
+                new JobTopology(
+                        new VertexInfo(source1, Map.of(), 10, 20, false, null),
+                        new VertexInfo(source2, Map.of(), 10, 20, false, null),
+                        new VertexInfo(sink1, Map.of(source1, HASH), 10, 20, false, null),
+                        new VertexInfo(sink2, Map.of(source2, HASH), 10, 20, false, null));
+
+        var conf = context.getConfiguration();
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.0);
+        conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 1.0);
+        conf.set(AutoScalerOptions.PROCESSING_RATE_BACKPROPAGATION_ENABLED, true);
+        var metrics =
+                new EvaluatedMetrics(
+                        Map.of(
+                                source1,
+                                evaluated(10, 100, 100),
+                                source2,
+                                evaluated(10, 200, 100),
+                                sink1,
+                                evaluated(10, 800, 100),
+                                sink2,
+                                evaluated(10, 500, 100)),
+                        dummyGlobalMetrics);
+        jobTopology.get(sink1).getInputRatios().put(source1, 8.0);
+        jobTopology.get(sink2).getInputRatios().put(source2, 2.5);
+        var now = Instant.now();
+        conf.set(AutoScalerOptions.PROCESSING_RATE_BACKPROPAGATION_IMPACT, 1.0);
+        assertTrue(
+                scalingExecutor.scaleResource(
+                        context,
+                        metrics,
+                        new HashMap<>(),
+                        new ScalingTracking(),
+                        now,
+                        jobTopology,
+                        new DelayedScaleDown()));
+        assertEquals(
+                25,
+                metrics.getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                80.0,
+                metrics.getVertexMetrics()
+                        .get(source2)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                200.0,
+                metrics.getVertexMetrics()
+                        .get(sink1)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                200.0,
+                metrics.getVertexMetrics()
+                        .get(sink2)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+    }
+
+    @Test
+    public void testComplexJobMetricsUpdate() throws Exception {
+        var source1HexString = "0bfd135746ac8efb3cce668b12e16d3a";
+        var source1 = JobVertexID.fromHexString(source1HexString);
+        var op1HexString = "b155797987c1d39a2c13f083476bce0d";
+        var op1 = JobVertexID.fromHexString(op1HexString);
+        var sink1HexString = "a6b7102b8d3e3a9564998c1ffeb5e2b7";
+        var sink1 = JobVertexID.fromHexString(sink1HexString);
+
+        var source2HexString = "74b8b4bd0762e2177f8d71481f79f07c";
+        var source2 = JobVertexID.fromHexString(source2HexString);
+        var op2HexString = "958f423134cae6985a59e2d16bde444e";
+        var op2 = JobVertexID.fromHexString(op2HexString);
+        var sink2HexString = "c044d7d1304e32489deb16b4e0b080ef";
+        var sink2 = JobVertexID.fromHexString(sink2HexString);
+
+        JobTopology jobTopology =
+                new JobTopology(
+                        new VertexInfo(source1, Map.of(), 10, 20, false, null),
+                        new VertexInfo(source2, Map.of(), 10, 20, false, null),
+                        new VertexInfo(
+                                op1, Map.of(source1, HASH, source2, HASH), 10, 20, false, null),
+                        new VertexInfo(
+                                op2, Map.of(source1, HASH, source2, HASH), 10, 20, false, null),
+                        new VertexInfo(sink1, Map.of(op1, HASH, op2, HASH), 10, 20, false, null),
+                        new VertexInfo(sink2, Map.of(op1, HASH, op2, HASH), 10, 20, false, null));
+
+        var conf = context.getConfiguration();
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.0);
+        conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 1.0);
+        var metrics =
+                new EvaluatedMetrics(
+                        Map.of(
+                                source1,
+                                evaluated(10, 100, 100),
+                                source2,
+                                evaluated(10, 100, 100),
+                                op1,
+                                evaluated(10, 200, 100),
+                                op2,
+                                evaluated(10, 200, 100),
+                                sink1,
+                                evaluated(10, 600, 100),
+                                sink2,
+                                evaluated(10, 500, 100)),
+                        dummyGlobalMetrics);
+        jobTopology.get(op1).getInputRatios().put(source1, 1.0);
+        jobTopology.get(op1).getInputRatios().put(source2, 1.0);
+        jobTopology.get(op2).getInputRatios().put(source1, 1.0);
+        jobTopology.get(op2).getInputRatios().put(source2, 1.0);
+
+        jobTopology.get(sink1).getInputRatios().put(op1, 1.0);
+        jobTopology.get(sink1).getInputRatios().put(op2, 2.0);
+        jobTopology.get(sink2).getInputRatios().put(op1, 2.0);
+        jobTopology.get(sink2).getInputRatios().put(op2, 0.5);
+
+        var now = Instant.now();
+        conf.set(AutoScalerOptions.PROCESSING_RATE_BACKPROPAGATION_IMPACT, 0.8);
+        assertTrue(
+                scalingExecutor.scaleResource(
+                        context,
+                        metrics,
+                        new HashMap<>(),
+                        new ScalingTracking(),
+                        now,
+                        jobTopology,
+                        new DelayedScaleDown()));
+        assertEquals(
+                46.667,
+                metrics.getVertexMetrics()
+                        .get(source1)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                46.667,
+                metrics.getVertexMetrics()
+                        .get(source2)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                93.333,
+                metrics.getVertexMetrics()
+                        .get(op1)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                93.333,
+                metrics.getVertexMetrics()
+                        .get(op2)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+
+        // since aggressive scaling down is disabled, the vertex is still a bottleneck
+        assertEquals(
+                280.0,
+                metrics.getVertexMetrics()
+                        .get(sink1)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+        assertEquals(
+                233.333,
+                metrics.getVertexMetrics()
+                        .get(sink2)
+                        .get(ScalingMetric.TARGET_DATA_RATE)
+                        .getAverage());
+    }
+
+    private Map<ScalingMetric, EvaluatedScalingMetric> evaluated(
+            int parallelism, double target, double trueProcessingRate) {
+        var metrics = new HashMap<ScalingMetric, EvaluatedScalingMetric>();
+        metrics.put(ScalingMetric.PARALLELISM, EvaluatedScalingMetric.of(parallelism));
+        metrics.put(ScalingMetric.MAX_PARALLELISM, EvaluatedScalingMetric.of(MAX_PARALLELISM));
+        metrics.put(ScalingMetric.TARGET_DATA_RATE, new EvaluatedScalingMetric(target, target));
+        metrics.put(ScalingMetric.CATCH_UP_DATA_RATE, EvaluatedScalingMetric.of(0.0));
+        metrics.put(
+                ScalingMetric.TRUE_PROCESSING_RATE,
+                new EvaluatedScalingMetric(trueProcessingRate, trueProcessingRate));
+        metrics.put(ScalingMetric.NUM_SOURCE_PARTITIONS, EvaluatedScalingMetric.of(150));
+
+        var restartTime = context.getConfiguration().get(AutoScalerOptions.RESTART_TIME);
+        ScalingMetricEvaluator.computeProcessingRateThresholds(
+                metrics, context.getConfiguration(), false, restartTime);
+        return metrics;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds logic for backpropagating processing rate from non-scalable bottlenecks to upstream operators, potentially reducing parallelism of bakcpressured vertices after scaling.

## Brief change log

 - Introduce an option for enabling back propagation checks during autoscaling
 - Update scaling functions to determine potential bottlenecks
 - Scaling of target capacity for each vertex by some coefficient
 - This coefficient is evaluated in the way jobs' bottlenecks are scaled as much as possible, but not exceed max parallelism.

## Verifying this change

This change added tests and can be verified as follows:

- Extended existing tests in JobVertexScalerTest to check updated logic for vertex exclusion and effects of backpropagations scale factor
- Extended ScalingExecutorTest by tests for testing Backpropagation on different jobs and vertices exclusion.
- Manually verified on different jobs with different max parallelism configuration causing bottlenecks appearance and with different sets of excluded vertices.
 
## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation
  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? yes, the brief explanation is here: https://docs.google.com/document/d/1CWT4Q_rv0_adba0nUoSFTpzvz1mzb7diUnGd2w4S074/edit?usp=sharing
