### PR TITLE
[FLINK-36018][autoscaler] Support lazy scale down to avoid frequent rescaling

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -147,16 +147,16 @@
             <td>Maximum cap for the observed restart time when 'job.autoscaler.restart.time-tracking.enabled' is set to true.</td>
         </tr>
         <tr>
+            <td><h5>job.autoscaler.scale-down.interval</h5></td>
+            <td style="word-wrap: break-word;">1 h</td>
+            <td>Duration</td>
+            <td>The delay time for scale down to be executed. If it is greater than 0, the scale down will be delayed. Delayed rescale can merge multiple scale downs within `scale-down.interval` into a scale down, thereby reducing the number of rescales. Reducing the frequency of job restarts can improve job availability. Scale down can be executed directly if it's less than or equal 0.</td>
+        </tr>
+        <tr>
             <td><h5>job.autoscaler.scale-down.max-factor</h5></td>
             <td style="word-wrap: break-word;">0.6</td>
             <td>Double</td>
             <td>Max scale down factor. 1 means no limit on scale down, 0.6 means job can only be scaled down with 60% of the original parallelism.</td>
-        </tr>
-        <tr>
-            <td><h5>job.autoscaler.scale-up.grace-period</h5></td>
-            <td style="word-wrap: break-word;">1 h</td>
-            <td>Duration</td>
-            <td>Duration in which no scale down of a vertex is allowed after it has been scaled up.</td>
         </tr>
         <tr>
             <td><h5>job.autoscaler.scale-up.max-factor</h5></td>

--- a/e2e-tests/data/autoscaler.yaml
+++ b/e2e-tests/data/autoscaler.yaml
@@ -40,6 +40,7 @@ spec:
     job.autoscaler.scaling.enabled: "true"
     job.autoscaler.stabilization.interval: "5s"
     job.autoscaler.metrics.window: "1m"
+    job.autoscaler.scale-down.interval: "0m"
 
 #    Invalid Validations for testing autoscaler configurations
 #    kubernetes.operator.job.autoscaler.scale-down.max-factor: "-0.6"

--- a/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStore.java
+++ b/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStore.java
@@ -19,6 +19,7 @@ package org.apache.flink.autoscaler.jdbc.state;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.autoscaler.DelayedScaleDown;
 import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.ScalingSummary;
 import org.apache.flink.autoscaler.ScalingTracking;
@@ -49,6 +50,7 @@ import java.util.TreeMap;
 
 import static org.apache.flink.autoscaler.jdbc.state.StateType.COLLECTED_METRICS;
 import static org.apache.flink.autoscaler.jdbc.state.StateType.CONFIG_OVERRIDES;
+import static org.apache.flink.autoscaler.jdbc.state.StateType.DELAYED_SCALE_DOWN;
 import static org.apache.flink.autoscaler.jdbc.state.StateType.PARALLELISM_OVERRIDES;
 import static org.apache.flink.autoscaler.jdbc.state.StateType.SCALING_HISTORY;
 import static org.apache.flink.autoscaler.jdbc.state.StateType.SCALING_TRACKING;
@@ -215,6 +217,35 @@ public class JdbcAutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
     }
 
     @Override
+    public void storeDelayedScaleDown(Context jobContext, DelayedScaleDown delayedScaleDown)
+            throws Exception {
+        jdbcStateStore.putSerializedState(
+                getSerializeKey(jobContext),
+                DELAYED_SCALE_DOWN,
+                serializeDelayedScaleDown(delayedScaleDown));
+    }
+
+    @Nonnull
+    @Override
+    public DelayedScaleDown getDelayedScaleDown(Context jobContext) {
+        Optional<String> delayedScaleDown =
+                jdbcStateStore.getSerializedState(getSerializeKey(jobContext), DELAYED_SCALE_DOWN);
+        if (delayedScaleDown.isEmpty()) {
+            return new DelayedScaleDown();
+        }
+
+        try {
+            return deserializeDelayedScaleDown(delayedScaleDown.get());
+        } catch (JacksonException e) {
+            LOG.error(
+                    "Could not deserialize delayed scale down, possibly the format changed. Discarding...",
+                    e);
+            jdbcStateStore.removeSerializedState(getSerializeKey(jobContext), DELAYED_SCALE_DOWN);
+            return new DelayedScaleDown();
+        }
+    }
+
+    @Override
     public void clearAll(Context jobContext) {
         jdbcStateStore.clearAll(getSerializeKey(jobContext));
     }
@@ -295,5 +326,17 @@ public class JdbcAutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
             LOG.error("Failed to deserialize ConfigOverrides", e);
             return null;
         }
+    }
+
+    private static String serializeDelayedScaleDown(DelayedScaleDown delayedScaleDown)
+            throws JacksonException {
+        return YAML_MAPPER.writeValueAsString(delayedScaleDown.getFirstTriggerTime());
+    }
+
+    private static DelayedScaleDown deserializeDelayedScaleDown(String delayedScaleDown)
+            throws JacksonException {
+        Map<JobVertexID, Instant> firstTriggerTime =
+                YAML_MAPPER.readValue(delayedScaleDown, new TypeReference<>() {});
+        return new DelayedScaleDown(firstTriggerTime);
     }
 }

