### PR TITLE
[FLINK-36646] Test different versions of the JDK in the Flink image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,19 +89,18 @@ jobs:
     strategy:
       matrix:
         http-client: [ "okhttp" ]
-        java-version: [ "11", "17", "21" ]
+        java-version: [ "11", "17"]
         flink-version:
           - "v1_20"
-          - "v1_18"
           - "v1_19"
-          - "v1_17"
-          - "v1_16"
+          - "v1_18"
     uses: ./.github/workflows/e2e.yaml
     with:
       java-version: ${{ matrix.java-version }}
       flink-version: ${{ matrix.flink-version }}
       http-client: ${{ matrix.http-client }}
       test: test_application_operations.sh
+      append-java-version: true
   e2e_namespace_tests:
     name: Alternative namespace tests
     needs: e2e_smoke_test
@@ -109,8 +108,8 @@ jobs:
       matrix:
         flink-version:
           - "v1_20"
-          - "v1_18"
           - "v1_19"
+          - "v1_18"
           - "v1_17"
           - "v1_16"
         mode:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,24 @@ jobs:
       flink-version: "v1_20"
       http-client: ${{ matrix.http-client }}
       test: test_application_operations.sh
+  java_rutimes:
+    name: Java runtimes smoke test
+    strategy:
+      matrix:
+        http-client: [ "okhttp" ]
+        java-version: [ "11", "17", "21" ]
+        flink-version:
+          - "v1_20"
+          - "v1_18"
+          - "v1_19"
+          - "v1_17"
+          - "v1_16"
+    uses: ./.github/workflows/e2e.yaml
+    with:
+      java-version: ${{ matrix.java-version }}
+      flink-version: ${{ matrix.flink-version }}
+      http-client: ${{ matrix.http-client }}
+      test: test_application_operations.sh
   e2e_namespace_tests:
     name: Alternative namespace tests
     needs: e2e_smoke_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
       test: test_application_operations.sh
   java_rutimes:
     name: Java runtimes smoke test
+    needs: e2e_smoke_test
     strategy:
       matrix:
         http-client: [ "okhttp" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       flink-version: "v1_20"
       http-client: ${{ matrix.http-client }}
       test: test_application_operations.sh
-  java_rutimes:
+  java_runtimes:
     name: Java runtimes smoke test
     needs: e2e_smoke_test
     strategy:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,6 +27,9 @@ on:
       create-namespace:
         type: boolean
         default: false
+      append-java-version:
+        type: boolean
+        default: false
 
 jobs:
   e2e_test:
@@ -77,7 +80,10 @@ jobs:
           kubectl get pods -n ${{ inputs.namespace }}
       - name: Run Flink e2e tests
         run: |
-          FLINK_IMAGE=$(sed --regexp-extended 's/v([0-9]+)_([0-9]+)/flink:\1.\2/g' <<< ${{ inputs.flink-version }} )-java${{ inputs.java-version }}
+          FLINK_IMAGE=$(sed --regexp-extended 's/v([0-9]+)_([0-9]+)/flink:\1.\2/g' <<< ${{ inputs.flink-version }} )
+          if [[ "${{ inputs.append-java-version }}" == "true" ]]; then
+            FLINK_IMAGE=${FLINK_IMAGE}-java${{ inputs.java-version }}
+          fi
           echo FLINK_IMAGE=${FLINK_IMAGE}
           sed -i "s/image: flink:.*/image: ${FLINK_IMAGE}/" e2e-tests/data/*.yaml
           sed -i "s/flinkVersion: .*/flinkVersion: ${{ inputs.flink-version }}/" e2e-tests/data/*.yaml

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -77,7 +77,7 @@ jobs:
           kubectl get pods -n ${{ inputs.namespace }}
       - name: Run Flink e2e tests
         run: |
-          FLINK_IMAGE=$(sed --regexp-extended 's/v([0-9]+)_([0-9]+)/flink:\1.\2/g' <<< ${{ inputs.flink-version }} )
+          FLINK_IMAGE=$(sed --regexp-extended 's/v([0-9]+)_([0-9]+)/flink:\1.\2/g' <<< ${{ inputs.flink-version }} )-java${{ inputs.java-version }}
           echo FLINK_IMAGE=${FLINK_IMAGE}
           sed -i "s/image: flink:.*/image: ${FLINK_IMAGE}/" e2e-tests/data/*.yaml
           sed -i "s/flinkVersion: .*/flinkVersion: ${{ inputs.flink-version }}/" e2e-tests/data/*.yaml


### PR DESCRIPTION
## What is the purpose of the change

* adding tests to demonstrate FLINK-36646


## Brief change log

* adding tests to demonstrate FLINK-36646

## Verifying this change

This change is already covered by existing tests, such as `test_application_operations.sh` should pass with each of the supported JDK versions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: **no**
  - Core observer or reconciler logic that is regularly executed: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
  