### PR TITLE
[FLINK-36037][snapshot] Add backwards compatibility for job upgrades

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtils.java
@@ -370,15 +370,23 @@ public class SnapshotUtils {
     public static boolean lastSavepointKnown(CommonStatus<?> status) {
         var lastSavepoint = status.getJobStatus().getUpgradeSnapshotReference();
 
-        if (lastSavepoint == null) {
-            return true;
+        if (lastSavepoint != null) {
+            if (StringUtils.isNotBlank(lastSavepoint.getName())) {
+                return true;
+            }
+
+            var location = lastSavepoint.getPath();
+            return location != null
+                    && !location.equals(AbstractJobReconciler.LAST_STATE_DUMMY_SP_PATH);
         }
 
-        if (StringUtils.isNotBlank(lastSavepoint.getName())) {
+        // Check legacy savepoint field too
+        var lastSavepointLegacy = status.getJobStatus().getSavepointInfo().getLastSavepoint();
+        if (lastSavepointLegacy == null) {
             return true;
         }
-
-        var location = lastSavepoint.getPath();
-        return location != null && !location.equals(AbstractJobReconciler.LAST_STATE_DUMMY_SP_PATH);
+        return !lastSavepointLegacy
+                .getLocation()
+                .equals(AbstractJobReconciler.LAST_STATE_DUMMY_SP_PATH);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Suspended `savepoint` upgrade-mode Flink jobs submitted with Operator version 1.9 won't restore from the proper savepoint unless this fix is applied. If `status.jobStatus.upgradeSnapshotReference` is null, the operator will fallback to `status.jobStatus.savepointInfo.lastSavepoint.location` when determining savepoint location.


## Brief change log

- Fallback to reading deprecated savepoint fields when using `upgradeSnapshotReference`

## Verifying this change

- Unit test
- Manual test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
