### PR TITLE
[FLINK-36449] Bump apache-rat-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.12</version><!--$NO-MVN-MAN-VER$-->
+                <version>0.16.1</version><!--$NO-MVN-MAN-VER$-->
                 <inherited>false</inherited>
                 <executions>
                     <execution>


### PR DESCRIPTION
## What is the purpose of the change

Bump apache-rat-plugin

## Brief change log

Bump apache-rat-plugin from 0.12 to 0.16.1 to remediate the underlying vulnerabilities in the dependencies.

Vulnerabilities from dependencies:
[CVE-2022-4245](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4245)
[CVE-2022-4244](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-4244)
[CVE-2020-15250](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
