### PR TITLE
[FLINK-36145] Rename flinkStateSnapshotReference to initialState

### DIFF
--- a/docs/content/docs/concepts/controller-flow.md
+++ b/docs/content/docs/concepts/controller-flow.md
@@ -98,7 +98,7 @@ It’s very important to understand that the Observer phase records a point-in-t
 The `AbstractFlinkResourceReconciler` encapsulates the core reconciliation flow for all Flink resource types. Let’s take a look at the high level flow before we go into specifics for session, application and session job resources.
 
 1. Check if the resource is ready for reconciliation or if there are any pending operations that should not be interrupted (manual savepoints for example)
-2. If this is the first deployment attempt for the resource, we simply deploy it. It’s important to note here that this is the only deploy operation where we use the `flinkStateSnapshotReference` provided in the spec.
+2. If this is the first deployment attempt for the resource, we simply deploy it. It’s important to note here that this is the only deploy operation where we use the `initialState` provided in the spec.
 3. Next we determine if the desired spec changed and the type of change: `IGNORE, SCALE, UPGRADE`. Only for scale and upgrade type changes do we need to execute further reconciliation logic.
 4. If we have upgrade/scale spec changes we execute the upgrade logic specific for the resource type
 5. If we did not receive any spec change we still have to ensure that the currently deployed resources are fully reconciled:

--- a/docs/content/docs/custom-resource/job-management.md
+++ b/docs/content/docs/custom-resource/job-management.md
@@ -247,17 +247,17 @@ Users have two options to restore a job from a target savepoint / checkpoint
 
 ### Redeploy using the savepointRedeployNonce
 
-It is possible to redeploy a `FlinkDeployment` or `FlinkSessionJob` resource from a target savepoint by using the combination of `savepointRedeployNonce` and `flinkStateSnapshotReference` in the job spec:
+It is possible to redeploy a `FlinkDeployment` or `FlinkSessionJob` resource from a target savepoint by using the combination of `savepointRedeployNonce` and `initialState` in the job spec:
 
 ```yaml
  job:
-   flinkStateSnapshotReference:
+   initialState:
      path: file://redeploy-target-savepoint
    # If not set previously, set to 1, otherwise increment, e.g. 2
    savepointRedeployNonce: 1
 ```
 
-When changing the `savepointRedeployNonce` the operator will redeploy the job to the savepoint defined in the `flinkStateSnapshotReference`. The savepoint path must not be empty. 
+When changing the `savepointRedeployNonce` the operator will redeploy the job to the savepoint defined in the `initialState`. The savepoint path must not be empty. 
 
 {{< hint warning >}}
 Rollbacks are not supported after redeployments.
@@ -271,7 +271,7 @@ However, this also means that savepoint history is lost and the operator won't c
  1. Locate the latest checkpoint/savepoint metafile in your configured checkpoint/savepoint directory.
  2. Delete the `FlinkDeployment` resource for your application
  3. Check that you have the current savepoint, and that your `FlinkDeployment` is deleted completely
- 4. Modify your `FlinkDeployment` JobSpec and set `flinkStateSnapshotReference.path` to your last checkpoint location
+ 4. Modify your `FlinkDeployment` JobSpec and set `initialState.path` to your last checkpoint location
  5. Recreate the deployment
 
 These steps ensure that the operator will start completely fresh from the user defined savepoint path and can hopefully fully recover.

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -188,7 +188,7 @@ This serves as a full reference for FlinkDeployment and FlinkSessionJob custom r
 | state | org.apache.flink.kubernetes.operator.api.spec.JobState | Desired state for the job. |
 | savepointTriggerNonce | java.lang.Long | Nonce used to manually trigger savepoint for the running job. In order to trigger a savepoint, change the number to a different non-null value. |
 | initialSavepointPath | java.lang.String | Savepoint path used by the job the first time it is deployed or during savepoint redeployments (triggered by changing the savepointRedeployNonce). |
-| flinkStateSnapshotReference | org.apache.flink.kubernetes.operator.api.spec.FlinkStateSnapshotReference | Snapshot reference used by the job the first time it is deployed or during savepoint redeployments (triggered by changing the savepointRedeployNonce). |
+| initialState | org.apache.flink.kubernetes.operator.api.spec.FlinkStateSnapshotReference | Snapshot reference used by the job the first time it is deployed or during savepoint redeployments (triggered by changing the savepointRedeployNonce). |
 | checkpointTriggerNonce | java.lang.Long | Nonce used to manually trigger checkpoint for the running job. In order to trigger a checkpoint, change the number to a different non-null value. |
 | upgradeMode | org.apache.flink.kubernetes.operator.api.spec.UpgradeMode | Upgrade mode of the Flink job. |
 | allowNonRestoredState | java.lang.Boolean | Allow checkpoint state that cannot be mapped to any job vertex in tasks. |

