### PR TITLE
[FLINK-35414] Rework last-state upgrade mode to support job cancellation as suspend mechanism

### DIFF
--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -84,13 +84,13 @@ Supported values: `stateless`, `savepoint`, `last-state`
 
 The `upgradeMode` setting controls both the stop and restore mechanisms as detailed in the following table:
 
-|                        | Stateless               | Last State                                 | Savepoint                              |
-|------------------------|-------------------------|--------------------------------------------|----------------------------------------|
-| Config Requirement     | None                    | Checkpointing & HA Enabled                 | Checkpoint/Savepoint directory defined |
-| Job Status Requirement | None                    | HA metadata available                      | Job Running*                           |
-| Suspend Mechanism      | Cancel / Delete         | Delete Flink deployment (keep HA metadata) | Cancel with savepoint                  |
-| Restore Mechanism      | Deploy from empty state | Recover last state using HA metadata       | Restore From savepoint                 |
-| Production Use         | Not recommended         | Recommended                                | Recommended                            |
+|                        | Stateless       | Last State                         | Savepoint                              |
+|------------------------|-----------------|------------------------------------|----------------------------------------|
+| Config Requirement     | None            | Checkpointing Enabled              | Checkpoint/Savepoint directory defined |
+| Job Status Requirement | None            | Job or HA metadata accessible      | Job Running*                           |
+| Suspend Mechanism      | Cancel / Delete | Cancel / Delete (keep HA metadata) | Cancel with savepoint                  |
+| Restore Mechanism      | Empty state     | Use HA metadata or last cp/sp      | Restore From savepoint                 |
+| Production Use         | Not recommended | Recommended                        | Recommended                            |
 
 
 *\* When HA is enabled the `savepoint` upgrade mode may fall back to the `last-state` behaviour in cases where the job is in an unhealthy state.*
