### PR TITLE
[FLINK-35493][snapshot] Add historical cleanup for FlinkStateSnapshot CRs

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -9,6 +9,24 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.operator.checkpoint.cleanup.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable clean up of checkpoint FlinkStateSnapshot resources created by the operator automatically. This will only remove the FlinkStateSnapshot CR, and will not remove any data on the filesystem.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.checkpoint.history.max.age</h5></td>
+            <td style="word-wrap: break-word;">1 d</td>
+            <td>Duration</td>
+            <td>Maximum age for checkpoint FlinkStateSnapshot resources to retain. Due to lazy clean-up, the most recent checkpoint may live longer than the max age.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.checkpoint.history.max.count</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>Maximum number of checkpoint FlinkStateSnapshot resources to retain.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.checkpoint.trigger.grace-period</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
@@ -156,7 +174,7 @@
             <td><h5>kubernetes.operator.savepoint.cleanup.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>Whether to enable clean up of savepoint history.</td>
+            <td>Whether to enable clean up of savepoint FlinkStateSnapshot resources. Savepoint state will be disposed of as well if the snapshot CR spec is configured as such. For automatic savepoints this can be configured via the kubernetes.operator.savepoint.dispose-on-delete config option.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.dispose-on-delete</h5></td>
@@ -174,13 +192,13 @@
             <td><h5>kubernetes.operator.savepoint.history.max.age</h5></td>
             <td style="word-wrap: break-word;">1 d</td>
             <td>Duration</td>
-            <td>Maximum age for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.</td>
+            <td>Maximum age for savepoint FlinkStateSnapshot resources to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.count</h5></td>
             <td style="word-wrap: break-word;">10</td>
             <td>Integer</td>
-            <td>Maximum number of savepoint history entries to retain.</td>
+            <td>Maximum number of savepoint FlinkStateSnapshot resources entries to retain.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.trigger.grace-period</h5></td>

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -9,24 +9,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>kubernetes.operator.checkpoint.cleanup.enabled</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Whether to enable clean up of checkpoint FlinkStateSnapshot resources created by the operator automatically. This will only remove the FlinkStateSnapshot CR, and will not remove any data on the filesystem.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.checkpoint.history.max.age</h5></td>
-            <td style="word-wrap: break-word;">1 d</td>
-            <td>Duration</td>
-            <td>Maximum age for checkpoint FlinkStateSnapshot resources to retain. Due to lazy clean-up, the most recent checkpoint may live longer than the max age.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.checkpoint.history.max.count</h5></td>
-            <td style="word-wrap: break-word;">10</td>
-            <td>Integer</td>
-            <td>Maximum number of checkpoint FlinkStateSnapshot resources to retain.</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.checkpoint.trigger.grace-period</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -9,6 +9,36 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.operator.checkpoint.cleanup.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable clean up of checkpoint FlinkStateSnapshot resources created by the operator automatically. This will only remove the FlinkStateSnapshot CR, and will not remove any data on the filesystem.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.checkpoint.history.max.age</h5></td>
+            <td style="word-wrap: break-word;">1 d</td>
+            <td>Duration</td>
+            <td>Maximum age for checkpoint FlinkStateSnapshot resources to retain. Due to lazy clean-up, the most recent checkpoint may live longer than the max age.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.checkpoint.history.max.age.threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Maximum age threshold for checkpoint FlinkStateSnapshot resources to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.checkpoint.history.max.count</h5></td>
+            <td style="word-wrap: break-word;">10</td>
+            <td>Integer</td>
+            <td>Maximum number of checkpoint FlinkStateSnapshot resources to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.checkpoint.history.max.count.threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>Maximum number threshold of checkpoint FlinkStateSnapshot resources to retain.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.checkpoint.trigger.grace-period</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>
@@ -354,7 +384,7 @@
             <td><h5>kubernetes.operator.savepoint.cleanup.enabled</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>Whether to enable clean up of savepoint history.</td>
+            <td>Whether to enable clean up of savepoint FlinkStateSnapshot resources. Savepoint state will be disposed of as well if the snapshot CR spec is configured as such. For automatic savepoints this can be configured via the kubernetes.operator.savepoint.dispose-on-delete config option.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.dispose-on-delete</h5></td>
@@ -372,25 +402,25 @@
             <td><h5>kubernetes.operator.savepoint.history.max.age</h5></td>
             <td style="word-wrap: break-word;">1 d</td>
             <td>Duration</td>
-            <td>Maximum age for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.</td>
+            <td>Maximum age for savepoint FlinkStateSnapshot resources to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.age.threshold</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>Maximum age threshold for savepoint history entries to retain.</td>
+            <td>Maximum age threshold for FlinkStateSnapshot resources to retain.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.count</h5></td>
             <td style="word-wrap: break-word;">10</td>
             <td>Integer</td>
-            <td>Maximum number of savepoint history entries to retain.</td>
+            <td>Maximum number of savepoint FlinkStateSnapshot resources entries to retain.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.count.threshold</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>Maximum number threshold of savepoint history entries to retain.</td>
+            <td>Maximum number threshold of savepoint FlinkStateSnapshot resources to retain.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.trigger.grace-period</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -9,36 +9,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>kubernetes.operator.checkpoint.cleanup.enabled</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Whether to enable clean up of checkpoint FlinkStateSnapshot resources created by the operator automatically. This will only remove the FlinkStateSnapshot CR, and will not remove any data on the filesystem.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.checkpoint.history.max.age</h5></td>
-            <td style="word-wrap: break-word;">1 d</td>
-            <td>Duration</td>
-            <td>Maximum age for checkpoint FlinkStateSnapshot resources to retain. Due to lazy clean-up, the most recent checkpoint may live longer than the max age.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.checkpoint.history.max.age.threshold</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Duration</td>
-            <td>Maximum age threshold for checkpoint FlinkStateSnapshot resources to retain.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.checkpoint.history.max.count</h5></td>
-            <td style="word-wrap: break-word;">10</td>
-            <td>Integer</td>
-            <td>Maximum number of checkpoint FlinkStateSnapshot resources to retain.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.checkpoint.history.max.count.threshold</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>Maximum number threshold of checkpoint FlinkStateSnapshot resources to retain.</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.checkpoint.trigger.grace-period</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/system_advanced_section.html
+++ b/docs/layouts/shortcodes/generated/system_advanced_section.html
@@ -9,6 +9,18 @@
     </thead>
     <tbody>
         <tr>
+            <td><h5>kubernetes.operator.checkpoint.history.max.age.threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Duration</td>
+            <td>Maximum age threshold for checkpoint FlinkStateSnapshot resources to retain.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.checkpoint.history.max.count.threshold</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Integer</td>
+            <td>Maximum number threshold of checkpoint FlinkStateSnapshot resources to retain.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.cluster.resource-view.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">-1 min</td>
             <td>Duration</td>
@@ -84,13 +96,13 @@
             <td><h5>kubernetes.operator.savepoint.history.max.age.threshold</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>
-            <td>Maximum age threshold for savepoint history entries to retain.</td>
+            <td>Maximum age threshold for FlinkStateSnapshot resources to retain.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.savepoint.history.max.count.threshold</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Integer</td>
-            <td>Maximum number threshold of savepoint history entries to retain.</td>
+            <td>Maximum number threshold of savepoint FlinkStateSnapshot resources to retain.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.startup.stop-on-informer-error</h5></td>

