### PR TITLE
FLINK-36551: [OLM] ensure that docker-entry.sh actually replaces the keystore pod volume

### DIFF
--- a/tools/olm/docker-entry.sh
+++ b/tools/olm/docker-entry.sh
@@ -85,7 +85,7 @@ generate_olm_bundle() {
 
   yq ea -i ".spec.install.spec.deployments[0].spec.template.spec.initContainers = load(\"${INIT_CONT}\").initContainers" "${CSV_FILE}"
 
-  yq ea -i '.spec.install.spec.deployments[0].spec.template.spec.volumes[1] = {"name": "keystore","emptyDir": {}}' "${CSV_FILE}"
+  yq ea -i '(.spec.install.spec.deployments[0].spec.template.spec.volumes[] | select(.name == "keystore")) = {"name": "keystore","emptyDir": {}}' "${CSV_FILE}"
 
   yq ea -i "(... | select(has(\"image\"))).image =\"${OPERATOR_IMG}\"" "${CSV_FILE}"
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a defect ([FLINK-36551](https://issues.apache.org/jira/browse/FLINK-36551))  in `tools/olm/docker_entry.sh`.  In order for Flink Kubernetes Operator to function under OLM the webhook utilises a serving certificate provided by OLM.  docker_entry.sh rewrites the deployment to allow this substitution to occur.

Unfortunately, `docker_entry.sh` makes an assumption about the index of the `keystore` volume within the deployment.  The index has changed over time, meaning  `docker_entry.sh` replaces the wrong volume entry.  This leads to a volume with a duplicate name.  The CSV fails to be become ready as a result.

## Brief change log

- [OLM] Fix indexing error when replacing the `keystore` volume within CSV. 

## Verifying this change

I manually verified the change, firstly by ensuring the `yq` command was having the right effect and secondly by generating a OLM using `generate-olm-bundle.sh`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
