### PR TITLE
[FLINK-36696] [flink-autoscaler-plugin-jdbc] Switch sql connection usages to datasource

### DIFF
--- a/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/event/JdbcAutoScalerEventHandler.java
+++ b/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/event/JdbcAutoScalerEventHandler.java
@@ -135,11 +135,12 @@ public class JdbcAutoScalerEventHandler<KEY, Context extends JobAutoScalerContex
     }
 
     @Override
-    public void close() {
+    public void close() throws Exception {
         if (Objects.nonNull(scheduledEventHandlerCleaner)
                 && !scheduledEventHandlerCleaner.isShutdown()) {
             scheduledEventHandlerCleaner.shutdownNow();
         }
+        jdbcEventInteractor.close();
     }
 
     @VisibleForTesting

--- a/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStore.java
+++ b/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStore.java
@@ -333,4 +333,9 @@ public class JdbcAutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
             throws JacksonException {
         return YAML_MAPPER.readValue(delayedScaleDown, new TypeReference<>() {});
     }
+
+    @Override
+    public void close() throws Exception {
+        jdbcStateStore.close();
+    }
 }

--- a/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcStateStore.java
+++ b/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcStateStore.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** The jdbc state store. */
-public class JdbcStateStore {
+public class JdbcStateStore implements AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(JdbcStateStore.class);
 
@@ -88,5 +88,10 @@ public class JdbcStateStore {
 
     private JobStateView createJobStateView(String jobKey) throws Exception {
         return new JobStateView(jdbcStateInteractor, jobKey);
+    }
+
+    @Override
+    public void close() throws Exception {
+        jdbcStateInteractor.close();
     }
 }

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/event/AbstractJdbcEventInteractorITCase.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/event/AbstractJdbcEventInteractorITCase.java
@@ -46,8 +46,7 @@ abstract class AbstractJdbcEventInteractorITCase implements DatabaseTest {
 
         // The datetime precision is seconds in MySQL by default.
         var createTime = Instant.now().truncatedTo(ChronoUnit.SECONDS);
-        try (var conn = getConnection()) {
-            var jdbcEventInteractor = new JdbcEventInteractor(conn);
+        try (var jdbcEventInteractor = new JdbcEventInteractor(getDataSource())) {
             jdbcEventInteractor.setClock(Clock.fixed(createTime, ZoneId.systemDefault()));
 
             jdbcEventInteractor.createEvent(

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/event/CountableJdbcEventInteractor.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/event/CountableJdbcEventInteractor.java
@@ -19,7 +19,8 @@ package org.apache.flink.autoscaler.jdbc.event;
 
 import org.apache.flink.autoscaler.event.AutoScalerEventHandler;
 
-import java.sql.Connection;
+import javax.sql.DataSource;
+
 import java.sql.Timestamp;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
@@ -34,8 +35,8 @@ class CountableJdbcEventInteractor extends JdbcEventInteractor {
     private final AtomicLong updateCounter;
     private final AtomicLong deleteExpiredCounter;
 
-    public CountableJdbcEventInteractor(Connection conn) {
-        super(conn);
+    public CountableJdbcEventInteractor(DataSource dataSource) {
+        super(dataSource);
         queryCounter = new AtomicLong();
         createCounter = new AtomicLong();
         updateCounter = new AtomicLong();

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/state/AbstractJdbcStateInteractorITCase.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/state/AbstractJdbcStateInteractorITCase.java
@@ -42,8 +42,7 @@ abstract class AbstractJdbcStateInteractorITCase implements DatabaseTest {
         var value1 = "value1";
         var value2 = "value2";
         var value3 = "value3";
-        try (var conn = getConnection()) {
-            var jdbcStateInteractor = new JdbcStateInteractor(conn);
+        try (var jdbcStateInteractor = new JdbcStateInteractor(getDataSource())) {
             assertThat(jdbcStateInteractor.queryData(jobKey)).isEmpty();
 
             // Test for creating data.

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/state/CountableJdbcStateInteractor.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/state/CountableJdbcStateInteractor.java
@@ -17,7 +17,8 @@
 
 package org.apache.flink.autoscaler.jdbc.state;
 
-import java.sql.Connection;
+import javax.sql.DataSource;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -32,8 +33,8 @@ public class CountableJdbcStateInteractor extends JdbcStateInteractor {
     private final AtomicLong createCounter;
     private final AtomicLong updateCounter;
 
-    public CountableJdbcStateInteractor(Connection conn) {
-        super(conn);
+    public CountableJdbcStateInteractor(DataSource dataSource) {
+        super(dataSource);
         queryCounter = new AtomicLong();
         deleteCounter = new AtomicLong();
         createCounter = new AtomicLong();

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStoreTest.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStoreTest.java
@@ -48,7 +48,7 @@ class JdbcAutoScalerStateStoreTest
 
     @Override
     protected void preSetup() throws Exception {
-        jdbcStateStore = new JdbcStateStore(new JdbcStateInteractor(getConnection()));
+        jdbcStateStore = new JdbcStateStore(new JdbcStateInteractor(getDataSource()));
         cachedStateStore = new JdbcAutoScalerStateStore<>(jdbcStateStore);
     }
 
@@ -56,7 +56,7 @@ class JdbcAutoScalerStateStoreTest
     protected AutoScalerStateStore<JobID, JobAutoScalerContext<JobID>>
             createPhysicalAutoScalerStateStore() throws Exception {
         return new JdbcAutoScalerStateStore<>(
-                new JdbcStateStore(new JdbcStateInteractor(getConnection())));
+                new JdbcStateStore(new JdbcStateInteractor(getDataSource())));
     }
 
     @Override

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/state/JobStateViewTest.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/state/JobStateViewTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Connection;
-import java.sql.SQLException;
+import javax.sql.DataSource;
+
 import java.util.Optional;
 
 import static org.apache.flink.autoscaler.jdbc.state.StateType.COLLECTED_METRICS;
@@ -36,22 +36,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 class JobStateViewTest implements DerbyTestBase {
 
     private static final String DEFAULT_JOB_KEY = "jobKey";
-    private Connection conn;
+    private DataSource dataSource;
     private CountableJdbcStateInteractor jdbcStateInteractor;
     private JobStateView jobStateView;
 
     @BeforeEach
     void beforeEach() throws Exception {
-        this.conn = getConnection();
-        this.jdbcStateInteractor = new CountableJdbcStateInteractor(conn);
+        this.dataSource = getDataSource();
+        this.jdbcStateInteractor = new CountableJdbcStateInteractor(dataSource);
         this.jobStateView = new JobStateView(jdbcStateInteractor, DEFAULT_JOB_KEY);
         jdbcStateInteractor.assertCountableJdbcInteractor(1, 0, 0, 0);
     }
 
     @AfterEach
-    void afterEach() throws SQLException {
-        if (conn != null) {
-            conn.close();
+    void afterEach() throws Exception {
+        if (jdbcStateInteractor != null) {
+            jdbcStateInteractor.close();
         }
     }
 
@@ -195,7 +195,7 @@ class JobStateViewTest implements DerbyTestBase {
     }
 
     private Optional<String> getValueFromDatabase(StateType stateType) throws Exception {
-        var jdbcInteractor = new JdbcStateInteractor(conn);
+        var jdbcInteractor = new JdbcStateInteractor(dataSource);
         return Optional.ofNullable(jdbcInteractor.queryData(DEFAULT_JOB_KEY).get(stateType));
     }
 }

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/DatabaseTest.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/DatabaseTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.flink.autoscaler.jdbc.testutils.databases;
 
-import java.sql.Connection;
+import javax.sql.DataSource;
 
 /** Database testing. */
 public interface DatabaseTest {
 
-    Connection getConnection() throws Exception;
+    DataSource getDataSource() throws Exception;
 }

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/derby/DerbyTestBase.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/derby/DerbyTestBase.java
@@ -21,7 +21,7 @@ import org.apache.flink.autoscaler.jdbc.testutils.databases.DatabaseTest;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.sql.Connection;
+import javax.sql.DataSource;
 
 /** Derby database for testing. */
 public interface DerbyTestBase extends DatabaseTest {
@@ -29,7 +29,7 @@ public interface DerbyTestBase extends DatabaseTest {
     @RegisterExtension DerbyExtension DERBY_EXTENSION = new DerbyExtension();
 
     @Override
-    default Connection getConnection() throws Exception {
-        return DERBY_EXTENSION.getConnection();
+    default DataSource getDataSource() throws Exception {
+        return DERBY_EXTENSION.getDataSource();
     }
 }

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQL56TestBase.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQL56TestBase.java
@@ -21,14 +21,14 @@ import org.apache.flink.autoscaler.jdbc.testutils.databases.DatabaseTest;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.sql.Connection;
+import javax.sql.DataSource;
 
 /** MySQL 5.6.x database for testing. */
 public interface MySQL56TestBase extends DatabaseTest {
 
     @RegisterExtension MySQLExtension MYSQL_EXTENSION = new MySQLExtension("5.6.51");
 
-    default Connection getConnection() throws Exception {
-        return MYSQL_EXTENSION.getConnection();
+    default DataSource getDataSource() throws Exception {
+        return MYSQL_EXTENSION.getDataSource();
     }
 }

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQL57TestBase.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQL57TestBase.java
@@ -21,14 +21,14 @@ import org.apache.flink.autoscaler.jdbc.testutils.databases.DatabaseTest;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.sql.Connection;
+import javax.sql.DataSource;
 
 /** MySQL 5.7.x database for testing. */
 public interface MySQL57TestBase extends DatabaseTest {
 
     @RegisterExtension MySQLExtension MYSQL_EXTENSION = new MySQLExtension("5.7.41");
 
-    default Connection getConnection() throws Exception {
-        return MYSQL_EXTENSION.getConnection();
+    default DataSource getDataSource() throws Exception {
+        return MYSQL_EXTENSION.getDataSource();
     }
 }

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQL8TestBase.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQL8TestBase.java
@@ -21,14 +21,14 @@ import org.apache.flink.autoscaler.jdbc.testutils.databases.DatabaseTest;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.sql.Connection;
+import javax.sql.DataSource;
 
 /** MySQL 8.x database for testing. */
 public interface MySQL8TestBase extends DatabaseTest {
 
     @RegisterExtension MySQLExtension MYSQL_EXTENSION = new MySQLExtension("8.0.32");
 
-    default Connection getConnection() throws Exception {
-        return MYSQL_EXTENSION.getConnection();
+    default DataSource getDataSource() throws Exception {
+        return MYSQL_EXTENSION.getDataSource();
     }
 }

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQLExtension.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQLExtension.java
@@ -17,14 +17,14 @@
 
 package org.apache.flink.autoscaler.jdbc.testutils.databases.mysql;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.MySQLContainer;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 
 /** The extension of MySQL. */
@@ -50,9 +50,13 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback, AfterEachCa
                         .withEnv("MYSQL_ROOT_HOST", "%");
     }
 
-    public Connection getConnection() throws Exception {
-        return DriverManager.getConnection(
-                container.getJdbcUrl(), container.getUsername(), container.getPassword());
+    public HikariDataSource getDataSource() throws Exception {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(container.getJdbcUrl());
+        config.setUsername(container.getUsername());
+        config.setPassword(container.getPassword());
+        config.setValidationTimeout(1000);
+        return new HikariDataSource(config);
     }
 
     @Override
@@ -67,7 +71,8 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback, AfterEachCa
 
     @Override
     public void afterEach(ExtensionContext extensionContext) throws Exception {
-        try (var conn = getConnection();
+        try (var dataSource = getDataSource();
+                var conn = dataSource.getConnection();
                 var st = conn.createStatement()) {
             for (var tableName : TABLES) {
                 st.executeUpdate(String.format("DELETE from %s", tableName));

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/postgres/PostgreSQLExtension.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/postgres/PostgreSQLExtension.java
@@ -71,7 +71,7 @@ class PostgreSQLExtension implements BeforeAllCallback, AfterAllCallback, AfterE
     @Override
     public void afterEach(ExtensionContext extensionContext) throws Exception {
         try (var dataSource = getDataSource();
-                var conn = getDataSource().getConnection();
+                var conn = dataSource.getConnection();
                 var st = conn.createStatement()) {
             for (var tableName : TABLES) {
                 st.executeUpdate(String.format("DELETE from %s", tableName));

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/postgres/PostgreSQLExtension.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/postgres/PostgreSQLExtension.java
@@ -17,14 +17,14 @@
 
 package org.apache.flink.autoscaler.jdbc.testutils.databases.postgres;
 
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.PostgreSQLContainer;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 
 /** The extension of PostgreSQL. */
@@ -49,9 +49,13 @@ class PostgreSQLExtension implements BeforeAllCallback, AfterAllCallback, AfterE
                         .withEnv("POSTGRES_MAX_CONNECTIONS", "10");
     }
 
-    public Connection getConnection() throws Exception {
-        return DriverManager.getConnection(
-                container.getJdbcUrl(), container.getUsername(), container.getPassword());
+    public HikariDataSource getDataSource() throws Exception {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(container.getJdbcUrl());
+        config.setUsername(container.getUsername());
+        config.setPassword(container.getPassword());
+        config.setValidationTimeout(1000);
+        return new HikariDataSource(config);
     }
 
     @Override
@@ -66,7 +70,8 @@ class PostgreSQLExtension implements BeforeAllCallback, AfterAllCallback, AfterE
 
     @Override
     public void afterEach(ExtensionContext extensionContext) throws Exception {
-        try (var conn = getConnection();
+        try (var dataSource = getDataSource();
+                var conn = getDataSource().getConnection();
                 var st = conn.createStatement()) {
             for (var tableName : TABLES) {
                 st.executeUpdate(String.format("DELETE from %s", tableName));

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/postgres/PostgreSQLTestBase.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/postgres/PostgreSQLTestBase.java
@@ -21,14 +21,14 @@ import org.apache.flink.autoscaler.jdbc.testutils.databases.DatabaseTest;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.sql.Connection;
+import javax.sql.DataSource;
 
 /** PostgreSQL database for testing. */
 public interface PostgreSQLTestBase extends DatabaseTest {
 
     @RegisterExtension PostgreSQLExtension POSTGRE_SQL_EXTENSION = new PostgreSQLExtension("15.1");
 
-    default Connection getConnection() throws Exception {
-        return POSTGRE_SQL_EXTENSION.getConnection();
+    default DataSource getDataSource() throws Exception {
+        return POSTGRE_SQL_EXTENSION.getDataSource();
     }
 }

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactory.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactory.java
@@ -73,8 +73,8 @@ public class AutoscalerEventHandlerFactory {
     private static <KEY, Context extends JobAutoScalerContext<KEY>>
             AutoScalerEventHandler<KEY, Context> createJdbcEventHandler(Configuration conf)
                     throws Exception {
-        var conn = HikariJDBCUtil.getConnection(conf);
+        var dataSource = HikariJDBCUtil.getDataSource(conf);
         return new JdbcAutoScalerEventHandler<>(
-                new JdbcEventInteractor(conn), conf.get(JDBC_EVENT_HANDLER_TTL));
+                new JdbcEventInteractor(dataSource), conf.get(JDBC_EVENT_HANDLER_TTL));
     }
 }

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactory.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactory.java
@@ -74,7 +74,8 @@ public class AutoscalerStateStoreFactory {
     private static <KEY, Context extends JobAutoScalerContext<KEY>>
             AutoScalerStateStore<KEY, Context> createJdbcStateStore(Configuration conf)
                     throws Exception {
-        var conn = HikariJDBCUtil.getConnection(conf);
-        return new JdbcAutoScalerStateStore<>(new JdbcStateStore(new JdbcStateInteractor(conn)));
+        var dataSource = HikariJDBCUtil.getDataSource(conf);
+        return new JdbcAutoScalerStateStore<>(
+                new JdbcStateStore(new JdbcStateInteractor(dataSource)));
     }
 }

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
@@ -33,7 +33,6 @@ import org.slf4j.MDC;
 
 import javax.annotation.Nonnull;
 
-import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -56,7 +55,7 @@ import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandalone
 
 /** The executor of the standalone autoscaler. */
 public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerContext<KEY>>
-        implements Closeable {
+        implements AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(StandaloneAutoscalerExecutor.class);
 
@@ -113,7 +112,7 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
     }
 
     @Override
-    public void close() {
+    public void close() throws Exception {
         scheduledExecutorService.shutdownNow();
         scalingThreadPool.shutdownNow();
         eventHandler.close();

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/utils/HikariJDBCUtil.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/utils/HikariJDBCUtil.java
@@ -23,7 +23,6 @@ import org.apache.flink.util.StringUtils;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
-import java.sql.Connection;
 import java.sql.SQLException;
 
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.JDBC_PASSWORD_ENV_VARIABLE;
@@ -39,7 +38,7 @@ public class HikariJDBCUtil {
                     "%s is required when jdbc state store or jdbc event handler is used.",
                     JDBC_URL.key());
 
-    public static Connection getConnection(Configuration conf) throws SQLException {
+    public static HikariDataSource getDataSource(Configuration conf) throws SQLException {
         final var jdbcUrl = conf.get(JDBC_URL);
         checkArgument(!StringUtils.isNullOrWhitespaceOnly(jdbcUrl), JDBC_URL_REQUIRED_HINT);
         var user = conf.get(JDBC_USERNAME);
@@ -48,6 +47,6 @@ public class HikariJDBCUtil {
         hikariConfig.setJdbcUrl(jdbcUrl);
         hikariConfig.setUsername(user);
         hikariConfig.setPassword(password);
-        return new HikariDataSource(hikariConfig).getConnection();
+        return new HikariDataSource(hikariConfig);
     }
 }

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactoryTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactoryTest.java
@@ -68,14 +68,16 @@ class AutoscalerEventHandlerFactoryTest {
         final var conf = new Configuration();
         conf.set(EVENT_HANDLER_TYPE, JDBC);
         conf.set(JDBC_URL, String.format("%s;create=true", jdbcUrl));
-        HikariJDBCUtil.getConnection(conf).close();
+        HikariJDBCUtil.getDataSource(conf).close();
 
         var eventHandler = AutoscalerEventHandlerFactory.create(conf);
         assertThat(eventHandler).isInstanceOf(JdbcAutoScalerEventHandler.class);
+        conf.set(JDBC_URL, String.format("%s;shutdown=true", jdbcUrl));
 
         try {
-            conf.set(JDBC_URL, String.format("%s;shutdown=true", jdbcUrl));
-            HikariJDBCUtil.getConnection(conf).close();
+            var datasource = HikariJDBCUtil.getDataSource(conf);
+            datasource.getConnection().close();
+            datasource.close();
         } catch (RuntimeException ignored) {
             // database shutdown ignored exception
         }

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactoryTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/AutoscalerStateStoreFactoryTest.java
@@ -67,14 +67,16 @@ class AutoscalerStateStoreFactoryTest {
         final var conf = new Configuration();
         conf.set(STATE_STORE_TYPE, JDBC);
         conf.set(JDBC_URL, String.format("%s;create=true", jdbcUrl));
-        HikariJDBCUtil.getConnection(conf).close();
+        HikariJDBCUtil.getDataSource(conf).close();
 
         var stateStore = AutoscalerStateStoreFactory.create(conf);
         assertThat(stateStore).isInstanceOf(JdbcAutoScalerStateStore.class);
+        conf.set(JDBC_URL, String.format("%s;shutdown=true", jdbcUrl));
 
         try {
-            conf.set(JDBC_URL, String.format("%s;shutdown=true", jdbcUrl));
-            HikariJDBCUtil.getConnection(conf).close();
+            var datasource = HikariJDBCUtil.getDataSource(conf);
+            datasource.getConnection().close();
+            datasource.close();
         } catch (RuntimeException ignored) {
             // database shutdown ignored exception
         }

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutorTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutorTest.java
@@ -110,7 +110,7 @@ class StandaloneAutoscalerExecutorTest {
     }
 
     @Test
-    void testFetchException() {
+    void testFetchException() throws Exception {
         var eventCollector = new TestingEventCollector<JobID, JobAutoScalerContext<JobID>>();
         try (var autoscalerExecutor =
                 new StandaloneAutoscalerExecutor<>(
@@ -137,7 +137,7 @@ class StandaloneAutoscalerExecutorTest {
     }
 
     @Test
-    void testScalingParallelism() {
+    void testScalingParallelism() throws Exception {
         var parallelism = 10;
 
         var jobList = new ArrayList<JobAutoScalerContext<JobID>>();

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoScalerEventHandler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoScalerEventHandler.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import javax.annotation.Nullable;
 
-import java.io.Closeable;
 import java.time.Duration;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -44,7 +43,7 @@ import static org.apache.flink.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_
  */
 @Experimental
 public interface AutoScalerEventHandler<KEY, Context extends JobAutoScalerContext<KEY>>
-        extends Closeable {
+        extends AutoCloseable {
     String SCALING_SUMMARY_ENTRY =
             "{ Vertex ID %s | Parallelism %d -> %d | Processing capacity %.2f -> %.2f | Target data rate %.2f}";
     String SCALING_EXECUTION_DISABLED_REASON = "%s:%s, recommended parallelism change:";
@@ -100,9 +99,6 @@ public interface AutoScalerEventHandler<KEY, Context extends JobAutoScalerContex
                 SCALING_REPORT_KEY,
                 interval);
     }
-
-    /** Close the related resource. */
-    default void close() {}
 
     static String scalingReport(Map<JobVertexID, ScalingSummary> scalingSummaries, String message) {
         StringBuilder sb = new StringBuilder(message);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/LoggingEventHandler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/LoggingEventHandler.java
@@ -49,4 +49,7 @@ public class LoggingEventHandler<KEY, Context extends JobAutoScalerContext<KEY>>
                 messageKey,
                 interval);
     }
+
+    @Override
+    public void close() throws Exception {}
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
@@ -39,7 +39,8 @@ import java.util.SortedMap;
  * @param <Context> Instance of JobAutoScalerContext.
  */
 @Experimental
-public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<KEY>> {
+public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<KEY>>
+        extends AutoCloseable {
 
     void storeScalingHistory(
             Context jobContext, Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory)

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/InMemoryAutoScalerStateStore.java
@@ -191,4 +191,7 @@ public class InMemoryAutoScalerStateStore<KEY, Context extends JobAutoScalerCont
                         delayedScaleDownStore)
                 .anyMatch(m -> m.containsKey(k));
     }
+
+    @Override
+    public void close() throws Exception {}
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/event/TestingEventCollector.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/event/TestingEventCollector.java
@@ -77,6 +77,9 @@ public class TestingEventCollector<KEY, Context extends JobAutoScalerContext<KEY
         return context.getJobID() + type.name() + reason + message;
     }
 
+    @Override
+    public void close() throws Exception {}
+
     /** The collected event. */
     public static class Event<KEY, Context extends JobAutoScalerContext<KEY>> {
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerEventHandler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerEventHandler.java
@@ -103,4 +103,7 @@ public class KubernetesAutoScalerEventHandler
                     labels);
         }
     }
+
+    @Override
+    public void close() throws Exception {}
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
@@ -403,4 +403,7 @@ public class KubernetesAutoScalerStateStore
         loaderOptions.setCodePointLimit(20 * 1024 * 1024);
         return YAMLFactory.builder().loaderOptions(loaderOptions).build();
     }
+
+    @Override
+    public void close() throws Exception {}
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request makes changes to replace the usage of SQL connection with DataSource to improve the multithreaded performance of the JDBC plugin.


## Brief change log

  - *Replace all usages of SQL connection with DataSource *

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change is already covered by existing unit tests. The test cases have been modified appropriately to use DataSource rather than Connection everywhere


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
