### PR TITLE
[FLINK-36836][Autoscaler] Supports config the upper and lower limits of target utilization

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -202,13 +202,13 @@
         </tr>
         <tr>
             <td><h5>job.autoscaler.utilization.max</h5></td>
-            <td style="word-wrap: break-word;">1.0</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Double</td>
             <td>Max vertex utilization</td>
         </tr>
         <tr>
             <td><h5>job.autoscaler.utilization.min</h5></td>
-            <td style="word-wrap: break-word;">0.4</td>
+            <td style="word-wrap: break-word;">(none)</td>
             <td>Double</td>
             <td>Min vertex utilization</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -201,16 +201,22 @@
             <td>Stabilization period in which no new scaling will be executed</td>
         </tr>
         <tr>
-            <td><h5>job.autoscaler.target.utilization</h5></td>
+            <td><h5>job.autoscaler.utilization.max</h5></td>
+            <td style="word-wrap: break-word;">1.0</td>
+            <td>Double</td>
+            <td>Max vertex utilization</td>
+        </tr>
+        <tr>
+            <td><h5>job.autoscaler.utilization.min</h5></td>
+            <td style="word-wrap: break-word;">0.4</td>
+            <td>Double</td>
+            <td>Min vertex utilization</td>
+        </tr>
+        <tr>
+            <td><h5>job.autoscaler.utilization.target</h5></td>
             <td style="word-wrap: break-word;">0.7</td>
             <td>Double</td>
             <td>Target vertex utilization</td>
-        </tr>
-        <tr>
-            <td><h5>job.autoscaler.target.utilization.boundary</h5></td>
-            <td style="word-wrap: break-word;">0.3</td>
-            <td>Double</td>
-            <td>Target vertex utilization boundary. Scaling won't be performed if the processing capacity is within [target_rate / (target_utilization - boundary), (target_rate / (target_utilization + boundary)]</td>
         </tr>
         <tr>
             <td><h5>job.autoscaler.vertex.exclude.ids</h5></td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -49,7 +49,7 @@ import static org.apache.flink.autoscaler.config.AutoScalerOptions.MAX_SCALE_UP_
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALE_DOWN_INTERVAL;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_EVENT_INTERVAL;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.SCALING_KEY_GROUP_PARTITIONS_ADJUST_MODE;
-import static org.apache.flink.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_TARGET;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.VERTEX_MAX_PARALLELISM;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.VERTEX_MIN_PARALLELISM;
 import static org.apache.flink.autoscaler.metrics.ScalingMetric.EXPECTED_PROCESSING_RATE;
