### PR TITLE
[FLINK-36353][Flink Operator Helm chart] Allow to add affinity for operator pod of helm chart

### DIFF
--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -60,6 +60,9 @@ spec:
       {{- if .Values.operatorPod.nodeSelector }}
       nodeSelector: {{ toYaml .Values.operatorPod.nodeSelector | nindent 8 }}
       {{- end }}
+      {{- if .Values.operatorPod.affinity }}
+      affinity: {{ toYaml .Values.operatorPod.affinity | nindent 8 }}
+      {{- end }}
       {{- with .Values.operatorPod.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -72,12 +72,14 @@ operatorPod:
   #       key: ""
   # dnsPolicy: ""
   # dnsConfig: {}
-  # Node labels for operator pod assignment
+  # Node labels and affinity for operator pod assignment
   # https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
   envFrom:
   # - configMapRef:
   #     name: ""
   nodeSelector: {}
+
+  affinity: {}
   # Node tolerations for operator pod assignment
   # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: []


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The change allows the flink operator pod to be assigned a node based on pod affinity which gives more flexibility


## Brief change log
- Allow pod created by  flink operator to define affinity, so it is more flexible to select a node where the pod can start

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


- Just a change in K8 env to add a affinity. Node slector is already supported but in some cases its nice to have (https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) No
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no) No
  - Core observer or reconciler logic that is regularly executed: (yes / no) No

## Documentation

  - Does this pull request introduce a new feature? (yes / no) No
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)