### PR TITLE
[FLINK-37359] Pin qemu image to 7.0.0

### DIFF
--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          image: tonistiigi/binfmt:latest
+          image: tonistiigi/binfmt:qemu-v8.1.5
           platforms: all
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker_push.yml
+++ b/.github/workflows/docker_push.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v7.0.0
           platforms: all
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
The latest [qemu docker image release ](https://hub.docker.com/r/tonistiigi/binfmt) seemingly broke our docker builds. Rolling back and pinning the latest working version (`v7.0.0`)

## Verifying this change
CI

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

no