--- a/docs/content/docs/custom-resource/snapshots.md
+++ b/docs/content/docs/custom-resource/snapshots.md
@@ -38,7 +38,7 @@ If you set this to false, the operator will keep using the deprecated status fie
 To create a savepoint or checkpoint, exactly one of the spec fields `savepoint` or `checkpoint` must present. 
 Furthermore, in case of a savepoint you can signal to the operator that the savepoint already exists using the `alreadyExists` field, and the operator will mark it as a successful snapshot in the next reconciliation phase.
 
-You can also instruct the Operator to start a new FlinkDeployment/FlinkSessionJob from an existing snapshot CR by using `flinkStateSnapshotReference` in the job spec.
+You can also instruct the Operator to start a new FlinkDeployment/FlinkSessionJob from an existing snapshot CR by using `initialState` in the job spec.
 
 ## Examples
 
@@ -80,7 +80,7 @@ spec:
 
 ```yaml
  job:
-   flinkStateSnapshotReference:
+   initialState:
      namespace: flink  # not required if it's in the same namespace
      name: example-savepoint
 ```

--- a/docs/content/docs/operations/upgrade.md
+++ b/docs/content/docs/operations/upgrade.md
@@ -148,20 +148,20 @@ Here is a reference example of upgrading a `basic-checkpoint-ha-example` deploym
     ```
 5. Restore the job:
 
-   Deploy the previously deleted job using this [FlinkDeployemnt](https://raw.githubusercontent.com/apache/flink-kubernetes-operator/main/examples/basic-checkpoint-ha.yaml) with `v1beta1` and explicitly set the `job.flinkStateSnapshotReference.path` to the savepoint location obtained from the step 1.
+   Deploy the previously deleted job using this [FlinkDeployemnt](https://raw.githubusercontent.com/apache/flink-kubernetes-operator/main/examples/basic-checkpoint-ha.yaml) with `v1beta1` and explicitly set the `job.initialState.path` to the savepoint location obtained from the step 1.
 
     ```
     spec:
       ...
       job:
-        flinkStateSnapshotReference: 
+        initialState: 
           path: /flink-data/savepoints/savepoint-000000-aec3dd08e76d/_metadata
         upgradeMode: savepoint
       ...
     ```
     Alternatively, we may use this command to edit and deploy the manifest:
     ```sh
-    wget -qO - https://raw.githubusercontent.com/apache/flink-kubernetes-operator/main/examples/basic-checkpoint-ha.yaml| yq w - "spec.job.flinkStateSnapshotReference.path" "/flink-data/savepoints/savepoint-000000-aec3dd08e76d/_metadata"| kubectl apply -f -
+    wget -qO - https://raw.githubusercontent.com/apache/flink-kubernetes-operator/main/examples/basic-checkpoint-ha.yaml| yq w - "spec.job.initialState.path" "/flink-data/savepoints/savepoint-000000-aec3dd08e76d/_metadata"| kubectl apply -f -
     ```
    Finally, verify that `deploy/basic-checkpoint-ha-example` log has:
     ```

--- a/examples/snapshot/job-from-savepoint.yaml
+++ b/examples/snapshot/job-from-savepoint.yaml
@@ -64,6 +64,6 @@ spec:
     jarURI: local:///opt/flink/examples/streaming/StateMachineExample.jar
     parallelism: 2
     upgradeMode: savepoint
