### PR TITLE
[FLINK-35126] Rework default checkpoint progress check window

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -22,15 +22,15 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.cluster.health-check.checkpoint-progress.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Whether to enable checkpoint progress health check for clusters.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.cluster.health-check.checkpoint-progress.window</h5></td>
-            <td style="word-wrap: break-word;">5 min</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>If no checkpoints are completed within the defined time window, the job is considered unhealthy. This must be bigger than checkpointing interval.</td>
+            <td>If no checkpoints are completed within the defined time window, the job is considered unhealthy. The minimum window size is `max(checkpointingInterval, checkpointTimeout) * (tolerableCheckpointFailures + 2)`, which also serves as the default value when checkpointing is enabled. For example with checkpoint interval 10 minutes and 0 tolerable failures, the default progress check window will be 20 minutes.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.cluster.health-check.enabled</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -22,15 +22,15 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.cluster.health-check.checkpoint-progress.enabled</h5></td>
-            <td style="word-wrap: break-word;">false</td>
+            <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Whether to enable checkpoint progress health check for clusters.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.cluster.health-check.checkpoint-progress.window</h5></td>
-            <td style="word-wrap: break-word;">5 min</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>If no checkpoints are completed within the defined time window, the job is considered unhealthy. This must be bigger than checkpointing interval.</td>
+            <td>If no checkpoints are completed within the defined time window, the job is considered unhealthy. The minimum window size is `max(checkpointingInterval, checkpointTimeout) * (tolerableCheckpointFailures + 2)`, which also serves as the default value when checkpointing is enabled. For example with checkpoint interval 10 minutes and 0 tolerable failures, the default progress check window will be 20 minutes.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.cluster.health-check.enabled</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -502,7 +502,7 @@ public class KubernetesOperatorConfigOptions {
             OPERATOR_CLUSTER_HEALTH_CHECK_CHECKPOINT_PROGRESS_ENABLED =
                     operatorConfig("cluster.health-check.checkpoint-progress.enabled")
                             .booleanType()
-                            .defaultValue(false)
+                            .defaultValue(true)
                             .withDescription(
                                     "Whether to enable checkpoint progress health check for clusters.");
 
@@ -511,9 +511,9 @@ public class KubernetesOperatorConfigOptions {
             OPERATOR_CLUSTER_HEALTH_CHECK_CHECKPOINT_PROGRESS_WINDOW =
                     operatorConfig("cluster.health-check.checkpoint-progress.window")
                             .durationType()
-                            .defaultValue(Duration.ofMinutes(5))
+                            .noDefaultValue()
                             .withDescription(
-                                    "If no checkpoints are completed within the defined time window, the job is considered unhealthy. This must be bigger than checkpointing interval.");
+                                    "If no checkpoints are completed within the defined time window, the job is considered unhealthy. The minimum window size is `max(checkpointingInterval, checkpointTimeout) * (tolerableCheckpointFailures + 2)`, which also serves as the default value when checkpointing is enabled. For example with checkpoint interval 10 minutes and 0 tolerable failures, the default progress check window will be 20 minutes.");
 
     @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> OPERATOR_JOB_RESTART_FAILED =

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/UnhealthyDeploymentRestartTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/UnhealthyDeploymentRestartTest.java
@@ -138,7 +138,7 @@ public class UnhealthyDeploymentRestartTest {
         // Ensure the last savepoint has been taken more than 10 minutes ago (Default checkpoint
         // interval)
         clusterHealthInfo.setNumCompletedCheckpointsIncreasedTimeStamp(
-                clusterHealthInfo.getNumCompletedCheckpointsIncreasedTimeStamp() - 600000);
+                clusterHealthInfo.getNumCompletedCheckpointsIncreasedTimeStamp() - 1200000);
         setLastValidClusterHealthInfo(appCluster.getStatus().getClusterInfo(), clusterHealthInfo);
         testController.getStatusRecorder().patchAndCacheStatus(appCluster, kubernetesClient);
         testController.reconcile(appCluster, context);


### PR DESCRIPTION
## What is the purpose of the change

Currently the checkpoint progress health check window is configurable by Duration. This makes it hard to enable by default as the sensible interval depends on the checkpoint interval. 

At the same time the operator already contains logic for a minimum progress check interval computed from the checkpoint timeout , tolerable failures and checkpoint interval.

Furthermore for any job with checkpointing enabled this health check is very valuable to have enabled by default similar to the restart health check. This PR also proposes to enable this feature by default with the the minimum checkpoint check interval set.

## Brief change log

  - Enable checkpoint progress health check by default (for jobs with checkpointing configured)
  - Set the minimum based on the calculated that already enforces the lower bound 

## Verifying this change

Unit tests + manual verification

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
