### PR TITLE
[FLINK-36179] bump log4j version

### DIFF
--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -53,10 +53,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:3.14.0
 - org.apache.commons:commons-math3:3.6.1
 - org.apache.commons:commons-text:jar:1.10.0
-- org.apache.logging.log4j:log4j-1.2-api:2.17.1
-- org.apache.logging.log4j:log4j-api:2.17.1
-- org.apache.logging.log4j:log4j-core:2.17.1
-- org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+- org.apache.logging.log4j:log4j-1.2-api:2.23.1
+- org.apache.logging.log4j:log4j-api:2.23.1
+- org.apache.logging.log4j:log4j-core:2.23.1
+- org.apache.logging.log4j:log4j-slf4j-impl:2.23.1
 - org.javassist:javassist:3.24.0-GA
 - org.jetbrains.kotlin:kotlin-stdlib-common:1.9.10
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.21

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@ under the License.
         <flink.version>1.19.1</flink.version>
 
         <slf4j.version>1.7.36</slf4j.version>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.23.1</log4j.version>
 
         <spotless.version>2.40.0</spotless.version>
         <it.skip>true</it.skip>


### PR DESCRIPTION
Bumping **log4j** to the latest version (2.23.1) - this will remediate a lot of vulnerabilities in dependant packages.

**Package details:**

https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-1.2-api/2.23.1
https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j-impl/2.23.1
https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api/2.23.1
https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core/2.23.1

**Release notes:**
https://logging.apache.org/log4j/2.x/release-notes.html

Lot of bug fixes has been done in the newer versions and I don't see any breaking changes as such.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes


## Documentation

  - Does this pull request introduce a new feature? no
