### PR TITLE
[FLINK-37236] Bump the flink version from 1.20.0 to 1.20.1

### DIFF
--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -6,8 +6,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.esotericsoftware.kryo:kryo:jar:2.24.0
-- com.esotericsoftware.minlog:minlog:jar:1.2
 - com.fasterxml.jackson.core:jackson-annotations:jar:2.15.0
 - com.fasterxml.jackson.core:jackson-core:jar:2.15.0
 - com.fasterxml.jackson.core:jackson-databind:jar:2.15.0
@@ -78,5 +76,5 @@ This project bundles the following dependencies under the Apache Software Licens
 This project bundles the following dependencies under the BSD License.
 See bundled license files for details.
 
-- com.esotericsoftware.kryo:kryo:2.24.0
-- com.esotericsoftware.minlog:minlog:1.2
+- com.esotericsoftware.kryo:kryo:jar:2.24.0
+- com.esotericsoftware.minlog:minlog:jar:1.2

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ under the License.
         <lombok.version>1.18.30</lombok.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-io.version>2.17.0</commons-io.version>
-        <flink.version>1.20.0</flink.version>
+        <flink.version>1.20.1</flink.version>
 
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.23.1</log4j.version>


### PR DESCRIPTION
## What is the purpose of the change

1.20.1 is available in mvn repo. It fixed several of bugs, and we always use the .1 (patch version) as the dependency to avoid some potential bugs.

## Brief change log

[FLINK-37236] Bump the flink version from 1.20.0 to 1.20.1
