### PR TITLE
[FLINK-36767] Bump cyclonedx-maven-plugin from 2.7.9 to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -488,7 +488,7 @@ under the License.
             <plugin>
                 <groupId>org.cyclonedx</groupId>
                 <artifactId>cyclonedx-maven-plugin</artifactId>
-                <version>2.7.9</version>
+                <version>2.9.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
## What is the purpose of the change

Bump commons-io from 2.11.0 to 2.17.0

## Brief change log

Bump cyclonedx-maven-plugin from 2.7.9 to 2.9.0 to remediate the findings in the dependant packages.

**Vulnerabilities from dependencies:**
[CVE-2024-38374](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-38374)

**Package details:**
https://mvnrepository.com/artifact/org.cyclonedx/cyclonedx-maven-plugin/2.9.0

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