@@ -148,10 +148,6 @@ spec:
     upgradeMode: last-state
     state: running
 ```
-
-{{< hint warning >}}
-Last state upgrade mode is currently only supported for `FlinkDeployments`.
-{{< /hint >}}
 
 ### Application restarts without spec change
 

--- a/docs/content/docs/custom-resource/overview.md
+++ b/docs/content/docs/custom-resource/overview.md
@@ -215,10 +215,6 @@ COPY flink-hadoop-fs-1.19-SNAPSHOT.jar $FLINK_PLUGINS_DIR/hadoop-fs/
 
 Alternatively, if you use helm to install flink-kubernetes-operator, it allows you to specify a postStart hook to download the required plugins.
 
-### Limitations
-
-- Last-state upgradeMode is currently not supported for FlinkSessionJobs
-
 ## Further information
 
  - [Snapshots]({{< ref "docs/custom-resource/snapshots" >}})

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -452,7 +452,7 @@ This serves as a full reference for FlinkDeployment and FlinkSessionJob custom r
 
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
-| lastSavepoint | org.apache.flink.kubernetes.operator.api.status.Savepoint | Last completed savepoint by the operator for manual and periodic snapshots. Only used if FlinkStateSnapshot resources are disabled. |
+| lastSavepoint | org.apache.flink.kubernetes.operator.api.status.Savepoint | Last completed savepoint by the operator. |
 | triggerId | java.lang.String | Trigger id of a pending savepoint operation. |
 | triggerTimestamp | java.lang.Long | Trigger timestamp of a pending savepoint operation. |
 | triggerType | org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType | Savepoint trigger mechanism. |

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -126,7 +126,7 @@
             <td><h5>kubernetes.operator.job.upgrade.last-state.job-cancel.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Cancel jobs during last-state upgrade.</td>
+            <td>Cancel jobs during last-state upgrade. This config is ignored for session jobs where cancel is the only mechanism to perform this type of upgrade.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.upgrade.last-state.max.allowed.checkpoint.age</h5></td>

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -123,6 +123,12 @@
             <td>Enables last-state fallback for savepoint upgrade mode. When the job is not running thus savepoint cannot be triggered but HA metadata is available for last state restore the operator can initiate the upgrade process when the flag is enabled.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.upgrade.last-state.job-cancel.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Cancel jobs during last-state upgrade.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.upgrade.last-state.max.allowed.checkpoint.age</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -216,7 +216,7 @@
             <td><h5>kubernetes.operator.job.upgrade.last-state.job-cancel.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Cancel jobs during last-state upgrade.</td>
+            <td>Cancel jobs during last-state upgrade. This config is ignored for session jobs where cancel is the only mechanism to perform this type of upgrade.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.job.upgrade.last-state.max.allowed.checkpoint.age</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -213,6 +213,12 @@
             <td>Enables last-state fallback for savepoint upgrade mode. When the job is not running thus savepoint cannot be triggered but HA metadata is available for last state restore the operator can initiate the upgrade process when the flag is enabled.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.job.upgrade.last-state.job-cancel.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Cancel jobs during last-state upgrade.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.job.upgrade.last-state.max.allowed.checkpoint.age</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Duration</td>

--- a/e2e-tests/test_sessionjob_operations.sh
+++ b/e2e-tests/test_sessionjob_operations.sh
@@ -54,6 +54,7 @@ if [ "$location" == "" ];then
   exit 1
 fi
 
+echo "Starting sessionjob savepoint upgrade test"
 # Testing savepoint mode upgrade
 # Update the FlinkSessionJob and trigger the savepoint upgrade
 kubectl patch sessionjob ${SESSION_JOB_NAME} --type merge --patch '{"spec":{"job": {"parallelism": 1 } } }'
@@ -67,15 +68,17 @@ assert_available_slots 1 $CLUSTER_ID
 
 echo "Successfully run the sessionjob savepoint upgrade test"
 
+echo "Starting sessionjob last-state upgrade test"
 # Testing last-state mode upgrade
 # Update the FlinkSessionJob and trigger the last-state upgrade
-kubectl patch sessionjob ${SESSION_JOB_NAME} --type merge --patch '{"spec":{"job": {"parallelism": 2, "upgradeMode": last-state } } }'
+kubectl patch sessionjob ${SESSION_JOB_NAME} --type merge --patch '{"spec":{"job": {"parallelism": 2, "upgradeMode": "last-state" } } }'
 
 # Check the job was restarted with the new parallelism
+wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.state' CANCELLING ${TIMEOUT} || exit 1
 wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
 assert_available_slots 0 $CLUSTER_ID
 
-echo "Successfully run the sessionjob savepoint upgrade test"
+echo "Successfully run the sessionjob last-state upgrade test"
 
 # Test Operator restart
 echo "Delete session job " + $SESSION_JOB_NAME

--- a/e2e-tests/test_sessionjob_operations.sh
+++ b/e2e-tests/test_sessionjob_operations.sh
@@ -67,6 +67,16 @@ assert_available_slots 1 $CLUSTER_ID
 
 echo "Successfully run the sessionjob savepoint upgrade test"
 
+# Testing last-state mode upgrade
+# Update the FlinkSessionJob and trigger the last-state upgrade
+kubectl patch sessionjob ${SESSION_JOB_NAME} --type merge --patch '{"spec":{"job": {"parallelism": 2, "upgradeMode": last-state } } }'
+
+# Check the job was restarted with the new parallelism
+wait_for_status $SESSION_JOB_IDENTIFIER '.status.jobStatus.state' RUNNING ${TIMEOUT} || exit 1
+assert_available_slots 0 $CLUSTER_ID
+
+echo "Successfully run the sessionjob savepoint upgrade test"
+
 # Test Operator restart
 echo "Delete session job " + $SESSION_JOB_NAME
 kubectl delete flinksessionjob $SESSION_JOB_NAME

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/docs/CrdReferenceDoclet.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/docs/CrdReferenceDoclet.java
@@ -219,6 +219,9 @@ public class CrdReferenceDoclet implements Doclet {
                     }
                     break;
                 case FIELD:
+                    if (e.getModifiers().contains(Modifier.STATIC)) {
+                        return null;
+                    }
                     out.println(
                             "| "
                                     + getNameOrJsonPropValue(e)

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
@@ -18,12 +18,10 @@
 package org.apache.flink.kubernetes.operator.api.status;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState;
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.fabric8.crd.generator.annotation.PrinterColumn;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -98,10 +96,4 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
 
         return ResourceLifecycleState.DEPLOYED;
     }
-
-    /**
-     * Internal flag to signal that due to some condition we need to schedule a new reconciliation
-     * loop immediately. For example autoscaler overrides have changed and we need to apply them.
-     */
-    @JsonIgnore @Internal private boolean immediateReconciliationNeeded = false;
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/ReconciliationStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/ReconciliationStatus.java
@@ -20,7 +20,6 @@ package org.apache.flink.kubernetes.operator.api.status;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
-import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.utils.SpecUtils;
 import org.apache.flink.kubernetes.operator.api.utils.SpecWithMeta;
 
@@ -99,23 +98,5 @@ public abstract class ReconciliationStatus<SPEC extends AbstractFlinkSpec> {
     @JsonIgnore
     public boolean isBeforeFirstDeployment() {
         return lastReconciledSpec == null;
-    }
-
-    /**
-     * This method is only here for backward compatibility reasons. The current version of the
-     * operator does not leave the resources in UPGRADING state during in-place scaling therefore
-     * this method will always return false.
-     *
-     * @return True if in-place scaling is in progress.
-     */
-    @JsonIgnore
-    @Deprecated
-    public boolean scalingInProgress() {
-        if (isBeforeFirstDeployment() || state != ReconciliationState.UPGRADING) {
-            return false;
-        }
-        var job = deserializeLastReconciledSpec().getJob();
-        // For regular full upgrades the jobstate is suspended in UPGRADING state
-        return job != null && job.getState() == JobState.RUNNING;
     }
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/SavepointInfo.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/SavepointInfo.java
@@ -24,6 +24,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +42,9 @@ public class SavepointInfo implements SnapshotInfo {
      * Last completed savepoint by the operator for manual and periodic snapshots. Only used if
      * FlinkStateSnapshot resources are disabled.
      */
+    private static final Logger LOG = LoggerFactory.getLogger(SavepointInfo.class);
+
+    /** Last completed savepoint by the operator. */
     private Savepoint lastSavepoint;
 
     /** Trigger id of a pending savepoint operation. */
@@ -82,7 +87,11 @@ public class SavepointInfo implements SnapshotInfo {
      * @param savepoint Savepoint to be added.
      */
     public void updateLastSavepoint(Savepoint savepoint) {
-        if (lastSavepoint == null || !lastSavepoint.getLocation().equals(savepoint.getLocation())) {
+        if (savepoint == null) {
+            lastSavepoint = null;
+        } else if (lastSavepoint == null
+                || !lastSavepoint.getLocation().equals(savepoint.getLocation())) {
+            LOG.debug("Updating last savepoint to {}", savepoint);
             lastSavepoint = savepoint;
             savepointHistory.add(savepoint);
             if (savepoint.getTriggerType() == SnapshotTriggerType.PERIODIC) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -59,6 +59,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import static org.apache.flink.configuration.CheckpointingOptions.SAVEPOINT_DIRECTORY;
+import static org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder.applyJobConfig;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.K8S_OP_CONF_PREFIX;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.NAMESPACE_CONF_PREFIX;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_DYNAMIC_CONFIG_CHECK_INTERVAL;
@@ -292,7 +293,7 @@ public class FlinkConfigManager {
      * @return Session job config
      */
     public Configuration getSessionJobConfig(
-            FlinkDeployment deployment, FlinkSessionJobSpec sessionJobSpec) {
+            String name, FlinkDeployment deployment, FlinkSessionJobSpec sessionJobSpec) {
         Configuration sessionJobConfig = getObserveConfig(deployment);
 
         // merge session job specific config
@@ -300,6 +301,7 @@ public class FlinkConfigManager {
         if (sessionJobFlinkConfiguration != null) {
             sessionJobFlinkConfiguration.forEach(sessionJobConfig::setString);
         }
+        applyJobConfig(name, sessionJobConfig, sessionJobSpec.getJob());
         return sessionJobConfig;
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -465,6 +465,13 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Max allowed checkpoint age for initiating last-state upgrades on running jobs. If a checkpoint is not available within the desired age (and nothing in progress) a savepoint will be triggered.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> OPERATOR_JOB_UPGRADE_LAST_STATE_CANCEL_JOB =
+            operatorConfig("job.upgrade.last-state.job-cancel.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Cancel jobs during last-state upgrade.");
+
     @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Boolean> OPERATOR_HEALTH_PROBE_ENABLED =
             operatorConfig("health.probe.enabled")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -470,7 +470,8 @@ public class KubernetesOperatorConfigOptions {
             operatorConfig("job.upgrade.last-state.job-cancel.enabled")
                     .booleanType()
                     .defaultValue(false)
-                    .withDescription("Cancel jobs during last-state upgrade.");
+                    .withDescription(
+                            "Cancel jobs during last-state upgrade. This config is ignored for session jobs where cancel is the only mechanism to perform this type of upgrade.");
 
     @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Boolean> OPERATOR_HEALTH_PROBE_ENABLED =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobContext.java
@@ -53,7 +53,10 @@ public class FlinkSessionJobContext extends FlinkResourceContext<FlinkSessionJob
         var session = getJosdkContext().getSecondaryResource(FlinkDeployment.class);
 
         if (sessionClusterReady(session)) {
-            return configManager.getSessionJobConfig(session.get(), (FlinkSessionJobSpec) spec);
+            return configManager.getSessionJobConfig(
+                    getResource().getMetadata().getName(),
+                    session.get(),
+                    (FlinkSessionJobSpec) spec);
         }
         return null;
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/UpgradeFailureException.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/exception/UpgradeFailureException.java
@@ -18,11 +18,16 @@
 package org.apache.flink.kubernetes.operator.exception;
 
 /** Exception to signal non-terminal deployment failure. */
-public class RecoveryFailureException extends RuntimeException {
+public class UpgradeFailureException extends RuntimeException {
     private final String reason;
 
-    public RecoveryFailureException(String message, String reason) {
+    public UpgradeFailureException(String message, String reason) {
         super(message);
+        this.reason = reason;
+    }
+
+    public UpgradeFailureException(String message, String reason, Throwable throwable) {
+        super(message, throwable);
         this.reason = reason;
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/AuditUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/AuditUtils.java
@@ -44,6 +44,10 @@ public class AuditUtils {
 
     public static <R extends AbstractFlinkResource<?, S>, S extends CommonStatus<?>>
             void logContext(FlinkResourceListener.StatusUpdateContext<R, S> ctx) {
+        if (ctx.getPreviousStatus().getLifecycleState() == ctx.getNewStatus().getLifecycleState()) {
+            // Unchanged state, nothing to log
+            return;
+        }
         LOG.info(format(ctx.getNewStatus()));
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -122,7 +122,7 @@ public class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
             // upgrading state and retry the upgrade (if possible)
             resource.getStatus().getReconciliationStatus().setState(ReconciliationState.DEPLOYED);
         }
-        jobStatus.setState(org.apache.flink.api.common.JobStatus.RECONCILING.name());
+        jobStatus.setState(JobStatus.RECONCILING.name());
         resource.getStatus().setError(JOB_NOT_FOUND_ERR);
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -89,23 +89,12 @@ public class ApplicationReconciler
         }
         var flinkService = ctx.getFlinkService();
 
-        boolean lastStateAllowed =
-                deployment.getSpec().getJob().getUpgradeMode() == UpgradeMode.LAST_STATE
-                        || deployConfig.getBoolean(
-                                KubernetesOperatorConfigOptions
-                                        .OPERATOR_JOB_UPGRADE_LAST_STATE_FALLBACK_ENABLED);
-
-        if (lastStateAllowed
-                && HighAvailabilityMode.isHighAvailabilityModeActivated(deployConfig)
+        if (HighAvailabilityMode.isHighAvailabilityModeActivated(deployConfig)
                 && HighAvailabilityMode.isHighAvailabilityModeActivated(ctx.getObserveConfig())
-                && !flinkVersionChanged(
-                        ReconciliationUtils.getDeployedSpec(deployment), deployment.getSpec())) {
-
-            if (flinkService.isHaMetadataAvailable(deployConfig)) {
-                LOG.info(
-                        "Job is not running but HA metadata is available for last state restore, ready for upgrade");
-                return JobUpgrade.lastStateUsingHaMeta();
-            }
+                && flinkService.isHaMetadataAvailable(deployConfig)) {
+            LOG.info(
+                    "Job is not running but HA metadata is available for last state restore, ready for upgrade");
+            return JobUpgrade.lastStateUsingHaMeta();
         }
 
         var jmDeployStatus = status.getJobManagerDeploymentStatus();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -23,25 +23,25 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkSessionJobSpec;
-import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
+import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.autoscaler.KubernetesJobAutoScalerContext;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
+import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
+import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.deployment.AbstractJobReconciler;
-import org.apache.flink.kubernetes.operator.service.AbstractFlinkService;
+import org.apache.flink.kubernetes.operator.service.SuspendMode;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
 import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
-import org.apache.commons.lang3.ObjectUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
-import java.util.concurrent.ExecutionException;
 
 /** The reconciler for the {@link FlinkSessionJob}. */
 public class SessionJobReconciler
@@ -98,14 +98,13 @@ public class SessionJobReconciler
     }
 
     @Override
-    protected void cancelJob(FlinkResourceContext<FlinkSessionJob> ctx, UpgradeMode upgradeMode)
+    protected boolean cancelJob(FlinkResourceContext<FlinkSessionJob> ctx, SuspendMode suspendMode)
             throws Exception {
-        var conf = ObjectUtils.firstNonNull(ctx.getObserveConfig(), new Configuration());
-
-        ctx.getFlinkService()
-                .cancelSessionJob(ctx.getResource(), upgradeMode, conf)
-                .ifPresent(location -> setUpgradeSavepointPath(ctx, location));
-        ctx.getResource().getStatus().getJobStatus().setJobId(null);
+        var result =
+                ctx.getFlinkService()
+                        .cancelSessionJob(ctx.getResource(), suspendMode, ctx.getObserveConfig());
+        result.getSavepointPath().ifPresent(location -> setUpgradeSavepointPath(ctx, location));
+        return result.isPending();
     }
 
     @Override
@@ -115,6 +114,25 @@ public class SessionJobReconciler
 
     @Override
     public DeleteControl cleanupInternal(FlinkResourceContext<FlinkSessionJob> ctx) {
+        var status = ctx.getResource().getStatus();
+        long delay = ctx.getOperatorConfig().getProgressCheckInterval().toMillis();
+        if (status.getReconciliationStatus().isBeforeFirstDeployment()
+                || ReconciliationUtils.isJobInTerminalState(status)
+                || status.getReconciliationStatus()
+                                .deserializeLastReconciledSpec()
+                                .getJob()
+                                .getState()
+                        == JobState.SUSPENDED
+                || JobStatusObserver.JOB_NOT_FOUND_ERR.equals(status.getError())) {
+            // Job is not running, nothing to do...
+            return DeleteControl.defaultDelete();
+        }
+
+        if (ReconciliationUtils.isJobCancelling(status)) {
+            LOG.info("Waiting for pending cancellation");
+            return DeleteControl.noFinalizerRemoval().rescheduleAfter(delay);
+        }
+
         Optional<FlinkDeployment> flinkDepOptional =
                 ctx.getJosdkContext().getSecondaryResource(FlinkDeployment.class);
 
@@ -123,25 +141,21 @@ public class SessionJobReconciler
             if (jobID != null) {
                 try {
                     var observeConfig = ctx.getObserveConfig();
-                    UpgradeMode upgradeMode =
+                    var suspendMode =
                             observeConfig.getBoolean(
                                             KubernetesOperatorConfigOptions.SAVEPOINT_ON_DELETION)
-                                    ? UpgradeMode.SAVEPOINT
-                                    : UpgradeMode.STATELESS;
-                    cancelJob(ctx, upgradeMode);
-                } catch (ExecutionException e) {
-                    if (AbstractFlinkService.isJobMissingOrTerminated(e)) {
-                        return DeleteControl.defaultDelete();
+                                    ? SuspendMode.SAVEPOINT
+                                    : SuspendMode.STATELESS;
+                    if (cancelJob(ctx, suspendMode)) {
+                        LOG.info("Waiting for pending cancellation");
+                        return DeleteControl.noFinalizerRemoval().rescheduleAfter(delay);
                     }
-                    long delay = ctx.getOperatorConfig().getProgressCheckInterval().toMillis();
+                } catch (Exception e) {
                     LOG.error(
-                            "Failed to cancel job {}, will reschedule after {} milliseconds.",
-                            jobID,
+                            "Failed to cancel job, will reschedule after {} milliseconds.",
                             delay,
                             e);
                     return DeleteControl.noFinalizerRemoval().rescheduleAfter(delay);
-                } catch (Exception e) {
-                    LOG.error("Failed to cancel job {}.", jobID, e);
                 }
             }
         } else {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -39,8 +39,6 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -50,8 +48,6 @@ import java.util.Optional;
 
 /** Service for submitting and interacting with Flink clusters and jobs. */
 public interface FlinkService {
-
-    Logger LOG = LoggerFactory.getLogger(FlinkService.class);
 
     KubernetesClient getKubernetesClient();
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -35,7 +35,6 @@ import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
-import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.artifact.ArtifactManager;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
@@ -67,7 +66,6 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -118,10 +116,10 @@ public class NativeFlinkService extends AbstractFlinkService {
     }
 
     @Override
-    public Optional<String> cancelJob(
-            FlinkDeployment deployment, UpgradeMode upgradeMode, Configuration configuration)
+    public CancelResult cancelJob(
+            FlinkDeployment deployment, SuspendMode suspendMode, Configuration configuration)
             throws Exception {
-        return cancelJob(deployment, upgradeMode, configuration, false);
+        return cancelJob(deployment, suspendMode, configuration, false);
     }
 
     @Override
@@ -131,12 +129,6 @@ public class NativeFlinkService extends AbstractFlinkService {
                 .inNamespace(namespace)
                 .withLabels(KubernetesUtils.getJobManagerSelectors(clusterId))
                 .list();
-    }
-
-    @Override
-    protected PodList getTmPodList(String namespace, String clusterId) {
-        // Native mode does not manage TaskManager
-        return new PodList();
     }
 
     protected void submitClusterInternal(Configuration conf) throws Exception {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
@@ -28,7 +28,6 @@ import org.apache.flink.kubernetes.KubernetesClusterClientFactory;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
-import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.artifact.ArtifactManager;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.config.Mode;
@@ -46,7 +45,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -81,10 +79,10 @@ public class StandaloneFlinkService extends AbstractFlinkService {
     }
 
     @Override
-    public Optional<String> cancelJob(
-            FlinkDeployment deployment, UpgradeMode upgradeMode, Configuration conf)
+    public CancelResult cancelJob(
+            FlinkDeployment deployment, SuspendMode suspendMode, Configuration conf)
             throws Exception {
-        return cancelJob(deployment, upgradeMode, conf, true);
+        return cancelJob(deployment, suspendMode, conf, true);
     }
 
     @Override
@@ -93,15 +91,6 @@ public class StandaloneFlinkService extends AbstractFlinkService {
                 .pods()
                 .inNamespace(namespace)
                 .withLabels(StandaloneKubernetesUtils.getJobManagerSelectors(clusterId))
-                .list();
-    }
-
-    @Override
-    protected PodList getTmPodList(String namespace, String clusterId) {
-        return kubernetesClient
-                .pods()
-                .inNamespace(namespace)
-                .withLabels(StandaloneKubernetesUtils.getTaskManagerSelectors(clusterId))
                 .list();
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/SuspendMode.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/SuspendMode.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.service;
+
+import lombok.RequiredArgsConstructor;
+
+/** Suspend mode. */
+@RequiredArgsConstructor
+public enum SuspendMode {
+    NOOP,
+    STATELESS,
+    SAVEPOINT,
+    CANCEL,
+    LAST_STATE;
+
+    public boolean deleteCluster() {
+        return this == STATELESS || this == LAST_STATE;
+    }
+
+    public boolean deleteHaMeta() {
+        return this != LAST_STATE;
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/RollbackTest.java
@@ -159,7 +159,7 @@ public class RollbackTest {
                     dep.getSpec().setRestartNonce(10L);
                     testController.reconcile(dep, context);
                 },
-                true);
+                false);
     }
 
     @Test
@@ -265,7 +265,7 @@ public class RollbackTest {
                     testController.reconcile(dep, context);
                     flinkService.setPortReady(true);
                 },
-                false);
+                true);
     }
 
     @Test
@@ -352,7 +352,7 @@ public class RollbackTest {
             FlinkDeployment deployment,
             ThrowingRunnable<Exception> triggerRollback,
             ThrowingRunnable<Exception> validateAndRecover,
-            boolean injectValidationError)
+            boolean expectTwoStepRollback)
             throws Exception {
 
         var flinkConfiguration = deployment.getSpec().getFlinkConfiguration();
@@ -376,12 +376,12 @@ public class RollbackTest {
 
         assertFalse(deployment.getStatus().getReconciliationStatus().isLastReconciledSpecStable());
         assertEquals(
-                deployment.getSpec().getJob() != null
+                expectTwoStepRollback
                         ? ReconciliationState.ROLLING_BACK
                         : ReconciliationState.ROLLED_BACK,
                 deployment.getStatus().getReconciliationStatus().getState());
 
-        if (injectValidationError) {
+        if (expectTwoStepRollback) {
             deployment.getSpec().setLogConfiguration(Map.of("invalid", "entry"));
         }
         flinkService.setJobManagerReady(true);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.observer;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.configuration.PipelineOptionsInternal;
+import org.apache.flink.kubernetes.operator.OperatorTestBase;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.api.spec.JobState;
+import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
+import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
+import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import lombok.Getter;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for the {@link JobStatusObserver}. */
+@EnableKubernetesMockClient(crud = true)
+public class JobStatusObserverTest extends OperatorTestBase {
+
+    @Getter private KubernetesClient kubernetesClient;
+    private JobStatusObserver<FlinkDeployment> observer;
+
+    @Override
+    public void setup() {
+        observer = new JobStatusObserver<>(eventRecorder);
+    }
+
+    @ParameterizedTest
+    @MethodSource("cancellingArgs")
+    void testCancellingToMissing(
+            JobStatus fromStatus, UpgradeMode upgradeMode, JobState expectedAfter) {
+        var job = initSessionJob();
+        job.getSpec().getJob().setUpgradeMode(upgradeMode);
+        var status = job.getStatus();
+        var jobStatus = status.getJobStatus();
+        jobStatus.setState(fromStatus.name());
+        assertEquals(
+                JobState.RUNNING,
+                status.getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getState());
+        observer.observe(
+                (FlinkResourceContext)
+                        getResourceContext(
+                                job,
+                                TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient)));
+        assertEquals(
+                JobStatusObserver.JOB_NOT_FOUND_ERR,
+                flinkResourceEventCollector.events.poll().getMessage());
+        assertEquals(
+                expectedAfter,
+                status.getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getState());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = JobStatus.class, mode = EnumSource.Mode.EXCLUDE, names = "CANCELED")
+    void testCancellingToTerminal(JobStatus fromStatus) throws Exception {
+        var deployment = initDeployment();
+        var status = deployment.getStatus();
+        var jobStatus = status.getJobStatus();
+        jobStatus.setState(fromStatus.name());
+        assertEquals(
+                JobState.RUNNING,
+                status.getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getState());
+        var ctx = getResourceContext(deployment);
+        flinkService.submitApplicationCluster(
+                deployment.getSpec().getJob(), ctx.getDeployConfig(deployment.getSpec()), false);
+        flinkService.cancelJob(JobID.fromHexString(jobStatus.getJobId()), false);
+        observer.observe(ctx);
+        assertEquals(
+                EventRecorder.Reason.JobStatusChanged.name(),
+                flinkResourceEventCollector.events.poll().getReason());
+        assertEquals(
+                JobState.SUSPENDED,
+                status.getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getState());
+    }
+
+    private static Stream<Arguments> cancellingArgs() {
+        var args = new ArrayList<Arguments>();
+        for (var status : JobStatus.values()) {
+            for (var upgradeMode : UpgradeMode.values()) {
+                args.add(
+                        Arguments.of(
+                                status,
+                                upgradeMode,
+                                upgradeMode == UpgradeMode.STATELESS
+                                                && !status.isGloballyTerminalState()
+                                        ? JobState.SUSPENDED
+                                        : JobState.RUNNING));
+            }
+        }
+        return args.stream();
+    }
+
+    private static FlinkDeployment initDeployment() {
+        FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        var jobId = new JobID().toHexString();
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID.key(), jobId);
+        deployment.getStatus().getJobStatus().setJobId(jobId);
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
+        return deployment;
+    }
+
+    private static FlinkSessionJob initSessionJob() {
+        var job = TestUtils.buildSessionJob();
+        var jobId = new JobID().toHexString();
+        job.getSpec()
+                .getFlinkConfiguration()
+                .put(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID.key(), jobId);
+        job.getStatus().getJobStatus().setJobId(jobId);
+        job.getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(job.getSpec(), job);
+        return job;
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/FlinkSessionJobObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/sessionjob/FlinkSessionJobObserverTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.kubernetes.operator.OperatorTestBase;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkSessionJobSpec;
+import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType;
@@ -114,7 +115,19 @@ public class FlinkSessionJobObserverTest extends OperatorTestBase {
         observer.observe(sessionJob, readyContext);
         Assertions.assertEquals(
                 JobStatus.RECONCILING.name(), sessionJob.getStatus().getJobStatus().getState());
+        Assertions.assertEquals(
+                JobState.SUSPENDED,
+                sessionJob
+                        .getStatus()
+                        .getReconciliationStatus()
+                        .deserializeLastReconciledSpec()
+                        .getJob()
+                        .getState());
+
+        // reset
         sessionJob.getStatus().getJobStatus().setJobId(jobID);
+        ReconciliationUtils.updateLastReconciledSpec(
+                sessionJob, (s, m) -> s.getJob().setState(JobState.RUNNING));
 
         // testing multi job
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
@@ -40,7 +40,7 @@ import org.apache.flink.kubernetes.operator.api.status.Savepoint;
 import org.apache.flink.kubernetes.operator.api.status.SavepointFormatType;
 import org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
-import org.apache.flink.kubernetes.operator.exception.RecoveryFailureException;
+import org.apache.flink.kubernetes.operator.exception.UpgradeFailureException;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.TestReconcilerAdapter;
 import org.apache.flink.kubernetes.operator.service.CheckpointHistoryWrapper;
@@ -213,7 +213,7 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
         deployment.getStatus().getJobStatus().setState("RECONCILING");
 
         Assertions.assertThrows(
-                RecoveryFailureException.class,
+                UpgradeFailureException.class,
                 () -> {
                     deployment
                             .getStatus()
@@ -223,7 +223,7 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                 });
 
         Assertions.assertThrows(
-                RecoveryFailureException.class,
+                UpgradeFailureException.class,
                 () -> {
                     deployment
                             .getStatus()
@@ -367,9 +367,13 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
             assertEquals(JobState.RUNNING, lastReconciledSpec.getJob().getState());
         } else {
             assertEquals(
-                    JobManagerDeploymentStatus.MISSING,
+                    toMode == UpgradeMode.STATELESS
+                            ? JobManagerDeploymentStatus.MISSING
+                            : JobManagerDeploymentStatus.DEPLOYING,
                     deployment.getStatus().getJobManagerDeploymentStatus());
-            assertEquals(JobState.SUSPENDED, lastReconciledSpec.getJob().getState());
+            assertEquals(
+                    toMode == UpgradeMode.STATELESS ? JobState.SUSPENDED : JobState.RUNNING,
+                    lastReconciledSpec.getJob().getState());
             assertEquals(
                     toMode == UpgradeMode.STATELESS ? UpgradeMode.STATELESS : UpgradeMode.SAVEPOINT,
                     lastReconciledSpec.getJob().getUpgradeMode());
@@ -437,7 +441,9 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
         deployment.getSpec().setImage(newImage);
         reconciler.reconcile(deployment, context);
         assertEquals(
-                ReconciliationState.UPGRADING,
+                upgradeMode == UpgradeMode.STATELESS
+                        ? ReconciliationState.UPGRADING
+                        : ReconciliationState.DEPLOYED,
                 deployment.getStatus().getReconciliationStatus().getState());
         lastReconciledSpec =
                 deployment.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
@@ -464,11 +470,24 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                 flinkService.listJobs().get(0).f0);
     }
 
-    @Test
-    public void testLastStateMaxCheckpointAge() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testLastStateMaxCheckpointAge(boolean cancellable) throws Exception {
         var deployment = TestUtils.buildApplicationCluster();
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(
+                        KubernetesOperatorConfigOptions.OPERATOR_JOB_UPGRADE_LAST_STATE_CANCEL_JOB
+                                .key(),
+                        Boolean.toString(cancellable));
         deployment.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
         ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
+
+        var expectedWhenNoSavepoint =
+                cancellable
+                        ? AbstractJobReconciler.JobUpgrade.lastStateUsingCancel()
+                        : AbstractJobReconciler.JobUpgrade.lastStateUsingHaMeta();
 
         // Set job status to running
         var jobStatus = deployment.getStatus().getJobStatus();
@@ -482,9 +501,7 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
         var ctx = getResourceContext(deployment);
         var deployConf = ctx.getDeployConfig(deployment.getSpec());
 
-        assertEquals(
-                AbstractJobReconciler.AvailableUpgradeMode.of(UpgradeMode.LAST_STATE),
-                jobReconciler.getAvailableUpgradeMode(ctx, deployConf));
+        assertEquals(expectedWhenNoSavepoint, jobReconciler.getJobUpgrade(ctx, deployConf));
 
         deployConf.set(
                 KubernetesOperatorConfigOptions.OPERATOR_JOB_UPGRADE_LAST_STATE_CHECKPOINT_MAX_AGE,
@@ -495,15 +512,13 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
 
         // Job started just now
         jobStatus.setStartTime(Long.toString(now));
-        assertEquals(
-                AbstractJobReconciler.AvailableUpgradeMode.of(UpgradeMode.LAST_STATE),
-                jobReconciler.getAvailableUpgradeMode(ctx, deployConf));
+        assertEquals(expectedWhenNoSavepoint, jobReconciler.getJobUpgrade(ctx, deployConf));
 
         // Job started more than a minute ago
         jobStatus.setStartTime(Long.toString(now - 61000));
         assertEquals(
-                AbstractJobReconciler.AvailableUpgradeMode.of(UpgradeMode.SAVEPOINT),
-                jobReconciler.getAvailableUpgradeMode(ctx, deployConf));
+                AbstractJobReconciler.JobUpgrade.savepoint(false),
+                jobReconciler.getJobUpgrade(ctx, deployConf));
 
         // If we have a pending savepoint within the max age, wait
         flinkService.setCheckpointInfo(
@@ -513,8 +528,8 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                                 new CheckpointHistoryWrapper.PendingCheckpointInfo(
                                         0, now - 30000))));
         assertEquals(
-                AbstractJobReconciler.AvailableUpgradeMode.pendingUpgrade(),
-                jobReconciler.getAvailableUpgradeMode(ctx, deployConf));
+                AbstractJobReconciler.JobUpgrade.pendingUpgrade(),
+                jobReconciler.getJobUpgrade(ctx, deployConf));
 
         // If pending savepoint triggered before max age, use savepoint
         flinkService.setCheckpointInfo(
@@ -524,14 +539,12 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                                 new CheckpointHistoryWrapper.PendingCheckpointInfo(
                                         0, now - 61000))));
         assertEquals(
-                AbstractJobReconciler.AvailableUpgradeMode.of(UpgradeMode.SAVEPOINT),
-                jobReconciler.getAvailableUpgradeMode(ctx, deployConf));
+                AbstractJobReconciler.JobUpgrade.savepoint(false),
+                jobReconciler.getJobUpgrade(ctx, deployConf));
 
         // Allow fallback to job start even with pending savepoint
         jobStatus.setStartTime(Long.toString(now - 30000));
-        assertEquals(
-                AbstractJobReconciler.AvailableUpgradeMode.of(UpgradeMode.LAST_STATE),
-                jobReconciler.getAvailableUpgradeMode(ctx, deployConf));
+        assertEquals(expectedWhenNoSavepoint, jobReconciler.getJobUpgrade(ctx, deployConf));
 
         // Recent completed checkpoint
         jobStatus.setStartTime(Long.toString(now - 61000));
@@ -543,9 +556,7 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                         Optional.of(
                                 new CheckpointHistoryWrapper.PendingCheckpointInfo(
                                         0, now - 61000))));
-        assertEquals(
-                AbstractJobReconciler.AvailableUpgradeMode.of(UpgradeMode.LAST_STATE),
-                jobReconciler.getAvailableUpgradeMode(ctx, deployConf));
+        assertEquals(expectedWhenNoSavepoint, jobReconciler.getJobUpgrade(ctx, deployConf));
 
         // Job start and checkpoint too old, trigger savepoint
         jobStatus.setStartTime(Long.toString(now - 61000));
@@ -558,8 +569,8 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                                 new CheckpointHistoryWrapper.PendingCheckpointInfo(
                                         0, now - 61000))));
         assertEquals(
-                AbstractJobReconciler.AvailableUpgradeMode.of(UpgradeMode.SAVEPOINT),
-                jobReconciler.getAvailableUpgradeMode(ctx, deployConf));
+                AbstractJobReconciler.JobUpgrade.savepoint(false),
+                jobReconciler.getJobUpgrade(ctx, deployConf));
     }
 
     private static Stream<Arguments> testInitialJmDeployCannotStartParams() {
@@ -681,11 +692,10 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
     }
 
     @Test
-    public void testUpgradeModeChangedToLastStateShouldTriggerSavepointWhileHADisabled()
-            throws Exception {
+    public void testUpgradeModeChangedToLastStateShouldCancelWhileHADisabled() throws Exception {
         flinkService.setHaDataAvailable(false);
 
-        final FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        var deployment = TestUtils.buildApplicationCluster();
         deployment.getSpec().getFlinkConfiguration().remove(HighAvailabilityOptions.HA_MODE.key());
 
         reconciler.reconcile(deployment, context);
@@ -694,7 +704,7 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                 deployment.getStatus().getJobManagerDeploymentStatus());
 
         // Not ready for spec changes, the reconciliation is not performed
-        final String newImage = "new-image-1";
+        String newImage = "new-image-1";
         deployment.getSpec().getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
         deployment.getSpec().setImage(newImage);
         reconciler.reconcile(deployment, context);
@@ -711,6 +721,15 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
         // Ready for spec changes, the reconciliation should be performed
         verifyAndSetRunningJobsToStatus(deployment, flinkService.listJobs());
         reconciler.reconcile(deployment, context);
+        assertEquals("CANCELLING", deployment.getStatus().getJobStatus().getState());
+
+        String expectedSavepointPath = "savepoint_0";
+        var jobStatus = deployment.getStatus().getJobStatus();
+        jobStatus.setState("CANCELED");
+        jobStatus
+                .getSavepointInfo()
+                .setLastSavepoint(Savepoint.of(expectedSavepointPath, SnapshotTriggerType.UNKNOWN));
+
         reconciler.reconcile(deployment, context);
         assertEquals(
                 newImage,
@@ -720,10 +739,8 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                         .deserializeLastReconciledSpec()
                         .getImage());
         // Upgrade mode changes from stateless to last-state should trigger a savepoint
-        final String expectedSavepointPath = "savepoint_0";
-        var snapshots = TestUtils.getFlinkStateSnapshotsForResource(kubernetesClient, deployment);
-        assertThat(snapshots).isNotEmpty();
-        assertEquals(expectedSavepointPath, snapshots.get(0).getSpec().getSavepoint().getPath());
+        var runningJobs = flinkService.listJobs();
+        assertEquals(expectedSavepointPath, runningJobs.get(0).f0);
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test for {@link org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils}. */
 public class ReconciliationUtilsTest {
@@ -63,20 +62,6 @@ public class ReconciliationUtilsTest {
         assertFalse(updateControl.isUpdateResource());
         assertFalse(updateControl.isUpdateStatus());
         assertNotEquals(0, updateControl.getScheduleDelay().get());
-    }
-
-    @Test
-    public void testRescheduleIfImmediateFlagSet() {
-        var previous = BaseTestUtils.buildApplicationCluster();
-        var current = BaseTestUtils.buildApplicationCluster();
-        var updateControl =
-                ReconciliationUtils.toUpdateControl(operatorConfiguration, current, previous, true);
-        assertTrue(updateControl.getScheduleDelay().get() > 0);
-
-        current.getStatus().setImmediateReconciliationNeeded(true);
-        updateControl =
-                ReconciliationUtils.toUpdateControl(operatorConfiguration, current, previous, true);
-        assertEquals(0, updateControl.getScheduleDelay().get());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Rework the last-state upgrade mode to not be solely reliant on HA metadata but to be flexible and use the job cancel mechanism in other cases. This change also allows the session jobs to use last-state upgrade mode where HA metadata is not accessible the same way as for Application clusters.

### Last state upgrades using cancel

Currently last-state upgrade mode relies purely on HA metadata that is available for application deployments to simulate a failover during upgrade and make the JM pick up the correct last state automatically. This has a couple limitations, first and foremost is that it is not applicable to session jobs.

With this PR we introduce a new mechanism for last-state upgrades of non-terminal jobs (the terminal case is already covered by existing mechanisms):

1. Cancel the job through rest API (async operation)
2. Wait until the job cancellation completes and the job becomes CANCELLED (terminal state)
3. Observe last state information through REST API and use that for upgrade (upgrade flow already there for terminal jobs) 

This new mechanism is similar to what a human operator would do for these jobs and does not rely on HA metadata and works for both application and session jobs and also in cases where HA metadata is not usable otherwise such as during version upgrades, or if HA is disabled etc.

### Changes to the reconciliation flow for correct cancellation during upgrades

Currently the async nature of cancellation is not handled correctly in the reconciler even though session jobs use this to cancel jobs which can lead to in extreme cases 2 parallel jobs running on the same cluster.

To handle this, the reconciler now explicitly checks for cancelling state and does not perform other upgrade actions until that completes. Also after initiating an async cancel action through the REST API we immediately exit and re-schedule the observation to wait until the cancellation completes and we can observe the last state of the cluster.

The observer now recognises the CANCELLING state also as special user initiated action and when the job becomes CANCELLED (or not found in case of session jobs) it marks it explicitly SUSPENDED. This means that the reconciler will always resumes it subsequently, eliminating a risk of ending up with a cancelled job if the spec change was rolled back in the meantime.

### Refactored and improved FlinkService cancel methods

To eliminate duplicate logic and overall reduce complexity the cancel application / session jobs methods have been refactored to re-use the common parts. Also a significant portion of the logic has been removed by separating the suspend and restore (upgrade) mechanism.

The `JobUpgrade` utility class now encapsulates the necessary suspend and restore mechanism for the stateful upgrade depending on the current observed state and also. This allows us to better handle cases of async cancellation (SuspendMode.CANCEL) or if the job is already cancelled (or in terminal state) do nothing (SuspendMode.NOOP) and simply perform the restore.

### Misc session job changes / fixes

In addition to making last-state upgrade mode generally available for session jobs this PR includes several critical fixes to the core upgrade cleanup logic as a result of this work such as:

 - Improved cleanup method that correctly waits until the job is fully cancelled instead of deleting the CR too early (risk of leaving the job there)
 - Call observe during cancel for session jobs for correct behaviour
 - Use correct job config generation for session jobs similar to applications, such as retaining checkpoints during cancellation by default which is needed for the above cancel mechanism

### Other changes / improvements as an outcome

- Remove last-state upgrade limitations for apps and use cancel in these cases (flink version upgrade for non-running jobs, jobs without HA enabled)

## Verifying this change

 - Existing unit and E2Es guard the current behaviour
 - New unit tests have been added to cover the session job last-state upgrades and the improved observe, reconcile, cleanup flow
 - Extensive manual testing on local kubernetes
 - Session job e2e extended with last-state test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs updated
