### PR TITLE
[FLINK-36332] Missed webhook okhttp reference.

### DIFF
--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -96,6 +96,11 @@ under the License.
             <version>${log4j.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -63,22 +63,6 @@ under the License.
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.fabric8</groupId>
-            <artifactId>kubernetes-client</artifactId>
-            <version>${fabric8.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.fabric8</groupId>
-                    <artifactId>kubernetes-httpclient-okhttp</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- Utils -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -63,6 +63,11 @@ under the License.
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+        </dependency>
+        
         <!-- Utils -->
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -37,8 +37,6 @@ under the License.
             <!-- required by FlinkConfigManagerTest -->
             --add-opens=java.base/java.util=ALL-UNNAMED
         </surefire.module.config>
-        <!-- valid options can be checked at https://central.sonatype.com/search?q=kubernetes-httpclient- currently: okhttp, jdk, jetty, vertx -->
-        <fabric8.httpclient.impl>okhttp</fabric8.httpclient.impl>
     </properties>
 
     <dependencies>
@@ -420,22 +418,6 @@ under the License.
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>depend-on-okhttp4</id>
-            <activation>
-                <property>
-                    <name>fabric8.httpclient.impl</name>
-                    <value>okhttp</value>
-                </property>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
-                    <version>${okhttp.version}</version>
-                </dependency>
-            </dependencies>
         </profile>
     </profiles>
 

--- a/flink-kubernetes-webhook/pom.xml
+++ b/flink-kubernetes-webhook/pom.xml
@@ -24,7 +24,7 @@ under the License.
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-kubernetes-operator-parent</artifactId>
         <version>1.11-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>flink-kubernetes-webhook</artifactId>
@@ -78,22 +78,6 @@ under the License.
             <scope>test</scope>
         </dependency>
 
-        <!-- okhttp -->
-        <!--
-            Regarding the okhttp explicit version
-            see https://github.com/fabric8io/kubernetes-client/issues/4290
-            and https://issues.apache.org/jira/browse/FLINK-28637
-            -->
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
-            <version>${okhttp.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>logging-interceptor</artifactId>
-            <version>${okhttp.version}</version>
-        </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>

--- a/flink-kubernetes-webhook/pom.xml
+++ b/flink-kubernetes-webhook/pom.xml
@@ -63,12 +63,6 @@ under the License.
             <artifactId>kubernetes-server-mock</artifactId>
             <version>${fabric8.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>mockwebserver</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/flink-kubernetes-webhook/pom.xml
+++ b/flink-kubernetes-webhook/pom.xml
@@ -63,6 +63,12 @@ under the License.
             <artifactId>kubernetes-server-mock</artifactId>
             <version>${fabric8.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>mockwebserver</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,10 @@ under the License.
 
         <derby.version>10.15.2.0</derby.version>
         <awaitility.version>4.2.2</awaitility.version>
+
+        <!-- valid options can be checked at https://central.sonatype.com/search?q=kubernetes-httpclient- currently: okhttp, jdk, jetty, vertx -->
+        <!-- when using a value other than okhttp disable the `depend-on-okhttp4` profile as well. -->
+        <fabric8.httpclient.impl>okhttp</fabric8.httpclient.impl>
     </properties>
 
     <dependencyManagement>
@@ -188,6 +192,22 @@ under the License.
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>depend-on-okhttp4</id>
+            <activation>
+                <property>
+                    <name>fabric8.httpclient.impl</name>
+                    <value>okhttp</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                    <version>${okhttp.version}</version>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,33 @@ under the License.
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-client</artifactId>
+                <version>${fabric8.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>kubernetes-httpclient-okhttp</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-server-mock</artifactId>
+                <version>${fabric8.version}</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>mockwebserver</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -196,10 +196,7 @@ under the License.
         <profile>
             <id>depend-on-okhttp4</id>
             <activation>
-                <property>
-                    <name>fabric8.httpclient.impl</name>
-                    <value>okhttp</value>
-                </property>
+                <activeByDefault>true</activeByDefault>
             </activation>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
## What is the purpose of the change

There is still a stray reference to OkHTTP via the webhook.

## Brief change log

*(for example:)*
  - Fully exclude OkHttp
  
## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: **no**
  - Core observer or reconciler logic that is regularly executed: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**


I'd also like to back port this to release-1.10 if possible.