### PR TITLE
[FLINK-37320] [Observer] FINISHED finite streaming jobs incorrectly being set to RECONCILING

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -152,7 +152,10 @@ public abstract class AbstractFlinkDeploymentObserver
         }
 
         deploymentStatus.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
-        deploymentStatus.getJobStatus().setState(JobStatus.RECONCILING);
+
+        if (!ReconciliationUtils.isJobInTerminalState(deploymentStatus)) {
+            deploymentStatus.getJobStatus().setState(JobStatus.RECONCILING);
+        }
 
         if (previousJmStatus != JobManagerDeploymentStatus.MISSING
                 && previousJmStatus != JobManagerDeploymentStatus.ERROR) {


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a bug where the observer tries changing the JOB STATUS of a FINISHED finite/bounded streaming job back to RECONCILING if the JM is MISSING.

## Brief change log
Wraps [AbstractFlinkDeploymentObserver.observeJmDeployment](https://github.com/apache/flink-kubernetes-operator/blob/main/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java#L155) in an if-statement that only executes if the job is NOT in a terminal state.

## Verifying this change

- Tested locally
- Unit test to guard against accidental future regression

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: No
  - Core observer or reconciler logic that is regularly executed: Yes

## Documentation
  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? not applicable
