### PR TITLE
[FLINK-36469] Bump commons-io from 2.11.0 to 2.17.0

### DIFF
--- a/flink-autoscaler-standalone/src/main/resources/META-INF/NOTICE
+++ b/flink-autoscaler-standalone/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-collections:commons-collections:3.2.2
 - org.apache.commons:commons-math3:3.6.1
 - com.twitter:chill-java:0.7.6
-- commons-io:commons-io:2.11.0
+- commons-io:commons-io:2.17.0
 - org.apache.commons:commons-lang3:3.12.0
 - commons-cli:commons-cli:1.5.0
 - org.javassist:javassist:3.24.0-GA

--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -20,7 +20,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.twitter:chill-java:0.7.6
 - commons-cli:commons-cli:1.5.0
 - commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.11.0
+- commons-io:commons-io:2.17.0
 - io.fabric8:kubernetes-client-api:jar:6.13.2
 - io.fabric8:kubernetes-client:jar:6.13.2
 - io.fabric8:kubernetes-httpclient-okhttp:jar:6.13.2

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ under the License.
 
         <lombok.version>1.18.30</lombok.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
-        <commons-io.version>2.11.0</commons-io.version>
+        <commons-io.version>2.17.0</commons-io.version>
         <flink.version>1.19.1</flink.version>
 
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
## What is the purpose of the change

Bump commons-io from 2.11.0 to 2.17.0


## Brief change log

Commons-io version 2.11.0 has a direct vulnerability and bumping it to the newer version (2.17.0) will remediate this finding.

**Direct vulnerabilities:**
[CVE-2024-47554](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554)

**Package details:**
https://mvnrepository.com/artifact/commons-io/commons-io/2.17.0


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
