### PR TITLE
[FLINK-37126] Add Validator for Autoscler

### DIFF
--- a/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerValidatorTest.java
+++ b/flink-autoscaler-standalone/src/test/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerValidatorTest.java
@@ -1,0 +1,73 @@
+package org.apache.flink.autoscaler.standalone;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.autoscaler.JobAutoScaler;
+import org.apache.flink.autoscaler.JobAutoScalerContext;
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.autoscaler.event.TestingEventCollector;
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StandaloneAutoscalerValidatorTest {
+    @Test
+    public void testAutoScalerWithInvalidConfig() {
+        var jobList = new ArrayList<JobAutoScalerContext<JobID>>();
+        var eventCollector = new TestingEventCollector<JobID, JobAutoScalerContext<JobID>>();
+
+        Configuration correctConfiguration = new Configuration();
+        correctConfiguration.set(AutoScalerOptions.AUTOSCALER_ENABLED, true);
+        Configuration invalidConfiguration = new Configuration();
+        invalidConfiguration.set(AutoScalerOptions.AUTOSCALER_ENABLED, true);
+        invalidConfiguration.set(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, -1.);
+
+        var correctConfigurationJob = createJobAutoScalerContextWithConf(correctConfiguration);
+        var illegalConfigurationJob = createJobAutoScalerContextWithConf(invalidConfiguration);
+        var scaleCounter = new ConcurrentHashMap<JobID, Integer>();
+
+        try (var autoscalerExecutor =
+                new StandaloneAutoscalerExecutor<>(
+                        new Configuration(),
+                        baseConf -> jobList,
+                        eventCollector,
+                        new JobAutoScaler<>() {
+                            @Override
+                            public void scale(JobAutoScalerContext<JobID> context) {
+                                scaleCounter.put(
+                                        context.getJobKey(),
+                                        scaleCounter.getOrDefault(context.getJobKey(), 0) + 1);
+                            }
+
+                            @Override
+                            public void cleanup(JobAutoScalerContext<JobID> context) {
+                                // do nothing
+                            }
+                        })) {
+            jobList.add(correctConfigurationJob);
+            jobList.add(illegalConfigurationJob);
+            List<CompletableFuture<Void>> scaledFutures = autoscalerExecutor.scaling();
+
+            assertThat(scaledFutures).hasSize(2);
+            assertThat(scaleCounter).size().isEqualTo(1);
+
+            assertThat(eventCollector.events).size().isEqualTo(1);
+            assertThat(eventCollector.events)
+                    .allMatch(event -> event.getContext().equals(illegalConfigurationJob));
+        }
+    }
+
+    private static JobAutoScalerContext<JobID> createJobAutoScalerContextWithConf(
+            Configuration configuration) {
+        var jobID = new JobID();
+        return new JobAutoScalerContext<>(
+                jobID, jobID, JobStatus.RUNNING, configuration, null, null);
+    }
+}

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/validation/AutoscalerValidator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/validation/AutoscalerValidator.java
@@ -1,0 +1,17 @@
+package org.apache.flink.autoscaler.validation;
+
+import org.apache.flink.configuration.Configuration;
+
+import java.util.Optional;
+
+/** Validator for Autoscaler. */
+public interface AutoscalerValidator {
+
+    /**
+     * Validate autoscaler config and return optional error.
+     *
+     * @param configuration autoscaler config
+     * @return Optional error string, should be present iff validation resulted in an error
+     */
+    Optional<String> validateAutoscalerOptions(Configuration configuration);
+}

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/validation/DefaultAutoscalerValidator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/validation/DefaultAutoscalerValidator.java
@@ -1,0 +1,66 @@
+package org.apache.flink.autoscaler.validation;
+
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.autoscaler.utils.CalendarUtils;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+
+import java.util.Optional;
+
+/** Default implementation of {@link AutoscalerValidator}. */
+public class DefaultAutoscalerValidator implements AutoscalerValidator {
+
+    @Override
+    public Optional<String> validateAutoscalerOptions(Configuration configuration) {
+        if (!configuration.get(AutoScalerOptions.AUTOSCALER_ENABLED)) {
+            return Optional.empty();
+        }
+        return firstPresent(
+                validateNumber(configuration, AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.0d),
+                validateNumber(configuration, AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.0d),
+                validateNumber(configuration, AutoScalerOptions.TARGET_UTILIZATION, 0.0d),
+                validateNumber(configuration, AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.0d),
+                CalendarUtils.validateExcludedPeriods(configuration));
+    }
+
+    @SafeVarargs
+    private static Optional<String> firstPresent(Optional<String>... errOpts) {
+        for (Optional<String> opt : errOpts) {
+            if (opt.isPresent()) {
+                return opt;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static <T extends Number> Optional<String> validateNumber(
+            Configuration flinkConfiguration,
+            ConfigOption<T> autoScalerConfig,
+            Double min,
+            Double max) {
+        try {
+            var configValue = flinkConfiguration.get(autoScalerConfig);
+            if (configValue != null) {
+                double value = configValue.doubleValue();
+                if ((min != null && value < min) || (max != null && value > max)) {
+                    return Optional.of(
+                            String.format(
+                                    "The AutoScalerOption %s is invalid, it should be a value within the range [%s, %s]",
+                                    autoScalerConfig.key(),
+                                    min != null ? min.toString() : "-Infinity",
+                                    max != null ? max.toString() : "+Infinity"));
+                }
+            }
+            return Optional.empty();
+        } catch (IllegalArgumentException e) {
+            return Optional.of(
+                    String.format(
+                            "Invalid value in the autoscaler config %s", autoScalerConfig.key()));
+        }
+    }
+
+    private static <T extends Number> Optional<String> validateNumber(
+            Configuration flinkConfiguration, ConfigOption<T> autoScalerConfig, Double min) {
+        return validateNumber(flinkConfiguration, autoScalerConfig, min, null);
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add Validator for Autoscler, Facilitates StandaloneAutoscaler to detect configuration anomalies in advance

## Brief change log

  - Migrate the verification part of Autoscaler in `DefaultAutoscalerValidator` to the Autoscaler module
  - Verify the Autoscaler config separately in StandaloneAutoscaler. If there are illegal parameters, report them through events.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change added tests and can be verified as follows:

  - add `StandaloneAutoscalerValidatorTest` Used to verify parameter verification under standloneAutoscaler
  - The old test cases cover the test for Autoscaler parameter verification under the **operator**


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
