### PR TITLE
[FLINK-36109][snapshot] Add labels to snapshot resources

### DIFF
--- a/docs/content/docs/custom-resource/snapshots.md
+++ b/docs/content/docs/custom-resource/snapshots.md
@@ -127,7 +127,6 @@ This however requires the referenced Flink resource to be alive, as this operati
 
 This feature is not available for checkpoints.
 
-
 ## Triggering snapshots
 
 Upgrade savepoints are triggered automatically by the system during the upgrade process as we have seen in the previous sections.
@@ -208,3 +207,19 @@ Legacy savepoints found in FlinkDeployment/FlinkSessionJob CRs under the depreca
 - For max count and FlinkStateSnapshot resources **disabled**, it will be cleaned up when `savepointHistory` exceeds max count
 - For max count and FlinkStateSnapshot resources **enabled**, it will be cleaned up when `savepointHistory` + number of FlinkStateSnapshot CRs related to the job exceed max count
 
+
+## Advanced Snapshot Filtering
+
+At the end of each snapshot reconciliation phase, the operator will update its labels to reflect the latest status and spec of the resources.
+This will allow the Kubernetes API server to filter snapshots without having to query all resources, since filtering by status or spec fields of custom resources is not supported in Kubernetes by default.
+Example queries with label selectors using `kubectl`:
+```shell
+# Query all checkpoints
+kubectl -n flink get flinksnp -l 'snapshot.type=CHECKPOINT'
+
+# Query all savepoints with states
+kubectl -n flink get flinksnp -l 'snapshot.state in (COMPLETED,ABANDONED),snapshot.type=SAVEPOINT'
+
+# Query all savepoints/checkpoints with job reference
+kubectl -n flink get flinksnp -l 'job-reference.kind=FlinkDeployment,job-reference.name=test-job'
+```

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/CrdConstants.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/CrdConstants.java
@@ -30,4 +30,8 @@ public class CrdConstants {
     public static final String EPHEMERAL_STORAGE = "ephemeral-storage";
 
     public static final String LABEL_SNAPSHOT_TYPE = "snapshot.type";
+    public static final String LABEL_SNAPSHOT_TRIGGER_TYPE = "snapshot.trigger-type";
+    public static final String LABEL_SNAPSHOT_STATE = "snapshot.state";
+    public static final String LABEL_SNAPSHOT_JOB_REFERENCE_KIND = "job-reference.kind";
+    public static final String LABEL_SNAPSHOT_JOB_REFERENCE_NAME = "job-reference.name";
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotContext.java
@@ -33,6 +33,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Context;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Map;
 import java.util.Optional;
 
 /** Context for reconciling a snapshot. */
@@ -42,6 +43,7 @@ public class FlinkStateSnapshotContext {
 
     private final FlinkStateSnapshot resource;
     private final FlinkStateSnapshotStatus originalStatus;
+    private final Map<String, String> originalLabels;
     private final Context<FlinkStateSnapshot> josdkContext;
     private final FlinkConfigManager configManager;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SnapshotTriggerTimestampStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SnapshotTriggerTimestampStore.java
@@ -80,7 +80,7 @@ public class SnapshotTriggerTimestampStore {
                                                                 .getLabels()
                                                                 .get(
                                                                         CrdConstants
-                                                                                .LABEL_SNAPSHOT_TYPE)))
+                                                                                .LABEL_SNAPSHOT_TRIGGER_TYPE)))
                         .map(
                                 s ->
                                         DateTimeUtils.parseKubernetes(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
@@ -35,6 +35,8 @@ import org.apache.flink.kubernetes.operator.metrics.OperatorMetricUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
+
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import org.slf4j.Logger;
@@ -76,7 +78,11 @@ public class FlinkResourceContextFactory {
     public FlinkStateSnapshotContext getFlinkStateSnapshotContext(
             FlinkStateSnapshot savepoint, Context<FlinkStateSnapshot> josdkContext) {
         return new FlinkStateSnapshotContext(
-                savepoint, savepoint.getStatus().toBuilder().build(), josdkContext, configManager);
+                savepoint,
+                savepoint.getStatus().toBuilder().build(),
+                ImmutableMap.copyOf(savepoint.getMetadata().getLabels()),
+                josdkContext,
+                configManager);
     }
 
     public <CR extends AbstractFlinkResource<?, ?>> FlinkResourceContext<CR> getResourceContext(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
@@ -61,7 +61,7 @@ public class EventSourceUtils {
                         .map(Enum::name)
                         .collect(Collectors.joining(","));
         var labelSelector =
-                String.format("%s in (%s)", CrdConstants.LABEL_SNAPSHOT_TYPE, labelFilters);
+                String.format("%s in (%s)", CrdConstants.LABEL_SNAPSHOT_TRIGGER_TYPE, labelFilters);
         var configuration =
                 InformerConfiguration.from(FlinkStateSnapshot.class, context)
                         .withLabelSelector(labelSelector)

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverTest.java
@@ -266,7 +266,10 @@ public class SnapshotObserverTest extends OperatorTestBase {
         var metadata =
                 new ObjectMetaBuilder()
                         .withName(UUID.randomUUID().toString())
-                        .withLabels(Map.of(CrdConstants.LABEL_SNAPSHOT_TYPE, triggerType.name()))
+                        .withLabels(
+                                Map.of(
+                                        CrdConstants.LABEL_SNAPSHOT_TRIGGER_TYPE,
+                                        triggerType.name()))
                         .withCreationTimestamp(
                                 DateTimeUtils.kubernetes(Instant.ofEpochMilli(timestamp)))
                         .build();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/SnapshotTriggerTimestampStoreTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/SnapshotTriggerTimestampStoreTest.java
@@ -135,7 +135,7 @@ class SnapshotTriggerTimestampStoreTest {
         }
         snapshot.getMetadata()
                 .getLabels()
-                .put(CrdConstants.LABEL_SNAPSHOT_TYPE, triggerType.name());
+                .put(CrdConstants.LABEL_SNAPSHOT_TRIGGER_TYPE, triggerType.name());
         snapshot.setStatus(new FlinkStateSnapshotStatus());
         snapshot.getStatus().setState(COMPLETED);
         return snapshot;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -310,7 +310,11 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
         assertThat(snapshots.get(0).getSpec().getSavepoint().getPath()).isEqualTo("savepoint_0");
         assertEquals(
                 SnapshotTriggerType.UPGRADE.name(),
-                snapshots.get(0).getMetadata().getLabels().get(CrdConstants.LABEL_SNAPSHOT_TYPE));
+                snapshots
+                        .get(0)
+                        .getMetadata()
+                        .getLabels()
+                        .get(CrdConstants.LABEL_SNAPSHOT_TRIGGER_TYPE));
 
         // Make sure jobId rotated on savepoint
         verifyNewJobId(runningJobs.get(0).f1, runningJobs.get(0).f2, jobId);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
@@ -179,7 +179,11 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
         assertEquals("savepoint_0", snapshots.get(0).getSpec().getSavepoint().getPath());
         assertEquals(
                 SnapshotTriggerType.UPGRADE.name(),
-                snapshots.get(0).getMetadata().getLabels().get(CrdConstants.LABEL_SNAPSHOT_TYPE));
+                snapshots
+                        .get(0)
+                        .getMetadata()
+                        .getLabels()
+                        .get(CrdConstants.LABEL_SNAPSHOT_TRIGGER_TYPE));
     }
 
     @ParameterizedTest

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
@@ -410,7 +410,7 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
                             .get(0)
                             .getMetadata()
                             .getLabels()
-                            .get(CrdConstants.LABEL_SNAPSHOT_TYPE));
+                            .get(CrdConstants.LABEL_SNAPSHOT_TRIGGER_TYPE));
             assertEquals(
                     snapshots.get(0).getSpec().getSavepoint().getPath(),
                     statefulSessionJob.getStatus().getJobStatus().getUpgradeSavepointPath());


### PR DESCRIPTION
## What is the purpose of the change

Adds labels to FlinkStateSnapshot resources managed by the operator to allow for filtering. Currently we have no way to easily filter snapshots resources (e.g. by job reference, snapshot type or state), since the API server only allows to filter by labels for custom resources. 

The only way currently is to download all resources from the API-server and filter the resources client-side. Filtering by labels allows the API-server to serve the snapshots in a more optimized way.

Once [KEP-4358](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/4358-custom-resource-field-selectors/README.md) is available as GA, we can hopefully gradually switch to using spec and status fields as field selectors.


## Brief change log

- Before the end of each reconciliation phase of a snapshot, update its labels to reflect the latest spec/status.
- Change `UpdateControl` logic to also update the resource if the labels have changed.

## Verifying this change

- Unit testing
- Manual testing

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes, but only labels were added/changed
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