--- a/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/StateType.java
+++ b/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/StateType.java
@@ -27,7 +27,8 @@ public enum StateType {
     SCALING_TRACKING("scalingTracking"),
     COLLECTED_METRICS("collectedMetrics"),
     PARALLELISM_OVERRIDES("parallelismOverrides"),
-    CONFIG_OVERRIDES("configOverrides");
+    CONFIG_OVERRIDES("configOverrides"),
+    DELAYED_SCALE_DOWN("delayedScaleDown");
 
     /**
      * The identifier of each state type, it will be used to store. Please ensure the identifier is

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/DelayedScaleDown.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/DelayedScaleDown.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import lombok.Getter;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/** All delayed scale down requests. */
+public class DelayedScaleDown {
+
+    @Getter private final Map<JobVertexID, Instant> firstTriggerTime;
+
+    // Have any scale down request been updated? It doesn't need to be stored, it is only used to
+    // determine whether DelayedScaleDown needs to be stored.
+    @Getter private boolean isUpdated = false;
+
+    public DelayedScaleDown() {
+        this.firstTriggerTime = new HashMap<>();
+    }
+
+    public DelayedScaleDown(Map<JobVertexID, Instant> firstTriggerTime) {
+        this.firstTriggerTime = firstTriggerTime;
+    }
+
+    Optional<Instant> getFirstTriggerTimeForVertex(JobVertexID vertex) {
+        return Optional.ofNullable(firstTriggerTime.get(vertex));
+    }
+
+    void updateTriggerTime(JobVertexID vertex, Instant instant) {
+        firstTriggerTime.put(vertex, instant);
+        isUpdated = true;
+    }
+
+    void clearVertex(JobVertexID vertex) {
+        Instant removed = firstTriggerTime.remove(vertex);
+        if (removed != null) {
+            isUpdated = true;
+        }
+    }
+
+    void clearAll() {
+        if (firstTriggerTime.isEmpty()) {
+            return;
+        }
+        firstTriggerTime.clear();
+        isUpdated = true;
+    }
+}

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -214,9 +214,20 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
             return;
         }
 
+        var delayedScaleDown = stateStore.getDelayedScaleDown(ctx);
         var parallelismChanged =
                 scalingExecutor.scaleResource(
-                        ctx, evaluatedMetrics, scalingHistory, scalingTracking, now, jobTopology);
+                        ctx,
+                        evaluatedMetrics,
+                        scalingHistory,
+                        scalingTracking,
+                        now,
+                        jobTopology,
+                        delayedScaleDown);
+
+        if (delayedScaleDown.isUpdated()) {
+            stateStore.storeDelayedScaleDown(ctx, delayedScaleDown);
+        }
 
         if (parallelismChanged) {
             autoscalerMetrics.incrementScaling();

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -28,6 +28,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.Preconditions;
 
+import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,11 +38,12 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.SortedMap;
 
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.MAX_SCALE_DOWN_FACTOR;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.MAX_SCALE_UP_FACTOR;
-import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALE_UP_GRACE_PERIOD;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALE_DOWN_INTERVAL;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_EVENT_INTERVAL;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.VERTEX_MAX_PARALLELISM;
@@ -51,6 +53,7 @@ import static org.apache.flink.autoscaler.metrics.ScalingMetric.MAX_PARALLELISM;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.PARALLELISM;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_RATE;
 import static org.apache.flink.autoscaler.topology.ShipStrategy.HASH;
+import static org.apache.flink.util.Preconditions.checkArgument;
 
 /** Component responsible for computing vertex parallelism based on the scaling metrics. */
 public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
@@ -71,13 +74,66 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
         this.autoScalerEventHandler = autoScalerEventHandler;
     }
 
-    public int computeScaleTargetParallelism(
+    /**
+     * The rescaling will be triggered if any vertex's ParallelismResult is required. This means
+     * that if all vertices' ParallelismResult is optional, rescaling will be ignored.
+     */
+    @Getter
+    public static class ParallelismResult {
+
+        // This rescale is required or optional.
+        private final boolean required;
+        private final int newParallelism;
+
+        private ParallelismResult(boolean required, int newParallelism) {
+            this.required = required;
+            this.newParallelism = newParallelism;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ParallelismResult that = (ParallelismResult) o;
+            return required == that.required && newParallelism == that.newParallelism;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(required, newParallelism);
+        }
+
+        @Override
+        public String toString() {
+            return "ParallelismResult{"
+                    + "required="
+                    + required
+                    + ", newParallelism="
+                    + newParallelism
+                    + '}';
+        }
+
+        public static ParallelismResult required(int newParallelism) {
+            return new ParallelismResult(true, newParallelism);
+        }
+
+        public static ParallelismResult optional(int newParallelism) {
+            return new ParallelismResult(false, newParallelism);
+        }
+    }
+
+    public ParallelismResult computeScaleTargetParallelism(
             Context context,
             JobVertexID vertex,
             Collection<ShipStrategy> inputShipStrategies,
             Map<ScalingMetric, EvaluatedScalingMetric> evaluatedMetrics,
             SortedMap<Instant, ScalingSummary> history,
-            Duration restartTime) {
+            Duration restartTime,
+            DelayedScaleDown delayedScaleDown) {
         var conf = context.getConfiguration();
         var currentParallelism = (int) evaluatedMetrics.get(PARALLELISM).getCurrent();
         double averageTrueProcessingRate = evaluatedMetrics.get(TRUE_PROCESSING_RATE).getAverage();
@@ -85,7 +141,7 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
             LOG.warn(
                     "True processing rate is not available for {}, cannot compute new parallelism",
                     vertex);
-            return currentParallelism;
+            return ParallelismResult.optional(currentParallelism);
         }
 
         double targetCapacity =
@@ -95,7 +151,7 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
             LOG.warn(
                     "Target data rate is not available for {}, cannot compute new parallelism",
                     vertex);
-            return currentParallelism;
+            return ParallelismResult.optional(currentParallelism);
         }
 
         LOG.debug("Target processing capacity for {} is {}", vertex, targetCapacity);
