### PR TITLE
[FLINK-36170] bump assert4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ under the License.
         <okhttp.version>4.12.0</okhttp.version>
         <curator-test.version>5.2.0</curator-test.version>
 
-        <assertj.version>3.21.0</assertj.version>
+        <assertj.version>3.26.3</assertj.version>
 
         <quartz.version>2.3.2</quartz.version>
         <hikari.version>5.1.0</hikari.version>


### PR DESCRIPTION
Bump the **assertj-core** version to remediate vulnerabilities on the dependant packages.

Package info:

https://mvnrepository.com/artifact/org.assertj/assertj-core/3.26.3

change info:

https://github.com/r-sidd/flink-kubernetes-operator/blob/main/pom.xml#L99
