### PR TITLE
[FLINK-37229] Add/record DELETING/DELETED lifecycle states

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/lifecycle/ResourceLifecycleState.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/lifecycle/ResourceLifecycleState.java
@@ -35,7 +35,9 @@ public enum ResourceLifecycleState {
     STABLE(true, "The resource deployment is considered to be stable and won’t be rolled back"),
     ROLLING_BACK(false, "The resource is being rolled back to the last stable spec"),
     ROLLED_BACK(true, "The resource is deployed with the last stable spec"),
-    FAILED(true, "The job terminally failed");
+    FAILED(true, "The job terminally failed"),
+    DELETING(false, "The resource is being deleted"),
+    DELETED(true, "The resource is deleted");
 
     @JsonIgnore private final boolean terminal;
     @JsonIgnore @Getter private final String description;

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
@@ -60,6 +60,11 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
     public abstract ReconciliationStatus<SPEC> getReconciliationStatus();
 
     public ResourceLifecycleState getLifecycleState() {
+        if (ResourceLifecycleState.DELETING == lifecycleState
+                || ResourceLifecycleState.DELETED == lifecycleState) {
+            return lifecycleState;
+        }
+
         var reconciliationStatus = getReconciliationStatus();
 
         if (reconciliationStatus.isBeforeFirstDeployment()) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
@@ -98,19 +98,7 @@ public class StatusRecorder<CR extends CustomResource<?, STATUS>, STATUS> {
             return;
         }
 
-        Class<?> statusClass;
-        if (resource instanceof FlinkDeployment) {
-            statusClass = FlinkDeploymentStatus.class;
-        } else if (resource instanceof FlinkSessionJob) {
-            statusClass = FlinkSessionJobStatus.class;
-        } else if (resource instanceof FlinkStateSnapshot) {
-            statusClass = FlinkStateSnapshotStatus.class;
-        } else {
-            throw new RuntimeException(
-                    String.format("Resource is unknown class: %s", resource.getClass()));
-        }
-
-        var prevStatus = (STATUS) objectMapper.convertValue(previousStatusNode, statusClass);
+        var prevStatus = convertPreviousStatus(resource, previousStatusNode);
 
         Exception err = null;
         for (int i = 0; i < 3; i++) {
@@ -132,6 +120,21 @@ public class StatusRecorder<CR extends CustomResource<?, STATUS>, STATUS> {
         statusCache.put(resourceId, newStatusNode);
         statusUpdateListener.accept(resource, prevStatus);
         metricManager.onUpdate(resource);
+    }
+
+    private STATUS convertPreviousStatus(CR resource, ObjectNode previousStatusNode) {
+        Class<?> statusClass;
+        if (resource instanceof FlinkDeployment) {
+            statusClass = FlinkDeploymentStatus.class;
+        } else if (resource instanceof FlinkSessionJob) {
+            statusClass = FlinkSessionJobStatus.class;
+        } else if (resource instanceof FlinkStateSnapshot) {
+            statusClass = FlinkStateSnapshotStatus.class;
+        } else {
+            throw new RuntimeException(
+                    String.format("Resource is unknown class: %s", resource.getClass()));
+        }
+        return (STATUS) objectMapper.convertValue(previousStatusNode, statusClass);
     }
 
     private void replaceStatus(CR resource, STATUS prevStatus, KubernetesClient client)
@@ -240,13 +243,15 @@ public class StatusRecorder<CR extends CustomResource<?, STATUS>, STATUS> {
     }
 
     /**
-     * Remove cached status for Flink resource.
+     * Clean up resource after deletion and send a last status update.
      *
      * @param resource Flink resource.
      */
-    public void removeCachedStatus(CR resource) {
-        statusCache.remove(ResourceID.fromResource(resource));
+    public void cleanupForDeletion(CR resource) {
+        var prevJson = statusCache.remove(ResourceID.fromResource(resource));
+        var prevStatus = convertPreviousStatus(resource, prevJson);
         metricManager.onRemove(resource);
+        statusUpdateListener.accept(resource, prevStatus);
     }
 
     public static <S extends CommonStatus<?>, CR extends AbstractFlinkResource<?, S>>

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilderTest.java
@@ -63,7 +63,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.apache.flink.configuration.DeploymentOptions.SHUTDOWN_ON_APPLICATION_FINISH;
 import static org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils.IMAGE;
@@ -933,14 +932,5 @@ public class FlinkConfigBuilderTest {
         var pod =
                 TestUtils.getTestPodTemplate("hostname", List.of(mainContainer, sideCarContainer));
         return pod;
-    }
-
-    private static Stream<KubernetesConfigOptions.ServiceExposedType> serviceExposedTypes() {
-        return Stream.of(
-                null,
-                KubernetesConfigOptions.ServiceExposedType.ClusterIP,
-                KubernetesConfigOptions.ServiceExposedType.LoadBalancer,
-                KubernetesConfigOptions.ServiceExposedType.Headless_ClusterIP,
-                KubernetesConfigOptions.ServiceExposedType.NodePort);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -153,6 +153,17 @@ public class FlinkDeploymentControllerTest {
         assertEquals(
                 appCluster.getStatus().getReconciliationStatus().getLastReconciledSpec(),
                 appCluster.getStatus().getReconciliationStatus().getLastStableSpec());
+
+        testController.cleanup(appCluster, context);
+        // Make sure status is recorded and sent out at the end of cleanup
+        assertEquals(
+                ResourceLifecycleState.DELETED,
+                testController
+                        .getStatusUpdateCounter()
+                        .currentResource
+                        .getStatus()
+                        .getLifecycleState());
+        assertEquals(ResourceLifecycleState.DELETED, appCluster.getStatus().getLifecycleState());
     }
 
     @ParameterizedTest

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -69,7 +69,7 @@ public class TestingFlinkDeploymentController
 
     @Getter private ReconcilerFactory reconcilerFactory;
     private FlinkDeploymentController flinkDeploymentController;
-    private StatusUpdateCounter statusUpdateCounter = new StatusUpdateCounter();
+    @Getter private StatusUpdateCounter statusUpdateCounter = new StatusUpdateCounter();
     private FlinkResourceEventCollector flinkResourceEventCollector =
             new FlinkResourceEventCollector();
 
@@ -174,11 +174,12 @@ public class TestingFlinkDeploymentController
         return flinkResourceEventCollector.events;
     }
 
-    private static class StatusUpdateCounter
+    /** Test status consumer. */
+    protected static class StatusUpdateCounter
             implements BiConsumer<FlinkDeployment, FlinkDeploymentStatus> {
 
-        private FlinkDeployment currentResource;
-        private int counter;
+        FlinkDeployment currentResource;
+        int counter;
 
         @Override
         public void accept(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
@@ -65,8 +65,11 @@ public class TestingFlinkSessionJobController
 
     @Getter private CanaryResourceManager<FlinkSessionJob> canaryResourceManager;
     private FlinkSessionJobController flinkSessionJobController;
+
+    @Getter
     private TestingFlinkSessionJobController.StatusUpdateCounter statusUpdateCounter =
             new TestingFlinkSessionJobController.StatusUpdateCounter();
+
     private FlinkResourceEventCollector flinkResourceEventCollector =
             new FlinkResourceEventCollector();
     private EventRecorder eventRecorder;
@@ -161,10 +164,11 @@ public class TestingFlinkSessionJobController
         return flinkResourceEventCollector.events;
     }
 
-    private static class StatusUpdateCounter
+    /** Test status consumer. */
+    protected static class StatusUpdateCounter
             implements BiConsumer<FlinkSessionJob, FlinkSessionJobStatus> {
 
-        private FlinkSessionJob currentResource;
+        FlinkSessionJob currentResource;
         private int counter;
 
         @Override

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -10378,6 +10378,8 @@ spec:
               lifecycleState:
                 enum:
                 - CREATED
+                - DELETED
+                - DELETING
                 - DEPLOYED
                 - FAILED
                 - ROLLED_BACK

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -220,6 +220,8 @@ spec:
               lifecycleState:
                 enum:
                 - CREATED
+                - DELETED
+                - DELETING
                 - DEPLOYED
                 - FAILED
                 - ROLLED_BACK


### PR DESCRIPTION
## What is the purpose of the change

The current lifecycle states and events don't properly track resources that are being deleted. Long / stuck delete operations do not result in intuitive states.

This changes introduces 2 new states, deleting and deleted to track the deletion process. Once a resource is marked for deletion it will always return DELETING until the deletion success which will return a one time DELETED state (but this will only be seen as an event as the deleted resource won't be in kubernetes anymore)

## Brief change log

- Introduce new states and update reconciler logic
- tests 

## Verifying this change

Tests, and validation in various envs

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