@@ -131,65 +187,92 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
                         Math.min(currentParallelism, conf.getInteger(VERTEX_MIN_PARALLELISM)),
                         Math.max(currentParallelism, conf.getInteger(VERTEX_MAX_PARALLELISM)));
 
-        if (newParallelism == currentParallelism
-                || blockScalingBasedOnPastActions(
-                        context,
-                        vertex,
-                        conf,
-                        evaluatedMetrics,
-                        history,
-                        currentParallelism,
-                        newParallelism)) {
-            return currentParallelism;
+        if (newParallelism == currentParallelism) {
+            // Clear delayed scale down request if the new parallelism is equal to
+            // currentParallelism.
+            delayedScaleDown.clearVertex(vertex);
+            return ParallelismResult.optional(currentParallelism);
         }
 
         // We record our expectations for this scaling operation
         evaluatedMetrics.put(
                 ScalingMetric.EXPECTED_PROCESSING_RATE,
                 EvaluatedScalingMetric.of(cappedTargetCapacity));
-        return newParallelism;
+
+        return detectBlockScaling(
+                context,
+                vertex,
+                conf,
+                evaluatedMetrics,
+                history,
+                currentParallelism,
+                newParallelism,
+                delayedScaleDown);
     }
 
-    private boolean blockScalingBasedOnPastActions(
+    private ParallelismResult detectBlockScaling(
             Context context,
             JobVertexID vertex,
             Configuration conf,
             Map<ScalingMetric, EvaluatedScalingMetric> evaluatedMetrics,
             SortedMap<Instant, ScalingSummary> history,
             int currentParallelism,
-            int newParallelism) {
+            int newParallelism,
+            DelayedScaleDown delayedScaleDown) {
+        checkArgument(
+                currentParallelism != newParallelism,
+                "The newParallelism is equal to currentParallelism, no scaling is needed. This is probably a bug.");
 
-        // If we don't have past scaling actions for this vertex, there is nothing to do
-        if (history.isEmpty()) {
-            return false;
-        }
+        var scaledUp = currentParallelism < newParallelism;
 
-        boolean scaledUp = currentParallelism < newParallelism;
-        var lastScalingTs = history.lastKey();
-        var lastSummary = history.get(lastScalingTs);
+        if (scaledUp) {
+            // Clear delayed scale down request if the new parallelism is greater than
+            // currentParallelism.
+            delayedScaleDown.clearVertex(vertex);
 
-        if (currentParallelism == lastSummary.getNewParallelism() && lastSummary.isScaledUp()) {
-            if (scaledUp) {
-                return detectIneffectiveScaleUp(
-                        context, vertex, conf, evaluatedMetrics, lastSummary);
-            } else {
-                return detectImmediateScaleDownAfterScaleUp(vertex, conf, lastScalingTs);
+            // If we don't have past scaling actions for this vertex, don't block scale up.
+            if (history.isEmpty()) {
+                return ParallelismResult.required(newParallelism);
             }
+
+            var lastSummary = history.get(history.lastKey());
+            if (currentParallelism == lastSummary.getNewParallelism()
+                    && lastSummary.isScaledUp()
+                    && detectIneffectiveScaleUp(
+                            context, vertex, conf, evaluatedMetrics, lastSummary)) {
+                // Block scale up when last rescale is ineffective.
+                return ParallelismResult.optional(currentParallelism);
+            }
+
+            return ParallelismResult.required(newParallelism);
+        } else {
+            return detectImmediateScaleDown(delayedScaleDown, vertex, conf, newParallelism);
         }
-        return false;
     }
 
-    private boolean detectImmediateScaleDownAfterScaleUp(
-            JobVertexID vertex, Configuration conf, Instant lastScalingTs) {
+    private ParallelismResult detectImmediateScaleDown(
+            DelayedScaleDown delayedScaleDown,
+            JobVertexID vertex,
+            Configuration conf,
+            int newParallelism) {
+        var scaleDownInterval = conf.get(SCALE_DOWN_INTERVAL);
+        if (scaleDownInterval.toMillis() <= 0) {
+            // The scale down interval is disable, so don't block scaling.
+            return ParallelismResult.required(newParallelism);
+        }
 
-        var gracePeriod = conf.get(SCALE_UP_GRACE_PERIOD);
-        if (lastScalingTs.plus(gracePeriod).isAfter(clock.instant())) {
-            LOG.info(
-                    "Skipping immediate scale down after scale up within grace period for {}",
-                    vertex);
-            return true;
+        var firstTriggerTime = delayedScaleDown.getFirstTriggerTimeForVertex(vertex);
+        if (firstTriggerTime.isEmpty()) {
+            LOG.info("The scale down request is delayed for {}", vertex);
+            delayedScaleDown.updateTriggerTime(vertex, clock.instant());
+            return ParallelismResult.optional(newParallelism);
+        }
+
+        if (clock.instant().isBefore(firstTriggerTime.get().plus(scaleDownInterval))) {
+            LOG.debug("Try to skip immediate scale down within scale-down interval for {}", vertex);
+            return ParallelismResult.optional(newParallelism);
         } else {
-            return false;
+            return ParallelismResult.required(newParallelism);
         }
     }
 
@@ -258,7 +341,7 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
             double scaleFactor,
             int parallelismLowerLimit,
             int parallelismUpperLimit) {
-        Preconditions.checkArgument(
+        checkArgument(
                 parallelismLowerLimit <= parallelismUpperLimit,
                 "The parallelism lower limitation must not be greater than the parallelism upper limitation.");
         if (parallelismLowerLimit > maxParallelism) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingExecutor.java
@@ -45,7 +45,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.EXCLUDED_PERIODS;
@@ -100,22 +102,23 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
             Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory,
             ScalingTracking scalingTracking,
             Instant now,
-            JobTopology jobTopology)
+            JobTopology jobTopology,
+            DelayedScaleDown delayedScaleDown)
             throws Exception {
         var conf = context.getConfiguration();
         var restartTime = scalingTracking.getMaxRestartTimeOrDefault(conf);
 
         var scalingSummaries =
                 computeScalingSummary(
-                        context, evaluatedMetrics, scalingHistory, restartTime, jobTopology);
+                        context,
+                        evaluatedMetrics,
+                        scalingHistory,
+                        restartTime,
+                        jobTopology,
+                        delayedScaleDown);
 
         if (scalingSummaries.isEmpty()) {
             LOG.info("All job vertices are currently running at their target parallelism.");
-            return false;
-        }
-
-        if (allVerticesWithinUtilizationTarget(
-                evaluatedMetrics.getVertexMetrics(), scalingSummaries)) {
             return false;
         }
 
@@ -156,6 +159,9 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
 
         autoScalerStateStore.storeConfigChanges(context, configOverrides);
 
+        // Try to clear all delayed scale down requests after scaling.
+        delayedScaleDown.clearAll();
+
         return true;
     }
 
@@ -172,12 +178,16 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                                                 scalingSummary.getNewParallelism())));
     }
 
