### PR TITLE
FLINK-36545: [OLM] fix uid/gid mixup when generating the OLM bundle.

### DIFF
--- a/tools/olm/generate-olm-bundle.sh
+++ b/tools/olm/generate-olm-bundle.sh
@@ -39,8 +39,8 @@ CSV_TEMPLATE_DIR="${BASEDIR}/csv-template"
 
 # Generate bundle in a docker container
 generate_olm_bundle() {
-  uid="$(id -g ${USER})"
-  gid="$(id -u ${USER})"
+  uid="$(id -u ${USER})"
+  gid="$(id -g ${USER})"
   cp -r ../../helm ./
   docker build -t "${OLMTOOL_IMG}" -f utils.Dockerfile ${BASEDIR}
   docker run --user="${uid}:${gid}" -v ${BASEDIR}:/olm  "${OLMTOOL_IMG}"


### PR DESCRIPTION
The docker container was being run with the uid/gid arguments switched about.

<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

As pointed out by https://issues.apache.org/jira/browse/FLINK-36545, when generating the OLM bundle, the container is run with uid/gid values switched around.

## Brief change log

- *Correct uid/gid values used when creating the OLM bundle.*
 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed:  no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
