### PR TITLE
[FLINK-36876] Add proxy for restClient

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -154,7 +154,7 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.flink.client.io.threads</h5></td>
-            <td style="word-wrap: break-word;">60</td>
+            <td style="word-wrap: break-word;">10</td>
             <td>Integer</td>
             <td>The maximum number of io threads used by the flink rest client.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -153,6 +153,12 @@
             <td>The timeout for the observer to wait the flink rest client to return.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.flink.client.io.threads</h5></td>
+            <td style="word-wrap: break-word;">60</td>
+            <td>Integer</td>
+            <td>The maximum number of io threads used by the flink rest client.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.health.canary.resource.timeout</h5></td>
             <td style="word-wrap: break-word;">1 min</td>
             <td>Duration</td>

--- a/docs/layouts/shortcodes/generated/system_section.html
+++ b/docs/layouts/shortcodes/generated/system_section.html
@@ -51,6 +51,12 @@
             <td>The timeout for the observer to wait the flink rest client to return.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.flink.client.io.threads</h5></td>
+            <td style="word-wrap: break-word;">60</td>
+            <td>Integer</td>
+            <td>The maximum number of io threads used by the flink rest client.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.leader-election.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/system_section.html
+++ b/docs/layouts/shortcodes/generated/system_section.html
@@ -52,7 +52,7 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.flink.client.io.threads</h5></td>
-            <td style="word-wrap: break-word;">60</td>
+            <td style="word-wrap: break-word;">10</td>
             <td>Integer</td>
             <td>The maximum number of io threads used by the flink rest client.</td>
         </tr>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -53,6 +53,7 @@ public class FlinkOperatorConfiguration {
     Duration progressCheckInterval;
     Duration restApiReadyDelay;
     Duration flinkClientTimeout;
+    int flinkClientIOThreads;
     String flinkServiceHostOverride;
     Set<String> watchedNamespaces;
     boolean dynamicNamespacesEnabled;
@@ -98,6 +99,10 @@ public class FlinkOperatorConfiguration {
 
         Duration flinkClientTimeout =
                 operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_FLINK_CLIENT_TIMEOUT);
+
+        int flinkClientIOThreads =
+                operatorConfig.getInteger(
+                        KubernetesOperatorConfigOptions.OPERATOR_FLINK_CLIENT_IO_THREADS);
 
         Duration flinkCancelJobTimeout =
                 operatorConfig.get(
@@ -209,6 +214,7 @@ public class FlinkOperatorConfiguration {
                 progressCheckInterval,
                 restApiReadyDelay,
                 flinkClientTimeout,
+                flinkClientIOThreads,
                 flinkServiceHostOverride,
                 watchedNamespaces,
                 dynamicNamespacesEnabled,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -119,7 +119,7 @@ public class KubernetesOperatorConfigOptions {
     public static final ConfigOption<Integer> OPERATOR_FLINK_CLIENT_IO_THREADS =
             operatorConfig("flink.client.io.threads")
                     .intType()
-                    .defaultValue(60)
+                    .defaultValue(10)
                     .withDescription(
                             "The maximum number of io threads used by the flink rest client.");
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -117,7 +117,7 @@ public class KubernetesOperatorConfigOptions {
 
     @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Integer> OPERATOR_FLINK_CLIENT_IO_THREADS =
-            operatorConfig("kubernetes.operator.flink.client.io.threads")
+            operatorConfig("flink.client.io.threads")
                     .intType()
                     .defaultValue(60)
                     .withDescription(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -116,6 +116,14 @@ public class KubernetesOperatorConfigOptions {
                             "The timeout for the observer to wait the flink rest client to return.");
 
     @Documentation.Section(SECTION_SYSTEM)
+    public static final ConfigOption<Integer> OPERATOR_FLINK_CLIENT_IO_THREADS =
+            operatorConfig("kubernetes.operator.flink.client.io.threads")
+                    .intType()
+                    .defaultValue(60)
+                    .withDescription(
+                            "The maximum number of io threads used by the flink rest client.");
+
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Duration> OPERATOR_FLINK_CLIENT_CANCEL_TIMEOUT =
             operatorConfig("flink.client.cancel.timeout")
                     .durationType()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -24,6 +24,8 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.utils.JobStatusUtils;
 import org.apache.flink.client.program.rest.RestClusterClient;
+import org.apache.flink.client.program.rest.retry.ExponentialWaitStrategy;
+import org.apache.flink.client.program.rest.retry.WaitStrategy;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.RestOptions;
@@ -56,6 +58,7 @@ import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.ExceptionUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.highavailability.ClientHighAvailabilityServicesFactory;
 import org.apache.flink.runtime.highavailability.nonha.standalone.StandaloneClientHAServices;
 import org.apache.flink.runtime.jobmaster.JobResult;
 import org.apache.flink.runtime.messages.FlinkJobNotFoundException;
@@ -109,6 +112,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Iterables;
+import org.apache.flink.shaded.netty4.io.netty.channel.EventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
@@ -129,6 +133,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
@@ -175,17 +180,20 @@ public abstract class AbstractFlinkService implements FlinkService {
     protected final ExecutorService executorService;
     protected final FlinkOperatorConfiguration operatorConfig;
     protected final ArtifactManager artifactManager;
+    private final EventLoopGroup flinkClientSharedEventLoopGroup;
     private static final String EMPTY_JAR = createEmptyJar();
 
     public AbstractFlinkService(
             KubernetesClient kubernetesClient,
             ArtifactManager artifactManager,
             ExecutorService executorService,
-            FlinkOperatorConfiguration operatorConfig) {
+            FlinkOperatorConfiguration operatorConfig,
+            EventLoopGroup flinkClientEventLoopGroup) {
         this.kubernetesClient = kubernetesClient;
         this.artifactManager = artifactManager;
         this.executorService = executorService;
         this.operatorConfig = operatorConfig;
+        this.flinkClientSharedEventLoopGroup = flinkClientEventLoopGroup;
     }
 
     protected abstract PodList getJmPodList(String namespace, String clusterId);
@@ -842,11 +850,34 @@ public abstract class AbstractFlinkService implements FlinkService {
                         operatorConfig.getFlinkServiceHostOverride(),
                         ExternalServiceDecorator.getNamespacedExternalServiceName(
                                 clusterId, namespace));
+
         final String restServerAddress = String.format("http://%s:%s", host, port);
-        return new RestClusterClient<>(
-                operatorRestConf,
-                clusterId,
-                (c, e) -> new StandaloneClientHAServices(restServerAddress));
+        RestClient restClient =
+                new RestClientProxy(
+                        operatorRestConf,
+                        executorService,
+                        host,
+                        port,
+                        flinkClientSharedEventLoopGroup);
+
+        Constructor<?> clusterClientConstructor =
+                RestClusterClient.class.getDeclaredConstructor(
+                        Configuration.class,
+                        RestClient.class,
+                        Object.class,
+                        WaitStrategy.class,
+                        ClientHighAvailabilityServicesFactory.class);
+
+        clusterClientConstructor.setAccessible(true);
+
+        return (RestClusterClient<String>)
+                clusterClientConstructor.newInstance(
+                        operatorRestConf,
+                        restClient,
+                        clusterId,
+                        new ExponentialWaitStrategy(10L, 2000L),
+                        (ClientHighAvailabilityServicesFactory)
+                                (c, e) -> new StandaloneClientHAServices(restServerAddress));
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -51,6 +51,8 @@ import org.apache.flink.runtime.rest.messages.job.JobResourceRequirementsBody;
 import org.apache.flink.runtime.rest.messages.job.JobResourceRequirementsHeaders;
 import org.apache.flink.runtime.rest.messages.job.JobResourcesRequirementsUpdateHeaders;
 
+import org.apache.flink.shaded.netty4.io.netty.channel.EventLoopGroup;
+
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -89,7 +91,28 @@ public class NativeFlinkService extends AbstractFlinkService {
             ExecutorService executorService,
             FlinkOperatorConfiguration operatorConfig,
             EventRecorder eventRecorder) {
-        super(kubernetesClient, artifactManager, executorService, operatorConfig);
+        this(
+                kubernetesClient,
+                artifactManager,
+                executorService,
+                operatorConfig,
+                eventRecorder,
+                null);
+    }
+
+    public NativeFlinkService(
+            KubernetesClient kubernetesClient,
+            ArtifactManager artifactManager,
+            ExecutorService executorService,
+            FlinkOperatorConfiguration operatorConfig,
+            EventRecorder eventRecorder,
+            EventLoopGroup flinkClientEventLoopGroup) {
+        super(
+                kubernetesClient,
+                artifactManager,
+                executorService,
+                operatorConfig,
+                flinkClientEventLoopGroup);
         this.eventRecorder = eventRecorder;
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/RestClientProxy.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/RestClientProxy.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.service;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rest.RestClient;
+import org.apache.flink.util.ConfigurationException;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.netty4.io.netty.bootstrap.AbstractBootstrap;
+import org.apache.flink.shaded.netty4.io.netty.bootstrap.Bootstrap;
+import org.apache.flink.shaded.netty4.io.netty.channel.EventLoopGroup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+/** Proxy for the {@link RestClient}. */
+public class RestClientProxy extends RestClient {
+    private static final Logger LOG = LoggerFactory.getLogger(RestClientProxy.class);
+
+    private final boolean useSharedEventLoopGroup;
+    private Field groupField;
+    private Bootstrap bootstrap;
+    private CompletableFuture<Void> terminationFuture;
+
+    public RestClientProxy(
+            Configuration configuration,
+            ExecutorService executor,
+            String host,
+            int port,
+            EventLoopGroup sharedGroup)
+            throws ConfigurationException, NoSuchFieldException, IllegalAccessException {
+        super(configuration, executor, host, port);
+
+        if (sharedGroup != null) {
+            Preconditions.checkArgument(
+                    !sharedGroup.isShuttingDown() && !sharedGroup.isShutdown(),
+                    "provided eventLoopGroup is shut/shutting down");
+
+            // get private field
+            Field bootstrapField = RestClient.class.getDeclaredField("bootstrap");
+            Field terminationFutureField = RestClient.class.getDeclaredField("terminationFuture");
+            Field groupField = AbstractBootstrap.class.getDeclaredField("group");
+
+            bootstrapField.setAccessible(true);
+            terminationFutureField.setAccessible(true);
+            groupField.setAccessible(true);
+
+            // TODO check null
+            this.terminationFuture = (CompletableFuture<Void>) terminationFutureField.get(this);
+            this.bootstrap = (Bootstrap) bootstrapField.get(this);
+            this.groupField = groupField;
+
+            // close previous group
+            bootstrap.config().group().shutdown();
+            // setup share group
+            groupField.set(bootstrap, sharedGroup);
+
+            useSharedEventLoopGroup = true;
+        } else {
+            useSharedEventLoopGroup = false;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Void> closeAsync() {
+        if (useSharedEventLoopGroup) {
+            this.shutdownInternal();
+        }
+
+        return super.closeAsync();
+    }
+
+    @Override
+    public void shutdown(Time timeout) {
+        if (useSharedEventLoopGroup) {
+            this.shutdownInternal();
+        }
+        super.shutdown(timeout);
+    }
+
+    private void shutdownInternal() {
+        try {
+            // replace bootstrap's group to null to avoid shutdown shared group
+            groupField.set(bootstrap, null);
+            terminationFuture.complete(null);
+        } catch (IllegalAccessException e) {
+            LOG.error("Failed to setup rest client event group .", e);
+        }
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/RestClientProxy.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/RestClientProxy.java
@@ -66,7 +66,6 @@ public class RestClientProxy extends RestClient {
             terminationFutureField.setAccessible(true);
             groupField.setAccessible(true);
 
-            // TODO check null
             this.terminationFuture = (CompletableFuture<Void>) terminationFutureField.get(this);
             this.bootstrap = (Bootstrap) bootstrapField.get(this);
             this.groupField = groupField;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/StandaloneFlinkService.java
@@ -39,6 +39,8 @@ import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfi
 import org.apache.flink.kubernetes.operator.utils.StandaloneKubernetesUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
+import org.apache.flink.shaded.netty4.io.netty.channel.EventLoopGroup;
+
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -61,7 +63,21 @@ public class StandaloneFlinkService extends AbstractFlinkService {
             ArtifactManager artifactManager,
             ExecutorService executorService,
             FlinkOperatorConfiguration operatorConfig) {
-        super(kubernetesClient, artifactManager, executorService, operatorConfig);
+        this(kubernetesClient, artifactManager, executorService, operatorConfig, null);
+    }
+
+    public StandaloneFlinkService(
+            KubernetesClient kubernetesClient,
+            ArtifactManager artifactManager,
+            ExecutorService executorService,
+            FlinkOperatorConfiguration operatorConfig,
+            EventLoopGroup flinkClientEventLoopGroup) {
+        super(
+                kubernetesClient,
+                artifactManager,
+                executorService,
+                operatorConfig,
+                flinkClientEventLoopGroup);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -71,8 +71,10 @@ import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedMetricsRespo
 import org.apache.flink.runtime.rest.messages.job.metrics.AggregatedSubtaskMetricsHeaders;
 import org.apache.flink.runtime.rest.util.RestClientException;
 import org.apache.flink.util.SerializedThrowable;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.flink.util.concurrent.Executors;
 
+import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
@@ -171,7 +173,9 @@ public class TestingFlinkService extends AbstractFlinkService {
                 kubernetesClient,
                 null,
                 Executors.newDirectExecutorService(),
-                FlinkOperatorConfiguration.fromConfiguration(new Configuration()));
+                FlinkOperatorConfiguration.fromConfiguration(new Configuration()),
+                new NioEventLoopGroup(
+                        4, new ExecutorThreadFactory("flink-rest-client-netty-shared")));
     }
 
     public <T extends HasMetadata> Context<T> getContext() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -92,10 +92,12 @@ import org.apache.flink.runtime.webmonitor.handlers.JarUploadResponseBody;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.SerializedThrowable;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.function.TriFunction;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import io.fabric8.kubernetes.api.model.DeletionPropagation;
@@ -1334,7 +1336,10 @@ public class AbstractFlinkServiceTest {
                     client,
                     AbstractFlinkServiceTest.this.artifactManager,
                     AbstractFlinkServiceTest.this.executorService,
-                    AbstractFlinkServiceTest.this.operatorConfig);
+                    AbstractFlinkServiceTest.this.operatorConfig,
+                    new NioEventLoopGroup(
+                            AbstractFlinkServiceTest.this.operatorConfig.getFlinkClientIOThreads(),
+                            new ExecutorThreadFactory("flink-rest-client-netty-shared")));
             this.clusterClient = clusterClient;
             this.restClient = restClient;
         }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/RestClientProxyTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/RestClientProxyTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.service;
+
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.apache.flink.shaded.netty4.io.netty.channel.EventLoopGroup;
+import org.apache.flink.shaded.netty4.io.netty.channel.nio.NioEventLoopGroup;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder.FLINK_VERSION;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * @link RestClientProxy unit tests
+ */
+public class RestClientProxyTest {
+
+    private final Configuration configuration = new Configuration();
+
+    private final FlinkConfigManager configManager = new FlinkConfigManager(configuration);
+    private ExecutorService executorService;
+
+    private EventLoopGroup flinkClientEventLoopGroup;
+
+    @BeforeEach
+    public void setup() {
+        configuration.set(KubernetesConfigOptions.CLUSTER_ID, TestUtils.TEST_DEPLOYMENT_NAME);
+        configuration.set(KubernetesConfigOptions.NAMESPACE, TestUtils.TEST_NAMESPACE);
+        configuration.set(FLINK_VERSION, FlinkVersion.v1_18);
+
+        executorService = Executors.newDirectExecutorService();
+
+        flinkClientEventLoopGroup =
+                new NioEventLoopGroup(
+                        configManager.getOperatorConfiguration().getFlinkClientIOThreads(),
+                        new ExecutorThreadFactory("flink-rest-client-netty-shared"));
+    }
+
+    @Test
+    public void testClose() throws Exception {
+        RestClientProxy restClientProxy =
+                new RestClientProxy(
+                        configuration, executorService, "localhost", -1, flinkClientEventLoopGroup);
+
+        restClientProxy.close();
+        assertFalse(flinkClientEventLoopGroup.isShutdown());
+    }
+
+    @Test
+    public void testShutdown() throws Exception {
+        RestClientProxy restClientProxy =
+                new RestClientProxy(
+                        configuration, executorService, "localhost", -1, flinkClientEventLoopGroup);
+
+        restClientProxy.shutdown(Time.seconds(5));
+        assertFalse(flinkClientEventLoopGroup.isShutdown());
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Add proxy for restClient, which supports to use shared `EventLoopGroup`


## Brief change log

- *Introduce a new class `RestClientProxy` as the proxy of restClient*
- *Introduce a new configuration: `kubernetes.operator.flink.client.io.threads` to specify the total thread of sharded eventLoopGroup*
- *RestClientProxy supports to use sharded eventLoopGroup*



## Verifying this change
Unit tests + manual verification


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