-    protected static boolean allVerticesWithinUtilizationTarget(
+    @VisibleForTesting
+    static boolean allRequiredVerticesWithinUtilizationTarget(
             Map<JobVertexID, Map<ScalingMetric, EvaluatedScalingMetric>> evaluatedMetrics,
-            Map<JobVertexID, ScalingSummary> scalingSummaries) {
+            Set<JobVertexID> requiredVertices) {
+        // All vertices' ParallelismResult is optional, rescaling will be ignored.
+        if (requiredVertices.isEmpty()) {
+            return true;
+        }
 
-        for (Map.Entry<JobVertexID, ScalingSummary> entry : scalingSummaries.entrySet()) {
-            var vertex = entry.getKey();
+        for (JobVertexID vertex : requiredVertices) {
             var metrics = evaluatedMetrics.get(vertex);
 
             double trueProcessingRate = metrics.get(TRUE_PROCESSING_RATE).getAverage();
@@ -212,7 +222,8 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
             EvaluatedMetrics evaluatedMetrics,
             Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory,
             Duration restartTime,
-            JobTopology jobTopology) {
+            JobTopology jobTopology,
+            DelayedScaleDown delayedScaleDown) {
         LOG.debug("Restart time used in scaling summary computation: {}", restartTime);
 
         if (isJobUnderMemoryPressure(context, evaluatedMetrics.getGlobalMetrics())) {
@@ -221,6 +232,8 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
         }
 
         var out = new HashMap<JobVertexID, ScalingSummary>();
+        var requiredVertices = new HashSet<JobVertexID>();
+
         var excludeVertexIdList =
                 context.getConfiguration().get(AutoScalerOptions.VERTEX_EXCLUDE_IDS);
         evaluatedMetrics
@@ -235,7 +248,7 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                                 var currentParallelism =
                                         (int) metrics.get(ScalingMetric.PARALLELISM).getCurrent();
 
-                                var newParallelism =
+                                var parallelismResult =
                                         jobVertexScaler.computeScaleTargetParallelism(
                                                 context,
                                                 v,
@@ -243,15 +256,30 @@ public class ScalingExecutor<KEY, Context extends JobAutoScalerContext<KEY>> {
                                                 metrics,
                                                 scalingHistory.getOrDefault(
                                                         v, Collections.emptySortedMap()),
-                                                restartTime);
-                                if (currentParallelism != newParallelism) {
-                                    out.put(
-                                            v,
-                                            new ScalingSummary(
-                                                    currentParallelism, newParallelism, metrics));
+                                                restartTime,
+                                                delayedScaleDown);
+                                if (currentParallelism == parallelismResult.getNewParallelism()) {
+                                    return;
                                 }
+                                if (parallelismResult.isRequired()) {
+                                    requiredVertices.add(v);
+                                }
+                                out.put(
+                                        v,
+                                        new ScalingSummary(
+                                                currentParallelism,
+                                                parallelismResult.getNewParallelism(),
+                                                metrics));
                             }
                         });
+
+        // If the Utilization of all required tasks is within range, we can skip scaling.
+        // It means that if only optional tasks are out of scope, we still need to ignore scale.
+        if (allRequiredVerticesWithinUtilizationTarget(
+                evaluatedMetrics.getVertexMetrics(), requiredVertices)) {
+            return Map.of();
+        }
+
         return out;
     }
 

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -102,13 +102,20 @@ public class AutoScalerOptions {
                     .withFallbackKeys(oldOperatorConfigKey("target.utilization.boundary"))
                     .withDescription(
                             "Target vertex utilization boundary. Scaling won't be performed if the processing capacity is within [target_rate / (target_utilization - boundary), (target_rate / (target_utilization + boundary)]");
-    public static final ConfigOption<Duration> SCALE_UP_GRACE_PERIOD =
-            autoScalerConfig("scale-up.grace-period")
+
+    public static final ConfigOption<Duration> SCALE_DOWN_INTERVAL =
+            autoScalerConfig("scale-down.interval")
                     .durationType()
                     .defaultValue(Duration.ofHours(1))
-                    .withFallbackKeys(oldOperatorConfigKey("scale-up.grace-period"))
+                    .withDeprecatedKeys(autoScalerConfigKey("scale-up.grace-period"))
+                    .withFallbackKeys(
+                            oldOperatorConfigKey("scale-up.grace-period"),
+                            oldOperatorConfigKey("scale-down.interval"))
                     .withDescription(
-                            "Duration in which no scale down of a vertex is allowed after it has been scaled up.");
+                            "The delay time for scale down to be executed. If it is greater than 0, the scale down will be delayed. "
+                                    + "Delayed rescale can merge multiple scale downs within `scale-down.interval` into a scale down, thereby reducing the number of rescales. "
+                                    + "Reducing the frequency of job restarts can improve job availability. "
+                                    + "Scale down can be executed directly if it's less than or equal 0.");
 
     public static final ConfigOption<Integer> VERTEX_MIN_PARALLELISM =
             autoScalerConfig("vertex.min-parallelism")

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
@@ -18,6 +18,7 @@
 package org.apache.flink.autoscaler.state;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.autoscaler.DelayedScaleDown;
 import org.apache.flink.autoscaler.JobAutoScalerContext;
 import org.apache.flink.autoscaler.ScalingSummary;
 import org.apache.flink.autoscaler.ScalingTracking;
@@ -76,6 +77,12 @@ public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
     ConfigChanges getConfigChanges(Context jobContext) throws Exception;
 
     void removeConfigChanges(Context jobContext) throws Exception;
+
+    void storeDelayedScaleDown(Context jobContext, DelayedScaleDown delayedScaleDown)
+            throws Exception;
+
+    @Nonnull
+    DelayedScaleDown getDelayedScaleDown(Context jobContext) throws Exception;
 
     /** Removes all data from this context. Flush stil needs to be called. */
     void clearAll(Context jobContext) throws Exception;

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
@@ -97,7 +97,7 @@ public class BacklogBasedScalingTest {
         defaultConf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, (double) Integer.MAX_VALUE);
         defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.8);
         defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.1);