@@ -158,7 +158,7 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
 
         double targetCapacity =
                 AutoScalerUtils.getTargetProcessingCapacity(
-                        evaluatedMetrics, conf, conf.get(TARGET_UTILIZATION), true, restartTime);
+                        evaluatedMetrics, conf, conf.get(UTILIZATION_TARGET), true, restartTime);
         if (Double.isNaN(targetCapacity)) {
             LOG.warn(
                     "Target data rate is not available for {}, cannot compute new parallelism",

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -287,6 +287,7 @@ public class ScalingMetricEvaluator {
             Duration restartTime) {
 
         double targetUtilization = conf.get(UTILIZATION_TARGET);
+        double utilizationBoundary = conf.get(TARGET_UTILIZATION_BOUNDARY);
 
         double upperUtilization;
         double lowerUtilization;
@@ -297,16 +298,12 @@ public class ScalingMetricEvaluator {
             upperUtilization = 1.0;
             lowerUtilization = 0.0;
         } else {
-            if (conf.getOptional(UTILIZATION_MAX).isPresent()
-                    || conf.getOptional(UTILIZATION_MIN).isPresent()
-                    || conf.getOptional(TARGET_UTILIZATION_BOUNDARY).isEmpty()) {
-                upperUtilization = conf.get(UTILIZATION_MAX);
-                lowerUtilization = conf.get(UTILIZATION_MIN);
-            } else {
-                Double boundary = conf.get(TARGET_UTILIZATION_BOUNDARY);
-                upperUtilization = targetUtilization + boundary;
-                lowerUtilization = targetUtilization - boundary;
-            }
+            upperUtilization =
+                    conf.getOptional(UTILIZATION_MAX)
+                            .orElse(targetUtilization + utilizationBoundary);
+            lowerUtilization =
+                    conf.getOptional(UTILIZATION_MIN)
+                            .orElse(targetUtilization - utilizationBoundary);
         }
 
         double scaleUpThreshold =

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -89,13 +89,17 @@ public class AutoScalerOptions {
                                     + "seconds suffix, daily expression's formation is startTime-endTime, such as 9:30:30-10:50:20, when exclude from 9:30:30-10:50:20 in Monday and Thursday "
                                     + "we can express it as 9:30:30-10:50:20 && * * * ? * 2,5");
 
-    public static final ConfigOption<Double> TARGET_UTILIZATION =
-            autoScalerConfig("target.utilization")
+    public static final ConfigOption<Double> UTILIZATION_TARGET =
+            autoScalerConfig("utilization.target")
                     .doubleType()
                     .defaultValue(0.7)
-                    .withFallbackKeys(oldOperatorConfigKey("target.utilization"))
+                    .withDeprecatedKeys(autoScalerConfigKey("target.utilization"))
+                    .withFallbackKeys(
+                            oldOperatorConfigKey("utilization.target"),
+                            oldOperatorConfigKey("target.utilization"))
                     .withDescription("Target vertex utilization");
 
+    @Deprecated
     public static final ConfigOption<Double> TARGET_UTILIZATION_BOUNDARY =
             autoScalerConfig("target.utilization.boundary")
                     .doubleType()
@@ -103,6 +107,20 @@ public class AutoScalerOptions {
                     .withFallbackKeys(oldOperatorConfigKey("target.utilization.boundary"))
                     .withDescription(
                             "Target vertex utilization boundary. Scaling won't be performed if the processing capacity is within [target_rate / (target_utilization - boundary), (target_rate / (target_utilization + boundary)]");
+
+    public static final ConfigOption<Double> UTILIZATION_MAX =
+            autoScalerConfig("utilization.max")
+                    .doubleType()
+                    .defaultValue(1.)
+                    .withFallbackKeys(oldOperatorConfigKey("utilization.max"))
+                    .withDescription("Max vertex utilization");
+
+    public static final ConfigOption<Double> UTILIZATION_MIN =
+            autoScalerConfig("utilization.min")
+                    .doubleType()
+                    .defaultValue(0.4)
+                    .withFallbackKeys(oldOperatorConfigKey("utilization.min"))
+                    .withDescription("Min vertex utilization");
 
     public static final ConfigOption<Duration> SCALE_DOWN_INTERVAL =
             autoScalerConfig("scale-down.interval")

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -111,14 +111,14 @@ public class AutoScalerOptions {
     public static final ConfigOption<Double> UTILIZATION_MAX =
             autoScalerConfig("utilization.max")
                     .doubleType()
-                    .defaultValue(1.)
+                    .noDefaultValue()
                     .withFallbackKeys(oldOperatorConfigKey("utilization.max"))
                     .withDescription("Max vertex utilization");
 
     public static final ConfigOption<Double> UTILIZATION_MIN =
             autoScalerConfig("utilization.min")
                     .doubleType()
-                    .defaultValue(0.4)
+                    .noDefaultValue()
                     .withFallbackKeys(oldOperatorConfigKey("utilization.min"))
                     .withDescription("Min vertex utilization");
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/BacklogBasedScalingTest.java
@@ -95,8 +95,9 @@ public class BacklogBasedScalingTest {
         defaultConf.set(AutoScalerOptions.SCALING_ENABLED, true);
         defaultConf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 1.);
         defaultConf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, (double) Integer.MAX_VALUE);
-        defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.8);
-        defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.1);
+        defaultConf.set(AutoScalerOptions.UTILIZATION_TARGET, 0.8);
+        defaultConf.set(AutoScalerOptions.UTILIZATION_MAX, 0.9);
+        defaultConf.set(AutoScalerOptions.UTILIZATION_MIN, 0.7);
         defaultConf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
         defaultConf.set(AutoScalerOptions.BACKLOG_PROCESSING_LAG_THRESHOLD, Duration.ofSeconds(1));
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -49,6 +49,7 @@ import static org.apache.flink.autoscaler.JobVertexScaler.INEFFECTIVE_MESSAGE_FO
 import static org.apache.flink.autoscaler.JobVertexScaler.INEFFECTIVE_SCALING;
 import static org.apache.flink.autoscaler.JobVertexScaler.SCALE_LIMITED_MESSAGE_FORMAT;
 import static org.apache.flink.autoscaler.JobVertexScaler.SCALING_LIMITED;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_TARGET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -98,7 +99,7 @@ public class JobVertexScalerTest {
     @MethodSource("adjustmentInputsProvider")
     public void testParallelismScaling(Collection<ShipStrategy> inputShipStrategies) {
         var op = new JobVertexID();
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(UTILIZATION_TARGET, 1.);
         conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
         var delayedScaleDown = new DelayedScaleDown();
 
@@ -113,7 +114,7 @@ public class JobVertexScalerTest {
                         restartTime,
                         delayedScaleDown));
 
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
+        conf.set(UTILIZATION_TARGET, .8);
         assertEquals(
                 ParallelismChange.build(8),
                 vertexScaler.computeScaleTargetParallelism(
@@ -125,7 +126,7 @@ public class JobVertexScalerTest {
                         restartTime,
                         delayedScaleDown));
 
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
+        conf.set(UTILIZATION_TARGET, .8);
         assertEquals(
                 ParallelismChange.noChange(),
                 vertexScaler.computeScaleTargetParallelism(
@@ -137,7 +138,7 @@ public class JobVertexScalerTest {
                         restartTime,
                         delayedScaleDown));
 
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
+        conf.set(UTILIZATION_TARGET, .8);
         assertEquals(
                 ParallelismChange.build(8),
                 vertexScaler.computeScaleTargetParallelism(
@@ -160,7 +161,7 @@ public class JobVertexScalerTest {
                         restartTime,
                         delayedScaleDown));
 
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.5);
+        conf.set(UTILIZATION_TARGET, 0.5);
         assertEquals(
                 ParallelismChange.build(10),
                 vertexScaler.computeScaleTargetParallelism(
@@ -172,7 +173,7 @@ public class JobVertexScalerTest {
                         restartTime,
                         delayedScaleDown));
 
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
+        conf.set(UTILIZATION_TARGET, 0.6);
         assertEquals(
                 ParallelismChange.build(4),
                 vertexScaler.computeScaleTargetParallelism(
@@ -184,7 +185,7 @@ public class JobVertexScalerTest {
                         restartTime,
                         delayedScaleDown));
 
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(UTILIZATION_TARGET, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.5);
         assertEquals(
                 ParallelismChange.build(5),
@@ -209,7 +210,7 @@ public class JobVertexScalerTest {
                         restartTime,
                         delayedScaleDown));
 
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(UTILIZATION_TARGET, 1.);
         conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.5);
         assertEquals(
                 ParallelismChange.build(15),
@@ -558,7 +559,7 @@ public class JobVertexScalerTest {
     @Test
     public void testMaxParallelismLimitIsUsed() {
         conf.setInteger(AutoScalerOptions.VERTEX_MAX_PARALLELISM, 10);
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(UTILIZATION_TARGET, 1.);
         var delayedScaleDown = new DelayedScaleDown();
 
         assertEquals(
@@ -587,7 +588,7 @@ public class JobVertexScalerTest {
 
     @Test
     public void testDisableScaleDownInterval() {
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(UTILIZATION_TARGET, 1.);
         conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofMinutes(0));
 
         var delayedScaleDown = new DelayedScaleDown();
@@ -597,7 +598,7 @@ public class JobVertexScalerTest {
 
     @Test
     public void testScaleDownAfterInterval() {
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(UTILIZATION_TARGET, 1.);
         conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofMinutes(1));
         var instant = Instant.now();
 
@@ -629,7 +630,7 @@ public class JobVertexScalerTest {
 
     @Test
     public void testImmediateScaleUpWithinScaleDownInterval() {
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(UTILIZATION_TARGET, 1.);
         conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofMinutes(1));
         var instant = Instant.now();
 
@@ -655,7 +656,7 @@ public class JobVertexScalerTest {
 
     @Test
     public void testCancelDelayedScaleDownAfterNewParallelismIsSame() {
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(UTILIZATION_TARGET, 1.);
         conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofMinutes(1));
         var instant = Instant.now();
 
@@ -701,7 +702,7 @@ public class JobVertexScalerTest {
     public void testIneffectiveScalingDetection() {
         var op = new JobVertexID();
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
+        conf.set(UTILIZATION_TARGET, 1.);
         conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
 
         var evaluated = evaluated(5, 100, 50);
@@ -826,7 +827,7 @@ public class JobVertexScalerTest {
     public void testSendingIneffectiveScalingEvents(Collection<ShipStrategy> inputShipStrategies) {
         var jobVertexID = new JobVertexID();
         conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED, true);
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.0);
+        conf.set(UTILIZATION_TARGET, 1.0);
         conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
 
         var evaluated = evaluated(5, 100, 50);
@@ -1082,7 +1083,7 @@ public class JobVertexScalerTest {
     @Test
     public void testSendingScalingLimitedEvents() {
         var jobVertexID = new JobVertexID();
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.0);
+        conf.set(UTILIZATION_TARGET, 1.0);
         conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
         conf.set(AutoScalerOptions.SCALING_EVENT_INTERVAL, Duration.ZERO);
         var evaluated = evaluated(10, 200, 100);

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/MetricsCollectionAndEvaluationTest.java
@@ -123,8 +123,9 @@ public class MetricsCollectionAndEvaluationTest {
     @Test
     public void testEndToEnd() throws Exception {
         var conf = context.getConfiguration();
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.);
+        conf.set(AutoScalerOptions.UTILIZATION_TARGET, 1.);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 1.);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 1.);
 
         setDefaultMetrics(metricsCollector);
 
@@ -344,8 +345,9 @@ public class MetricsCollectionAndEvaluationTest {
     @Test
     public void testClearHistoryOnTopoChange() throws Exception {
         var conf = context.getConfiguration();
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.);
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.);
+        conf.set(AutoScalerOptions.UTILIZATION_TARGET, 1.);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 1.);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 1.);
 
         setDefaultMetrics(metricsCollector);
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RecommendedParallelismTest.java
@@ -86,8 +86,9 @@ public class RecommendedParallelismTest {
         defaultConf.set(AutoScalerOptions.SCALING_ENABLED, true);
         defaultConf.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 1.);
         defaultConf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, (double) Integer.MAX_VALUE);
-        defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.8);
-        defaultConf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.1);
+        defaultConf.set(AutoScalerOptions.UTILIZATION_TARGET, 0.8);
+        defaultConf.set(AutoScalerOptions.UTILIZATION_MAX, 0.9);
+        defaultConf.set(AutoScalerOptions.UTILIZATION_MIN, 0.7);
         defaultConf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
 
         autoscaler =

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -128,15 +128,17 @@ public class ScalingExecutorTest {
 
         var op1 = new JobVertexID();
 
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.);
+        conf.set(AutoScalerOptions.UTILIZATION_TARGET, 0.6);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.6);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.6);
 
         var evaluated = Map.of(op1, evaluated(1, 70, 100));
         assertFalse(
                 ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
                         evaluated, evaluated.keySet()));
 
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.2);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.8);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.4);
         evaluated = Map.of(op1, evaluated(1, 70, 100));
         assertTrue(
                 ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
@@ -178,8 +180,9 @@ public class ScalingExecutorTest {
         var op2 = new JobVertexID();
 
         // All vertices are optional
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.);
+        conf.set(AutoScalerOptions.UTILIZATION_TARGET, 0.6);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.6);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.6);
 
         var evaluated =
                 Map.of(
@@ -194,7 +197,8 @@ public class ScalingExecutorTest {
 
         // One vertex is required, and it's within the range.
         // The op2 is optional, so it shouldn't affect the scaling even if it is out of range,
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.1);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.8);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.6);
         evaluated =
                 Map.of(
                         op1, evaluated(1, 65, 100),
@@ -206,15 +210,17 @@ public class ScalingExecutorTest {
     @Test
     public void testNoScaleDownOnZeroLowerUtilizationBoundary() throws Exception {
         var conf = context.getConfiguration();
-        // Target utilization and boundary are identical
+        // Utilization min max is set from 0 to 1
         // which will set the scale down boundary to infinity
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.6);
+        conf.set(AutoScalerOptions.UTILIZATION_TARGET, 0.6);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 1.2);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.);
 
         var vertex = new JobVertexID();
         int parallelism = 100;
         int expectedParallelism = 1;
         int targetRate = 1000;
+
         // Intentionally also set the true processing rate to infinity
         // to test the boundaries of the scaling condition.
         double trueProcessingRate = Double.POSITIVE_INFINITY;
@@ -250,6 +256,56 @@ public class ScalingExecutorTest {
     }
 
     @Test
+    public void testUtilizationBoundariesAndUtilizationMinMaxCompatibility() {
+        var conf = context.getConfiguration();
+        conf.set(AutoScalerOptions.RESTART_TIME, Duration.ZERO);
+        conf.set(AutoScalerOptions.CATCH_UP_DURATION, Duration.ZERO);
+        var op1 = new JobVertexID();
+        var op2 = new JobVertexID();
+
+        // All vertices are optional
+        conf.set(AutoScalerOptions.UTILIZATION_TARGET, 0.6);
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.1);
+        var evaluated =
+                Map.of(
+                        op1, evaluated(1, 70, 100),
+                        op2, evaluated(1, 85, 100));
+
+        // target boundary 0.1, target 0.6, max 0.7, min 0.5
+        boolean boundaryOp1 =
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(evaluated, Set.of(op1));
+        boolean boundaryOp2 =
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(evaluated, Set.of(op2));
+
+        // Remove target boundary and use min max, should get the same result
+        conf.removeConfig(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.7);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.5);
+        boolean minMaxOp1 =
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(evaluated, Set.of(op1));
+        boolean minMaxOp2 =
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(evaluated, Set.of(op2));
+        assertEquals(boundaryOp1, minMaxOp1);
+        assertEquals(boundaryOp2, minMaxOp2);
+
+        // When the target boundary parameter is used,
+        // but the min max parameter is also set,
+        // the min max parameter shall prevail.
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 1.);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.7);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.3);
+
+        evaluated =
+                Map.of(
+                        op1, evaluated(2, 150, 100),
+                        op2, evaluated(1, 85, 100));
+
+        assertFalse(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
+                        evaluated, evaluated.keySet()));
+    }
+
+    @Test
     public void testVertexesExclusionForScaling() throws Exception {
         var sourceHexString = "0bfd135746ac8efb3cce668b12e16d3a";
         var source = JobVertexID.fromHexString(sourceHexString);
@@ -266,7 +322,7 @@ public class ScalingExecutorTest {
 
         var conf = context.getConfiguration();
         conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ofSeconds(0));
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, .8);
+        conf.set(AutoScalerOptions.UTILIZATION_TARGET, .8);
         var metrics =
                 new EvaluatedMetrics(
                         Map.of(
@@ -720,7 +776,7 @@ public class ScalingExecutorTest {
                                 null));
 
         var conf = context.getConfiguration();
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 1.d);
+        conf.set(AutoScalerOptions.UTILIZATION_TARGET, 1.d);
 
         // The expected new parallelism is 7 without adjustment by max parallelism.
         var metrics =
