### PR TITLE
[FLINK-37086] Clean up should remove all autoscaler state

### DIFF
--- a/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStore.java
+++ b/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStore.java
@@ -247,17 +247,13 @@ public class JdbcAutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
 
     @Override
     public void clearAll(Context jobContext) {
-        jdbcStateStore.clearAll(getSerializeKey(jobContext));
+        var serializedKey = getSerializeKey(jobContext);
+        jdbcStateStore.clearAll(serializedKey);
     }
 
     @Override
     public void flush(Context jobContext) throws Exception {
         jdbcStateStore.flush(getSerializeKey(jobContext));
-    }
-
-    @Override
-    public void removeInfoFromCache(KEY jobKey) {
-        jdbcStateStore.removeInfoFromCache(getSerializeKey(jobKey));
     }
 
     private String getSerializeKey(Context jobContext) {

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
@@ -40,12 +40,15 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.CONTROL_LOOP_INTERVAL;
@@ -74,10 +77,10 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
     private final Set<KEY> scalingJobKeys;
 
     /**
-     * Maintain a set of scaling job keys for the last control loop, it should be accessed at {@link
+     * Maintain a map of scaling job keys for the last control loop, it should be accessed at {@link
      * #scheduledExecutorService} thread.
      */
-    private Set<KEY> lastScalingKeys;
+    private Map<KEY, Context> lastScaling;
 
     public StandaloneAutoscalerExecutor(
             @Nonnull Configuration conf,
@@ -151,12 +154,12 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
                                                     throwable);
                                         }
                                         scalingJobKeys.remove(jobKey);
-                                        if (!lastScalingKeys.contains(jobKey)) {
+                                        if (!lastScaling.containsKey(jobKey)) {
                                             // Current job has been stopped. lastScalingKeys doesn't
                                             // contain jobKey means current job key was scaled in a
                                             // previous control loop, and current job is stopped in
                                             // the latest control loop.
-                                            autoScaler.cleanup(jobKey);
+                                            autoScaler.cleanup(jobContext);
                                         }
                                     },
                                     scheduledExecutorService));
