### PR TITLE
【update】Add new operator config "savepoint-create-subdir" to allow user to configure whether to create sub-directories named by job id under the 'state.savepoints.dir'

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -72,6 +72,7 @@ public class FlinkOperatorConfiguration {
     LeaderElectionConfiguration leaderElectionConfiguration;
     DeletionPropagation deletionPropagation;
     boolean savepointOnDeletion;
+    boolean savepointCreateSubdir;
 
     public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
         Duration reconcileInterval =
@@ -185,6 +186,9 @@ public class FlinkOperatorConfiguration {
         boolean savepointOnDeletion =
                 operatorConfig.get(KubernetesOperatorConfigOptions.SAVEPOINT_ON_DELETION);
 
+        boolean savepointCreateSubdir =
+                operatorConfig.get(KubernetesOperatorConfigOptions.SAVEPOINT_CREATE_SUBDIR);
+
         return new FlinkOperatorConfiguration(
                 reconcileInterval,
                 reconcilerMaxParallelism,
@@ -212,7 +216,8 @@ public class FlinkOperatorConfiguration {
                 labelSelector,
                 getLeaderElectionConfig(operatorConfig),
                 deletionPropagation,
-                savepointOnDeletion);
+                savepointOnDeletion,
+                savepointCreateSubdir);
     }
 
     private static LeaderElectionConfiguration getLeaderElectionConfig(Configuration conf) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -533,4 +533,11 @@ public class KubernetesOperatorConfigOptions {
                     .defaultValue(false)
                     .withDescription(
                             "Indicate whether a savepoint must be taken when deleting a FlinkDeployment or FlinkSessionJob.");
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> SAVEPOINT_CREATE_SUBDIR =
+            operatorConfig("job.savepoint-create-subdir")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Indicate whether to create sub-directories named by job id under the 'state.savepoints.dir'");
 }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add new operator config "savepoint-create-subdir" to allow user to configure whether to create sub-directories named by job id under the 'state.savepoints.dir'


## Brief change log
Added new operator config.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:  no
  - Core observer or reconciler logic that is regularly executed: no
## Documentation

  - Does this pull request introduce a new feature?  yes
  - If yes, how is the feature documented?  docs 
