### PR TITLE
[FLINK-36932][metrics] Added resource-level metrics for different states/statuses

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/FlinkDeploymentMetrics.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.metrics;
 
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
@@ -24,6 +25,7 @@ import org.apache.flink.kubernetes.operator.service.AbstractFlinkService;
 import org.apache.flink.runtime.rest.messages.DashboardConfiguration;
 import org.apache.flink.util.StringUtils;
 
+import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 
 import java.util.Map;
@@ -37,8 +39,9 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
     private final Configuration configuration;
 
     // map(namespace, map(status, set(deployment))
-    private final Map<String, Map<JobManagerDeploymentStatus, Set<String>>> deploymentStatuses =
+    private final Map<String, Map<JobManagerDeploymentStatus, Set<String>>> jmDeploymentStatuses =
             new ConcurrentHashMap<>();
+    private final Map<String, Map<JobStatus, Set<String>>> jobStatuses = new ConcurrentHashMap<>();
     // map(namespace, map(version, set(deployment)))
     private final Map<String, Map<String, Set<String>>> deploymentFlinkVersions =
             new ConcurrentHashMap<>();
@@ -53,9 +56,11 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
     public static final String FLINK_MINOR_VERSION_GROUP_NAME = "FlinkMinorVersion";
     public static final String UNKNOWN_VERSION = "UNKNOWN";
     public static final String MALFORMED_MINOR_VERSION = "MALFORMED";
-    public static final String STATUS_GROUP_NAME = "JmDeploymentStatus";
+    public static final String JM_DEPLOYMENT_STATUS_GROUP_NAME = "JmDeploymentStatus";
+    public static final String JOB_STATUS_GROUP_NAME = "JobStatus";
     public static final String RESOURCE_USAGE_GROUP_NAME = "ResourceUsage";
     public static final String COUNTER_NAME = "Count";
+    public static final String IN_STATUS_NAME = "InStatus";
     public static final String CPU_NAME = "Cpu";
     public static final String MEMORY_NAME = "Memory";
 
@@ -65,27 +70,21 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
         this.configuration = configuration;
     }
 
+    @Override
     public void onUpdate(FlinkDeployment flinkApp) {
         onRemove(flinkApp);
 
+        var flinkAppState = flinkApp.getStatus();
         var namespace = flinkApp.getMetadata().getNamespace();
-        var clusterInfo = flinkApp.getStatus().getClusterInfo();
+        var clusterInfo = flinkAppState.getClusterInfo();
         var deploymentName = flinkApp.getMetadata().getName();
 
-        deploymentStatuses
-                .computeIfAbsent(
-                        namespace,
-                        ns -> {
-                            initNamespaceDeploymentCounts(ns);
-                            initNamespaceStatusCounts(ns);
-                            return createDeploymentStatusMap();
-                        })
-                .get(flinkApp.getStatus().getJobManagerDeploymentStatus())
-                .add(deploymentName);
+        initJmDeploymentMetrics(namespace, deploymentName, flinkApp);
+        initJobMetrics(namespace, deploymentName, flinkApp);
 
         // Full runtime version queried from the JobManager REST API
         var flinkVersion =
-                flinkApp.getStatus()
+                flinkAppState
                         .getClusterInfo()
                         .getOrDefault(DashboardConfiguration.FIELD_NAME_FLINK_VERSION, "");
         if (StringUtils.isNullOrWhitespaceOnly(flinkVersion)) {
@@ -146,12 +145,61 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
                                         AbstractFlinkService.FIELD_NAME_TOTAL_MEMORY, "0")));
     }
 