-    flinkStateSnapshotReference:
+    initialState:
       name: example-savepoint
       namespace: flink

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
@@ -80,7 +80,7 @@ public class JobSpec implements Diffable<JobSpec> {
      * redeployments (triggered by changing the savepointRedeployNonce).
      */
     @SpecDiff(DiffType.IGNORE)
-    private FlinkStateSnapshotReference flinkStateSnapshotReference;
+    private FlinkStateSnapshotReference initialState;
 
     /**
      * Nonce used to manually trigger checkpoint for the running job. In order to trigger a

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -184,11 +184,10 @@ public abstract class AbstractFlinkResourceReconciler<
             return Optional.empty();
         }
 
-        if (spec.getJob().getFlinkStateSnapshotReference() != null) {
+        if (spec.getJob().getInitialState() != null) {
             return Optional.of(
                     FlinkStateSnapshotUtils.getValidatedFlinkStateSnapshotPath(
-                            ctx.getKubernetesClient(),
-                            spec.getJob().getFlinkStateSnapshotReference()));
+                            ctx.getKubernetesClient(), spec.getJob().getInitialState()));
         }
 
         return Optional.ofNullable(spec.getJob().getInitialSavepointPath());
@@ -233,7 +232,7 @@ public abstract class AbstractFlinkResourceReconciler<
             CR cr, SPEC spec, Configuration deployConfig, STATUS status, KubernetesClient client) {
         if (spec.getJob() != null) {
             var initialUpgradeMode = UpgradeMode.STATELESS;
-            var snapshotRef = spec.getJob().getFlinkStateSnapshotReference();
+            var snapshotRef = spec.getJob().getInitialState();
             var initialSp = spec.getJob().getInitialSavepointPath();
 
             if (snapshotRef != null) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -498,7 +498,7 @@ public abstract class AbstractJobReconciler<
         cancelJob(ctx, UpgradeMode.STATELESS);
         currentDeploySpec.getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
 
-        var snapshotRef = currentDeploySpec.getJob().getFlinkStateSnapshotReference();
+        var snapshotRef = currentDeploySpec.getJob().getInitialState();
         var initialSavepointPath = currentDeploySpec.getJob().getInitialSavepointPath();
 
         if (snapshotRef == null && initialSavepointPath != null) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -295,9 +295,9 @@ public class DefaultValidator implements FlinkResourceValidator {
         }
 
         if (!StringUtils.isNullOrWhitespaceOnly(job.getInitialSavepointPath())
-                && job.getFlinkStateSnapshotReference() != null) {
+                && job.getInitialState() != null) {
             return Optional.of(
-                    "Cannot set both initialSavepointPath and flinkStateSnapshotReference in the job spec");
+                    "Cannot set both initialSavepointPath and initialState in the job spec");
         }
 
         return Optional.empty();
@@ -475,9 +475,9 @@ public class DefaultValidator implements FlinkResourceValidator {
                     && !newJob.getSavepointRedeployNonce()
                             .equals(oldJob.getSavepointRedeployNonce())) {
                 if (StringUtils.isNullOrWhitespaceOnly(newJob.getInitialSavepointPath())
-                        && newJob.getFlinkStateSnapshotReference() == null) {
+                        && newJob.getInitialState() == null) {
                     return Optional.of(
-                            "InitialSavepointPath and flinkStateSnapshotReference must not be empty for savepoint redeployment");
+                            "InitialSavepointPath and initialState must not be empty for savepoint redeployment");
                 }
             }
         }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -532,11 +532,11 @@ public class DefaultValidatorTest {
                 dep -> {
                     dep.getSpec()
                             .getJob()
-                            .setFlinkStateSnapshotReference(
+                            .setInitialState(
                                     FlinkStateSnapshotReference.builder().name("snapshot").build());
                     dep.getSpec().getJob().setInitialSavepointPath("s0");
                 },
-                "Cannot set both initialSavepointPath and flinkStateSnapshotReference in the job spec");
+                "Cannot set both initialSavepointPath and initialState in the job spec");
     }
 
     @Test
@@ -615,9 +615,9 @@ public class DefaultValidatorTest {
                             .serializeAndSetLastReconciledSpec(dep.getSpec(), dep);
                     job.setSavepointRedeployNonce(1L);
                     job.setInitialSavepointPath(null);
-                    job.setFlinkStateSnapshotReference(null);
+                    job.setInitialState(null);
                 },
-                "InitialSavepointPath and flinkStateSnapshotReference must not be empty for savepoint redeployment");
+                "InitialSavepointPath and initialState must not be empty for savepoint redeployment");
 
         testError(
                 dep -> {
@@ -628,7 +628,7 @@ public class DefaultValidatorTest {
                     job.setSavepointRedeployNonce(1L);
                     job.setInitialSavepointPath(" ");
                 },
-                "InitialSavepointPath and flinkStateSnapshotReference must not be empty for savepoint redeploymen");
+                "InitialSavepointPath and initialState must not be empty for savepoint redeploymen");
 
         testError(
                 dep -> {
@@ -642,7 +642,7 @@ public class DefaultValidatorTest {
                     job.setSavepointRedeployNonce(2L);
                     job.setInitialSavepointPath(null);
                 },
-                "InitialSavepointPath and flinkStateSnapshotReference must not be empty for savepoint redeploymen");
+                "InitialSavepointPath and initialState must not be empty for savepoint redeploymen");
     }
 
     @ParameterizedTest

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -88,7 +88,9 @@ spec:
                     type: integer
                   entryClass:
                     type: string
-                  flinkStateSnapshotReference:
+                  initialSavepointPath:
+                    type: string
+                  initialState:
                     properties:
                       name:
                         type: string
@@ -97,8 +99,6 @@ spec:
                       path:
                         type: string
                     type: object
-                  initialSavepointPath:
-                    type: string
                   jarURI:
                     type: string
                   parallelism:

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -49,7 +49,9 @@ spec:
                     type: integer
                   entryClass:
                     type: string
-                  flinkStateSnapshotReference:
+                  initialSavepointPath:
+                    type: string
+                  initialState:
                     properties:
                       name:
                         type: string
@@ -58,8 +60,6 @@ spec:
                       path:
                         type: string
                     type: object
-                  initialSavepointPath:
-                    type: string
                   jarURI:
                     type: string
                   parallelism:


### PR DESCRIPTION
## What is the purpose of the change

Rename JobSpec.flinkStateSnapshotReference to JobSpec.initialState. This should make less verbose and easier to memorize for users. 

flinkStateSnapshotReference field has not been released officially yet, so this change should not affect production users.

## Brief change log

- Rename in Java, Markdown files and examples
- Regenerate CRDs

## Verifying this change

- Unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? updated