@@ -774,8 +830,9 @@ public class ScalingExecutorTest {
         conf.setString("taskmanager.numberOfTaskSlots", "2");
         cpuQuota.ifPresent(v -> conf.set(AutoScalerOptions.CPU_QUOTA, v));
         memoryQuota.ifPresent(v -> conf.set(AutoScalerOptions.MEMORY_QUOTA, MemorySize.parse(v)));
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION, 0.6);
-        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.);
+        conf.set(AutoScalerOptions.UTILIZATION_TARGET, 0.6);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.6);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.6);
 
         testQuotaReached(slotSharingGroupId1, slotSharingGroupId2, quotaReached, ctx);
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -294,12 +294,46 @@ public class ScalingExecutorTest {
         conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 1.);
         conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.7);
         conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.3);
-
         evaluated =
                 Map.of(
                         op1, evaluated(2, 150, 100),
                         op2, evaluated(1, 85, 100));
+        assertFalse(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
+                        evaluated, evaluated.keySet()));
 
+        // When the target boundary parameter is used,
+        // but the max parameter is also set,
+        conf.removeConfig(AutoScalerOptions.UTILIZATION_MIN);
+        conf.set(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 1.);
+        conf.set(AutoScalerOptions.UTILIZATION_TARGET, 0.5);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.6);
+
+        evaluated =
+                Map.of(
+                        op1, evaluated(2, 100, 99999),
+                        op2, evaluated(1, 80, 99999));
+        assertTrue(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
+                        evaluated, evaluated.keySet()));
+
+        evaluated = Map.of(op2, evaluated(1, 85, 100));
+        assertFalse(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
+                        evaluated, evaluated.keySet()));
+
+        conf.removeConfig(AutoScalerOptions.UTILIZATION_MAX);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.3);
+
+        evaluated =
+                Map.of(
+                        op1, evaluated(2, 80, 81),
+                        op2, evaluated(1, 100, 101));
+        assertTrue(
+                ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
+                        evaluated, evaluated.keySet()));
+
+        evaluated = Map.of(op1, evaluated(1, 80, 79));
         assertFalse(
                 ScalingExecutor.allChangedVerticesWithinUtilizationTarget(
                         evaluated, evaluated.keySet()));

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -41,8 +41,7 @@ import java.util.TreeMap;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.CATCH_UP_DURATION;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.PREFER_TRACKED_RESTART_TIME;
 import static org.apache.flink.autoscaler.config.AutoScalerOptions.RESTART_TIME;
