### PR TITLE
[FLINK-36473] Wait for metrics before asserting on them

### DIFF
--- a/flink-autoscaler/pom.xml
+++ b/flink-autoscaler/pom.xml
@@ -107,6 +107,12 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/flink-autoscaler/pom.xml
+++ b/flink-autoscaler/pom.xml
@@ -111,6 +111,7 @@ under the License.
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${awaitility.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
@@ -52,10 +52,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 /** Tests for {@link RestApiMetricsCollector}. */
 class RestApiMetricsCollectorTest {

--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -32,7 +32,6 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <awaitility.version>4.1.0</awaitility.version>
         <plugins.tmp.dir>${project.build.directory}/plugins</plugins.tmp.dir>
     </properties>
 

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -32,7 +32,6 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <awaitility.version>4.1.0</awaitility.version>
         <plugins.tmp.dir>${project.build.directory}/plugins</plugins.tmp.dir>
         <surefire.module.config>
             <!-- required by FlinkConfigManagerTest -->

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesClientMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/KubernetesClientMetricsTest.java
@@ -52,6 +52,7 @@ import static org.apache.flink.kubernetes.operator.metrics.KubernetesClientMetri
 import static org.apache.flink.kubernetes.operator.metrics.KubernetesClientMetrics.KUBE_CLIENT_GROUP;
 import static org.apache.flink.kubernetes.operator.metrics.KubernetesClientMetrics.METER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.byLessThan;
 import static org.assertj.core.api.InstanceOfAssertFactories.LONG;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -356,17 +357,20 @@ class KubernetesClientMetricsTest {
     }
 
     private static void assertRateIsZero(TestingMetricListener listener, String meterId) {
-        assertPositiveRate(listener, meterId, meter -> assertThat(meter.getRate()).isEqualTo(0.0));
+        assertRate(
+                listener,
+                meterId,
+                meter -> assertThat(meter.getRate()).isCloseTo(0.0, byLessThan(0.00001)));
     }
 
     private static void assertPositiveRate(TestingMetricListener listener, String meterId) {
-        assertPositiveRate(
+        assertRate(
                 listener,
                 meterId,
                 meter -> assertThat(meter.getRate()).isGreaterThanOrEqualTo(0.01));
     }
 
-    private static void assertPositiveRate(
+    private static void assertRate(
             TestingMetricListener listener, String meterId, Consumer<Meter> meterConsumer) {
         assertThat(listener.getMeter(listener.getMetricId(meterId)))
                 .hasValueSatisfying(meterConsumer);

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@ under the License.
         <surefire.module.config/>
 
         <derby.version>10.15.2.0</derby.version>
+        <awaitility.version>4.1.0</awaitility.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@ under the License.
         <surefire.module.config/>
 
         <derby.version>10.15.2.0</derby.version>
-        <awaitility.version>4.1.0</awaitility.version>
+        <awaitility.version>4.2.2</awaitility.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Operator metrics are lazily initialised. This PR addresses race conditions in tests trying to assert metrics.

An alternative to the `Thread.sleep` proposed in https://github.com/apache/flink-kubernetes-operator/pull/891 
## Brief change log

Wait for metrics to be initialised in integration tests.

## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
This change is purely a fix to `RestApiMetricsCollectorTest` & `KubernetesClientMetricsTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: **no**
  - Core observer or reconciler logic that is regularly executed: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**