### PR TITLE
[FLINK-36264] Fix can not setup other values for parameter `rest-service.exposed.type`

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -249,17 +249,6 @@ public class FlinkConfigBuilder {
         return this;
     }
 
-    protected FlinkConfigBuilder applyIngressDomain() {
-        // Web UI
-        if (spec.getIngress() != null
-                && effectiveConfig.getOptional(REST_SERVICE_EXPOSED_TYPE).isEmpty()) {
-            effectiveConfig.set(
-                    REST_SERVICE_EXPOSED_TYPE,
-                    KubernetesConfigOptions.ServiceExposedType.ClusterIP);
-        }
-        return this;
-    }
-
     protected FlinkConfigBuilder applyServiceAccount() {
         if (spec.getServiceAccount() != null) {
             effectiveConfig.set(
@@ -413,7 +402,6 @@ public class FlinkConfigBuilder {
                 .applyImagePullPolicy()
                 .applyServiceAccount()
                 .applyPodTemplate()
-                .applyIngressDomain()
                 .applyJobManagerSpec()
                 .applyTaskManagerSpec()
                 .applyJobOrSessionSpec()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -251,7 +251,8 @@ public class FlinkConfigBuilder {
 
     protected FlinkConfigBuilder applyIngressDomain() {
         // Web UI
-        if (spec.getIngress() != null) {
+        if (spec.getIngress() != null
+                && effectiveConfig.getOptional(REST_SERVICE_EXPOSED_TYPE).isEmpty()) {
             effectiveConfig.set(
                     REST_SERVICE_EXPOSED_TYPE,
                     KubernetesConfigOptions.ServiceExposedType.ClusterIP);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -349,30 +349,6 @@ public class FlinkConfigBuilderTest {
                 PodTemplateSpec.class);
     }
 
-    @ParameterizedTest
-    @MethodSource("serviceExposedTypes")
-    public void testApplyIngressDomain(
-            KubernetesConfigOptions.ServiceExposedType serviceExposedType) {
-
-        final Configuration configuration =
-                new FlinkConfigBuilder(
-                                flinkDeployment,
-                                serviceExposedType == null
-                                        ? new Configuration()
-                                        : new Configuration()
-                                                .set(
-                                                        KubernetesConfigOptions
-                                                                .REST_SERVICE_EXPOSED_TYPE,
-                                                        serviceExposedType))
-                        .applyIngressDomain()
-                        .build();
-        assertEquals(
-                serviceExposedType == null
-                        ? KubernetesConfigOptions.ServiceExposedType.ClusterIP
-                        : serviceExposedType,
-                configuration.get(KubernetesConfigOptions.REST_SERVICE_EXPOSED_TYPE));
-    }
-
     @Test
     public void testApplyServiceAccount() {
         final Configuration configuration =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix can not setup other values for parameter `rest-service.exposed.type` when using ingress

## Brief change log

Only if using ingress and the `rest-service.exposed.type=null`, operator will setup as `ClusterIp` when 

## Verifying this change
Unit tests + manual verification

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