-import static org.apache.flink.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION;
-import static org.apache.flink.autoscaler.config.AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_TARGET;
 import static org.apache.flink.autoscaler.topology.ShipStrategy.REBALANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -265,8 +264,9 @@ public class ScalingMetricEvaluatorTest {
     public void testUtilizationBoundaryComputation() {
 
         var conf = new Configuration();
-        conf.set(TARGET_UTILIZATION, 0.8);
-        conf.set(TARGET_UTILIZATION_BOUNDARY, 0.1);
+        conf.set(UTILIZATION_TARGET, 0.8);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.9);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.7);
         conf.set(RESTART_TIME, Duration.ofSeconds(1));
         conf.set(CATCH_UP_DURATION, Duration.ZERO);
 
@@ -287,8 +287,9 @@ public class ScalingMetricEvaluatorTest {
     public void testUtilizationBoundaryComputationWithRestartTimesTracking() {
 
         var conf = new Configuration();
-        conf.set(TARGET_UTILIZATION, 0.8);
-        conf.set(TARGET_UTILIZATION_BOUNDARY, 0.1);
+        conf.set(UTILIZATION_TARGET, 0.8);
+        conf.set(AutoScalerOptions.UTILIZATION_MAX, 0.9);
+        conf.set(AutoScalerOptions.UTILIZATION_MIN, 0.7);
         conf.set(RESTART_TIME, Duration.ofMinutes(10));
         conf.set(CATCH_UP_DURATION, Duration.ZERO);
         conf.set(PREFER_TRACKED_RESTART_TIME, true);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -65,6 +65,10 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_MAX;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_MIN;
+import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_TARGET;
+
 /** Default validator implementation for {@link FlinkDeployment}. */
 public class DefaultValidator implements FlinkResourceValidator {
 
@@ -605,9 +609,19 @@ public class DefaultValidator implements FlinkResourceValidator {
         return firstPresent(
                 validateNumber(flinkConfiguration, AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.0d),
                 validateNumber(flinkConfiguration, AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.0d),
-                validateNumber(flinkConfiguration, AutoScalerOptions.TARGET_UTILIZATION, 0.0d),
+                validateNumber(flinkConfiguration, UTILIZATION_TARGET, 0.0d, 1.0d),
                 validateNumber(
                         flinkConfiguration, AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.0d),
+                validateNumber(
+                        flinkConfiguration,
+                        UTILIZATION_MAX,
+                        flinkConfiguration.get(UTILIZATION_TARGET),
+                        1.0d),
+                validateNumber(
+                        flinkConfiguration,
+                        UTILIZATION_MIN,
+                        0.0d,
+                        flinkConfiguration.get(UTILIZATION_TARGET)),
                 CalendarUtils.validateExcludedPeriods(flinkConfiguration));
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -802,22 +802,34 @@ public class DefaultValidatorTest {
         var result =
                 testAutoScalerConfiguration(
                         flinkConf ->
-                                flinkConf.put(AutoScalerOptions.TARGET_UTILIZATION.key(), "-0.6"));
+                                flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "-0.6"));
         assertErrorContains(
-                result, getFormattedErrorMessage(AutoScalerOptions.TARGET_UTILIZATION, 0.0d));
+                result, getFormattedErrorMessage(AutoScalerOptions.UTILIZATION_TARGET, 0.0d, 1.0d));
     }
 
     @Test
     public void testAutoScalerDeploymentWithInvalidNegativeUtilizationBoundary() {
-        var result =
+        var resultMaxUtilization =
                 testAutoScalerConfiguration(
                         flinkConf ->
-                                flinkConf.put(
-                                        AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY.key(),
-                                        "-0.6"));
+                                flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "-0.6"));
         assertErrorContains(
-                result,
-                getFormattedErrorMessage(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.0d));
+                resultMaxUtilization,
+                getFormattedErrorMessage(
+                        AutoScalerOptions.UTILIZATION_MAX,
+                        AutoScalerOptions.UTILIZATION_TARGET.defaultValue(),
+                        1.0));
+
+        var resultMinUtilization =
+                testAutoScalerConfiguration(
+                        flinkConf ->
+                                flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "-0.6"));
+        assertErrorContains(
+                resultMinUtilization,
+                getFormattedErrorMessage(
+                        AutoScalerOptions.UTILIZATION_MIN,
+                        0.0d,
+                        AutoScalerOptions.UTILIZATION_TARGET.defaultValue()));
     }
 
     @Test
