### PR TITLE
[FLINK-36583] Add Slow Request Kube Client Metrics

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_metric_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_metric_configuration.html
@@ -33,6 +33,12 @@
             <td>Enable KubernetesClient metrics for measuring the HTTP traffic to the Kubernetes API Server by response code group, e.g. 1xx, 2xx.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.kubernetes.client.metrics.slow.request.threshold</h5></td>
+            <td style="word-wrap: break-word;">5 s</td>
+            <td>Duration</td>
+            <td>Threshold value that triggers slow request counter for Kubernetes client metrics</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.metrics.histogram.sample.size</h5></td>
             <td style="word-wrap: break-word;">1000</td>
             <td>Integer</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricOptions.OPERATOR_KUBERNETES_SLOW_REQUEST_THRESHOLD;
 import static org.apache.flink.kubernetes.operator.utils.EnvUtils.ENV_WATCH_NAMESPACES;
 
 /** Configuration class for operator. */
@@ -75,6 +76,7 @@ public class FlinkOperatorConfiguration {
     LeaderElectionConfiguration leaderElectionConfiguration;
     DeletionPropagation deletionPropagation;
     boolean snapshotResourcesEnabled;
+    Duration slowRequestThreshold;
 
     public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
         Duration reconcileInterval =
@@ -190,6 +192,9 @@ public class FlinkOperatorConfiguration {
         boolean snapshotResourcesEnabled =
                 operatorConfig.get(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED);
 
+        Duration slowRequestThreshold =
+                operatorConfig.get(OPERATOR_KUBERNETES_SLOW_REQUEST_THRESHOLD);
+
         return new FlinkOperatorConfiguration(
                 reconcileInterval,
                 reconcilerMaxParallelism,
@@ -218,7 +223,8 @@ public class FlinkOperatorConfiguration {
                 labelSelector,
                 getLeaderElectionConfig(operatorConfig),
                 deletionPropagation,
-                snapshotResourcesEnabled);
+                snapshotResourcesEnabled,
+                slowRequestThreshold);
     }
 
     private static GenericRetry getRetryConfig(Configuration conf) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/KubernetesOperatorMetricOptions.java
@@ -19,6 +19,8 @@ package org.apache.flink.kubernetes.operator.metrics;
 
 import org.apache.flink.configuration.ConfigOption;
 
+import java.time.Duration;
+
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.operatorConfig;
 
 /** Configuration options for metrics. */
@@ -51,6 +53,13 @@ public class KubernetesOperatorMetricOptions {
                             .defaultValue(false)
                             .withDescription(
                                     "Enable KubernetesClient metrics for measuring the HTTP traffic to the Kubernetes API Server by response code group, e.g. 1xx, 2xx.");
+
+    public static final ConfigOption<Duration> OPERATOR_KUBERNETES_SLOW_REQUEST_THRESHOLD =
+            operatorConfig("kubernetes.client.metrics.slow.request.threshold")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(5))
+                    .withDescription(
+                            "Threshold value that triggers slow request counter for Kubernetes client metrics");
 
     public static final ConfigOption<Boolean> OPERATOR_RESOURCE_METRICS_ENABLED =
             operatorConfig("resource.metrics.enabled")


### PR DESCRIPTION
## What is the purpose of the change

Adding a simple counter to monitor slow API requests, identifying those that exceed a predefined time threshold, e.g.:
```
kubernetes.client.metrics.slow.request.threshold=5s
```

## Verifying this change

- Unit tests where added
- Manually can be verified by reducing the threshold to a very low number, e.g.:
```
kubernetes.client.metrics.slow.request.threshold=1 MILLISECOND
```

```
-- Counters ---------------------------------------------------------------------
flink-kubernetes-operator-b48954fcf-w8p4z.k8soperator.default.flink-kubernetes-operator.system.KubeClient.HttpRequest.Slow.Count: 87
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs added for the new propery 