-        defaultConf.set(AutoScalerOptions.SCALE_UP_GRACE_PERIOD, Duration.ZERO);
+        defaultConf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
         defaultConf.set(AutoScalerOptions.BACKLOG_PROCESSING_LAG_THRESHOLD, Duration.ofSeconds(1));
 
         autoscaler =

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.autoscaler;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.autoscaler.JobVertexScaler.ParallelismResult;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.event.TestingEventCollector;
 import org.apache.flink.autoscaler.metrics.EvaluatedScalingMetric;
@@ -36,6 +37,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,7 +50,6 @@ import static org.apache.flink.autoscaler.JobVertexScaler.INEFFECTIVE_SCALING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test for vertex parallelism scaler logic. */
@@ -56,6 +57,8 @@ public class JobVertexScalerTest {
 
     private static final Collection<ShipStrategy> NOT_ADJUST_INPUTS =
             List.of(ShipStrategy.REBALANCE, ShipStrategy.RESCALE);
+
+    private final JobVertexID vertex = new JobVertexID();
 
     private TestingEventCollector<JobID, JobAutoScalerContext<JobID>> eventCollector;
     private JobVertexScaler<JobID, JobAutoScalerContext<JobID>> vertexScaler;
@@ -95,127 +98,139 @@ public class JobVertexScalerTest {
     public void testParallelismScaling(Collection<ShipStrategy> inputShipStrategies) {
         var op = new JobVertexID();
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        var delayedScaleDown = new DelayedScaleDown();
 
         assertEquals(
-                5,
+                ParallelismResult.optional(5),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(10, 50, 100),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
-                8,
+                ParallelismResult.optional(8),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(10, 50, 100),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
-                10,
+                ParallelismResult.optional(10),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(10, 80, 100),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
         assertEquals(
-                8,
+                ParallelismResult.optional(8),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(10, 60, 100),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         assertEquals(
-                8,
+                ParallelismResult.optional(8),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(10, 59, 100),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.5);
         assertEquals(
-                10,
+                ParallelismResult.required(10),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(2, 100, 40),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
         assertEquals(
-                4,
+                ParallelismResult.required(4),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(2, 100, 100),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.5);
         assertEquals(
-                5,
+                ParallelismResult.optional(5),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(10, 10, 100),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.6);
         assertEquals(
-                4,
+                ParallelismResult.optional(4),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(10, 10, 100),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.5);
         assertEquals(
-                15,
+                ParallelismResult.required(15),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(10, 200, 10),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.6);
         assertEquals(
-                16,
+                ParallelismResult.required(16),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         op,
                         inputShipStrategies,
                         evaluated(10, 200, 10),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
     }
 
     @Test
@@ -319,95 +334,179 @@ public class JobVertexScalerTest {
     @Test
     public void testMinParallelismLimitIsUsed() {
         conf.setInteger(AutoScalerOptions.VERTEX_MIN_PARALLELISM, 5);
+        var delayedScaleDown = new DelayedScaleDown();
+
         assertEquals(
-                5,
+                ParallelismResult.optional(5),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
                         NOT_ADJUST_INPUTS,
                         evaluated(10, 100, 500),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         // Make sure we respect current parallelism in case it's lower
         assertEquals(
-                4,
+                ParallelismResult.optional(4),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
                         NOT_ADJUST_INPUTS,
                         evaluated(4, 100, 500),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
     }
 
     @Test
     public void testMaxParallelismLimitIsUsed() {
         conf.setInteger(AutoScalerOptions.VERTEX_MAX_PARALLELISM, 10);
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        var delayedScaleDown = new DelayedScaleDown();
+
         assertEquals(
-                10,
+                ParallelismResult.optional(10),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
                         NOT_ADJUST_INPUTS,
                         evaluated(10, 500, 100),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
 
         // Make sure we respect current parallelism in case it's higher
         assertEquals(
-                12,
+                ParallelismResult.optional(12),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         new JobVertexID(),
                         NOT_ADJUST_INPUTS,
                         evaluated(12, 500, 100),
                         Collections.emptySortedMap(),
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
     }
 
     @Test
-    public void testScaleDownAfterScaleUpDetection() {
-        var op = new JobVertexID();
+    public void testDisableScaleDownInterval() {
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
-        conf.set(AutoScalerOptions.SCALE_UP_GRACE_PERIOD, Duration.ofMinutes(1));
-        var clock = Clock.systemDefaultZone();
-        vertexScaler.setClock(clock);
+        conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofMinutes(0));
 
-        var evaluated = evaluated(5, 100, 50);
-        var history = new TreeMap<Instant, ScalingSummary>();
-        assertEquals(
-                10,
-                vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
+        var delayedScaleDown = new DelayedScaleDown();
 
-        history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
+        assertParallelismResult(10, 50, 100, ParallelismResult.required(5), delayedScaleDown);
+    }
 
-        // Should not allow scale back down immediately
-        evaluated = evaluated(10, 50, 100);
-        assertEquals(
-                10,
-                vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
+    @Test
+    public void testRequiredScaleDownAfterInterval() {
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofMinutes(1));
+        var instant = Instant.now();
 
-        // Pass some time...
-        clock = Clock.offset(Clock.systemDefaultZone(), Duration.ofSeconds(61));
-        vertexScaler.setClock(clock);
+        var delayedScaleDown = new DelayedScaleDown();
 
-        assertEquals(
-                5,
-                vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
-        history.put(clock.instant(), new ScalingSummary(10, 5, evaluated));
+        // The scale down shouldn't be required.
+        vertexScaler.setClock(Clock.fixed(instant, ZoneId.systemDefault()));
+        assertParallelismResult(100, 800, 1000, ParallelismResult.optional(80), delayedScaleDown);
+
+        // Within scale down interval.
+        vertexScaler.setClock(
+                Clock.fixed(instant.plus(Duration.ofSeconds(10)), ZoneId.systemDefault()));
+        assertParallelismResult(100, 900, 1000, ParallelismResult.optional(90), delayedScaleDown);
+
+        vertexScaler.setClock(
+                Clock.fixed(instant.plus(Duration.ofSeconds(20)), ZoneId.systemDefault()));
+        assertParallelismResult(100, 820, 1000, ParallelismResult.optional(82), delayedScaleDown);
+
+        vertexScaler.setClock(
+                Clock.fixed(instant.plus(Duration.ofSeconds(40)), ZoneId.systemDefault()));
+        assertParallelismResult(100, 720, 1000, ParallelismResult.optional(72), delayedScaleDown);
+
+        vertexScaler.setClock(
+                Clock.fixed(instant.plus(Duration.ofSeconds(50)), ZoneId.systemDefault()));
+        assertParallelismResult(100, 600, 1000, ParallelismResult.optional(60), delayedScaleDown);
+
+        vertexScaler.setClock(
+                Clock.fixed(instant.plus(Duration.ofSeconds(59)), ZoneId.systemDefault()));
+        assertParallelismResult(100, 640, 1000, ParallelismResult.optional(64), delayedScaleDown);
+
+        // The scale down is required after the scale down interval ends.
+        vertexScaler.setClock(
+                Clock.fixed(instant.plus(Duration.ofSeconds(60)), ZoneId.systemDefault()));
+        assertParallelismResult(100, 700, 1000, ParallelismResult.required(70), delayedScaleDown);
+    }
+
+    @Test
+    public void testImmediateScaleUpWithinScaleDownInterval() {
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofMinutes(1));
+        var instant = Instant.now();
+
+        var delayedScaleDown = new DelayedScaleDown();
+
+        // The scale down shouldn't be required.
+        vertexScaler.setClock(Clock.fixed(instant, ZoneId.systemDefault()));
+        assertParallelismResult(100, 800, 1000, ParallelismResult.optional(80), delayedScaleDown);
+        assertThat(delayedScaleDown.getFirstTriggerTime()).isNotEmpty();
+
+        // Within scale down interval.
+        vertexScaler.setClock(
+                Clock.fixed(instant.plus(Duration.ofSeconds(10)), ZoneId.systemDefault()));
+        assertParallelismResult(100, 900, 1000, ParallelismResult.optional(90), delayedScaleDown);
+        assertThat(delayedScaleDown.getFirstTriggerTime()).isNotEmpty();
 
         // Allow immediate scale up
-        evaluated = evaluated(5, 100, 50);
+        vertexScaler.setClock(
+                Clock.fixed(instant.plus(Duration.ofSeconds(12)), ZoneId.systemDefault()));
+        assertParallelismResult(100, 1700, 1000, ParallelismResult.required(170), delayedScaleDown);
+        assertThat(delayedScaleDown.getFirstTriggerTime()).isEmpty();
+    }
+
+    @Test
+    public void testCancelDelayedScaleDownAfterNewParallelismIsSame() {
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofMinutes(1));
+        var instant = Instant.now();
+
+        var delayedScaleDown = new DelayedScaleDown();
+
+        // The scale down shouldn't be required.
+        vertexScaler.setClock(Clock.fixed(instant, ZoneId.systemDefault()));
+        assertParallelismResult(100, 800, 1000, ParallelismResult.optional(80), delayedScaleDown);
+        assertThat(delayedScaleDown.getFirstTriggerTime()).isNotEmpty();
+
+        // Within scale down interval.
+        vertexScaler.setClock(
+                Clock.fixed(instant.plus(Duration.ofSeconds(10)), ZoneId.systemDefault()));
+        assertParallelismResult(100, 900, 1000, ParallelismResult.optional(90), delayedScaleDown);
+        assertThat(delayedScaleDown.getFirstTriggerTime()).isNotEmpty();
+
+        // The delayed scale down is canceled when new parallelism is same with current parallelism.
+        vertexScaler.setClock(
+                Clock.fixed(instant.plus(Duration.ofSeconds(12)), ZoneId.systemDefault()));
+        assertParallelismResult(100, 1000, 1000, ParallelismResult.optional(100), delayedScaleDown);
+        assertThat(delayedScaleDown.getFirstTriggerTime()).isEmpty();
+    }
+
+    private void assertParallelismResult(
+            int parallelism,
+            int targetDataRate,
+            int trueProcessingRate,
+            ParallelismResult expectedParallelismResult,
+            DelayedScaleDown delayedScaleDown) {
         assertEquals(
-                10,
+                expectedParallelismResult,
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
-        history.put(clock.instant(), new ScalingSummary(5, 10, evaluated));
+                        context,
+                        vertex,
+                        NOT_ADJUST_INPUTS,
+                        evaluated(parallelism, targetDataRate, trueProcessingRate),
+                        new TreeMap<>(),
+                        restartTime,
+                        delayedScaleDown));
     }
 
     @Test
@@ -415,23 +514,37 @@ public class JobVertexScalerTest {
         var op = new JobVertexID();
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
-        conf.set(AutoScalerOptions.SCALE_UP_GRACE_PERIOD, Duration.ZERO);
+        conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
 
         var evaluated = evaluated(5, 100, 50);
         var history = new TreeMap<Instant, ScalingSummary>();
+        var delayedScaleDown = new DelayedScaleDown();
+
         assertEquals(
-                10,
+                ParallelismResult.required(10),
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
+                        context,
+                        op,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
         // Allow to scale higher if scaling was effective (80%)
         evaluated = evaluated(10, 180, 90);
         assertEquals(
-                20,
+                ParallelismResult.required(20),
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
+                        context,
+                        op,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
 
@@ -439,50 +552,84 @@ public class JobVertexScalerTest {
         // 90 -> 94. Do not try to scale above 20
         evaluated = evaluated(20, 180, 94);
         assertEquals(
-                20,
+                ParallelismResult.optional(20),
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
-        assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
+                        context,
+                        op,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
 
         // Still considered ineffective (less than <10%)
         evaluated = evaluated(20, 180, 98);
         assertEquals(
-                20,
+                ParallelismResult.optional(20),
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
-        assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
+                        context,
+                        op,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
 
         // Allow scale up if current parallelism doesnt match last (user rescaled manually)
         evaluated = evaluated(10, 180, 90);
         assertEquals(
-                20,
+                ParallelismResult.required(20),
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
+                        context,
+                        op,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
 
         // Over 10%, effective
         evaluated = evaluated(20, 180, 100);
         assertEquals(
-                36,
+                ParallelismResult.required(36),
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
+                        context,
+                        op,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
 
         // Ineffective but detection is turned off
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, false);
         evaluated = evaluated(20, 180, 90);
         assertEquals(
-                40,
+                ParallelismResult.required(40),
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
+                        context,
+                        op,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
 
         // Allow scale down even if ineffective
         evaluated = evaluated(20, 45, 90);
         assertEquals(
-                10,
+                ParallelismResult.required(10),
                 vertexScaler.computeScaleTargetParallelism(
-                        context, op, NOT_ADJUST_INPUTS, evaluated, history, restartTime));
+                        context,
+                        op,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
     }
 
@@ -492,33 +639,37 @@ public class JobVertexScalerTest {
         var jobVertexID = new JobVertexID();
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
         conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.0);
-        conf.set(AutoScalerOptions.SCALE_UP_GRACE_PERIOD, Duration.ZERO);
+        conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
 
         var evaluated = evaluated(5, 100, 50);
         var history = new TreeMap<Instant, ScalingSummary>();
+        var delayedScaleDown = new DelayedScaleDown();
+
         assertEquals(
-                10,
+                ParallelismResult.required(10),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         jobVertexID,
                         inputShipStrategies,
                         evaluated,
                         history,
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
         assertEquals(100, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(5, 10, evaluated));
 
         // Effective scale, no events triggered
         evaluated = evaluated(10, 180, 90);
         assertEquals(
-                20,
+                ParallelismResult.required(20),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         jobVertexID,
                         inputShipStrategies,
                         evaluated,
                         history,
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
         assertEquals(180, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
         history.put(Instant.now(), new ScalingSummary(10, 20, evaluated));
         assertEquals(0, eventCollector.events.size());
@@ -526,15 +677,15 @@ public class JobVertexScalerTest {
         // Ineffective scale, an event is triggered
         evaluated = evaluated(20, 180, 95);
         assertEquals(
-                20,
+                ParallelismResult.optional(20),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         jobVertexID,
                         inputShipStrategies,
                         evaluated,
                         history,
-                        restartTime));
-        assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
+                        restartTime,
+                        delayedScaleDown));
         assertEquals(1, eventCollector.events.size());
         var event = eventCollector.events.poll();
         assertThat(event).isNotNull();
@@ -552,15 +703,15 @@ public class JobVertexScalerTest {
                 ScalingMetric.TRUE_PROCESSING_RATE,
                 EvaluatedScalingMetric.avg(tpr.getAverage() + 0.01));
         assertEquals(
-                20,
+                ParallelismResult.optional(20),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         jobVertexID,
                         inputShipStrategies,
                         evaluated,
                         history,
-                        restartTime));
-        assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
+                        restartTime,
+                        delayedScaleDown));
         assertEquals(0, eventCollector.events.size());
 
         // reset tpr
@@ -569,29 +720,29 @@ public class JobVertexScalerTest {
         // Repeat ineffective scale with postive interval, no event is triggered
         conf.set(AutoScalerOptions.SCALING_EVENT_INTERVAL, Duration.ofSeconds(1800));
         assertEquals(
-                20,
+                ParallelismResult.optional(20),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         jobVertexID,
                         inputShipStrategies,
                         evaluated,
                         history,
-                        restartTime));
-        assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
+                        restartTime,
+                        delayedScaleDown));
         assertEquals(0, eventCollector.events.size());
 
         // Ineffective scale with interval set to 0, an event is triggered
         conf.set(AutoScalerOptions.SCALING_EVENT_INTERVAL, Duration.ZERO);
         assertEquals(
-                20,
+                ParallelismResult.optional(20),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         jobVertexID,
                         inputShipStrategies,
                         evaluated,
                         history,
-                        restartTime));
-        assertFalse(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
+                        restartTime,
+                        delayedScaleDown));
         assertEquals(1, eventCollector.events.size());
         event = eventCollector.events.poll();
         assertThat(event).isNotNull();
@@ -605,14 +756,15 @@ public class JobVertexScalerTest {
         // Test ineffective scaling switched off
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, false);
         assertEquals(
-                40,
+                ParallelismResult.required(40),
                 vertexScaler.computeScaleTargetParallelism(
                         context,
                         jobVertexID,
                         inputShipStrategies,
                         evaluated,
                         history,
-                        restartTime));
+                        restartTime,
+                        delayedScaleDown));
         assertEquals(1, eventCollector.events.size());
         event = eventCollector.events.poll();
         assertThat(event).isNotNull();

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -187,7 +187,8 @@ public class MetricsCollectionAndEvaluationTest {
                 new HashMap<>(),
                 new ScalingTracking(),
                 clock.instant(),
-                topology);
+                topology,
+                new DelayedScaleDown());
 
         var scaledParallelism = ScalingExecutorTest.getScaledParallelism(stateStore, context);
         assertEquals(4, scaledParallelism.size());
@@ -364,7 +365,7 @@ public class MetricsCollectionAndEvaluationTest {
     public void testTolerateAbsenceOfPendingRecordsMetric() throws Exception {
         var topology = new JobTopology(new VertexInfo(source1, Map.of(), 5, 720));
 
-        metricsCollector = new TestingMetricsCollector(topology);
+        metricsCollector = new TestingMetricsCollector<>(topology);
         metricsCollector.setJobUpdateTs(startTime);
 
         metricsCollector.updateMetrics(
@@ -378,6 +379,7 @@ public class MetricsCollectionAndEvaluationTest {
         var conf = context.getConfiguration();
         conf.set(AutoScalerOptions.STABILIZATION_INTERVAL, Duration.ZERO);
         conf.set(AutoScalerOptions.METRICS_WINDOW, Duration.ofSeconds(2));
+        conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofSeconds(0));
 
         metricsCollector.setClock(clock);
 
@@ -424,7 +426,8 @@ public class MetricsCollectionAndEvaluationTest {
                 new HashMap<>(),
                 new ScalingTracking(),
                 clock.instant(),
-                topology);
+                topology,
+                new DelayedScaleDown());
         var scaledParallelism = ScalingExecutorTest.getScaledParallelism(stateStore, context);
         assertEquals(1, scaledParallelism.get(source1));
     }
@@ -634,6 +637,9 @@ public class MetricsCollectionAndEvaluationTest {
         metricsCollector = new TestingMetricsCollector<>(topology);
         metricsCollector.setJobUpdateTs(startTime);
 
+        var conf = context.getConfiguration();
+        conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofSeconds(0));
+
         metricsCollector.updateMetrics(
                 source1,
                 TestMetrics.builder()
@@ -681,7 +687,8 @@ public class MetricsCollectionAndEvaluationTest {
                 new HashMap<>(),
                 new ScalingTracking(),
                 clock.instant(),
-                topology);
+                topology,
+                new DelayedScaleDown());
         var scaledParallelism = ScalingExecutorTest.getScaledParallelism(stateStore, context);
         assertEquals(1, scaledParallelism.get(source1));
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
@@ -88,7 +88,7 @@ public class RecommendedParallelismTest {
         defaultConf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, (double) Integer.MAX_VALUE);
         defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.8);
         defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.1);
-        defaultConf.set(AutoScalerOptions.SCALE_UP_GRACE_PERIOD, Duration.ZERO);
+        defaultConf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
 
         autoscaler =
                 new JobAutoScalerImpl<>(


### PR DESCRIPTION
## What is the purpose of the change

When the source traffic decreases, the autoscaler scales down job in time to save resources. It causes that each job rescales more than 20 times a day.

## Brief change log

- [FLINK-36018][autoscaler] Support lazy scale down to avoid frequent rescaling
- Configuration Option:
  - Introduce job.autoscaler.scale-down.interval, the default value could be 1 hour.
  - Replace job.autoscaler.scale-up.grace-period with job.autoscaler.scale-down.interval
- Core code change:
  -  Introducing the `DelayedScaleDown` to store the firstTriggerTime for all vertices.
      - The scale down can be triggered when the (now -  firstTriggerTime  > scale-down.interval).
  - Updating the return value type of `JobVertexScaler#computeScaleTargetParallelism` from `int` to `ParallelismResult`
      - `ParallelismResult` introduced the `required` field, it means the parallelism change of current vertex is required or optional.
      - In general, scale up the required, and scale down is optional if it's within `scale-down.interval`.
      - If all parallelism changes are optional, we could ignore rescaling.

## Verifying this change

- Added some unit tests for `JobVertexScalerTest` and `ScalingExecutorTest`.
- Improved the test of `AbstractAutoScalerStateStoreTest`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes, update the autoscaler option.
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature?  yes
  - If yes, how is the feature documented? Added the option description.
