### PR TITLE
[FLINK-36527][autoscaler] Introduce a parameter to support autoscaler adopt a more radical strategy when source vertex or upstream shuffle is keyBy

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -189,6 +189,12 @@
             <td>Time interval to resend the identical event</td>
         </tr>
         <tr>
+            <td><h5>job.autoscaler.scaling.radical.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If this option is enabled, The determination of parallelism will be more radical, which will maximize resource utilization, but may also cause data skew in some vertex.</td>
+        </tr>
+        <tr>
             <td><h5>job.autoscaler.stabilization.interval</h5></td>
             <td style="word-wrap: break-word;">5 min</td>
             <td>Duration</td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -416,21 +416,31 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
                         // Optimize the case where newParallelism <= maxParallelism / 2
                         newParallelism > numKeyGroupsOrPartitions / 2
                                 ? numKeyGroupsOrPartitions
-                                : numKeyGroupsOrPartitions / 2,
+                                : numKeyGroupsOrPartitions / 2 + numKeyGroupsOrPartitions % 2,
                         upperBound);
+
+        boolean scalingRadical =
+                context.getConfiguration().get(AutoScalerOptions.SCALING_RADICAL_ENABLED);
 
         // When the shuffle type of vertex inputs contains keyBy or vertex is a source,
         // we try to adjust the parallelism such that it divides
         // the numKeyGroupsOrPartitions without a remainder => data is evenly spread across subtasks
         for (int p = newParallelism; p <= upperBoundForAlignment; p++) {
-            if (numKeyGroupsOrPartitions % p == 0) {
+            if (numKeyGroupsOrPartitions % p == 0
+                    ||
+                    // When scaling radical is enabled, Try to find the smallest parallelism that
+                    // can satisfy the
+                    // current consumption rate.
+                    (scalingRadical
+                            && numKeyGroupsOrPartitions / p
+                                    < numKeyGroupsOrPartitions / newParallelism)) {
                 return p;
             }
         }
 
-        // When adjust the parallelism after rounding up cannot be evenly divided by
-        // numKeyGroupsOrPartitions, Try to find the smallest parallelism that can satisfy the
-        // current consumption rate.
+        // When adjust the parallelism after rounding up cannot be
+        // find the right degree of parallelism to meet requirements,
+        // Try to find the smallest parallelism that can satisfy the current consumption rate.
         int p = newParallelism;
         for (; p > 0; p--) {
             if (numKeyGroupsOrPartitions / p > numKeyGroupsOrPartitions / newParallelism) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -351,4 +351,13 @@ public class AutoScalerOptions {
                     .withFallbackKeys(oldOperatorConfigKey("quota.cpu"))
                     .withDescription(
                             "Quota of the CPU count. When scaling would go beyond this number the the scaling is not going to happen.");
+
+    public static final ConfigOption<Boolean> SCALING_RADICAL_ENABLED =
+            autoScalerConfig("scaling.radical.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withFallbackKeys(oldOperatorConfigKey("scaling.radical.enabled"))
+                    .withDescription(
+                            "If this option is enabled, The determination of parallelism will be more radical, which"
+                                    + " will maximize resource utilization, but may also cause data skew in some vertex.");
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -379,6 +379,37 @@ public class JobVertexScalerTest {
                         maxParallelism,
                         eventCollector,
                         context));
+
+        assertEquals(
+                32,
+                JobVertexScaler.scale(
+                        vertex,
+                        10,
+                        inputShipStrategies,
+                        0,
+                        128,
+                        2.5,
+                        minParallelism,
+                        maxParallelism,
+                        eventCollector,
+                        context));
+
+        // scaling.radical.enabled  = true
+        Configuration conf = context.getConfiguration();
+        conf.set(AutoScalerOptions.SCALING_RADICAL_ENABLED, true);
+        assertEquals(
+                26,
+                JobVertexScaler.scale(
+                        vertex,
+                        10,
+                        inputShipStrategies,
+                        0,
+                        128,
+                        2.5,
+                        minParallelism,
+                        maxParallelism,
+                        eventCollector,
+                        context));
     }
 
     @ParameterizedTest
@@ -1000,6 +1031,37 @@ public class JobVertexScalerTest {
                         200,
                         128,
                         1.4,
+                        parallelismLowerLimit,
+                        parallelismUpperLimit,
+                        eventCollector,
+                        context));
+
+        assertEquals(
+                199,
+                JobVertexScaler.scale(
+                        vertex,
+                        24,
+                        List.of(),
+                        199,
+                        256,
+                        4,
+                        parallelismLowerLimit,
+                        parallelismUpperLimit,
+                        eventCollector,
+                        context));
+
+        // scaling.radical.enabled  = true
+        Configuration conf = context.getConfiguration();
+        conf.set(AutoScalerOptions.SCALING_RADICAL_ENABLED, true);
+        assertEquals(
+                100,
+                JobVertexScaler.scale(
+                        vertex,
+                        24,
+                        List.of(),
+                        199,
+                        256,
+                        4,
                         parallelismLowerLimit,
                         parallelismUpperLimit,
                         eventCollector,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Introduce a parameter to support autoscaler adopt a more radical strategy when source vertex or upstream shuffle is keyBy

## Brief change log

  - *Add a new option: `scaling.radical.enabled`*
  - *Support use a more aggressive strategy（Resource utilization takes priority） to determine the degree of parallelism after Source or after keyby without first considering balanced consumption.*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

in `org.apache.flink.autoscaler.JobVertexScalerTest.JobVertexScalerTest`
* `testParallelismComputationWithAdjustment` and `testNumPartitionsAdjustment` add logic to test



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no)
  - Core observer or reconciler logic that is regularly executed: (yes / no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
