### PR TITLE
[FLINK-36890] Update observedGeneration on NOOP reconciliation

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -546,11 +546,6 @@ public class ReconciliationUtils {
         var lastSpecWithMeta = reconciliationStatus.deserializeLastReconciledSpecWithMeta();
         var newMeta = ReconciliationMetadata.from(resource);
 
-        if (newMeta.equals(lastSpecWithMeta.getMeta())) {
-            // Nothing to update
-            return;
-        }
-
         reconciliationStatus.setLastReconciledSpec(
                 SpecUtils.writeSpecWithMeta(lastSpecWithMeta.getSpec(), newMeta));
         resource.getStatus().setObservedGeneration(resource.getMetadata().getGeneration());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -1235,10 +1235,6 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
         // Submit no-op upgrade
         deployment.getSpec().getFlinkConfiguration().put("kubernetes.operator.test", "value");
         deployment.getMetadata().setGeneration(2L);
-        deployment
-                .getStatus()
-                .getReconciliationStatus()
-                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
 
         reconciler.reconcile(deployment, context);
         assertEquals(2L, deployment.getStatus().getObservedGeneration());


### PR DESCRIPTION
The observedGeneration field wasn't updated anymore when the spec update results in a NOOP reconciliation.

This is a regression of a10fb4501011be4e88fb6164156e3b9e8527950e / https://github.com/apache/flink-kubernetes-operator/pull/834