### PR TITLE
[hotfix] Fix testfail due to data race with after migration to Fabric8 interceptor

### DIFF
--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
@@ -160,6 +160,8 @@ public class RestApiMetricsCollectorTest {
                             (c, e) ->
                                     new StandaloneClientHAServices(
                                             miniCluster.getRestAddress().get().toString()));
+            // wait a little to ensure data is ready
+            Thread.sleep(500);
             do {
                 var collector = new RestApiMetricsCollector<>();
                 Map<FlinkMetric, Metric> flinkMetricMetricMap =


### PR DESCRIPTION
Tests that perform requests are usualy fail now on CI due to race conditions. 

To fix it, I addeв busywait for metrics with timeout as it is done in RestApiMetricsCollectorTest#testJmMetricCollection().
Also I added an extra delay in the RestApiMetricsCollectorTest#testJmMetricCollection(), it helps to avoid CI failing on my workload runs. 

Alternative fix:
Add blocks inside tests until requests are performed, but this requreis a lot of modifications 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