@@ -838,9 +850,9 @@ public class DefaultValidatorTest {
                             flinkConf.remove(AutoScalerOptions.AUTOSCALER_ENABLED.key());
                             flinkConf.put(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR.key(), "-1.6");
                             flinkConf.put(AutoScalerOptions.MAX_SCALE_UP_FACTOR.key(), "-1.6");
-                            flinkConf.put(AutoScalerOptions.TARGET_UTILIZATION.key(), "-1.6");
-                            flinkConf.put(
-                                    AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY.key(), "-1.6");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "-1.6");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "-1.6");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "-1.6");
                         });
         assertErrorNotContains(result);
     }
@@ -853,9 +865,9 @@ public class DefaultValidatorTest {
                             flinkConf.put(AutoScalerOptions.AUTOSCALER_ENABLED.key(), "false");
                             flinkConf.put(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR.key(), "-1.6");
                             flinkConf.put(AutoScalerOptions.MAX_SCALE_UP_FACTOR.key(), "-1.6");
-                            flinkConf.put(AutoScalerOptions.TARGET_UTILIZATION.key(), "-1.6");
-                            flinkConf.put(
-                                    AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY.key(), "-1.6");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "-1.6");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "-1.6");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "-1.6");
                         });
         assertErrorNotContains(result);
     }
