### PR TITLE
FLINK-36197 bump curator-test and postgres

### DIFF
--- a/flink-autoscaler-plugin-jdbc/pom.xml
+++ b/flink-autoscaler-plugin-jdbc/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
     <properties>
         <testcontainers.version>1.18.2</testcontainers.version>
-        <postgres.version>42.5.4</postgres.version>
+        <postgres.version>42.5.6</postgres.version>
         <mysql.version>8.0.33</mysql.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@ under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <okhttp.version>4.12.0</okhttp.version>
-        <curator-test.version>5.2.0</curator-test.version>
+        <curator-test.version>5.7.0</curator-test.version>
 
         <assertj.version>3.26.3</assertj.version>
 


### PR DESCRIPTION
Bump **curator-test** version to latest (**5.7.0**) to remediate the vulnerabilities in the dependant packages.

**Package details:**
https://mvnrepository.com/artifact/org.apache.curator/curator-test/5.7.0

Bump **postgresql** version to **42.5.6** to remediate a direct finding.
**Finding details:**
[CVE-2024-1597](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-1597)

**Package details:**
https://mvnrepository.com/artifact/org.postgresql/postgresql/42.5.6

Bump **derby** version to latest **(10.17.1.0)** to remediate direct finding.
**Finding details:**
[CVE-2022-46337](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-46337)

**Package details:**
https://mvnrepository.com/artifact/org.apache.derby/derby/10.17.1.0


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
 
## Documentation

  - Does this pull request introduce a new feature? no
