### PR TITLE
[FLINK-36522] [Kubernetes-operator] Bump mysql-connector-java from 8.0.33 to mysql-connecto…

### DIFF
--- a/flink-autoscaler-plugin-jdbc/pom.xml
+++ b/flink-autoscaler-plugin-jdbc/pom.xml
@@ -34,7 +34,7 @@ under the License.
     <properties>
         <testcontainers.version>1.18.2</testcontainers.version>
         <postgres.version>42.5.6</postgres.version>
-        <mysql.version>8.0.33</mysql.version>
+        <mysql.version>8.4.0</mysql.version>
     </properties>
 
     <dependencyManagement>
@@ -134,8 +134,8 @@ under the License.
 
         <!-- MySQL tests -->
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <version>${mysql.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION

## What is the purpose of the change

Bump mysql-connector-java from 8.0.33 to mysql-connector-j 8.4.0

## Brief change log

mysql-connector-java version 8.0.33 has a direct vulnerability CVE-2023-22102 which is remediated in the version of the same package (but moved to different name) mysql-connector-j version 8.4.0

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