@@ -891,35 +903,59 @@ public class DefaultValidatorTest {
         var result =
                 testSessionJobAutoScalerConfiguration(
                         flinkConf ->
-                                flinkConf.put(AutoScalerOptions.TARGET_UTILIZATION.key(), "-0.6"));
+                                flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "-0.6"));
         assertErrorContains(
-                result, getFormattedErrorMessage(AutoScalerOptions.TARGET_UTILIZATION, 0.0d));
+                result, getFormattedErrorMessage(AutoScalerOptions.UTILIZATION_TARGET, 0.0d, 1.0));
     }
 
     @Test
     public void testValidateSessionJobWithInvalidNegativeUtilizationBoundary() {
-        var result =
+        var resultMaxUtilization =
                 testSessionJobAutoScalerConfiguration(
                         flinkConf ->
-                                flinkConf.put(
-                                        AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY.key(),
-                                        "-0.6"));
+                                flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "-0.6"));
         assertErrorContains(
-                result,
-                getFormattedErrorMessage(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.0d));
+                resultMaxUtilization,
+                getFormattedErrorMessage(
+                        AutoScalerOptions.UTILIZATION_MAX,
+                        AutoScalerOptions.UTILIZATION_TARGET.defaultValue(),
+                        1.0d));
+
+        var resultMinUtilization =
+                testSessionJobAutoScalerConfiguration(
+                        flinkConf ->
+                                flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "-0.6"));
+        assertErrorContains(
+                resultMinUtilization,
+                getFormattedErrorMessage(
+                        AutoScalerOptions.UTILIZATION_MIN,
+                        0.0d,
+                        AutoScalerOptions.UTILIZATION_TARGET.defaultValue()));
     }
 
     @Test
     public void testValidateSessionJobWithInvalidUtilizationBoundary() {
-        var result =
+        var resultMaxUtilization =
                 testSessionJobAutoScalerConfiguration(
                         flinkConf ->
-                                flinkConf.put(
-                                        AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY.key(),
-                                        "-1.6"));
+                                flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "-0.6"));
         assertErrorContains(
-                result,
-                getFormattedErrorMessage(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.0d));
+                resultMaxUtilization,
+                getFormattedErrorMessage(
+                        AutoScalerOptions.UTILIZATION_MAX,
+                        AutoScalerOptions.UTILIZATION_TARGET.defaultValue(),
+                        1.0d));
+
+        var resultMinUtilization =
+                testSessionJobAutoScalerConfiguration(
+                        flinkConf ->
+                                flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "-0.6"));
+        assertErrorContains(
+                resultMinUtilization,
+                getFormattedErrorMessage(
+                        AutoScalerOptions.UTILIZATION_MIN,
+                        0.0,
+                        AutoScalerOptions.UTILIZATION_TARGET.defaultValue()));
     }
 
     @Test