@@ -165,18 +168,21 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
     }
 
     private void cleanupStoppedJob(Collection<Context> jobList) {
-        var currentScalingKeys =
-                jobList.stream().map(JobAutoScalerContext::getJobKey).collect(Collectors.toSet());
-        if (lastScalingKeys != null) {
-            lastScalingKeys.removeAll(currentScalingKeys);
-            for (KEY jobKey : lastScalingKeys) {
+        var jobs =
+                jobList.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        JobAutoScalerContext::getJobKey, Function.identity()));
+        if (lastScaling != null) {
+            jobs.keySet().forEach(lastScaling::remove);
+            for (Map.Entry<KEY, Context> job : lastScaling.entrySet()) {
                 // Current job may be scaling, and cleanup should happen after scaling.
-                if (!scalingJobKeys.contains(jobKey)) {
-                    autoScaler.cleanup(jobKey);
+                if (!scalingJobKeys.contains(job.getKey())) {
+                    autoScaler.cleanup(job.getValue());
                 }
             }
         }
-        lastScalingKeys = currentScalingKeys;
+        lastScaling = new ConcurrentHashMap<>(jobs);
     }
 
     @VisibleForTesting

--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutorTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutorTest.java
@@ -80,7 +80,7 @@ class StandaloneAutoscalerExecutorTest {
                     }
 
                     @Override
-                    public void cleanup(JobID jobKey) {
+                    public void cleanup(JobAutoScalerContext<JobID> context) {
                         fail("Should be called.");
                     }
                 };
@@ -126,7 +126,7 @@ class StandaloneAutoscalerExecutorTest {
                             }
 
                             @Override
-                            public void cleanup(JobID jobID) {
+                            public void cleanup(JobAutoScalerContext<JobID> context) {
                                 fail("Should be called.");
                             }
                         })) {
@@ -164,7 +164,7 @@ class StandaloneAutoscalerExecutorTest {
                             }
 
                             @Override
-                            public void cleanup(JobID jobID) {
+                            public void cleanup(JobAutoScalerContext<JobID> context) {
                                 fail("Should be called.");
                             }
                         })) {
@@ -221,7 +221,7 @@ class StandaloneAutoscalerExecutorTest {
                             }
 
                             @Override
-                            public void cleanup(JobID jobID) {
+                            public void cleanup(JobAutoScalerContext<JobID> context) {
                                 fail("Should be called.");
                             }
                         })) {
@@ -255,7 +255,8 @@ class StandaloneAutoscalerExecutorTest {
                             }
 
                             @Override
-                            public void cleanup(JobID jobID) {
+                            public void cleanup(JobAutoScalerContext<JobID> context) {
+                                var jobID = context.getJobKey();
                                 cleanupCounter.put(
                                         jobID, cleanupCounter.getOrDefault(jobID, 0) + 1);
                             }
@@ -346,7 +347,8 @@ class StandaloneAutoscalerExecutorTest {
                             }
 
                             @Override
-                            public void cleanup(JobID jobID) {
+                            public void cleanup(JobAutoScalerContext<JobID> context) {
+                                var jobID = context.getJobKey();
                                 cleanupCounter.put(
                                         jobID, cleanupCounter.getOrDefault(jobID, 0) + 1);
                             }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScaler.java
@@ -39,7 +39,7 @@ public interface JobAutoScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
     /**
      * Called when the job is deleted.
      *
-     * @param jobKey Job key.
+     * @param context Job context.
      */
-    void cleanup(KEY jobKey);
+    void cleanup(Context context);
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -118,12 +118,17 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
     }
 
     @Override
-    public void cleanup(KEY jobKey) {
+    public void cleanup(Context ctx) {
         LOG.info("Cleaning up autoscaling meta data");
-        metricsCollector.cleanup(jobKey);
-        lastEvaluatedMetrics.remove(jobKey);
-        flinkMetrics.remove(jobKey);
-        stateStore.removeInfoFromCache(jobKey);
+        metricsCollector.cleanup(ctx.getJobKey());
+        lastEvaluatedMetrics.remove(ctx.getJobKey());
+        flinkMetrics.remove(ctx.getJobKey());
+        try {
+            stateStore.clearAll(ctx);
+            stateStore.flush(ctx);
+        } catch (Exception e) {
+            LOG.error("Error cleaning up autoscaling meta data for {}", ctx.getJobKey(), e);
+        }
     }
 
     @VisibleForTesting

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/NoopJobAutoscaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/NoopJobAutoscaler.java
@@ -24,5 +24,5 @@ public class NoopJobAutoscaler<KEY, Context extends JobAutoScalerContext<KEY>>
     public void scale(Context context) throws Exception {}
 
     @Override
-    public void cleanup(KEY jobKey) {}
+    public void cleanup(Context jobKey) {}
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
@@ -93,7 +93,4 @@ public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
      * was changed through this interface.
      */
     void flush(Context jobContext) throws Exception;
-
-    /** Clean up all information related to the current job. */
-    void removeInfoFromCache(KEY jobKey);
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
@@ -266,11 +266,6 @@ public class KubernetesAutoScalerStateStore
         configMapStore.flush(jobContext);
     }
 
-    @Override
-    public void removeInfoFromCache(ResourceID resourceID) {
-        configMapStore.removeInfoFromCache(resourceID);
-    }
-
     @SneakyThrows
     protected static String serializeScalingHistory(
             Map<JobVertexID, SortedMap<Instant, ScalingSummary>> scalingHistory) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -276,7 +276,7 @@ public abstract class AbstractFlinkResourceReconciler<
 
     @Override
     public DeleteControl cleanup(FlinkResourceContext<CR> ctx) {
-        autoscaler.cleanup(ResourceID.fromResource(ctx.getResource()));
+        autoscaler.cleanup(ctx.getJobAutoScalerContext());
         return cleanupInternal(ctx);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The autoscaler cleanup logic currently does not actually delete the state of the job from the state store only the cache. This can cause leaks in some cases and unintended retrieval of wrong state if the job is deleted then restarted.

## Brief change log

- Change cleanup to clearAll and flush state store
- tests

## Verifying this change

Unit tests have been extended to cover this more.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
