### PR TITLE
[FlINK-36393] Update to GitHub build to use the current versions of actions 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,19 +32,13 @@ jobs:
       matrix:
         java-version: [ 11, 17, 21 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Build with Maven
         run: |
           mvn -B clean install javadoc:javadoc -Pgenerate-docs
@@ -148,19 +142,13 @@ jobs:
             java-version: 21
     name: e2e_ci
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
-      - name: Cache local Maven repository
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Start minikube
         run: |
           source e2e-tests/utils.sh


### PR DESCRIPTION
## What is the purpose of the change

Update to the latest version of the GitHub actions to avoid warnings about outdated NoeJS versions.

## Brief change log

Update to the latest version of the GitHub actions to avoid warnings about outdated NoeJS versions.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:  no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature?  no