### PR TITLE
[FLINK-36192][log] instruct how to change log level dynamically

### DIFF
--- a/docs/content.zh/docs/operations/helm.md
+++ b/docs/content.zh/docs/operations/helm.md
@@ -56,6 +56,10 @@ To override single parameters you can use `--set`, for example:
 ```
 helm install --set image.repository=apache/flink-kubernetes-operator --set image.tag={{< stable >}}{{< version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}} flink-kubernetes-operator helm/flink-kubernetes-operator
 ```
+Note, you should escape special characters in your `--set` lines, for example:
+```
+helm install --set defaultConfiguration."log4j-operator\.properties"=rootLogger.level\=DEBUG flink-kubernetes-operator helm/flink-kubernetes-operator
+```
 
 You can also provide your custom values file by using the `-f` flag:
 ```

--- a/docs/content.zh/docs/operations/metrics-logging.md
+++ b/docs/content.zh/docs/operations/metrics-logging.md
@@ -193,9 +193,13 @@ defaultConfiguration:
   log4j-operator.properties: |+
     # Flink Operator Logging Overrides
     # rootLogger.level = DEBUG
+    # The monitor interval in seconds to enable log4j automatic reconfiguration
+    # monitorInterval = 30
   log4j-console.properties: |+
     # Flink Deployment Logging Overrides
     # rootLogger.level = DEBUG
+    # The monitor interval in seconds to enable log4j automatic reconfiguration
+    # monitorInterval = 30
 ```
 
 {{< hint info >}}

--- a/docs/content/docs/operations/helm.md
+++ b/docs/content/docs/operations/helm.md
@@ -56,6 +56,10 @@ To override single parameters you can use `--set`, for example:
 ```
 helm install --set image.repository=apache/flink-kubernetes-operator --set image.tag={{< stable >}}{{< version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}} flink-kubernetes-operator helm/flink-kubernetes-operator
 ```
+Note, you should escape special characters in your `--set` lines, for example:
+```
+helm install --set defaultConfiguration."log4j-operator\.properties"=rootLogger.level\=DEBUG flink-kubernetes-operator helm/flink-kubernetes-operator
+```
 
 You can also provide your custom values file by using the `-f` flag:
 ```

--- a/docs/content/docs/operations/metrics-logging.md
+++ b/docs/content/docs/operations/metrics-logging.md
@@ -193,9 +193,13 @@ defaultConfiguration:
   log4j-operator.properties: |+
     # Flink Operator Logging Overrides
     # rootLogger.level = DEBUG
+    # The monitor interval in seconds to enable log4j automatic reconfiguration
+    # monitorInterval = 30
   log4j-console.properties: |+
     # Flink Deployment Logging Overrides
     # rootLogger.level = DEBUG
+    # The monitor interval in seconds to enable log4j automatic reconfiguration
+    # monitorInterval = 30
 ```
 
 {{< hint info >}}

--- a/helm/flink-kubernetes-operator/conf/log4j-console.properties
+++ b/helm/flink-kubernetes-operator/conf/log4j-console.properties
@@ -60,3 +60,6 @@ appender.rolling.strategy.max = 10
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
 logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
 logger.netty.level = OFF
+
+# The monitor interval in seconds to enable log4j automatic reconfiguration
+# monitorInterval = 30

--- a/helm/flink-kubernetes-operator/conf/log4j-operator.properties
+++ b/helm/flink-kubernetes-operator/conf/log4j-operator.properties
@@ -32,3 +32,6 @@ logger.conf.level = WARN
 # Avoid logging fallback key INFO messages
 logger.conf.name = org.apache.flink.configuration.Configuration
 logger.conf.level = WARN
+
+# The monitor interval in seconds to enable log4j automatic reconfiguration
+# monitorInterval = 30


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In the [doc](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/operations/metrics-logging/#logging), we didn't explicitly instruct users how to change log level dynamically for operator/job manager/task manager. This is important for troubleshooting, and it is already built-in config in Flink core.

## Brief change log

- In `log4j-console.properties` and `log4j-operator.properties` in Helm, added a hint to demo how to set config to change config dynamically.
- In the [doc](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/operations/metrics-logging/#logging), added a hint to demo how to set config to change config dynamically.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
