### PR TITLE
[FLINK-35493][snapshot] Fix cleanup for snapshots without status field

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
@@ -301,7 +301,10 @@ public class SnapshotObserver<
 
         var lastCompleteSnapshot =
                 snapshotList.stream()
-                        .filter(s -> COMPLETED.equals(s.getStatus().getState()))
+                        .filter(
+                                s ->
+                                        s.getStatus() != null
+                                                && COMPLETED.equals(s.getStatus().getState()))
                         .max(Comparator.comparing(EXTRACT_SNAPSHOT_TIME))
                         .orElse(null);
 


### PR DESCRIPTION
I ran into this issue while working on FLINK-36110 where the snapshot observer found FlinkStateSnapshot resources with their `status` fields not yet initialized. This check is required to circumvent this case.