### PR TITLE
[FLINK-36110][snapshot] Store periodic snapshot trigger timestamps in memory

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
@@ -301,7 +301,10 @@ public class SnapshotObserver<
 
         var lastCompleteSnapshot =
                 snapshotList.stream()
-                        .filter(s -> COMPLETED.equals(s.getStatus().getState()))
+                        .filter(
+                                s ->
+                                        s.getStatus() != null
+                                                && COMPLETED.equals(s.getStatus().getState()))
                         .max(Comparator.comparing(EXTRACT_SNAPSHOT_TIME))
                         .orElse(null);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
@@ -49,7 +49,6 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
@@ -241,14 +240,7 @@ public class SnapshotObserver<
 
     /** Clean up and dispose savepoints according to the configured max size/age. */
     private void cleanupSavepointHistory(FlinkResourceContext<CR> ctx) {
-        Set<FlinkStateSnapshot> snapshots = Collections.emptySet();
-        if (FlinkStateSnapshotUtils.isSnapshotResourceEnabled(
-                ctx.getOperatorConfig(), ctx.getObserveConfig())) {
-            snapshots = ctx.getJosdkContext().getSecondaryResources(FlinkStateSnapshot.class);
-            if (snapshots == null) {
-                snapshots = Set.of();
-            }
-        }
+        var snapshots = FlinkStateSnapshotUtils.getFlinkStateSnapshotsSupplier(ctx).get();
 
         cleanupSavepointHistoryLegacy(ctx, snapshots);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SnapshotTriggerTimestampStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SnapshotTriggerTimestampStore.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler;
+
+import org.apache.flink.autoscaler.utils.DateTimeUtils;
+import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.api.CrdConstants;
+import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
+import org.apache.flink.kubernetes.operator.api.status.SnapshotInfo;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import lombok.RequiredArgsConstructor;
+
+import javax.annotation.Nullable;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.COMPLETED;
+import static org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType.PERIODIC;
+import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.SAVEPOINT;
+
+/** Class used to store latest timestamps of periodic checkpoint/savepoint. */
+@RequiredArgsConstructor
+public class SnapshotTriggerTimestampStore {
+    private final SnapshotType snapshotType;
+    private final ConcurrentHashMap<String, Instant> lastTriggered = new ConcurrentHashMap<>();
+
+    /**
+     * Returns the time a periodic snapshot was last triggered for this resource. This is stored in
+     * memory, on operator start it will use the latest completed FlinkStateSnapshot CR creation
+     * timestamp. If none found, the return value will be the max of the resource creation timestamp
+     * and the latest triggered legacy snapshot.
+     *
+     * @param resource Flink resource
+     * @param snapshots related snapshot resources
+     * @return instant of last trigger
+     */
+    public Instant getLastPeriodicTriggerInstant(
+            AbstractFlinkResource<?, ?> resource, @Nullable Set<FlinkStateSnapshot> snapshots) {
+        if (lastTriggered.containsKey(resource.getMetadata().getUid())) {
+            return lastTriggered.get(resource.getMetadata().getUid());
+        }
+
+        return Optional.ofNullable(snapshots).orElse(Set.of()).stream()
+                .filter(s -> s.getStatus() != null && COMPLETED.equals(s.getStatus().getState()))
+                .filter(s -> (snapshotType == SAVEPOINT) == s.getSpec().isSavepoint())
+                .filter(
+                        s ->
+                                PERIODIC.name()
+                                        .equals(
+                                                s.getMetadata()
+                                                        .getLabels()
+                                                        .get(CrdConstants.LABEL_SNAPSHOT_TYPE)))
+                .map(s -> DateTimeUtils.parseKubernetes(s.getMetadata().getCreationTimestamp()))
+                .max(Comparator.naturalOrder())
+                .orElseGet(
+                        () -> {
+                            var legacyTs = getLegacyTimestamp(resource);
+                            var creationTs =
+                                    Instant.parse(resource.getMetadata().getCreationTimestamp());
+
+                            if (legacyTs.compareTo(creationTs) > 0) {
+                                return legacyTs;
+                            } else {
+                                return creationTs;
+                            }
+                        });
+    }
+
+    /**
+     * Updates the time a periodic snapshot was last triggered for this resource.
+     *
+     * @param resource Kubernetes resource
+     * @param instant new timestamp
+     */
+    public void updateLastPeriodicTriggerTimestamp(HasMetadata resource, Instant instant) {
+        lastTriggered.put(resource.getMetadata().getUid(), instant);
+    }
+
+    private Instant getLegacyTimestamp(AbstractFlinkResource<?, ?> resource) {
+        SnapshotInfo snapshotInfo;
+        switch (snapshotType) {
+            case SAVEPOINT:
+                snapshotInfo = resource.getStatus().getJobStatus().getSavepointInfo();
+                break;
+            case CHECKPOINT:
+                snapshotInfo = resource.getStatus().getJobStatus().getCheckpointInfo();
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported snapshot type: " + snapshotType);
+        }
+
+        return Instant.ofEpochMilli(snapshotInfo.getLastPeriodicTriggerTimestamp());
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/SnapshotTriggerTimestampStoreTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/SnapshotTriggerTimestampStoreTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.reconciler;
+
+import org.apache.flink.autoscaler.utils.DateTimeUtils;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.CrdConstants;
+import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
+import org.apache.flink.kubernetes.operator.api.spec.CheckpointSpec;
+import org.apache.flink.kubernetes.operator.api.spec.SavepointSpec;
+import org.apache.flink.kubernetes.operator.api.status.Checkpoint;
+import org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus;
+import org.apache.flink.kubernetes.operator.api.status.Savepoint;
+import org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Set;
+
+import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.COMPLETED;
+import static org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType.PERIODIC;
+import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.CHECKPOINT;
+import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.SAVEPOINT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SnapshotTriggerTimestampStoreTest {
+
+    @Test
+    public void testCheckpointTimestampStore() {
+        testTimestampStore(CHECKPOINT);
+    }
+
+    @Test
+    public void testSavepointTimestampStore() {
+        testTimestampStore(SAVEPOINT);
+    }
+
+    private void testTimestampStore(SnapshotType snapshotType) {
+        var resource = TestUtils.buildApplicationCluster();
+        var store = new SnapshotTriggerTimestampStore(snapshotType);
+
+        var instantCreation = Instant.ofEpochMilli(1);
+        resource.getMetadata().setCreationTimestamp(DateTimeUtils.kubernetes(instantCreation));
+
+        assertEquals(instantCreation, store.getLastPeriodicTriggerInstant(resource, Set.of()));
+
+        var instantLegacy = Instant.ofEpochMilli(2);
+        if (snapshotType == SAVEPOINT) {
+            resource.getStatus()
+                    .getJobStatus()
+                    .getSavepointInfo()
+                    .updateLastSavepoint(new Savepoint(2L, "", PERIODIC, null, null));
+        } else {
+            resource.getStatus()
+                    .getJobStatus()
+                    .getCheckpointInfo()
+                    .updateLastCheckpoint(new Checkpoint(2L, PERIODIC, null, null));
+        }
+        assertEquals(instantLegacy, store.getLastPeriodicTriggerInstant(resource, Set.of()));
+
+        var snapshots = Set.of(createSnapshot(snapshotType, SnapshotTriggerType.PERIODIC, 3L));
+        assertEquals(
+                Instant.ofEpochMilli(3), store.getLastPeriodicTriggerInstant(resource, snapshots));
+
+        snapshots =
+                Set.of(
+                        createSnapshot(snapshotType, SnapshotTriggerType.PERIODIC, 200L),
+                        createSnapshot(snapshotType, SnapshotTriggerType.PERIODIC, 300L),
+                        createSnapshot(snapshotType, SnapshotTriggerType.MANUAL, 10000L),
+                        createSnapshot(snapshotType, SnapshotTriggerType.PERIODIC, 0L));
+        assertEquals(
+                Instant.ofEpochMilli(300),
+                store.getLastPeriodicTriggerInstant(resource, snapshots));
+
+        var instantInMemory = Instant.ofEpochMilli(111L);
+        store.updateLastPeriodicTriggerTimestamp(resource, instantInMemory);
+        assertEquals(instantInMemory, store.getLastPeriodicTriggerInstant(resource, snapshots));
+
+        instantInMemory = Instant.ofEpochMilli(11L);
+        store.updateLastPeriodicTriggerTimestamp(resource, instantInMemory);
+        assertEquals(instantInMemory, store.getLastPeriodicTriggerInstant(resource, snapshots));
+    }
+
+    private FlinkStateSnapshot createSnapshot(
+            SnapshotType snapshotType, SnapshotTriggerType triggerType, Long timestamp) {
+        var snapshot = new FlinkStateSnapshot();
+        snapshot.getMetadata()
+                .setCreationTimestamp(DateTimeUtils.kubernetes(Instant.ofEpochMilli(timestamp)));
+        if (snapshotType == SAVEPOINT) {
+            snapshot.getSpec().setSavepoint(new SavepointSpec());
+        } else {
+            snapshot.getSpec().setCheckpoint(new CheckpointSpec());
+        }
+        snapshot.getMetadata()
+                .getLabels()
+                .put(CrdConstants.LABEL_SNAPSHOT_TYPE, triggerType.name());
+        snapshot.setStatus(new FlinkStateSnapshotStatus());
+        snapshot.getStatus().setState(COMPLETED);
+        return snapshot;
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtilsTest.java
@@ -78,7 +78,10 @@ public class SnapshotUtilsTest {
         assertEquals(
                 Optional.empty(),
                 SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+                        deployment,
+                        configManager.getObserveConfig(deployment),
+                        snapshotType,
+                        Instant.MIN));
 
         deployment.getSpec().getFlinkConfiguration().put(PERIODIC_CHECKPOINT_INTERVAL.key(), "10m");
         reconcileSpec(deployment);
@@ -86,21 +89,30 @@ public class SnapshotUtilsTest {
         assertEquals(
                 Optional.empty(),
                 SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+                        deployment,
+                        configManager.getObserveConfig(deployment),
+                        snapshotType,
+                        Instant.MIN));
         resetTrigger(deployment, snapshotType);
 
         setTriggerNonce(deployment, snapshotType, 123L);
         assertEquals(
                 Optional.empty(),
                 SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+                        deployment,
+                        configManager.getObserveConfig(deployment),
+                        snapshotType,
+                        Instant.MIN));
         resetTrigger(deployment, snapshotType);
 
-        setupCronTrigger(snapshotType, deployment);
+        var instant = setupCronTrigger(snapshotType, deployment);
         assertEquals(
                 Optional.empty(),
                 SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+                        deployment,
+                        configManager.getObserveConfig(deployment),
+                        snapshotType,
+                        instant));
         resetTrigger(deployment, snapshotType);
     }
 
@@ -112,7 +124,10 @@ public class SnapshotUtilsTest {
         assertEquals(
                 Optional.empty(),
                 SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+                        deployment,
+                        configManager.getObserveConfig(deployment),
+                        snapshotType,
+                        Instant.MIN));
 
         deployment
                 .getSpec()
@@ -123,7 +138,10 @@ public class SnapshotUtilsTest {
         assertEquals(
                 Optional.of(SnapshotTriggerType.PERIODIC),
                 SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+                        deployment,
+                        configManager.getObserveConfig(deployment),
+                        snapshotType,
+                        Instant.MIN));
         resetTrigger(deployment, snapshotType);
         deployment.getSpec().getFlinkConfiguration().put(periodicSnapshotIntervalOption.key(), "0");
         reconcileSpec(deployment);
@@ -132,15 +150,21 @@ public class SnapshotUtilsTest {
         assertEquals(
                 Optional.of(SnapshotTriggerType.MANUAL),
                 SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+                        deployment,
+                        configManager.getObserveConfig(deployment),
+                        snapshotType,
+                        Instant.MIN));
         resetTrigger(deployment, snapshotType);
         reconcileSpec(deployment);
 
-        setupCronTrigger(snapshotType, deployment);
+        var instant = setupCronTrigger(snapshotType, deployment);
         assertEquals(
                 Optional.of(SnapshotTriggerType.PERIODIC),
                 SnapshotUtils.shouldTriggerSnapshot(
-                        deployment, configManager.getObserveConfig(deployment), snapshotType));
+                        deployment,
+                        configManager.getObserveConfig(deployment),
+                        snapshotType,
+                        instant));
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

SnapshotObserver uses deprecated fields as the latest timestamp of triggered snapshots. These fields are not updated when using FlinkStateSnapshot though. This new method of storing these timestamps is meant to fix this case.

## Brief change log

- Add new class to store/retrieve last timestamp a snapshot was triggered
- Updated relevant code to store/retrieve last timestamp in new class

## Verifying this change

- Added unit tests
- Manual testing

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