--- a/docs/layouts/shortcodes/generated/system_advanced_section.html
+++ b/docs/layouts/shortcodes/generated/system_advanced_section.html
@@ -9,18 +9,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>kubernetes.operator.checkpoint.history.max.age.threshold</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Duration</td>
-            <td>Maximum age threshold for checkpoint FlinkStateSnapshot resources to retain.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.checkpoint.history.max.count.threshold</h5></td>
-            <td style="word-wrap: break-word;">(none)</td>
-            <td>Integer</td>
-            <td>Maximum number threshold of checkpoint FlinkStateSnapshot resources to retain.</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.cluster.resource-view.refresh-interval</h5></td>
             <td style="word-wrap: break-word;">-1 min</td>
             <td>Duration</td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/DateTimeUtils.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/DateTimeUtils.java
@@ -60,4 +60,14 @@ public class DateTimeUtils {
         ZonedDateTime dateTime = instant.atZone(ZoneId.systemDefault());
         return dateTime.format(DateTimeFormatter.ISO_INSTANT);
     }
+
+    /**
+     * Parses a Kubernetes-compatible datetime.
+     *
+     * @param datetime datetime in Kubernetes format
+     * @return time parsed
+     */
+    public static Instant parseKubernetes(String datetime) {
+        return Instant.parse(datetime);
+    }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -64,8 +64,6 @@ public class FlinkOperatorConfiguration {
     String artifactsBaseDir;
     Integer savepointHistoryCountThreshold;
     Duration savepointHistoryAgeThreshold;
-    Integer checkpointHistoryCountThreshold;
-    Duration checkpointHistoryAgeThreshold;
     GenericRetry retryConfiguration;
     RateLimiter<?> rateLimiter;
     boolean exceptionStackTraceEnabled;
@@ -117,15 +115,6 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions
                                 .OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD);
