### PR TITLE
[FLINK-35292] Set dummy savepoint path during last-state upgrade

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -225,6 +225,15 @@ public abstract class AbstractFlinkService implements FlinkService {
     }
 
     @Override
+    public boolean atLeastOneCheckpoint(Configuration conf) {
+        if (FlinkUtils.isKubernetesHAActivated(conf)) {
+            return FlinkUtils.isKubernetesHaMetadataAvailableWithCheckpoint(conf, kubernetesClient);
+        } else {
+            return isHaMetadataAvailable(conf);
+        }
+    }
+
+    @Override
     public JobID submitJobToSessionCluster(
             ObjectMeta meta,
             FlinkSessionJobSpec spec,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -58,6 +58,8 @@ public interface FlinkService {
 
     boolean isHaMetadataAvailable(Configuration conf);
 
+    boolean atLeastOneCheckpoint(Configuration conf);
+
     void submitSessionCluster(Configuration conf) throws Exception;
 
     JobID submitJobToSessionCluster(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -125,6 +125,7 @@ public class TestingFlinkService extends AbstractFlinkService {
     @Setter private boolean isFlinkJobTerminatedWithoutCancellation = false;
     @Setter private boolean isPortReady = true;
     @Setter private boolean haDataAvailable = true;
+    @Setter private boolean checkpointAvailable = true;
     @Setter private boolean jobManagerReady = true;
     @Setter private boolean deployFailure = false;
     @Setter private Runnable sessionJobSubmittedCallback;
@@ -234,6 +235,11 @@ public class TestingFlinkService extends AbstractFlinkService {
                             + "Manual restore required.",
                     "RestoreFailed");
         }
+    }
+
+    @Override
+    public boolean atLeastOneCheckpoint(Configuration conf) {
+        return isHaMetadataAvailable(conf) && checkpointAvailable;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

Currently the operator always sets the savepoint path even if last-state (HA metadata) must be used. 

This can be misleading to users as the set savepoint path normally should never take effect and can actually lead to incorrect state restored if the HA metadata is deleted by the user at the wrong moment.

To avoid this we can set an explicit dummy savepoint path which will prevent restoring from it accidentally. 

## Brief change log

  - Set dummy savepoint path during last-state upgrade
  - Add/update tests

## Verifying this change

Unit tests + manual verification

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
