### PR TITLE
[FLINK-36535][autoscaler] Optimize the scale down logic based on historical parallelism to reduce the rescale frequency

### DIFF
--- a/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStore.java
+++ b/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStore.java
@@ -237,7 +237,7 @@ public class JdbcAutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
         try {
             return deserializeDelayedScaleDown(delayedScaleDown.get());
         } catch (JacksonException e) {
-            LOG.error(
+            LOG.warn(
                     "Could not deserialize delayed scale down, possibly the format changed. Discarding...",
                     e);
             jdbcStateStore.removeSerializedState(getSerializeKey(jobContext), DELAYED_SCALE_DOWN);
@@ -330,13 +330,11 @@ public class JdbcAutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
 
     private static String serializeDelayedScaleDown(DelayedScaleDown delayedScaleDown)
             throws JacksonException {
-        return YAML_MAPPER.writeValueAsString(delayedScaleDown.getFirstTriggerTime());
+        return YAML_MAPPER.writeValueAsString(delayedScaleDown);
     }
 
     private static DelayedScaleDown deserializeDelayedScaleDown(String delayedScaleDown)
             throws JacksonException {
-        Map<JobVertexID, Instant> firstTriggerTime =
-                YAML_MAPPER.readValue(delayedScaleDown, new TypeReference<>() {});
-        return new DelayedScaleDown(firstTriggerTime);
+        return YAML_MAPPER.readValue(delayedScaleDown, new TypeReference<>() {});
     }
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/DelayedScaleDown.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/DelayedScaleDown.java
@@ -19,51 +19,81 @@ package org.apache.flink.autoscaler;
 
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Data;
 import lombok.Getter;
+
+import javax.annotation.Nonnull;
 
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 /** All delayed scale down requests. */
 public class DelayedScaleDown {
 
-    @Getter private final Map<JobVertexID, Instant> firstTriggerTime;
+    /** The delayed scale down info for vertex. */
+    @Data
+    public static class VertexDelayedScaleDownInfo {
+        private final Instant firstTriggerTime;
+        private int maxRecommendedParallelism;
+
+        @JsonCreator
+        public VertexDelayedScaleDownInfo(
+                @JsonProperty("firstTriggerTime") Instant firstTriggerTime,
+                @JsonProperty("maxRecommendedParallelism") int maxRecommendedParallelism) {
+            this.firstTriggerTime = firstTriggerTime;
+            this.maxRecommendedParallelism = maxRecommendedParallelism;
+        }
+    }
+
+    @Getter private final Map<JobVertexID, VertexDelayedScaleDownInfo> delayedVertices;
 
     // Have any scale down request been updated? It doesn't need to be stored, it is only used to
     // determine whether DelayedScaleDown needs to be stored.
-    @Getter private boolean isUpdated = false;
+    @JsonIgnore @Getter private boolean updated = false;
 
     public DelayedScaleDown() {
-        this.firstTriggerTime = new HashMap<>();
+        this.delayedVertices = new HashMap<>();
     }
 
-    public DelayedScaleDown(Map<JobVertexID, Instant> firstTriggerTime) {
-        this.firstTriggerTime = firstTriggerTime;
+    /** Trigger a scale down, and return the corresponding {@link VertexDelayedScaleDownInfo}. */
+    @Nonnull
+    public VertexDelayedScaleDownInfo triggerScaleDown(
+            JobVertexID vertex, Instant triggerTime, int parallelism) {
+        var vertexDelayedScaleDownInfo = delayedVertices.get(vertex);
+        if (vertexDelayedScaleDownInfo == null) {
+            // It's the first trigger
+            vertexDelayedScaleDownInfo = new VertexDelayedScaleDownInfo(triggerTime, parallelism);
+            delayedVertices.put(vertex, vertexDelayedScaleDownInfo);
+            updated = true;
+        } else if (parallelism > vertexDelayedScaleDownInfo.getMaxRecommendedParallelism()) {
+            // Not the first trigger, but the maxRecommendedParallelism needs to be updated.
+            vertexDelayedScaleDownInfo.setMaxRecommendedParallelism(parallelism);
+            updated = true;
+        }
+
+        return vertexDelayedScaleDownInfo;
     }
 
-    Optional<Instant> getFirstTriggerTimeForVertex(JobVertexID vertex) {
-        return Optional.ofNullable(firstTriggerTime.get(vertex));
-    }
-
-    void updateTriggerTime(JobVertexID vertex, Instant instant) {
-        firstTriggerTime.put(vertex, instant);
-        isUpdated = true;
-    }
-
+    // Clear the delayed scale down for corresponding vertex when the recommended parallelism is
+    // greater than or equal to the currentParallelism.
     void clearVertex(JobVertexID vertex) {
-        Instant removed = firstTriggerTime.remove(vertex);
+        VertexDelayedScaleDownInfo removed = delayedVertices.remove(vertex);
         if (removed != null) {
-            isUpdated = true;
+            updated = true;
         }
     }
 
+    // Clear all delayed scale down when rescale happens.
     void clearAll() {
-        if (firstTriggerTime.isEmpty()) {
+        if (delayedVertices.isEmpty()) {
             return;
         }
-        firstTriggerTime.clear();
-        isUpdated = true;
+        delayedVertices.clear();
+        updated = true;
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/DelayedScaleDownTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/DelayedScaleDownTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler;
+
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link DelayedScaleDown}. */
+public class DelayedScaleDownTest {
+
+    private final JobVertexID vertex = new JobVertexID();
+
+    @Test
+    void testTriggerUpdateAndClean() {
+        var instant = Instant.now();
+        var delayedScaleDown = new DelayedScaleDown();
+        assertThat(delayedScaleDown.isUpdated()).isFalse();
+
+        // First trigger time as the trigger time, and it won't be updated.
+        assertVertexDelayedScaleDownInfo(
+                delayedScaleDown.triggerScaleDown(vertex, instant, 5), instant, 5);
+        assertThat(delayedScaleDown.isUpdated()).isTrue();
+
+        // The lower parallelism doesn't update the result
+        assertVertexDelayedScaleDownInfo(
+                delayedScaleDown.triggerScaleDown(vertex, instant.plusSeconds(5), 3), instant, 5);
+
+        // The higher parallelism will update the result
+        assertVertexDelayedScaleDownInfo(
+                delayedScaleDown.triggerScaleDown(vertex, instant.plusSeconds(10), 8), instant, 8);
+
+        // The scale down could be re-triggered again after clean
+        delayedScaleDown.clearVertex(vertex);
+        assertThat(delayedScaleDown.getDelayedVertices()).isEmpty();
+        assertVertexDelayedScaleDownInfo(
+                delayedScaleDown.triggerScaleDown(vertex, instant.plusSeconds(15), 4),
+                instant.plusSeconds(15),
+                4);
+
+        // The scale down could be re-triggered again after cleanAll
+        delayedScaleDown.clearAll();
+        assertThat(delayedScaleDown.getDelayedVertices()).isEmpty();
+        assertVertexDelayedScaleDownInfo(
+                delayedScaleDown.triggerScaleDown(vertex, instant.plusSeconds(15), 2),
+                instant.plusSeconds(15),
+                2);
+    }
+
+    void assertVertexDelayedScaleDownInfo(
+            DelayedScaleDown.VertexDelayedScaleDownInfo vertexDelayedScaleDownInfo,
+            Instant expectedTriggerTime,
+            int expectedMaxRecommendedParallelism) {
+        assertThat(vertexDelayedScaleDownInfo.getFirstTriggerTime()).isEqualTo(expectedTriggerTime);
+        assertThat(vertexDelayedScaleDownInfo.getMaxRecommendedParallelism())
+                .isEqualTo(expectedMaxRecommendedParallelism);
+    }
+}

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -133,13 +133,13 @@ public class ScalingExecutorTest {
 
         var evaluated = Map.of(op1, evaluated(1, 70, 100));
         assertFalse(
-                ScalingExecutor.allRequiredVerticesWithinUtilizationTarget(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
                         evaluated, evaluated.keySet()));
 
         conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.2);
         evaluated = Map.of(op1, evaluated(1, 70, 100));
         assertTrue(
-                ScalingExecutor.allRequiredVerticesWithinUtilizationTarget(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
                         evaluated, evaluated.keySet()));
         assertTrue(getScaledParallelism(stateStore, context).isEmpty());
 
@@ -150,7 +150,7 @@ public class ScalingExecutorTest {
                         op2, evaluated(1, 85, 100));
 
         assertFalse(
-                ScalingExecutor.allRequiredVerticesWithinUtilizationTarget(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
                         evaluated, evaluated.keySet()));
 
         evaluated =
@@ -158,13 +158,13 @@ public class ScalingExecutorTest {
                         op1, evaluated(1, 70, 100),
                         op2, evaluated(1, 70, 100));
         assertTrue(
-                ScalingExecutor.allRequiredVerticesWithinUtilizationTarget(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
                         evaluated, evaluated.keySet()));
 
         // Test with backlog based scaling
         evaluated = Map.of(op1, evaluated(1, 70, 100, 15));
         assertFalse(
-                ScalingExecutor.allRequiredVerticesWithinUtilizationTarget(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
                         evaluated, evaluated.keySet()));
     }
 
@@ -186,11 +186,11 @@ public class ScalingExecutorTest {
                         op1, evaluated(1, 70, 100),
                         op2, evaluated(1, 85, 100));
 
-        assertTrue(ScalingExecutor.allRequiredVerticesWithinUtilizationTarget(evaluated, Set.of()));
+        assertTrue(ScalingExecutor.allChangedVerticesWithinUtilizationTarget(evaluated, Set.of()));
 
         // One vertex is required, and it's out of range.
         assertFalse(
-                ScalingExecutor.allRequiredVerticesWithinUtilizationTarget(evaluated, Set.of(op1)));
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(evaluated, Set.of(op1)));
 
         // One vertex is required, and it's within the range.
         // The op2 is optional, so it shouldn't affect the scaling even if it is out of range,
@@ -200,7 +200,7 @@ public class ScalingExecutorTest {
                         op1, evaluated(1, 65, 100),
                         op2, evaluated(1, 85, 100));
         assertTrue(
-                ScalingExecutor.allRequiredVerticesWithinUtilizationTarget(evaluated, Set.of(op1)));
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(evaluated, Set.of(op1)));
     }
 
     @Test
@@ -225,7 +225,7 @@ public class ScalingExecutorTest {
                         dummyGlobalMetrics);
 
         assertTrue(
-                ScalingExecutor.allRequiredVerticesWithinUtilizationTarget(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
                         evaluated.getVertexMetrics(), evaluated.getVertexMetrics().keySet()));
 
         // Execute the full scaling path

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
@@ -247,7 +247,7 @@ public class KubernetesAutoScalerStateStore
         try {
             return deserializeDelayedScaleDown(delayedScaleDown.get());
         } catch (JacksonException e) {
-            LOG.error(
+            LOG.warn(
                     "Could not deserialize delayed scale down, possibly the format changed. Discarding...",
                     e);
             configMapStore.removeSerializedState(jobContext, DELAYED_SCALE_DOWN);
@@ -334,14 +334,12 @@ public class KubernetesAutoScalerStateStore
 
     private static String serializeDelayedScaleDown(DelayedScaleDown delayedScaleDown)
             throws JacksonException {
-        return YAML_MAPPER.writeValueAsString(delayedScaleDown.getFirstTriggerTime());
+        return YAML_MAPPER.writeValueAsString(delayedScaleDown);
     }
 
     private static DelayedScaleDown deserializeDelayedScaleDown(String delayedScaleDown)
             throws JacksonException {
-        Map<JobVertexID, Instant> firstTriggerTime =
-                YAML_MAPPER.readValue(delayedScaleDown, new TypeReference<>() {});
-        return new DelayedScaleDown(firstTriggerTime);
+        return YAML_MAPPER.readValue(delayedScaleDown, new TypeReference<>() {});
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## What is the purpose of the change

Get more details from FLINK-36535.


## Brief change log

[FLINK-36535][autoscaler] Optimize the scale down logic based on historical parallelism
1. Using the maximum parallelism within the window instead of the latest parallelism when scaling down
2. Never scale down when (currentTime - triggerTime) < scale-down.interval

## Verifying this change

This change added tests and can be verified as follows:

- Added the DelayedScaleDownTest
- Rewrite the `testRequiredScaleDownAfterInterval` to `testScaleDownAfterInterval`
- Update the `AbstractAutoScalerStateStoreTest`, `JobVertexScalerTest` and `ScalingExecutorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