-
-        Integer checkpointHistoryCountThreshold =
-                operatorConfig.get(
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT_THRESHOLD);
-        Duration checkpointHistoryAgeThreshold =
-                operatorConfig.get(
-                        KubernetesOperatorConfigOptions
-                                .OPERATOR_CHECKPOINT_HISTORY_MAX_AGE_THRESHOLD);
 
         Boolean exceptionStackTraceEnabled =
                 operatorConfig.get(
@@ -219,8 +208,6 @@ public class FlinkOperatorConfiguration {
                 artifactsBaseDir,
                 savepointHistoryCountThreshold,
                 savepointHistoryAgeThreshold,
-                checkpointHistoryCountThreshold,
-                checkpointHistoryAgeThreshold,
                 retryConfiguration,
                 rateLimiter,
                 exceptionStackTraceEnabled,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -64,6 +64,8 @@ public class FlinkOperatorConfiguration {
     String artifactsBaseDir;
     Integer savepointHistoryCountThreshold;
     Duration savepointHistoryAgeThreshold;
+    Integer checkpointHistoryCountThreshold;
+    Duration checkpointHistoryAgeThreshold;
     GenericRetry retryConfiguration;
     RateLimiter<?> rateLimiter;
     boolean exceptionStackTraceEnabled;
@@ -115,6 +117,16 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions
                                 .OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD);
+
+        Integer checkpointHistoryCountThreshold =
+                operatorConfig.get(
+                        KubernetesOperatorConfigOptions
+                                .OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT_THRESHOLD);
+        Duration checkpointHistoryAgeThreshold =
+                operatorConfig.get(
+                        KubernetesOperatorConfigOptions
+                                .OPERATOR_CHECKPOINT_HISTORY_MAX_AGE_THRESHOLD);
+
         Boolean exceptionStackTraceEnabled =
                 operatorConfig.get(
                         KubernetesOperatorConfigOptions.OPERATOR_EXCEPTION_STACK_TRACE_ENABLED);
@@ -207,6 +219,8 @@ public class FlinkOperatorConfiguration {
                 artifactsBaseDir,
                 savepointHistoryCountThreshold,
                 savepointHistoryAgeThreshold,
+                checkpointHistoryCountThreshold,
+                checkpointHistoryAgeThreshold,
                 retryConfiguration,
                 rateLimiter,
                 exceptionStackTraceEnabled,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -211,18 +211,45 @@ public class KubernetesOperatorConfigOptions {
                             "Whether to enable recovery of missing/deleted jobmanager deployments.");
 
     @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> OPERATOR_JOB_SAVEPOINT_DISPOSE_ON_DELETE =
+            operatorConfig("savepoint.dispose-on-delete")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Savepoint data for FlinkStateSnapshot resources created by the operator during upgrades and periodic savepoints will be disposed of automatically when the generated Kubernetes resource is deleted.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<SavepointFormatType> OPERATOR_SAVEPOINT_FORMAT_TYPE =
+            operatorConfig("savepoint.format.type")
+                    .enumType(SavepointFormatType.class)
+                    .defaultValue(SavepointFormatType.DEFAULT)
+                    .withDescription(
+                            "Type of the binary format in which a savepoint should be taken.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<CheckpointType> OPERATOR_CHECKPOINT_TYPE =
+            operatorConfig("checkpoint.type")
+                    .enumType(CheckpointType.class)
+                    .defaultValue(CheckpointType.FULL)
+                    .withDescription("Type of checkpoint.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> OPERATOR_SAVEPOINT_CLEANUP_ENABLED =
             operatorConfig("savepoint.cleanup.enabled")
                     .booleanType()
                     .defaultValue(true)
-                    .withDescription("Whether to enable clean up of savepoint history.");
+                    .withDescription(
+                            String.format(
+                                    "Whether to enable clean up of savepoint FlinkStateSnapshot resources. Savepoint state will be disposed of as well if the snapshot CR spec is configured as such. For automatic savepoints this can be configured via the %s config option.",
+                                    OPERATOR_JOB_SAVEPOINT_DISPOSE_ON_DELETE.key()));
 
     @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Integer> OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT =
             operatorConfig("savepoint.history.max.count")
                     .intType()
                     .defaultValue(10)
-                    .withDescription("Maximum number of savepoint history entries to retain.");
+                    .withDescription(
+                            "Maximum number of savepoint FlinkStateSnapshot resources entries to retain.");
 
     @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Integer> OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT_THRESHOLD =
@@ -230,7 +257,7 @@ public class KubernetesOperatorConfigOptions {
                     .intType()
                     .noDefaultValue()
                     .withDescription(
-                            "Maximum number threshold of savepoint history entries to retain.");
+                            "Maximum number threshold of savepoint FlinkStateSnapshot resources to retain.");
 
     @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_MAX_AGE =
@@ -238,7 +265,55 @@ public class KubernetesOperatorConfigOptions {
                     .durationType()
                     .defaultValue(Duration.ofHours(24))
                     .withDescription(
-                            "Maximum age for savepoint history entries to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.");
+                            "Maximum age for savepoint FlinkStateSnapshot resources to retain. Due to lazy clean-up, the most recent savepoint may live longer than the max age.");
+
+    @Documentation.Section(SECTION_ADVANCED)
+    public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD =
+            ConfigOptions.key(OPERATOR_SAVEPOINT_HISTORY_MAX_AGE.key() + ".threshold")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Maximum age threshold for FlinkStateSnapshot resources to retain.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> OPERATOR_CHECKPOINT_CLEANUP_ENABLED =
+            operatorConfig("checkpoint.cleanup.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to enable clean up of checkpoint FlinkStateSnapshot resources created by the operator automatically. This will only remove the FlinkStateSnapshot CR, and will not remove any data on the filesystem.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Integer> OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT =
+            operatorConfig("checkpoint.history.max.count")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "Maximum number of checkpoint FlinkStateSnapshot resources to retain.");
+
+    @Documentation.Section(SECTION_ADVANCED)
+    public static final ConfigOption<Integer> OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT_THRESHOLD =
+            ConfigOptions.key(OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT.key() + ".threshold")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Maximum number threshold of checkpoint FlinkStateSnapshot resources to retain.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Duration> OPERATOR_CHECKPOINT_HISTORY_MAX_AGE =
+            operatorConfig("checkpoint.history.max.age")
+                    .durationType()
+                    .defaultValue(Duration.ofHours(24))
+                    .withDescription(
+                            "Maximum age for checkpoint FlinkStateSnapshot resources to retain. Due to lazy clean-up, the most recent checkpoint may live longer than the max age.");
+
+    @Documentation.Section(SECTION_ADVANCED)
+    public static final ConfigOption<Duration> OPERATOR_CHECKPOINT_HISTORY_MAX_AGE_THRESHOLD =
+            ConfigOptions.key(OPERATOR_CHECKPOINT_HISTORY_MAX_AGE.key() + ".threshold")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Maximum age threshold for checkpoint FlinkStateSnapshot resources to retain.");
 
     @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Boolean> OPERATOR_EXCEPTION_STACK_TRACE_ENABLED =
@@ -279,14 +354,6 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(new HashMap<>())
                     .withDescription(
                             "Key-Value pair where key is the REGEX to filter through the exception messages and value is the string to be included in CR status error label field if the REGEX matches. Expected format: headerKey1:headerValue1,headerKey2:headerValue2.");
-
-    @Documentation.Section(SECTION_ADVANCED)
-    public static final ConfigOption<Duration> OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD =
-            ConfigOptions.key(OPERATOR_SAVEPOINT_HISTORY_MAX_AGE.key() + ".threshold")
-                    .durationType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "Maximum age threshold for savepoint history entries to retain.");
 
     @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Map<String, String>> JAR_ARTIFACT_HTTP_HEADER =
@@ -437,29 +504,6 @@ public class KubernetesOperatorConfigOptions {
                     .noDefaultValue()
                     .withDescription(
                             "Max allowed checkpoint age for initiating last-state upgrades on running jobs. If a checkpoint is not available within the desired age (and nothing in progress) a savepoint will be triggered.");
-
-    @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<Boolean> OPERATOR_JOB_SAVEPOINT_DISPOSE_ON_DELETE =
-            operatorConfig("savepoint.dispose-on-delete")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "Savepoint data for FlinkStateSnapshot resources created by the operator during upgrades and periodic savepoints will be disposed of automatically when the generated Kubernetes resource is deleted.");
-
-    @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<SavepointFormatType> OPERATOR_SAVEPOINT_FORMAT_TYPE =
-            operatorConfig("savepoint.format.type")
-                    .enumType(SavepointFormatType.class)
-                    .defaultValue(SavepointFormatType.DEFAULT)
-                    .withDescription(
-                            "Type of the binary format in which a savepoint should be taken.");
-
-    @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<CheckpointType> OPERATOR_CHECKPOINT_TYPE =
-            operatorConfig("checkpoint.type")
-                    .enumType(CheckpointType.class)
-                    .defaultValue(CheckpointType.FULL)
-                    .withDescription("Type of checkpoint.");
 
     @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Boolean> OPERATOR_HEALTH_PROBE_ENABLED =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -275,46 +275,6 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Maximum age threshold for FlinkStateSnapshot resources to retain.");
 
-    @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<Boolean> OPERATOR_CHECKPOINT_CLEANUP_ENABLED =
-            operatorConfig("checkpoint.cleanup.enabled")
-                    .booleanType()
-                    .defaultValue(true)
-                    .withDescription(
-                            "Whether to enable clean up of checkpoint FlinkStateSnapshot resources created by the operator automatically. This will only remove the FlinkStateSnapshot CR, and will not remove any data on the filesystem.");
-
-    @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<Integer> OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT =
-            operatorConfig("checkpoint.history.max.count")
-                    .intType()
-                    .defaultValue(10)
-                    .withDescription(
-                            "Maximum number of checkpoint FlinkStateSnapshot resources to retain.");
-
-    @Documentation.Section(SECTION_ADVANCED)
-    public static final ConfigOption<Integer> OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT_THRESHOLD =
-            ConfigOptions.key(OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT.key() + ".threshold")
-                    .intType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "Maximum number threshold of checkpoint FlinkStateSnapshot resources to retain.");
-
-    @Documentation.Section(SECTION_DYNAMIC)
-    public static final ConfigOption<Duration> OPERATOR_CHECKPOINT_HISTORY_MAX_AGE =
-            operatorConfig("checkpoint.history.max.age")
-                    .durationType()
-                    .defaultValue(Duration.ofHours(24))
-                    .withDescription(
-                            "Maximum age for checkpoint FlinkStateSnapshot resources to retain. Due to lazy clean-up, the most recent checkpoint may live longer than the max age.");
-
-    @Documentation.Section(SECTION_ADVANCED)
-    public static final ConfigOption<Duration> OPERATOR_CHECKPOINT_HISTORY_MAX_AGE_THRESHOLD =
-            ConfigOptions.key(OPERATOR_CHECKPOINT_HISTORY_MAX_AGE.key() + ".threshold")
-                    .durationType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "Maximum age threshold for checkpoint FlinkStateSnapshot resources to retain.");
-
     @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Boolean> OPERATOR_EXCEPTION_STACK_TRACE_ENABLED =
             operatorConfig("exception.stacktrace.enabled")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -199,7 +199,8 @@ public class FlinkDeploymentController
             EventSourceContext<FlinkDeployment> context) {
         return EventSourceInitializer.nameEventSources(
                 EventSourceUtils.getSessionJobInformerEventSource(context),
-                EventSourceUtils.getDeploymentInformerEventSource(context));
+                EventSourceUtils.getDeploymentInformerEventSource(context),
+                EventSourceUtils.getStateSnapshotForFlinkResourceInformerEventSource(context));
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.controller;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
@@ -31,6 +32,7 @@ import org.apache.flink.kubernetes.operator.reconciler.deployment.ReconcilerFact
 import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.EventSourceUtils;
+import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
@@ -49,6 +51,8 @@ import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -197,10 +201,19 @@ public class FlinkDeploymentController
     @Override
     public Map<String, EventSource> prepareEventSources(
             EventSourceContext<FlinkDeployment> context) {
-        return EventSourceInitializer.nameEventSources(
-                EventSourceUtils.getSessionJobInformerEventSource(context),
-                EventSourceUtils.getDeploymentInformerEventSource(context),
-                EventSourceUtils.getStateSnapshotForFlinkResourceInformerEventSource(context));
+        List<EventSource> eventSources = new ArrayList<>();
+        eventSources.add(EventSourceUtils.getSessionJobInformerEventSource(context));
+        eventSources.add(EventSourceUtils.getDeploymentInformerEventSource(context));
+
+        if (KubernetesClientUtils.isCrdInstalled(FlinkStateSnapshot.class)) {
+            eventSources.add(
+                    EventSourceUtils.getStateSnapshotForFlinkResourceInformerEventSource(context));
+        } else {
+            LOG.warn(
+                    "Could not initialize informer for snapshots as the CRD has not been installed!");
+        }
+
+        return EventSourceInitializer.nameEventSources(eventSources.toArray(EventSource[]::new));
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -161,7 +161,8 @@ public class FlinkSessionJobController
     public Map<String, EventSource> prepareEventSources(
             EventSourceContext<FlinkSessionJob> context) {
         return EventSourceInitializer.nameEventSources(
-                EventSourceUtils.getFlinkDeploymentInformerEventSource(context));
+                EventSourceUtils.getFlinkDeploymentInformerEventSource(context),
+                EventSourceUtils.getStateSnapshotForFlinkResourceInformerEventSource(context));
     }
 
     private boolean validateSessionJob(FlinkResourceContext<FlinkSessionJob> ctx) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.controller;
 
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
 import org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.kubernetes.operator.health.CanaryResourceManager;
@@ -28,6 +29,7 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.EventSourceUtils;
+import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
@@ -45,6 +47,8 @@ import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -160,9 +164,18 @@ public class FlinkSessionJobController
     @Override
     public Map<String, EventSource> prepareEventSources(
             EventSourceContext<FlinkSessionJob> context) {
-        return EventSourceInitializer.nameEventSources(
-                EventSourceUtils.getFlinkDeploymentInformerEventSource(context),
-                EventSourceUtils.getStateSnapshotForFlinkResourceInformerEventSource(context));
+        List<EventSource> eventSources = new ArrayList<>();
+        eventSources.add(EventSourceUtils.getFlinkDeploymentInformerEventSource(context));
+
+        if (KubernetesClientUtils.isCrdInstalled(FlinkStateSnapshot.class)) {
+            eventSources.add(
+                    EventSourceUtils.getStateSnapshotForFlinkResourceInformerEventSource(context));
+        } else {
+            LOG.warn(
+                    "Could not initialize informer for snapshots as the CRD has not been installed!");
+        }
+
+        return EventSourceInitializer.nameEventSources(eventSources.toArray(EventSource[]::new));
     }
 
     private boolean validateSessionJob(FlinkResourceContext<FlinkSessionJob> ctx) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
@@ -290,6 +290,7 @@ public class SnapshotObserver<
             SnapshotType snapshotType) {
         var snapshotList =
                 snapshots.stream()
+                        .filter(s -> !s.isMarkedForDeletion())
                         .filter(
                                 s ->
                                         CLEAN_UP_SNAPSHOT_TRIGGER_TYPES.contains(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
@@ -317,6 +317,11 @@ public class SnapshotObserver<
                 continue;
             }
 
+            // We should keep the last snapshot, even if not complete.
+            if (result.size() == snapshotList.size() - 1) {
+                break;
+            }
+
             var ts = EXTRACT_SNAPSHOT_TIME.apply(snapshot).toEpochMilli();
             if (snapshotList.size() - result.size() > maxCount || ts < maxTms) {
                 result.add(snapshot);
@@ -430,12 +435,14 @@ public class SnapshotObserver<
             SnapshotType snapshotType) {
         switch (snapshotType) {
             case CHECKPOINT:
-                return observeConfig.get(MAX_RETAINED_CHECKPOINTS);
+                return Math.max(1, observeConfig.get(MAX_RETAINED_CHECKPOINTS));
             case SAVEPOINT:
-                return ConfigOptionUtils.getValueWithThreshold(
-                        observeConfig,
-                        OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT,
-                        operatorConfig.getSavepointHistoryCountThreshold());
+                return Math.max(
+                        1,
+                        ConfigOptionUtils.getValueWithThreshold(
+                                observeConfig,
+                                OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT,
+                                operatorConfig.getSavepointHistoryCountThreshold()));
             default:
                 throw new IllegalArgumentException(
                         String.format("Unknown snapshot type %s", snapshotType.name()));

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /** Utility class to locate secondary resources. */
 public class EventSourceUtils {
@@ -56,11 +57,12 @@ public class EventSourceUtils {
             InformerEventSource<FlinkStateSnapshot, T>
                     getStateSnapshotForFlinkResourceInformerEventSource(
                             EventSourceContext<T> context) {
-
+        var labelFilters =
+                Stream.of(SnapshotTriggerType.PERIODIC, SnapshotTriggerType.UPGRADE)
+                        .map(Enum::name)
+                        .collect(Collectors.joining(","));
         var labelSelector =
-                String.format(
-                        "%s=%s",
-                        CrdConstants.LABEL_SNAPSHOT_TYPE, SnapshotTriggerType.PERIODIC.name());
+                String.format("%s in (%s)", CrdConstants.LABEL_SNAPSHOT_TYPE, labelFilters);
         var configuration =
                 InformerConfiguration.from(FlinkStateSnapshot.class, context)
                         .withLabelSelector(labelSelector)

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkStateSnapshotUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkStateSnapshotUtils.java
@@ -139,6 +139,23 @@ public class FlinkStateSnapshotUtils {
     }
 
     /**
+     * Extracts snapshot trigger type from a snapshot resource. If unable to do so, return {@link
+     * SnapshotTriggerType#UNKNOWN}
+     *
+     * @param snapshot resource to check
+     * @return trigger type
+     */
+    public static SnapshotTriggerType getSnapshotTriggerType(FlinkStateSnapshot snapshot) {
+        var triggerTypeStr =
+                snapshot.getMetadata().getLabels().get(CrdConstants.LABEL_SNAPSHOT_TYPE);
+        try {
+            return SnapshotTriggerType.valueOf(triggerTypeStr);
+        } catch (NullPointerException | IllegalArgumentException e) {
+            return SnapshotTriggerType.UNKNOWN;
+        }
+    }
+
+    /**
      * Creates a checkpoint {@link FlinkStateSnapshot} resource on the Kubernetes cluster.
      *
      * @param kubernetesClient kubernetes client

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/KubernetesClientUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/KubernetesClientUtils.java
@@ -71,6 +71,7 @@ public class KubernetesClientUtils {
 
     /**
      * Checks if the class for a Custom Resource is installed in the current Kubernetes cluster.
+     * TODO: remove method when FlinkStateSnapshot CRD is made mandatory
      *
      * @param clazz class of Custom Resource
      * @return true if the CRD present in the Kubernetes cluster
@@ -80,7 +81,7 @@ public class KubernetesClientUtils {
             client.resources(clazz).list().getItems();
             return true;
         } catch (Throwable t) {
-            LOG.warn("Failed to find CRD {}", clazz.getSimpleName());
+            LOG.debug("Could not find CRD {}", clazz.getSimpleName());
             return false;
         }
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverLegacyTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverLegacyTest.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.observer;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.CheckpointType;
+import org.apache.flink.kubernetes.operator.OperatorTestBase;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
+import org.apache.flink.kubernetes.operator.api.status.Savepoint;
+import org.apache.flink.kubernetes.operator.api.status.SavepointFormatType;
+import org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+import org.apache.flink.kubernetes.operator.utils.SnapshotStatus;
+import org.apache.flink.kubernetes.operator.utils.SnapshotUtils;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import lombok.Getter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.CHECKPOINT;
+import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.SAVEPOINT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link SnapshotObserver}. */
+@EnableKubernetesMockClient(crud = true)
+public class SnapshotObserverLegacyTest extends OperatorTestBase {
+
+    @Getter private KubernetesClient kubernetesClient;
+    private SnapshotObserver<FlinkDeployment, FlinkDeploymentStatus> observer;
+
+    @Override
+    public void setup() {
+        observer = new SnapshotObserver<>(eventRecorder);
+    }
+
+    @Test
+    public void testBasicObserve() {
+        Configuration conf = new Configuration();
+        conf.set(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED, false);
+        configManager.updateDefaultConfig(conf);
+
+        var deployment = TestUtils.buildApplicationCluster();
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
+        var spInfo = deployment.getStatus().getJobStatus().getSavepointInfo();
+        Assertions.assertTrue(spInfo.getSavepointHistory().isEmpty());
+
+        Savepoint sp =
+                new Savepoint(
+                        1, "sp1", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
+        spInfo.updateLastSavepoint(sp);
+        observer.cleanupSavepointHistory(getResourceContext(deployment));
+
+        Assertions.assertNotNull(spInfo.getSavepointHistory());
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp), spInfo.getSavepointHistory());
+    }
+
+    @Test
+    public void testAgeBasedDispose() {
+        var cr = TestUtils.buildSessionCluster();
+        cr.getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(cr.getSpec(), cr);
+        Configuration conf = new Configuration();
+        conf.set(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED, false);
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                Duration.ofMillis(5));
+        configManager.updateDefaultConfig(conf);
+
+        var spInfo = cr.getStatus().getJobStatus().getSavepointInfo();
+
+        var sp1 =
+                new Savepoint(
+                        1, "sp1", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
+        spInfo.updateLastSavepoint(sp1);
+        observer.cleanupSavepointHistory(getResourceContext(cr));
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp1), spInfo.getSavepointHistory());
+        Assertions.assertIterableEquals(
+                Collections.emptyList(), flinkService.getDisposedSavepoints());
+
+        Savepoint sp2 =
+                new Savepoint(
+                        2, "sp2", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
+        spInfo.updateLastSavepoint(sp2);
+        observer.cleanupSavepointHistory(getResourceContext(cr));
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp2), spInfo.getSavepointHistory());
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp1.getLocation()), flinkService.getDisposedSavepoints());
+    }
+
+    @Test
+    public void testAgeBasedDisposeWithAgeThreshold() {
+        var deployment = TestUtils.buildApplicationCluster();
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
+        Configuration conf = new Configuration();
+        conf.set(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED, false);
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                Duration.ofMillis(System.currentTimeMillis() * 2));
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
+                Duration.ofMillis(5));
+        configManager.updateDefaultConfig(conf);
+        var spInfo = deployment.getStatus().getJobStatus().getSavepointInfo();
+
+        var sp1 =
+                new Savepoint(
+                        1, "sp1", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
+        spInfo.updateLastSavepoint(sp1);
+        observer.cleanupSavepointHistory(getResourceContext(deployment));
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp1), spInfo.getSavepointHistory());
+        Assertions.assertIterableEquals(
+                Collections.emptyList(), flinkService.getDisposedSavepoints());
+
+        var sp2 =
+                new Savepoint(
+                        2, "sp2", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
+        spInfo.updateLastSavepoint(sp2);
+        observer.cleanupSavepointHistory(getResourceContext(deployment));
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp2), spInfo.getSavepointHistory());
+        Assertions.assertIterableEquals(
+                Collections.singletonList(sp1.getLocation()), flinkService.getDisposedSavepoints());
+
+        configManager.updateDefaultConfig(new Configuration());
+    }
+
+    @Test
+    public void testDisabledDispose() {
+        var deployment = TestUtils.buildApplicationCluster();
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
+        Configuration conf = new Configuration();
+        conf.set(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED, false);
+        conf.set(KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_CLEANUP_ENABLED, false);
+        conf.set(KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT, 1000);
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                Duration.ofDays(100L));
+
+        configManager.updateDefaultConfig(conf);
+
+        var spInfo = deployment.getStatus().getJobStatus().getSavepointInfo();
+
+        Savepoint sp1 =
+                new Savepoint(
+                        9999999999999998L,
+                        "sp1",
+                        SnapshotTriggerType.MANUAL,
+                        SavepointFormatType.CANONICAL,
+                        123L);
+        spInfo.updateLastSavepoint(sp1);
+        observer.cleanupSavepointHistory(getResourceContext(deployment));
+
+        Savepoint sp2 =
+                new Savepoint(
+                        9999999999999999L,
+                        "sp2",
+                        SnapshotTriggerType.MANUAL,
+                        SavepointFormatType.CANONICAL,
+                        123L);
+        spInfo.updateLastSavepoint(sp2);
+        observer.cleanupSavepointHistory(getResourceContext(deployment));
+        Assertions.assertIterableEquals(List.of(sp1, sp2), spInfo.getSavepointHistory());
+        Assertions.assertIterableEquals(
+                Collections.emptyList(), flinkService.getDisposedSavepoints());
+    }
+
+    @Test
+    public void testPeriodicSavepoint() throws Exception {
+        var conf = new Configuration();
+        conf.set(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED, false);
+        configManager.updateDefaultConfig(conf);
+
+        var deployment = TestUtils.buildApplicationCluster();
+        var status = deployment.getStatus();
+        var jobStatus = status.getJobStatus();
+        status.getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
+        jobStatus.setState("RUNNING");
+
+        var savepointInfo = jobStatus.getSavepointInfo();
+        flinkService.triggerSavepointLegacy(null, SnapshotTriggerType.PERIODIC, deployment, conf);
+
+        var triggerTs = savepointInfo.getTriggerTimestamp();
+        assertEquals(0L, savepointInfo.getLastPeriodicSavepointTimestamp());
+        assertEquals(SnapshotTriggerType.PERIODIC, savepointInfo.getTriggerType());
+        assertTrue(SnapshotUtils.savepointInProgress(jobStatus));
+        assertEquals(
+                SnapshotStatus.PENDING, SnapshotUtils.getLastSnapshotStatus(deployment, SAVEPOINT));
+        assertTrue(triggerTs > 0);
+
+        // Pending
+        observer.observeSavepointStatus(getResourceContext(deployment));
+        // Completed
+        observer.observeSavepointStatus(getResourceContext(deployment));
+        assertEquals(triggerTs, savepointInfo.getLastPeriodicSavepointTimestamp());
+        assertFalse(SnapshotUtils.savepointInProgress(jobStatus));
+        assertEquals(
+                SnapshotUtils.getLastSnapshotStatus(deployment, SAVEPOINT),
+                SnapshotStatus.SUCCEEDED);
+        assertEquals(savepointInfo.getLastSavepoint(), savepointInfo.getSavepointHistory().get(0));
+        assertEquals(
+                SnapshotTriggerType.PERIODIC, savepointInfo.getLastSavepoint().getTriggerType());
+        assertNull(savepointInfo.getLastSavepoint().getTriggerNonce());
+    }
+
+    @Test
+    public void testPeriodicCheckpoint() {
+        var conf = new Configuration();
+        var deployment = TestUtils.buildApplicationCluster();
+        var status = deployment.getStatus();
+        var jobStatus = status.getJobStatus();
+        status.getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
+        jobStatus.setState("RUNNING");
+
+        var checkpointInfo = jobStatus.getCheckpointInfo();
+        var triggerId = flinkService.triggerCheckpoint(null, CheckpointType.FULL, conf);
+        checkpointInfo.setTrigger(
+                triggerId,
+                SnapshotTriggerType.PERIODIC,
+                org.apache.flink.kubernetes.operator.api.status.CheckpointType.FULL);
+
+        var triggerTs = checkpointInfo.getTriggerTimestamp();
+        assertEquals(0L, checkpointInfo.getLastPeriodicTriggerTimestamp());
+        assertTrue(SnapshotUtils.checkpointInProgress(jobStatus));
+        assertEquals(
+                SnapshotStatus.PENDING,
+                SnapshotUtils.getLastSnapshotStatus(deployment, CHECKPOINT));
+        assertTrue(triggerTs > 0);
+
+        // Pending
+        observer.observeCheckpointStatus(getResourceContext(deployment));
+        // Completed
+        observer.observeCheckpointStatus(getResourceContext(deployment));
+        assertEquals(triggerTs, checkpointInfo.getLastPeriodicTriggerTimestamp());
+        assertFalse(SnapshotUtils.checkpointInProgress(jobStatus));
+        assertEquals(
+                SnapshotUtils.getLastSnapshotStatus(deployment, CHECKPOINT),
+                SnapshotStatus.SUCCEEDED);
+        assertEquals(
+                SnapshotTriggerType.PERIODIC, checkpointInfo.getLastCheckpoint().getTriggerType());
+        assertNull(checkpointInfo.getLastCheckpoint().getTriggerNonce());
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverTest.java
@@ -253,6 +253,8 @@ public class SnapshotObserverTest extends OperatorTestBase {
                 new ObjectMetaBuilder()
                         .withName(UUID.randomUUID().toString())
                         .withLabels(Map.of(CrdConstants.LABEL_SNAPSHOT_TYPE, triggerType.name()))
+                        .withCreationTimestamp(
+                                DateTimeUtils.kubernetes(Instant.ofEpochMilli(timestamp)))
                         .build();
 
         var spec = new FlinkStateSnapshotSpec();
@@ -262,11 +264,7 @@ public class SnapshotObserverTest extends OperatorTestBase {
             spec.setCheckpoint(new CheckpointSpec());
         }
 
-        var status =
-                FlinkStateSnapshotStatus.builder()
-                        .resultTimestamp(DateTimeUtils.kubernetes(Instant.ofEpochMilli(timestamp)))
-                        .state(snapshotState)
-                        .build();
+        var status = FlinkStateSnapshotStatus.builder().state(snapshotState).build();
 
         var snapshot = new FlinkStateSnapshot();
         snapshot.setMetadata(metadata);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverTest.java
@@ -17,36 +17,50 @@
 
 package org.apache.flink.kubernetes.operator.observer;
 
+import org.apache.flink.autoscaler.utils.DateTimeUtils;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.core.execution.CheckpointType;
 import org.apache.flink.kubernetes.operator.OperatorTestBase;
-import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.CrdConstants;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
+import org.apache.flink.kubernetes.operator.api.spec.CheckpointSpec;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkStateSnapshotSpec;
+import org.apache.flink.kubernetes.operator.api.spec.SavepointSpec;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
-import org.apache.flink.kubernetes.operator.api.status.Savepoint;
-import org.apache.flink.kubernetes.operator.api.status.SavepointFormatType;
-import org.apache.flink.kubernetes.operator.api.status.SavepointInfo;
+import org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus;
 import org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType;
-import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
-import org.apache.flink.kubernetes.operator.utils.SnapshotStatus;
-import org.apache.flink.kubernetes.operator.utils.SnapshotUtils;
+import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
+import org.apache.flink.kubernetes.operator.reconciler.SnapshotType;
 
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import lombok.Getter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
-import java.util.Collections;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
+import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.COMPLETED;
+import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.TRIGGER_PENDING;
+import static org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType.MANUAL;
+import static org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType.PERIODIC;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CHECKPOINT_HISTORY_MAX_AGE;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CHECKPOINT_HISTORY_MAX_AGE_THRESHOLD;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT_THRESHOLD;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT;
+import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT_THRESHOLD;
 import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.CHECKPOINT;
 import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.SAVEPOINT;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link SnapshotObserver}. */
 @EnableKubernetesMockClient(crud = true)
@@ -61,215 +75,169 @@ public class SnapshotObserverTest extends OperatorTestBase {
     }
 
     @Test
-    public void testBasicObserve() {
-        var deployment = TestUtils.buildApplicationCluster();
-        deployment
-                .getStatus()
-                .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
-        SavepointInfo spInfo = new SavepointInfo();
-        Assertions.assertTrue(spInfo.getSavepointHistory().isEmpty());
+    public void testSnapshotTypeCleanup() {
+        var conf =
+                new Configuration()
+                        .set(OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT, 1)
+                        .set(OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT, 1);
+        var operatorConfig = FlinkOperatorConfiguration.fromConfiguration(conf);
 
-        Savepoint sp =
-                new Savepoint(
-                        1, "sp1", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
-        spInfo.updateLastSavepoint(sp);
-        observer.cleanupSavepointHistory(getResourceContext(deployment), spInfo);
+        var testData =
+                List.of(
+                        createSnapshot(CHECKPOINT, 0, PERIODIC, COMPLETED),
+                        createSnapshot(CHECKPOINT, 1, PERIODIC, COMPLETED),
+                        createSnapshot(CHECKPOINT, 2, PERIODIC, COMPLETED),
+                        createSnapshot(SAVEPOINT, 3, PERIODIC, COMPLETED),
+                        createSnapshot(SAVEPOINT, 4, PERIODIC, COMPLETED),
+                        createSnapshot(SAVEPOINT, 5, PERIODIC, COMPLETED));
 
-        Assertions.assertNotNull(spInfo.getSavepointHistory());
-        Assertions.assertIterableEquals(
-                Collections.singletonList(sp), spInfo.getSavepointHistory());
+        var savepointResult =
+                observer.getFlinkStateSnapshotsToCleanUp(testData, conf, operatorConfig, SAVEPOINT);
+        assertThat(savepointResult).containsExactlyInAnyOrder(testData.get(3), testData.get(4));
+
+        var checkpointResult =
+                observer.getFlinkStateSnapshotsToCleanUp(
+                        testData, conf, operatorConfig, CHECKPOINT);
+        assertThat(checkpointResult).containsExactlyInAnyOrder(testData.get(0), testData.get(1));
     }
 
-    @Test
-    public void testAgeBasedDispose() {
-        var cr = TestUtils.buildSessionCluster();
-        cr.getStatus()
-                .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(cr.getSpec(), cr);
-        Configuration conf = new Configuration();
-        conf.set(
-                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
-                Duration.ofMillis(5));
-        configManager.updateDefaultConfig(conf);
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testAgeBasedCleanup(boolean setThreshold) {
+        var conf =
+                new Configuration()
+                        .set(OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT, 10000)
+                        .set(OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT, 10000);
 
-        SavepointInfo spInfo = new SavepointInfo();
+        if (setThreshold) {
+            conf.set(OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD, Duration.ofMillis(5));
+            conf.set(OPERATOR_CHECKPOINT_HISTORY_MAX_AGE_THRESHOLD, Duration.ofMillis(5));
+            conf.set(
+                    OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                    Duration.ofMillis(System.currentTimeMillis() * 2));
+            conf.set(
+                    OPERATOR_CHECKPOINT_HISTORY_MAX_AGE,
+                    Duration.ofMillis(System.currentTimeMillis() * 2));
+        } else {
+            conf.set(OPERATOR_SAVEPOINT_HISTORY_MAX_AGE, Duration.ofMillis(5));
+            conf.set(OPERATOR_CHECKPOINT_HISTORY_MAX_AGE, Duration.ofMillis(5));
+        }
 
-        Savepoint sp1 =
-                new Savepoint(
-                        1, "sp1", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
-        spInfo.updateLastSavepoint(sp1);
-        observer.cleanupSavepointHistory(getResourceContext(cr), spInfo);
-        Assertions.assertIterableEquals(
-                Collections.singletonList(sp1), spInfo.getSavepointHistory());
-        Assertions.assertIterableEquals(
-                Collections.emptyList(), flinkService.getDisposedSavepoints());
+        var operatorConfig = FlinkOperatorConfiguration.fromConfiguration(conf);
 
-        Savepoint sp2 =
-                new Savepoint(
-                        2, "sp2", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
-        spInfo.updateLastSavepoint(sp2);
-        observer.cleanupSavepointHistory(getResourceContext(cr), spInfo);
-        Assertions.assertIterableEquals(
-                Collections.singletonList(sp2), spInfo.getSavepointHistory());
-        Assertions.assertIterableEquals(
-                Collections.singletonList(sp1.getLocation()), flinkService.getDisposedSavepoints());
+        var testDataSavepoints =
+                List.of(
+                        createSnapshot(SAVEPOINT, 0, MANUAL, COMPLETED),
+                        createSnapshot(SAVEPOINT, 1, PERIODIC, COMPLETED),
+                        createSnapshot(SAVEPOINT, 2, PERIODIC, TRIGGER_PENDING),
+                        createSnapshot(SAVEPOINT, 3, PERIODIC, COMPLETED),
+                        createSnapshot(SAVEPOINT, Long.MAX_VALUE, PERIODIC, COMPLETED));
+
+        var testDataCheckpoints =
+                List.of(
+                        createSnapshot(CHECKPOINT, 0, MANUAL, COMPLETED),
+                        createSnapshot(CHECKPOINT, 1, PERIODIC, COMPLETED),
+                        createSnapshot(CHECKPOINT, 2, PERIODIC, TRIGGER_PENDING),
+                        createSnapshot(CHECKPOINT, 3, PERIODIC, COMPLETED),
+                        createSnapshot(CHECKPOINT, Long.MAX_VALUE, PERIODIC, COMPLETED));
+
+        var removedSavepoints =
+                observer.getFlinkStateSnapshotsToCleanUp(
+                        testDataSavepoints, conf, operatorConfig, SAVEPOINT);
+        assertThat(removedSavepoints)
+                .containsExactlyInAnyOrder(testDataSavepoints.get(1), testDataSavepoints.get(3));
+
+        var removedCheckpoints =
+                observer.getFlinkStateSnapshotsToCleanUp(
+                        testDataCheckpoints, conf, operatorConfig, CHECKPOINT);
+        assertThat(removedCheckpoints)
+                .containsExactlyInAnyOrder(testDataCheckpoints.get(1), testDataCheckpoints.get(3));
     }
 
-    @Test
-    public void testAgeBasedDisposeWithAgeThreshold() {
-        var deployment = TestUtils.buildApplicationCluster();
-        deployment
-                .getStatus()
-                .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
-        Configuration conf = new Configuration();
-        conf.set(
-                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
-                Duration.ofMillis(System.currentTimeMillis() * 2));
-        conf.set(
-                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE_THRESHOLD,
-                Duration.ofMillis(5));
-        configManager.updateDefaultConfig(conf);
-        SavepointInfo spInfo = new SavepointInfo();
-
-        Savepoint sp1 =
-                new Savepoint(
-                        1, "sp1", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
-        spInfo.updateLastSavepoint(sp1);
-        observer.cleanupSavepointHistory(getResourceContext(deployment), spInfo);
-        Assertions.assertIterableEquals(
-                Collections.singletonList(sp1), spInfo.getSavepointHistory());
-        Assertions.assertIterableEquals(
-                Collections.emptyList(), flinkService.getDisposedSavepoints());
-
-        Savepoint sp2 =
-                new Savepoint(
-                        2, "sp2", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 123L);
-        spInfo.updateLastSavepoint(sp2);
-        observer.cleanupSavepointHistory(getResourceContext(deployment), spInfo);
-        Assertions.assertIterableEquals(
-                Collections.singletonList(sp2), spInfo.getSavepointHistory());
-        Assertions.assertIterableEquals(
-                Collections.singletonList(sp1.getLocation()), flinkService.getDisposedSavepoints());
-
-        configManager.updateDefaultConfig(new Configuration());
-    }
-
-    @Test
-    public void testDisabledDispose() {
-        var deployment = TestUtils.buildApplicationCluster();
-        deployment
-                .getStatus()
-                .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
-        Configuration conf = new Configuration();
-        conf.set(KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_CLEANUP_ENABLED, false);
-        conf.set(KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT, 1000);
-        conf.set(
-                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
-                Duration.ofDays(100L));
-
-        configManager.updateDefaultConfig(conf);
-
-        SavepointInfo spInfo = new SavepointInfo();
-
-        Savepoint sp1 =
-                new Savepoint(
-                        9999999999999998L,
-                        "sp1",
-                        SnapshotTriggerType.MANUAL,
-                        SavepointFormatType.CANONICAL,
-                        123L);
-        spInfo.updateLastSavepoint(sp1);
-        observer.cleanupSavepointHistory(getResourceContext(deployment), spInfo);
-
-        Savepoint sp2 =
-                new Savepoint(
-                        9999999999999999L,
-                        "sp2",
-                        SnapshotTriggerType.MANUAL,
-                        SavepointFormatType.CANONICAL,
-                        123L);
-        spInfo.updateLastSavepoint(sp2);
-        observer.cleanupSavepointHistory(getResourceContext(deployment), spInfo);
-        Assertions.assertIterableEquals(List.of(sp1, sp2), spInfo.getSavepointHistory());
-        Assertions.assertIterableEquals(
-                Collections.emptyList(), flinkService.getDisposedSavepoints());
-    }
-
-    @Test
-    public void testPeriodicSavepoint() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testCountBasedCleanup(boolean setThreshold) {
         var conf = new Configuration();
-        var deployment = TestUtils.buildApplicationCluster();
-        var status = deployment.getStatus();
-        var jobStatus = status.getJobStatus();
-        status.getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
-        jobStatus.setState("RUNNING");
 
-        var savepointInfo = jobStatus.getSavepointInfo();
-        flinkService.triggerSavepointLegacy(null, SnapshotTriggerType.PERIODIC, deployment, conf);
+        if (setThreshold) {
+            conf.set(OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT_THRESHOLD, 2);
+            conf.set(OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT_THRESHOLD, 2);
+            conf.set(OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT, 10000);
+            conf.set(OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT, 10000);
+        } else {
+            conf.set(OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT, 2);
+            conf.set(OPERATOR_CHECKPOINT_HISTORY_MAX_COUNT, 2);
+        }
+        var operatorConfig = FlinkOperatorConfiguration.fromConfiguration(conf);
 
-        var triggerTs = savepointInfo.getTriggerTimestamp();
-        assertEquals(0L, savepointInfo.getLastPeriodicSavepointTimestamp());
-        assertEquals(SnapshotTriggerType.PERIODIC, savepointInfo.getTriggerType());
-        assertTrue(SnapshotUtils.savepointInProgress(jobStatus));
-        assertEquals(
-                SnapshotStatus.PENDING, SnapshotUtils.getLastSnapshotStatus(deployment, SAVEPOINT));
-        assertTrue(triggerTs > 0);
+        var testDataSavepoints =
+                List.of(
+                        createSnapshot(SAVEPOINT, Long.MAX_VALUE - 1, MANUAL, COMPLETED),
+                        createSnapshot(SAVEPOINT, Long.MAX_VALUE - 2, PERIODIC, COMPLETED),
+                        createSnapshot(SAVEPOINT, Long.MAX_VALUE - 3, PERIODIC, TRIGGER_PENDING),
+                        createSnapshot(SAVEPOINT, Long.MAX_VALUE - 4, PERIODIC, COMPLETED),
+                        createSnapshot(SAVEPOINT, Long.MAX_VALUE - 5, PERIODIC, COMPLETED),
+                        createSnapshot(SAVEPOINT, Long.MAX_VALUE - 6, PERIODIC, COMPLETED),
+                        createSnapshot(SAVEPOINT, Long.MAX_VALUE - 7, PERIODIC, COMPLETED));
 
-        // Pending
-        observer.observeSavepointStatus(getResourceContext(deployment));
-        // Completed
-        observer.observeSavepointStatus(getResourceContext(deployment));
-        assertEquals(triggerTs, savepointInfo.getLastPeriodicSavepointTimestamp());
-        assertFalse(SnapshotUtils.savepointInProgress(jobStatus));
-        assertEquals(
-                SnapshotUtils.getLastSnapshotStatus(deployment, SAVEPOINT),
-                SnapshotStatus.SUCCEEDED);
-        assertEquals(savepointInfo.getLastSavepoint(), savepointInfo.getSavepointHistory().get(0));
-        assertEquals(
-                SnapshotTriggerType.PERIODIC, savepointInfo.getLastSavepoint().getTriggerType());
-        assertNull(savepointInfo.getLastSavepoint().getTriggerNonce());
+        var testDataCheckpoints =
+                List.of(
+                        createSnapshot(CHECKPOINT, Long.MAX_VALUE - 1, MANUAL, COMPLETED),
+                        createSnapshot(CHECKPOINT, Long.MAX_VALUE - 2, PERIODIC, COMPLETED),
+                        createSnapshot(CHECKPOINT, Long.MAX_VALUE - 3, PERIODIC, TRIGGER_PENDING),
+                        createSnapshot(CHECKPOINT, Long.MAX_VALUE - 4, PERIODIC, COMPLETED),
+                        createSnapshot(CHECKPOINT, Long.MAX_VALUE - 5, PERIODIC, COMPLETED),
+                        createSnapshot(CHECKPOINT, Long.MAX_VALUE - 6, PERIODIC, COMPLETED),
+                        createSnapshot(CHECKPOINT, Long.MAX_VALUE - 7, PERIODIC, COMPLETED));
+
+        var removedSavepoints =
+                observer.getFlinkStateSnapshotsToCleanUp(
+                        testDataSavepoints, conf, operatorConfig, SAVEPOINT);
+        assertThat(removedSavepoints)
+                .containsExactlyInAnyOrder(
+                        testDataSavepoints.get(6),
+                        testDataSavepoints.get(5),
+                        testDataSavepoints.get(4));
+
+        var removedCheckpoints =
+                observer.getFlinkStateSnapshotsToCleanUp(
+                        testDataCheckpoints, conf, operatorConfig, CHECKPOINT);
+        assertThat(removedCheckpoints)
+                .containsExactlyInAnyOrder(
+                        testDataCheckpoints.get(6),
+                        testDataCheckpoints.get(5),
+                        testDataCheckpoints.get(4));
     }
 
-    @Test
-    public void testPeriodicCheckpoint() {
-        var conf = new Configuration();
-        var deployment = TestUtils.buildApplicationCluster();
-        var status = deployment.getStatus();
-        var jobStatus = status.getJobStatus();
-        status.getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
-        jobStatus.setState("RUNNING");
+    private static FlinkStateSnapshot createSnapshot(
+            SnapshotType snapshotType,
+            long timestamp,
+            SnapshotTriggerType triggerType,
+            FlinkStateSnapshotStatus.State snapshotState) {
+        var metadata =
+                new ObjectMetaBuilder()
+                        .withName(UUID.randomUUID().toString())
+                        .withLabels(Map.of(CrdConstants.LABEL_SNAPSHOT_TYPE, triggerType.name()))
+                        .build();
 
-        var checkpointInfo = jobStatus.getCheckpointInfo();
-        var triggerId = flinkService.triggerCheckpoint(null, CheckpointType.FULL, conf);
-        checkpointInfo.setTrigger(
-                triggerId,
-                SnapshotTriggerType.PERIODIC,
-                org.apache.flink.kubernetes.operator.api.status.CheckpointType.FULL);
+        var spec = new FlinkStateSnapshotSpec();
+        if (snapshotType == SAVEPOINT) {
+            spec.setSavepoint(new SavepointSpec());
+        } else if (snapshotType == CHECKPOINT) {
+            spec.setCheckpoint(new CheckpointSpec());
+        }
 
-        var triggerTs = checkpointInfo.getTriggerTimestamp();
-        assertEquals(0L, checkpointInfo.getLastPeriodicTriggerTimestamp());
-        assertTrue(SnapshotUtils.checkpointInProgress(jobStatus));
-        assertEquals(
-                SnapshotStatus.PENDING,
-                SnapshotUtils.getLastSnapshotStatus(deployment, CHECKPOINT));
-        assertTrue(triggerTs > 0);
+        var status =
+                FlinkStateSnapshotStatus.builder()
+                        .resultTimestamp(DateTimeUtils.kubernetes(Instant.ofEpochMilli(timestamp)))
+                        .state(snapshotState)
+                        .build();
 
-        // Pending
-        observer.observeCheckpointStatus(getResourceContext(deployment));
-        // Completed
-        observer.observeCheckpointStatus(getResourceContext(deployment));
-        assertEquals(triggerTs, checkpointInfo.getLastPeriodicTriggerTimestamp());
-        assertFalse(SnapshotUtils.checkpointInProgress(jobStatus));
-        assertEquals(
-                SnapshotUtils.getLastSnapshotStatus(deployment, CHECKPOINT),
-                SnapshotStatus.SUCCEEDED);
-        assertEquals(
-                SnapshotTriggerType.PERIODIC, checkpointInfo.getLastCheckpoint().getTriggerType());
-        assertNull(checkpointInfo.getLastCheckpoint().getTriggerNonce());
+        var snapshot = new FlinkStateSnapshot();
+        snapshot.setMetadata(metadata);
+        snapshot.setSpec(spec);
+        snapshot.setStatus(status);
+
+        return snapshot;
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -241,6 +241,10 @@ public class ApplicationObserverTest extends OperatorTestBase {
         deployment.getSpec().getJob().setSavepointTriggerNonce(timedOutNonce);
         Configuration conf =
                 configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED.key(), "false");
         flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
         bringToReadyStatus(deployment);
         assertTrue(ReconciliationUtils.isJobRunning(deployment.getStatus()));

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkStateSnapshotUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkStateSnapshotUtilsTest.java
@@ -69,6 +69,36 @@ public class FlinkStateSnapshotUtilsTest {
     private static final String SAVEPOINT_PATH = "/tmp/savepoint-01";
 
     @Test
+    public void testGetSnapshotTriggerType() {
+        var snapshot = new FlinkStateSnapshot();
+
+        assertThat(FlinkStateSnapshotUtils.getSnapshotTriggerType(snapshot))
+                .isEqualTo(SnapshotTriggerType.UNKNOWN);
+
+        snapshot.getMetadata().getLabels().put(CrdConstants.LABEL_SNAPSHOT_TYPE, "");
+        assertThat(FlinkStateSnapshotUtils.getSnapshotTriggerType(snapshot))
+                .isEqualTo(SnapshotTriggerType.UNKNOWN);
+
+        snapshot.getMetadata()
+                .getLabels()
+                .put(CrdConstants.LABEL_SNAPSHOT_TYPE, SnapshotTriggerType.MANUAL.name());
+        assertThat(FlinkStateSnapshotUtils.getSnapshotTriggerType(snapshot))
+                .isEqualTo(SnapshotTriggerType.MANUAL);
+
+        snapshot.getMetadata()
+                .getLabels()
+                .put(CrdConstants.LABEL_SNAPSHOT_TYPE, SnapshotTriggerType.UPGRADE.name());
+        assertThat(FlinkStateSnapshotUtils.getSnapshotTriggerType(snapshot))
+                .isEqualTo(SnapshotTriggerType.UPGRADE);
+
+        snapshot.getMetadata()
+                .getLabels()
+                .put(CrdConstants.LABEL_SNAPSHOT_TYPE, SnapshotTriggerType.PERIODIC.name());
+        assertThat(FlinkStateSnapshotUtils.getSnapshotTriggerType(snapshot))
+                .isEqualTo(SnapshotTriggerType.PERIODIC);
+    }
+
+    @Test
     public void testGetValidatedFlinkStateSnapshotPathPathGiven() {
         var snapshotRef = FlinkStateSnapshotReference.builder().path(SAVEPOINT_PATH).build();
         var snapshotResult =


### PR DESCRIPTION
## Brief change log

- *Added InformerEventSource for Flink resources to be able to list linked snapshots during reconciliation*
- *If FlinkStateSnapshot resources are enabled, clean them up by age/count in SnapshotObserver*
- *Add unit tests*

## Verifying this change

- Added unit tests
- Manual testing with checkpoint and snapshot resources, with age and count based cleanup policies

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? documentation and examples will be provided in PR #854 
