### PR TITLE
[FLINK-35937] RBAC cleanup

### DIFF
--- a/helm/flink-kubernetes-operator/templates/rbac.yaml
+++ b/helm/flink-kubernetes-operator/templates/rbac.yaml
@@ -50,8 +50,6 @@ rules:
       - apps
     resources:
       - deployments
-      - deployments/scale
-      - deployments/finalizers
       - replicasets
     verbs:
       - get
@@ -61,26 +59,20 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
-      - extensions
+      - apps
     resources:
-      - deployments
-      - ingresses
+      - deployments/scale
     verbs:
       - get
-      - list
-      - watch
-      - create
       - update
       - patch
-      - delete
   - apiGroups:
       - flink.apache.org
     resources:
       - flinkdeployments
-      - flinkdeployments/finalizers
       - flinksessionjobs
-      - flinksessionjobs/finalizers
     verbs:
       - get
       - list
@@ -89,6 +81,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - flink.apache.org
     resources:
@@ -110,6 +103,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - coordination.k8s.io
     resources:
@@ -122,6 +116,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
 {{- end }}
 
 {{/*
@@ -142,11 +137,11 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
   - apiGroups:
       - apps
     resources:
       - deployments
-      - deployments/finalizers
     verbs:
       - get
       - list
@@ -155,6 +150,7 @@ rules:
       - update
       - patch
       - delete
+      - deletecollection
 {{- end }}
 
 ---
@@ -245,7 +241,14 @@ rules:
     resources:
       - leases
     verbs:
-      - "*"
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
 {{- end }}
 ---
 {{- if and .Values.rbac.operatorRole.create (not (has .Release.Namespace .Values.watchNamespaces)) }}


### PR DESCRIPTION
## What is the purpose of the change

In further research and testing with Kyverno I figured out that some apiGroups seem to be invalid and I removed them with this PR.

It seems that the "extensions" apiGroups does not exist on our recent cluster (Kubernetes 1.29.4). I'm not sure but it might be related to these deprecation notices: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#deployment-v116

Same holds for the "finalizers" resources. They do not seem to exist anymore and lead to problems with our deployment. So I also removed them.

To complete the verb list I also added "deleteCollections" where applicable.

Ref: https://issues.apache.org/jira/projects/FLINK/issues/FLINK-35310

## Brief change log

- Remove "invalid" RBAC apiGroups and resouces
- Replace another occurence of wildcard ("*") verbs with the actual verbs

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
