### PR TITLE
[FLINK-36640] Add autoscalerResetNonce to jobSpec

### DIFF
--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -182,6 +182,7 @@ This serves as a full reference for FlinkDeployment and FlinkSessionJob custom r
 | upgradeMode | org.apache.flink.kubernetes.operator.api.spec.UpgradeMode | Upgrade mode of the Flink job. |
 | allowNonRestoredState | java.lang.Boolean | Allow checkpoint state that cannot be mapped to any job vertex in tasks. |
 | savepointRedeployNonce | java.lang.Long | Nonce used to trigger a full redeployment of the job from the savepoint path specified in initialSavepointPath. In order to trigger redeployment, change the number to a different non-null value. Rollback is not possible after redeployment. |
+| autoscalerResetNonce | java.lang.Long | Nonce used to reset the autoscaler metrics, parallelism overrides and history for the job. This can be used to quickly go back to the initial user-provided parallelism settings without having to toggle the autoscaler on and off. In order to trigger the reset behaviour simply change the nonce to a new non-null value. |
 
 ### JobState
 **Class**: org.apache.flink.kubernetes.operator.api.spec.JobState

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobSpec.java
@@ -97,4 +97,13 @@ public class JobSpec implements Diffable<JobSpec> {
      */
     @SpecDiff(value = DiffType.SAVEPOINT_REDEPLOY, onNullIgnore = true)
     private Long savepointRedeployNonce;
+
+    /**
+     * Nonce used to reset the autoscaler metrics, parallelism overrides and history for the job.
+     * This can be used to quickly go back to the initial user-provided parallelism settings without
+     * having to toggle the autoscaler on and off. In order to trigger the reset behaviour simply
+     * change the nonce to a new non-null value.
+     */
+    @SpecDiff(value = DiffType.IGNORE)
+    private Long autoscalerResetNonce;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -211,6 +211,19 @@ public class ReconciliationUtils {
         reconciliationStatus.setReconciliationTimestamp(System.currentTimeMillis());
     }
 
+    public static <SPEC extends AbstractFlinkSpec> void updateLastReconciledAutoscalerResetNonce(
+            AbstractFlinkResource<SPEC, ?> target) {
+        var spec = target.getSpec();
+        var reconciliationStatus = target.getStatus().getReconciliationStatus();
+        var lastReconciledSpec = reconciliationStatus.deserializeLastReconciledSpec();
+
+        lastReconciledSpec
+                .getJob()
+                .setAutoscalerResetNonce(spec.getJob().getAutoscalerResetNonce());
+        reconciliationStatus.serializeAndSetLastReconciledSpec(lastReconciledSpec, target);
+        reconciliationStatus.setReconciliationTimestamp(System.currentTimeMillis());
+    }
+
     private static void updateLastReconciledJobSpec(
             JobSpec lastReconciledJobSpec, JobSpec jobSpec, SnapshotType snapshotType) {
         switch (snapshotType) {

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -84,6 +84,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  autoscalerResetNonce:
+                    type: integer
                   checkpointTriggerNonce:
                     type: integer
                   entryClass:

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -45,6 +45,8 @@ spec:
                     items:
                       type: string
                     type: array
+                  autoscalerResetNonce:
+                    type: integer
                   checkpointTriggerNonce:
                     type: integer
                   entryClass:


### PR DESCRIPTION
## What is the purpose of the change

The main purpose is to allow users to easily and explicitly clear all autoscaler state and parallelism overrides.

Currently users need to toggle the autoscaler on/off to clear the parallelism settings which relies on implicit internal behaviour and is not always easy to execute safely. Unfortunately the on-off workaround requires 2 spec changes which need to be submitted carefully one after the other as the operator may only look at the 2nd one and then nothing happens.

## Brief change log

  - *Add autoscalerResetNonce to jobSpec*
  - *Tests*

## Verifying this change

New unit tests have been added to cover the reset logic

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  JavaDocs