@@ -940,11 +976,98 @@ public class DefaultValidatorTest {
                             flinkConf.put(AutoScalerOptions.AUTOSCALER_ENABLED.key(), "false");
                             flinkConf.put(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR.key(), "-1.6");
                             flinkConf.put(AutoScalerOptions.MAX_SCALE_UP_FACTOR.key(), "-1.6");
-                            flinkConf.put(AutoScalerOptions.TARGET_UTILIZATION.key(), "-1.6");
-                            flinkConf.put(
-                                    AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY.key(), "-1.6");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "-1.6");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "-1.6");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "-1.6");
                         });
         assertErrorNotContains(result);
+    }
+
+    @Test
+    public void testAutoScalerUtilizationConfiguration() {
+        var deploymentResult =
+                testAutoScalerConfiguration(
+                        flinkConf -> {
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "0.3");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "0.5");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "0.4");
+                        });
+        assertErrorContains(
+                deploymentResult,
+                getFormattedErrorMessage(AutoScalerOptions.UTILIZATION_MAX, 0.5, 1.0));
+
+        deploymentResult =
+                testAutoScalerConfiguration(
+                        flinkConf -> {
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "0.8");
+                        });
+        assertErrorContains(
+                deploymentResult,
+                getFormattedErrorMessage(
+                        AutoScalerOptions.UTILIZATION_MIN,
+                        0.0,
+                        AutoScalerOptions.UTILIZATION_TARGET.defaultValue()));
+
+        deploymentResult =
+                testAutoScalerConfiguration(
+                        flinkConf -> {
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "1.5");
+                        });
+
+        assertErrorContains(
+                deploymentResult,
+                getFormattedErrorMessage(AutoScalerOptions.UTILIZATION_TARGET, 0.0, 1.0));
+
+        deploymentResult =
+                testAutoScalerConfiguration(
+                        flinkConf -> {
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "0.2");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "0.5");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "0.6");
+                        });
+        assertErrorNotContains(deploymentResult);
+
+        var sessionResult =
+                testSessionJobAutoScalerConfiguration(
+                        flinkConf -> {
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "0.3");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "0.5");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "0.4");
+                        });
+        assertErrorContains(
+                sessionResult,
+                getFormattedErrorMessage(AutoScalerOptions.UTILIZATION_MAX, 0.5, 1.0));
+
+        sessionResult =
+                testSessionJobAutoScalerConfiguration(
+                        flinkConf -> {
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "0.6");
+                        });
+        assertErrorContains(
+                sessionResult,
+                getFormattedErrorMessage(
+                        AutoScalerOptions.UTILIZATION_MAX,
+                        AutoScalerOptions.UTILIZATION_TARGET.defaultValue(),
+                        1.0));
+
+        sessionResult =
+                testSessionJobAutoScalerConfiguration(
+                        flinkConf -> {
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "1.5");
+                        });
+
+        assertErrorContains(
+                sessionResult,
+                getFormattedErrorMessage(AutoScalerOptions.UTILIZATION_TARGET, 0.0, 1.0));
+
+        sessionResult =
+                testSessionJobAutoScalerConfiguration(
+                        flinkConf -> {
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "0.2");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "0.5");
+                            flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "0.6");
+                        });
+        assertErrorNotContains(sessionResult);
     }
 
     private Optional<String> testSessionJobAutoScalerConfiguration(
@@ -972,8 +1095,9 @@ public class DefaultValidatorTest {
         conf.put(AutoScalerOptions.MAX_SCALE_UP_FACTOR.key(), "100000.0");
         conf.put(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR.key(), "0.6");
         conf.put(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED.key(), "0.1");
-        conf.put(AutoScalerOptions.TARGET_UTILIZATION.key(), "0.7");
-        conf.put(AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY.key(), "0.4");
+        conf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "0.7");
+        conf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "1.0");
+        conf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "0.3");
         return conf;
     }
 
