### PR TITLE
[FLINK-36528] [Kubernetes Operator] Update org.apache.avro from 1.8.2 to 1.12.0

### DIFF
--- a/examples/flink-beam-example/pom.xml
+++ b/examples/flink-beam-example/pom.xml
@@ -54,7 +54,17 @@ under the License.
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.12.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## What is the purpose of the change

This PR updates the dependency "org.apache.avro:avro" version from 1.8.2 to 1.12.0


## Brief change log

The transitive dependency "org.apache.avro:avro" version 1.8.2 present in beam-sdks-java-core under flink-beam-example module has 2 direct and 12 vulnerabilities from dependent packages. Updating it to 1.12.0 removes all of them. List can be found here: https://mvnrepository.com/artifact/org.apache.avro/avro/1.8.2 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