+    private void initJmDeploymentMetrics(
+            String namespace, String deploymentName, FlinkDeployment flinkApp) {
+        var currentJmDeploymentStatus = flinkApp.getStatus().getJobManagerDeploymentStatus();
+
+        boolean deploymentRegistrationOccurred =
+                jmDeploymentStatuses
+                        .computeIfAbsent(
+                                namespace,
+                                ns -> {
+                                    initNamespaceDeploymentCounts(ns);
+                                    initNamespaceJmDeploymentStatusCounts(ns);
+                                    return createStatusMapFromEnum(
+                                            JobManagerDeploymentStatus.class);
+                                })
+                        .get(currentJmDeploymentStatus)
+                        .add(deploymentName);
+
+        if (deploymentRegistrationOccurred) {
+            initJmDeploymentStatusGauges(namespace, deploymentName);
+        }
+    }
+
+    private void initJobMetrics(String namespace, String deploymentName, FlinkDeployment flinkApp) {
+        var jobStatusDetails = flinkApp.getStatus().getJobStatus();
+        var jobStatus = jobStatusDetails.getState();
+        if (jobStatus == null) {
+            return;
+        }
+
+        boolean deploymentRegistrationOccurred =
+                jobStatuses
+                        .computeIfAbsent(
+                                namespace,
+                                ns -> {
+                                    initNamespaceJobStatusCounts(ns);
+                                    return createStatusMapFromEnum(JobStatus.class);
+                                })
+                        .get(jobStatus)
+                        .add(deploymentName);
+
+        if (deploymentRegistrationOccurred) {
+            initJobStatusGauges(namespace, deploymentName);
+        }
+    }
+
+    @Override
     public void onRemove(FlinkDeployment flinkApp) {
         var namespace = flinkApp.getMetadata().getNamespace();
         var name = flinkApp.getMetadata().getName();
 
-        if (deploymentStatuses.containsKey(namespace)) {
-            deploymentStatuses.get(namespace).values().forEach(names -> names.remove(name));
+        if (jmDeploymentStatuses.containsKey(namespace)) {
+            jmDeploymentStatuses.get(namespace).values().forEach(names -> names.remove(name));
+        }
+        if (jobStatuses.containsKey(namespace)) {
+            jobStatuses.get(namespace).values().forEach(names -> names.remove(name));
         }
         if (deploymentFlinkVersions.containsKey(namespace)) {
             deploymentFlinkVersions.get(namespace).values().forEach(names -> names.remove(name));
@@ -176,18 +224,60 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
                 .gauge(
                         COUNTER_NAME,
                         () ->
-                                deploymentStatuses.get(ns).values().stream()
+                                jmDeploymentStatuses.get(ns).values().stream()
                                         .mapToInt(Set::size)
                                         .sum());
     }
 
-    private void initNamespaceStatusCounts(String ns) {
+    private void initNamespaceJmDeploymentStatusCounts(String ns) {
         for (JobManagerDeploymentStatus status : JobManagerDeploymentStatus.values()) {
             parentMetricGroup
                     .createResourceNamespaceGroup(configuration, FlinkDeployment.class, ns)
-                    .addGroup(STATUS_GROUP_NAME)
+                    .addGroup(JM_DEPLOYMENT_STATUS_GROUP_NAME)
                     .addGroup(status.toString())
-                    .gauge(COUNTER_NAME, () -> deploymentStatuses.get(ns).get(status).size());
+                    .gauge(COUNTER_NAME, () -> jmDeploymentStatuses.get(ns).get(status).size());
+        }
+    }
+
+    private void initNamespaceJobStatusCounts(String ns) {
+        for (JobStatus status : JobStatus.values()) {
+            parentMetricGroup
+                    .createResourceNamespaceGroup(configuration, FlinkDeployment.class, ns)
+                    .addGroup(JOB_STATUS_GROUP_NAME)
+                    .addGroup(status.toString())
+                    .gauge(COUNTER_NAME, () -> jobStatuses.get(ns).get(status).size());
+        }
+    }
+
+    private void initJmDeploymentStatusGauges(String ns, String deploymentName) {
+        for (JobManagerDeploymentStatus status : JobManagerDeploymentStatus.values()) {
+            parentMetricGroup
+                    .createResourceNamespaceGroup(configuration, FlinkDeployment.class, ns)
+                    .createResourceGroup(configuration, deploymentName)
+                    .addGroup(JM_DEPLOYMENT_STATUS_GROUP_NAME)
+                    .addGroup(status.toString())
+                    .gauge(
+                            IN_STATUS_NAME,
+                            () ->
+                                    jmDeploymentStatuses
+                                                    .get(ns)
+                                                    .get(status)
+                                                    .contains(deploymentName)
+                                            ? 1
+                                            : 0);
+        }
+    }
+
+    private void initJobStatusGauges(String ns, String deploymentName) {
+        for (JobStatus status : JobStatus.values()) {
+            parentMetricGroup
+                    .createResourceNamespaceGroup(configuration, FlinkDeployment.class, ns)
+                    .createResourceGroup(configuration, deploymentName)
+                    .addGroup(JOB_STATUS_GROUP_NAME)
+                    .addGroup(status.toString())
+                    .gauge(
+                            IN_STATUS_NAME,
+                            () -> jobStatuses.get(ns).get(status).contains(deploymentName) ? 1 : 0);
         }
     }
 
@@ -231,9 +321,10 @@ public class FlinkDeploymentMetrics implements CustomResourceMetrics<FlinkDeploy
                                         .reduce(0L, Long::sum));
     }
 
-    private Map<JobManagerDeploymentStatus, Set<String>> createDeploymentStatusMap() {
-        Map<JobManagerDeploymentStatus, Set<String>> statuses = new ConcurrentHashMap<>();
-        for (JobManagerDeploymentStatus status : JobManagerDeploymentStatus.values()) {
+    private static <T extends Enum<T>> Map<T, Set<String>> createStatusMapFromEnum(
+            Class<T> statusType) {
+        Map<T, Set<String>> statuses = new ConcurrentHashMap<>();
+        for (T status : statusType.getEnumConstants()) {
             statuses.put(status, ConcurrentHashMap.newKeySet());
         }
         return statuses;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/ResourceLifecycleMetricTracker.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/ResourceLifecycleMetricTracker.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState;
 import org.apache.flink.metrics.Histogram;
 
+import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,8 @@ public class ResourceLifecycleMetricTracker {
 
     private static final Logger LOG = LoggerFactory.getLogger(ResourceLifecycleMetricTracker.class);
 
+    @Getter private final String namespace;
+    @Getter private final String resourceName;
     private final Map<String, List<Histogram>> transitionHistos;
     private final Map<ResourceLifecycleState, List<Histogram>> stateTimeHistos;
 
@@ -45,10 +48,14 @@ public class ResourceLifecycleMetricTracker {
     private ResourceLifecycleState currentState;
 
     public ResourceLifecycleMetricTracker(
+            String namespace,
+            String resourceName,
             ResourceLifecycleState initialState,
             Instant time,
             Map<String, List<Histogram>> transitionHistos,
             Map<ResourceLifecycleState, List<Histogram>> stateTimeHistos) {
+        this.namespace = namespace;
+        this.resourceName = resourceName;
         this.transitionHistos = transitionHistos;
         this.currentState = initialState;
         this.stateTimeHistos = stateTimeHistos;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/TestingMetricListener.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/TestingMetricListener.java
@@ -44,6 +44,11 @@ public class TestingMetricListener {
     private static final String HOST = "test-op-host";
     private final KubernetesOperatorMetricGroup metricGroup;
     private final Map<String, Metric> metrics = new HashMap();
+
+    public Map<String, Metric> getMetrics() {
+        return metrics;
+    }
+
     private final ScheduledExecutorService executor;
     private Configuration configuration;
     private ViewUpdater viewUpdater;


### PR DESCRIPTION
## What is the purpose of the change

This PR adds new metrics that help track the current value of different states/statuses at the resource level. In some cases, metrics already exists for some of these statuses/states, but those metrics represent namespace or system-wide counts, as opposed to per-resource gauges that indicate whether or not a deployment/session job is in a particular state.

In other cases, some statuses/states that weren't yet tracked through a dedicated metric (ex: job status) now have a resource-level gauge and namespace-level counter.

## Brief change log

Summary of the changes for each state/status:
- `JobManagerDeploymentStatus`: state gauge added at resource-level (FlinkDeployment only)
- `JobStatus`: status gauge added at resource-level (FlinkDeployment only), status counter at namespace-level
- `ResourceLifecycleState`: state gauge added at resource-level

## Verifying this change

This change added tests and can be verified as follows:

- Updated test cases for resource lifecycle metrics and Flink deployment metrics to account for new resource-level metrics
  - Also added utility methods to test classes to reduce duplicated test logic
- Changes were deployed and tested using our own fork/instance of the operator

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  
N.B. While these changes might not represent a full-on "feature", I'm planning to update the documentation that generates [this](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/operations/metrics-logging/) page. However, I've held off doing this as part of this initial commit in order to settle the naming and implementation. Once this is done, I can update the documentation accordingly.
