### PR TITLE
FLINK-36544: [OLM] - ensure file permissions are preserved on the CSV during bundle creation.

### DIFF
--- a/tools/olm/docker-entry.sh
+++ b/tools/olm/docker-entry.sh
@@ -98,7 +98,10 @@ generate_olm_bundle() {
   yq ea -i "del(.subjects[0].namespace)" "${ROLE_BINDING}"
 
   # Needed to replace description with new bundle values
-  sed -i "s/RELEASE_VERSION/${BUNDLE_VERSION}/" "${CSV_FILE}"
+  sed --in-place=.old "s/RELEASE_VERSION/${BUNDLE_VERSION}/" "${CSV_FILE}"
+  # Ensure that file permissions are preserved
+  chmod --reference="${CSV_FILE}".old "${CSV_FILE}"
+  rm "${CSV_FILE}".old
 }
 
 validate_olm_bundle() {


### PR DESCRIPTION

<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Bug fix: During OLM bundle creation, the generated bundle lacks necessary file permissions on the CSV.  This leads to a subscription failure.

I added a comment to the JIRA showing the investigation.

## Brief change log

* Ensure CSV file permissions are preserved during bundle creation.

## Verifying this change

Created the OLM bundle locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:  no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
