### PR TITLE
[FLINK-36106][autoscaler] Clean up the t_flink_autoscaler_event_handler table after each test

### DIFF
--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQLExtension.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQLExtension.java
@@ -34,7 +34,8 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback, AfterEachCa
     private static final String DATABASE_NAME = "flink_autoscaler";
     private static final String USER_NAME = "root";
     private static final String PASSWORD = "123456";
-    private static final List<String> TABLES = List.of("t_flink_autoscaler_state_store");
+    private static final List<String> TABLES =
+            List.of("t_flink_autoscaler_state_store", "t_flink_autoscaler_event_handler");
 
     private final MySQLContainer<?> container;
 

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/postgres/PostgreSQLExtension.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/postgres/PostgreSQLExtension.java
@@ -34,7 +34,8 @@ class PostgreSQLExtension implements BeforeAllCallback, AfterAllCallback, AfterE
     private static final String DATABASE_NAME = "flink_autoscaler";
     private static final String USER_NAME = "root";
     private static final String PASSWORD = "123456";
-    private static final List<String> TABLES = List.of("t_flink_autoscaler_state_store");
+    private static final List<String> TABLES =
+            List.of("t_flink_autoscaler_state_store", "t_flink_autoscaler_event_handler");
 
     private final PostgreSQLContainer<?> container;
 


### PR DESCRIPTION
## What is the purpose of the change

During review https://github.com/apache/flink-kubernetes-operator/pull/865, I found t_flink_autoscaler_event_handler is not cleaned after each testing



## Brief change log

- [FLINK-36106][autoscaler] Clean up the t_flink_autoscaler_event_handler table after each test

