### PR TITLE
FLINK-36332 Add option to select the Fabric8 httpclient implemention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
           cd flink-autoscaler-plugin-jdbc
           mvn -B verify -Dit.skip=false
           cd ..
-  e2e_smoketest:
+  e2e_smoke_test:
     name: HTTP Client smoke test
     runs-on: ubuntu-latest
     strategy:
@@ -131,6 +131,7 @@ jobs:
           source e2e-tests/utils.sh
           stop_minikube
   e2e_ci:
+    needs: e2e_smoke_test
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,69 @@ jobs:
           cd flink-autoscaler-plugin-jdbc
           mvn -B verify -Dit.skip=false
           cd ..
+  e2e_smoketest:
+    name: HTTP Client smoke test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        http-client: [ "okhttp", "jdk", "jetty", "vertx" ]
+        version: ["v1_20"]
+        mode: ["native"]
+        namespace: ["default"]
+        java-version: ["21"]
+        test:
+          - test_application_operations.sh
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Start minikube
+        run: |
+          source e2e-tests/utils.sh
+          start_minikube
+      - name: Install cert-manager
+        run: |
+          kubectl get pods -A
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
+          kubectl -n cert-manager wait --all=true --for=condition=Available --timeout=300s deploy
+      - name: Build image
+        run: |
+          export SHELL=/bin/bash
+          export DOCKER_BUILDKIT=1
+          eval $(minikube -p minikube docker-env)
+          HTTP_CLIENT=${{ matrix.http-client }}
+          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain --build-arg HTTP_CLIENT="${HTTP_CLIENT:-okhttp}" .
+          docker images
+      - name: Start the operator
+        run: |
+          if [[ "${{ matrix.test }}" == "test_flink_operator_ha.sh" ]]; then
+            sed -i "s/# kubernetes.operator.leader-election.enabled: false/kubernetes.operator.leader-election.enabled: true/" helm/flink-kubernetes-operator/conf/flink-conf.yaml
+            sed -i "s/# kubernetes.operator.leader-election.lease-name: flink-operator-lease/kubernetes.operator.leader-election.lease-name: flink-operator-lease/" helm/flink-kubernetes-operator/conf/flink-conf.yaml
+            sed -i "s/replicas: 1/replicas: 2/" helm/flink-kubernetes-operator/values.yaml
+          fi
+          helm --debug install flink-kubernetes-operator -n ${{ matrix.namespace }} helm/flink-kubernetes-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-latest ${{ matrix.extraArgs }}
+          kubectl wait --for=condition=Available --timeout=120s -n ${{ matrix.namespace }} deploy/flink-kubernetes-operator
+          kubectl get pods -n ${{ matrix.namespace }}
+      - name: Run Flink e2e tests
+        run: |
+          sed -i "s/image: flink:.*/image: ${{ matrix.image }}/" e2e-tests/data/*.yaml
+          sed -i "s/flinkVersion: .*/flinkVersion: ${{ matrix.version }}/" e2e-tests/data/*.yaml
+          sed -i "s/mode: .*/mode: ${{ matrix.mode }}/" e2e-tests/data/*.yaml
+          git diff HEAD
+          echo "Running e2e-tests/$test"
+          bash e2e-tests/${{ matrix.test }} || exit 1
+          git reset --hard
+      - name: Stop the operator
+        run: |
+          helm uninstall -n ${{ matrix.namespace }} flink-kubernetes-operator
+      - name: Stop minikube
+        run: |
+          source e2e-tests/utils.sh
+          stop_minikube
   e2e_ci:
     runs-on: ubuntu-latest
     strategy:
@@ -75,7 +138,6 @@ jobs:
         namespace: ["default","flink"]
         mode: ["native", "standalone"]
         java-version: [ 11, 17, 21 ]
-        http-client: [ "okhttp", "vertx", "jetty",  "jdk" ]
         test:
           - test_application_kubernetes_ha.sh
           - test_application_operations.sh
@@ -99,34 +161,6 @@ jobs:
             image: flink:1.17
           - version: v1_16
             image: flink:1.16
-          - version: v1_20
-            # Version isn't critical but should ideally be latest.
-            mode: "native"
-            namespace: "default"
-            test: test_application_operations.sh
-            http-client: "okhttp"
-            java-version: 21
-          - version: v1_20
-            # Version isn't critical but should ideally be latest.
-            mode: "native"
-            namespace: "default"
-            test: test_application_operations.sh
-            http-client: "vertx"
-            java-version: 21
-          - version: v1_20
-            # Version isn't critical but should ideally be latest.
-            mode: "native"
-            namespace: "default"
-            test: test_application_operations.sh
-            http-client: "jetty"
-            java-version: 21
-          - version: v1_20
-            # Version isn't critical but should ideally be latest.
-            mode: "native"
-            namespace: "default"
-            test: test_application_operations.sh
-            http-client: "jdk"
-            java-version: 21
         exclude:
           - namespace: default
             test: test_multi_sessionjob.sh
@@ -196,8 +230,7 @@ jobs:
           export DOCKER_BUILDKIT=1
           eval $(minikube -p minikube docker-env)
           export JAVA_VERSION=${{ matrix.java-version }}
-          export HTTP_CLIENT=${{ matrix.http-client }}
-          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain --build-arg JAVA_VERSION="${JAVA_VERSION:-11}" --build-arg HTTP_CLIENT="${HTTP_CLIENT:-okhttp}" .
+          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain --build-arg JAVA_VERSION="${JAVA_VERSION:-11}" .
           docker images
       - name: Start the operator
         run: |
@@ -206,7 +239,7 @@ jobs:
             sed -i "s/# kubernetes.operator.leader-election.lease-name: flink-operator-lease/kubernetes.operator.leader-election.lease-name: flink-operator-lease/" helm/flink-kubernetes-operator/conf/flink-conf.yaml
             sed -i "s/replicas: 1/replicas: 2/" helm/flink-kubernetes-operator/values.yaml
           fi
-          helm --debug install flink-kubernetes-operator -n ${{ matrix.namespace }} helm/flink-kubernetes-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-${{ matrix.http-client }}-latest ${{ matrix.extraArgs }}
+          helm --debug install flink-kubernetes-operator -n ${{ matrix.namespace }} helm/flink-kubernetes-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-latest ${{ matrix.extraArgs }}
           kubectl wait --for=condition=Available --timeout=120s -n ${{ matrix.namespace }} deploy/flink-kubernetes-operator
           kubectl get pods -n ${{ matrix.namespace }}
       - name: Run Flink e2e tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,9 @@ jobs:
           export SHELL=/bin/bash
           export DOCKER_BUILDKIT=1
           eval $(minikube -p minikube docker-env)
+          JAVA_VERSION=${{matrix.java-version}}
           HTTP_CLIENT=${{ matrix.http-client }}
-          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain --build-arg HTTP_CLIENT="${HTTP_CLIENT:-okhttp}" .
+          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain --build-arg JAVA_VERSION="${JAVA_VERSION:-11}" --build-arg HTTP_CLIENT="${HTTP_CLIENT:-okhttp}" .
           docker images
       - name: Start the operator
         run: |
@@ -230,7 +231,7 @@ jobs:
           export SHELL=/bin/bash
           export DOCKER_BUILDKIT=1
           eval $(minikube -p minikube docker-env)
-          export JAVA_VERSION=${{ matrix.java-version }}
+          JAVA_VERSION=${{ matrix.java-version }}
           docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain --build-arg JAVA_VERSION="${JAVA_VERSION:-11}" .
           docker images
       - name: Start the operator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
     strategy:
       matrix:
         java-version: [ 11, 17, 21 ]
+        http-client: ["okhttp", "vertx", "jetty",  "jdk"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java-version }}
@@ -44,7 +45,7 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: |
-          mvn -B clean install javadoc:javadoc -Pgenerate-docs
+          mvn -B clean install javadoc:javadoc -Pgenerate-docs -Dfabric8.httpclinent.impl=${{ matrix.httpclient }}
           if [[ $(git diff HEAD | wc -l) -gt 0 ]]; then
             echo "Please generate the java doc via 'mvn clean install -DskipTests -Pgenerate-docs' again"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
     strategy:
       matrix:
         java-version: [ 11, 17, 21 ]
-        http-client: ["okhttp", "vertx", "jetty",  "jdk"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java-version }}
@@ -45,7 +44,7 @@ jobs:
           cache: 'maven'
       - name: Build with Maven
         run: |
-          mvn -B clean install javadoc:javadoc -Pgenerate-docs -Dfabric8.httpclinent.impl=${{ matrix.httpclient }}
+          mvn -B clean install javadoc:javadoc -Pgenerate-docs
           if [[ $(git diff HEAD | wc -l) -gt 0 ]]; then
             echo "Please generate the java doc via 'mvn clean install -DskipTests -Pgenerate-docs' again"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
         namespace: ["default","flink"]
         mode: ["native", "standalone"]
         java-version: [ 11, 17, 21 ]
+        http-client: [ "okhttp", "vertx", "jetty",  "jdk" ]
         test:
           - test_application_kubernetes_ha.sh
           - test_application_operations.sh
@@ -167,7 +168,7 @@ jobs:
           export DOCKER_BUILDKIT=1
           eval $(minikube -p minikube docker-env)
           export JAVA_VERSION=${{ matrix.java-version }}
-          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain --build-arg JAVA_VERSION="${JAVA_VERSION:-11}" .
+          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain --build-arg JAVA_VERSION="${JAVA_VERSION:-11}" --build-arg HTTP_CLIENT=${{ matrix.http-client }} .
           docker images
       - name: Start the operator
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,34 @@ jobs:
             image: flink:1.17
           - version: v1_16
             image: flink:1.16
+          - version: v1_20
+            # Version isn't critical but should ideally be latest.
+            mode: "native"
+            namespace: "default"
+            test: test_application_operations.sh
+            http-client: "okhttp"
+            java-version: 21
+          - version: v1_20
+            # Version isn't critical but should ideally be latest.
+            mode: "native"
+            namespace: "default"
+            test: test_application_operations.sh
+            http-client: "vertx"
+            java-version: 21
+          - version: v1_20
+            # Version isn't critical but should ideally be latest.
+            mode: "native"
+            namespace: "default"
+            test: test_application_operations.sh
+            http-client: "jetty"
+            java-version: 21
+          - version: v1_20
+            # Version isn't critical but should ideally be latest.
+            mode: "native"
+            namespace: "default"
+            test: test_application_operations.sh
+            http-client: "jdk"
+            java-version: 21
         exclude:
           - namespace: default
             test: test_multi_sessionjob.sh
@@ -168,7 +196,8 @@ jobs:
           export DOCKER_BUILDKIT=1
           eval $(minikube -p minikube docker-env)
           export JAVA_VERSION=${{ matrix.java-version }}
-          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain --build-arg JAVA_VERSION="${JAVA_VERSION:-11}" --build-arg HTTP_CLIENT=${{ matrix.http-client }} .
+          export HTTP_CLIENT=${{ matrix.http-client }}
+          docker build --progress=plain --no-cache -f ./Dockerfile -t flink-kubernetes-operator:ci-latest --progress plain --build-arg JAVA_VERSION="${JAVA_VERSION:-11}" --build-arg HTTP_CLIENT="${HTTP_CLIENT:-okhttp}" .
           docker images
       - name: Start the operator
         run: |
@@ -177,7 +206,7 @@ jobs:
             sed -i "s/# kubernetes.operator.leader-election.lease-name: flink-operator-lease/kubernetes.operator.leader-election.lease-name: flink-operator-lease/" helm/flink-kubernetes-operator/conf/flink-conf.yaml
             sed -i "s/replicas: 1/replicas: 2/" helm/flink-kubernetes-operator/values.yaml
           fi
-          helm --debug install flink-kubernetes-operator -n ${{ matrix.namespace }} helm/flink-kubernetes-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-latest ${{ matrix.extraArgs }}
+          helm --debug install flink-kubernetes-operator -n ${{ matrix.namespace }} helm/flink-kubernetes-operator --set image.repository=flink-kubernetes-operator --set image.tag=ci-${{ matrix.http-client }}-latest ${{ matrix.extraArgs }}
           kubectl wait --for=condition=Available --timeout=120s -n ${{ matrix.namespace }} deploy/flink-kubernetes-operator
           kubectl get pods -n ${{ matrix.namespace }}
       - name: Run Flink e2e tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,13 @@
 ARG JAVA_VERSION=11
 FROM maven:3.8.8-eclipse-temurin-${JAVA_VERSION} AS build
 ARG SKIP_TESTS=true
+ARG HTTP_CLIENT=okhttp
 
 WORKDIR /app
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.m2 mvn -ntp clean install -pl flink-kubernetes-standalone,flink-kubernetes-operator-api,flink-kubernetes-operator,flink-autoscaler,flink-kubernetes-webhook -DskipTests=$SKIP_TESTS
+RUN --mount=type=cache,target=/root/.m2 mvn -ntp clean install -pl flink-kubernetes-standalone,flink-kubernetes-operator-api,flink-kubernetes-operator,flink-autoscaler,flink-kubernetes-webhook -DskipTests=$SKIP_TESTS -Dfabric8.httpclinent.impl="$HTTP_CLIENT"
 
 RUN cd /app/tools/license; mkdir jars; cd jars; \
     cp /app/flink-kubernetes-operator/target/flink-kubernetes-operator-*-shaded.jar . && \

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -38,6 +38,8 @@ under the License.
             <!-- required by FlinkConfigManagerTest -->
             --add-opens=java.base/java.util=ALL-UNNAMED
         </surefire.module.config>
+        <!-- valid options can be checked at https://central.sonatype.com/search?q=kubernetes-httpclient- currently: okhttp, jdk, jetty, vertx -->
+        <fabric8.httpclinent.impl>okhttp</fabric8.httpclinent.impl>
     </properties>
 
     <dependencies>
@@ -45,6 +47,12 @@ under the License.
             <groupId>io.javaoperatorsdk</groupId>
             <artifactId>operator-framework</artifactId>
             <version>${operator.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.fabric8</groupId>
+                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -60,25 +68,23 @@ under the License.
         </dependency>
 
         <dependency>
+            <!-- https://github.com/fabric8io/kubernetes-client/blob/main/doc/FAQ.md#what-artifacts-should-my-project-depend-on-->
             <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-httpclient-okhttp</artifactId>
+            <artifactId>kubernetes-httpclient-${fabric8.httpclinent.impl}</artifactId>
             <version>${fabric8.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>*</artifactId>
+                    <artifactId>okhttp</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>logging-interceptor</artifactId>
-            <version>${okhttp.version}</version>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${jetbrains.annotations.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Flink -->
@@ -174,6 +180,12 @@ under the License.
             <artifactId>kubernetes-server-mock</artifactId>
             <version>${fabric8.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>mockwebserver</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -412,6 +424,22 @@ under the License.
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>depend-on-okhttp4</id>
+            <activation>
+                <property>
+                    <name>fabric8.httpclinent.impl</name>
+                    <value>okhttp</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                    <version>${okhttp.version}</version>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -80,13 +80,6 @@ under the License.
             </exclusions>
         </dependency>
 
-        <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-            <version>${jetbrains.annotations.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Flink -->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
@@ -40,7 +40,6 @@ import org.apache.flink.shaded.jackson2.org.yaml.snakeyaml.LoaderOptions;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import lombok.SneakyThrows;
 import org.apache.commons.io.IOUtils;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -202,7 +201,7 @@ public class KubernetesAutoScalerStateStore
                 .orElse(new HashMap<>());
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public ConfigChanges getConfigChanges(KubernetesJobAutoScalerContext jobContext) {
         return configMapStore

--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -47,8 +47,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.fabric8:kubernetes-model-scheduling:jar:6.13.2
 - io.fabric8:kubernetes-model-storageclass:jar:6.13.2
 - io.fabric8:zjsonpatch:jar:0.3.0
-- io.javaoperatorsdk:operator-framework-core:jar:4.8.3
-- io.javaoperatorsdk:operator-framework:jar:4.8.3
+- io.javaoperatorsdk:operator-framework-core:jar:4.9.4
+- io.javaoperatorsdk:operator-framework:jar:4.9.4
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-lang3:3.14.0
 - org.apache.commons:commons-math3:3.6.1

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@ under the License.
         <surefire.module.config/>
 
         <derby.version>10.15.2.0</derby.version>
+        <jetbrains.annotations.version>24.1.0</jetbrains.annotations.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@ under the License.
         <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
         <git-commit-id-maven-plugin.version>5.0.0</git-commit-id-maven-plugin.version>
 
-        <operator.sdk.version>4.8.3</operator.sdk.version>
+        <operator.sdk.version>4.9.4</operator.sdk.version>
         <operator.sdk.webhook-framework.version>1.1.1</operator.sdk.webhook-framework.version>
 
         <fabric8.version>6.13.2</fabric8.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,6 @@ under the License.
         <surefire.module.config/>
 
         <derby.version>10.15.2.0</derby.version>
-        <jetbrains.annotations.version>24.1.0</jetbrains.annotations.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Enable the building of the operator using alternative Fabric8 http clients.

## Brief change log

Enable the building of the operator using alternative Fabric8 http clients.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.

The build should still work even when run with `-Dfabric8.httpclinent.impl=vertx` or `jdk` or `jetty` for that matter 😁 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes. 
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
