### PR TITLE
[FLINK-35265][snapshot] Create FlinkStateSnapshot in the namespace of job

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkStateSnapshotUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkStateSnapshotUtils.java
@@ -122,10 +122,12 @@ public class FlinkStateSnapshotUtils {
 
     protected static FlinkStateSnapshot createFlinkStateSnapshot(
             KubernetesClient kubernetesClient,
+            String namespace,
             String name,
             FlinkStateSnapshotSpec spec,
             SnapshotTriggerType triggerType) {
         var metadata = new ObjectMeta();
+        metadata.setNamespace(namespace);
         metadata.setName(name);
         metadata.getLabels().put(CrdConstants.LABEL_SNAPSHOT_TYPE, triggerType.name());
 
@@ -169,7 +171,12 @@ public class FlinkStateSnapshotUtils {
                         .build();
 
         var resourceName = getFlinkStateSnapshotName(SAVEPOINT, triggerType, resource);
-        return createFlinkStateSnapshot(kubernetesClient, resourceName, snapshotSpec, triggerType);
+        return createFlinkStateSnapshot(
+                kubernetesClient,
+                resource.getMetadata().getNamespace(),
+                resourceName,
+                snapshotSpec,
+                triggerType);
     }
 
     /**
@@ -191,7 +198,12 @@ public class FlinkStateSnapshotUtils {
                         .build();
 
         var resourceName = getFlinkStateSnapshotName(CHECKPOINT, triggerType, resource);
-        return createFlinkStateSnapshot(kubernetesClient, resourceName, snapshotSpec, triggerType);
+        return createFlinkStateSnapshot(
+                kubernetesClient,
+                resource.getMetadata().getNamespace(),
+                resourceName,
+                snapshotSpec,
+                triggerType);
     }
 
     /**

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -286,7 +286,12 @@ public class TestUtils extends BaseTestUtils {
     public static <CR extends AbstractFlinkResource<?, ?>>
             List<FlinkStateSnapshot> getFlinkStateSnapshotsForResource(
                     KubernetesClient kubernetesClient, CR resource) {
-        return kubernetesClient.resources(FlinkStateSnapshot.class).list().getItems().stream()
+        return kubernetesClient
+                .resources(FlinkStateSnapshot.class)
+                .inAnyNamespace()
+                .list()
+                .getItems()
+                .stream()
                 .filter(
                         s ->
                                 s.getSpec()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkStateSnapshotUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/FlinkStateSnapshotUtilsTest.java
@@ -230,6 +230,28 @@ public class FlinkStateSnapshotUtilsTest {
     }
 
     @Test
+    public void testCreateSnapshotInSameNamespace() {
+        var namespace = "different-namespace";
+        var deployment = initDeployment();
+        deployment.getMetadata().setNamespace(namespace);
+
+        var savepoint =
+                FlinkStateSnapshotUtils.createSavepointResource(
+                        client,
+                        deployment,
+                        SAVEPOINT_PATH,
+                        SnapshotTriggerType.PERIODIC,
+                        SavepointFormatType.CANONICAL,
+                        true);
+        assertThat(savepoint.getMetadata().getNamespace()).isEqualTo(namespace);
+
+        var checkpoint =
+                FlinkStateSnapshotUtils.createCheckpointResource(
+                        client, deployment, SnapshotTriggerType.MANUAL);
+        assertThat(checkpoint.getMetadata().getNamespace()).isEqualTo(namespace);
+    }
+
+    @Test
     public void testCreateCheckpointResource() {
         var deployment = initDeployment();
 


### PR DESCRIPTION
In case the operator is deployed in multiple namespaces, periodic and upgrade FlinkStateSnapshots will always be created in the default namespace.

With this fix, all new FlinkStateSnapshots will be created in the same namespace as the associated Flink job.