@@ -984,6 +1108,17 @@ public class DefaultValidatorTest {
                 configValue.key(),
                 min != null ? min.toString() : "-Infinity",
                 max != null ? max.toString() : "+Infinity");
+    }
+
+    private static String getFormattedNumberOrderErrorMessage(
+            ConfigOption<Double> configValueLeft, ConfigOption<Double> configValueRight) {
+        return String.format(
+                "The AutoScalerOption %s or %s is invalid, %s must be less than or equal to the value of "
+                        + "%s",
+                configValueLeft.key(),
+                configValueRight.key(),
+                configValueLeft.key(),
+                configValueRight.key());
     }
 
     private static String getFormattedErrorMessage(ConfigOption<Double> configValue, Double min) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

detail: FLINK-36836 


## Brief change log

  - *Introduce two new parameters `job.autoscaler.utilization.min` and `job.autoscaler.utilization.max` to determine the upper and lower limits of utilization*


## Verifying this change

  - Change the previous test cases related to `job.autoscaler.target.utilization.boundary` to `job.autoscaler.utilization.min` and `job.autoscaler.utilization.max` 
  - add test `ScalingExecutorTest#testUtilizationBoundariesAndUtilizationMinMaxCompatibility` Verify compatibility of parameters before and after


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / *no*)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / *no*)
  - Core observer or reconciler logic that is regularly executed: (yes / no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
