### PR TITLE
[FLINK-37430] Operator hides the actual error on deployment issues

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -238,6 +238,7 @@ public class FlinkConfigManager {
      *
      * @param baseConfMap The configuration map that should be searched for relevant Flink version
      *     prefixes.
+     * @param flinkVersion The FlinkVersion to be used
      * @return A list of relevant Flink version prefixes in order of ascending Flink version.
      */
     protected static List<String> getRelevantVersionPrefixes(
@@ -381,6 +382,7 @@ public class FlinkConfigManager {
      * Get configuration for interacting with session jobs. Similar to the observe configuration for
      * FlinkDeployments.
      *
+     * @param name The name of the job
      * @param deployment FlinkDeployment for the session cluster
      * @param sessionJobSpec Session job spec
      * @return Session job config

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -33,6 +33,7 @@ import org.apache.flink.kubernetes.operator.reconciler.deployment.ReconcilerFact
 import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.EventSourceUtils;
+import org.apache.flink.kubernetes.operator.utils.ExceptionUtils;
 import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
@@ -162,7 +163,7 @@ public class FlinkDeploymentController
                     flinkApp,
                     EventRecorder.Type.Warning,
                     "ClusterDeploymentException",
-                    e.getMessage(),
+                    ExceptionUtils.getExceptionMessage(e),
                     EventRecorder.Component.JobManagerDeployment,
                     josdkContext.getClient());
             throw new ReconciliationException(e);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -30,6 +30,7 @@ import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.EventSourceUtils;
+import org.apache.flink.kubernetes.operator.utils.ExceptionUtils;
 import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
@@ -124,7 +125,7 @@ public class FlinkSessionJobController
                     flinkSessionJob,
                     EventRecorder.Type.Warning,
                     "SessionJobException",
-                    e.getMessage(),
+                    ExceptionUtils.getExceptionMessage(e),
                     EventRecorder.Component.Job,
                     josdkContext.getClient());
             throw new ReconciliationException(e);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/FlinkResourceMutator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/mutator/FlinkResourceMutator.java
@@ -31,6 +31,7 @@ public interface FlinkResourceMutator extends Plugin {
      * Mutate deployment and return the mutated Object.
      *
      * @param deployment A Flink application or session cluster deployment.
+     * @return the mutated Flink application or session cluster deployment.
      */
     FlinkDeployment mutateDeployment(FlinkDeployment deployment);
 
@@ -39,6 +40,7 @@ public interface FlinkResourceMutator extends Plugin {
      *
      * @param sessionJob the session job to be mutated.
      * @param session the target session cluster of the session job to be Mutated.
+     * @return the mutated session job.
      */
     FlinkSessionJob mutateSessionJob(FlinkSessionJob sessionJob, Optional<FlinkDeployment> session);
 
@@ -46,6 +48,7 @@ public interface FlinkResourceMutator extends Plugin {
      * Mutate snapshot and return the mutated Object.
      *
      * @param stateSnapshot the snapshot to be mutated.
+     * @return the mutated snapshot.
      */
     FlinkStateSnapshot mutateStateSnapshot(FlinkStateSnapshot stateSnapshot);
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/AbstractFlinkResourceObserver.java
@@ -107,6 +107,7 @@ public abstract class AbstractFlinkResourceObserver<CR extends AbstractFlinkReso
      * DEPLOYED state.
      *
      * @param ctx Context for resource.
+     * @return true if the resource was already upgraded, false otherwise.
      */
     protected abstract boolean checkIfAlreadyUpgraded(FlinkResourceContext<CR> ctx);
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SnapshotTriggerTimestampStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/SnapshotTriggerTimestampStore.java
@@ -53,6 +53,7 @@ public class SnapshotTriggerTimestampStore {
      * updated with this value.
      *
      * @param resource Flink resource
+     * @param snapshotType the snapshot type
      * @param snapshotsSupplier supplies related snapshot resources
      * @return instant of last trigger
      */
@@ -103,6 +104,7 @@ public class SnapshotTriggerTimestampStore {
      * Updates the time a periodic snapshot was last triggered for this resource.
      *
      * @param resource Kubernetes resource
+     * @param snapshotType the snapshot type
      * @param instant new timestamp
      */
     public void updateLastPeriodicTriggerTimestamp(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -954,7 +954,15 @@ public abstract class AbstractFlinkService implements FlinkService {
         }
     }
 
-    /** Wait until Deployment is removed, return remaining timeout. */
+    /**
+     * Wait until Deployment is removed, return remaining timeout.
+     *
+     * @param name name of the deployment
+     * @param deployment The deployment resource
+     * @param propagation DeletePropagation
+     * @param timeout Timeout to wait
+     * @return remaining timeout after deletion
+     */
     @VisibleForTesting
     protected Duration deleteDeploymentBlocking(
             String name,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -122,10 +122,16 @@ public class EventRecorder {
     }
 
     /**
+     * @param resource The resource
+     * @param type The type
+     * @param reason the reason
+     * @param message the message
+     * @param component the component
+     * @param messageKey the message key
+     * @param client the client
      * @param interval Interval for dedupe. Null mean no dedupe.
-     * @return
      */
-    public boolean triggerEventWithInterval(
+    public void triggerEventWithInterval(
             AbstractFlinkResource<?, ?> resource,
             Type type,
             String reason,
@@ -134,7 +140,7 @@ public class EventRecorder {
             String messageKey,
             KubernetesClient client,
             @Nullable Duration interval) {
-        return EventUtils.createOrUpdateEventWithInterval(
+        EventUtils.createOrUpdateEventWithInterval(
                 client,
                 resource,
                 type,
@@ -166,12 +172,18 @@ public class EventRecorder {
     }
 
     /**
+     * @param resource The resource
+     * @param type The type
+     * @param reason the reason
+     * @param message the message
+     * @param component the component
+     * @param messageKey the message key
+     * @param client the client
      * @param interval Interval for dedupe. Null mean no dedupe.
      * @param dedupePredicate Predicate for dedupe algorithm..
      * @param labels Labels to store in meta data for dedupe. Do nothing if null.
-     * @return
      */
-    public boolean triggerEventWithLabels(
+    public void triggerEventWithLabels(
             AbstractFlinkResource<?, ?> resource,
             Type type,
             String reason,
@@ -182,7 +194,7 @@ public class EventRecorder {
             @Nullable Duration interval,
             @Nullable Predicate<Map<String, String>> dedupePredicate,
             @Nullable Map<String, String> labels) {
-        return EventUtils.createOrUpdateEventWithLabels(
+        EventUtils.createOrUpdateEventWithLabels(
                 client,
                 resource,
                 type,

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtils.java
@@ -100,15 +100,15 @@ public class ExceptionUtils {
         var msg =
                 Optional.ofNullable(throwable.getMessage())
                         .orElse(throwable.getClass().getSimpleName());
-        level++;
-        if (level == EXCEPTION_LIMIT_FOR_EVENT_MESSAGE) {
+
+        if (level >= EXCEPTION_LIMIT_FOR_EVENT_MESSAGE) {
             return msg;
         }
 
         if (throwable.getCause() == null) {
             return msg;
         } else {
-            return msg + " -> " + getExceptionMessage(throwable.getCause(), level);
+            return msg + " -> " + getExceptionMessage(throwable.getCause(), level + 1);
         }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtils.java
@@ -30,6 +30,12 @@ public class ExceptionUtils {
     /**
      * Based on the flink ExceptionUtils#findThrowableSerializedAware but fixes an infinite loop bug
      * resulting from SerializedThrowable deserialization errors.
+     *
+     * @param throwable the throwable to be processed
+     * @param searchType the type of the exception to search for
+     * @param classLoader the classloader to use for deserialization
+     * @param <T> the exception type
+     * @return the found exception, or empty if it is not found.
      */
     public static <T extends Throwable> Optional<T> findThrowableSerializedAware(
             Throwable throwable, Class<T> searchType, ClassLoader classLoader) {
@@ -65,8 +71,8 @@ public class ExceptionUtils {
      * exceptions in the hierarchy.
      *
      * @param throwable the throwable to be processed
-     * @return the exception message, which will have a format similar to "cause1 -> cause2 ->
-     *     cause3"
+     * @return the exception message, which will have a format similar to "cause1 &rarr; cause2
+     *     &rarr; cause3"
      */
     public static String getExceptionMessage(Throwable throwable) {
         return getExceptionMessage(throwable, 0);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/SnapshotUtils.java
@@ -134,6 +134,7 @@ public class SnapshotUtils {
      * @param resource The resource to be snapshotted.
      * @param conf The observe configuration of the resource.
      * @param snapshotType The type of the snapshot.
+     * @param lastTrigger the last time the snapshot was triggered.
      * @return An optional {@link SnapshotTriggerType}.
      */
     @VisibleForTesting

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/StatusRecorder.java
@@ -85,6 +85,7 @@ public class StatusRecorder<CR extends CustomResource<?, STATUS>, STATUS> {
      * operator behavior.
      *
      * @param resource Resource for which status update should be performed
+     * @param client Kubernetes client to use for the update
      */
     @SneakyThrows
     public void patchAndCacheStatus(CR resource, KubernetesClient client) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/FlinkResourceValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/FlinkResourceValidator.java
@@ -50,6 +50,7 @@ public interface FlinkResourceValidator extends Plugin {
      * Validate and return optional error.
      *
      * @param savepoint the savepoint to be validated.
+     * @param target the target resource of the savepoint to be validated.
      * @return Optional error string, should be present iff validation resulted in an error
      */
     Optional<String> validateStateSnapshot(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -130,6 +130,7 @@ public class TestingFlinkService extends AbstractFlinkService {
     @Setter private boolean checkpointAvailable = true;
     @Setter private boolean jobManagerReady = true;
     @Setter private boolean deployFailure = false;
+    @Setter private Exception makeItFailWith;
     @Setter private boolean triggerSavepointFailure = false;
     @Setter private boolean disposeSavepointFailure = false;
     @Setter private Runnable sessionJobSubmittedCallback;
@@ -212,6 +213,9 @@ public class TestingFlinkService extends AbstractFlinkService {
     }
 
     protected void deployApplicationCluster(JobSpec jobSpec, Configuration conf) throws Exception {
+        if (makeItFailWith != null) {
+            throw makeItFailWith;
+        }
         if (deployFailure) {
             throw new Exception("Deployment failure");
         }
@@ -269,6 +273,10 @@ public class TestingFlinkService extends AbstractFlinkService {
             Configuration conf,
             @Nullable String savepoint)
             throws Exception {
+
+        if (makeItFailWith != null) {
+            throw makeItFailWith;
+        }
 
         if (deployFailure) {
             throw new Exception("Deployment failure");

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
 import org.apache.flink.kubernetes.operator.service.CheckpointHistoryWrapper;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.util.SerializedThrowable;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
@@ -613,6 +614,31 @@ class FlinkSessionJobControllerTest {
         flinkService.setDeployFailure(false);
         testController.reconcile(sessionJob, context);
         assertEquals("msp", flinkService.listJobs().get(0).f0);
+    }
+
+    @Test
+    public void testErrorOnReconcileWithChainedExceptions() throws Exception {
+        sessionJob.getSpec().getJob().setInitialSavepointPath("msp");
+        flinkService.setMakeItFailWith(
+                new RuntimeException(
+                        "Deployment Failure",
+                        new IllegalStateException(
+                                null,
+                                new SerializedThrowable(new Exception("actual failure reason")))));
+        try {
+            testController.reconcile(sessionJob, context);
+            fail();
+        } catch (Exception expected) {
+        }
+        assertEquals(2, testController.events().size());
+
+        var event = testController.events().remove();
+        assertEquals("Submit", event.getReason());
+        event = testController.events().remove();
+        assertEquals("SessionJobException", event.getReason());
+        assertEquals(
+                "Deployment Failure -> IllegalStateException -> actual failure reason",
+                event.getMessage());
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtilsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.util.SerializedThrowable;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link ExceptionUtils}. */
+public class ExceptionUtilsTest {
+
+    @Test
+    void testGetExceptionMessage_nullThrowable() {
+        assertThat(ExceptionUtils.getExceptionMessage(null)).isNull();
+    }
+
+    @Test
+    void testGetExceptionMessage_simpleException() {
+        var ex = new RuntimeException("My Exception");
+        assertThat(ExceptionUtils.getExceptionMessage(ex)).isEqualTo("My Exception");
+    }
+
+    @Test
+    void testGetExceptionMessage_simpleExceptionNullCause() {
+        var ex = new OutOfMemoryError(null);
+        assertThat(ExceptionUtils.getExceptionMessage(ex)).isEqualTo("OutOfMemoryError");
+    }
+
+    @Test
+    void testGetExceptionMessage_exceptionWithCause() {
+        var ex = new RuntimeException("Root Cause");
+        var exWrapped = new RuntimeException("Wrapped Exception", ex);
+        assertThat(ExceptionUtils.getExceptionMessage(exWrapped))
+                .isEqualTo("Wrapped Exception -> Root Cause");
+    }
+
+    @Test
+    void testGetExceptionMessage_exactlyThree() {
+        var ex3 = new IllegalAccessException(null);
+        var ex2 = new RuntimeException("Cause 2", ex3);
+        var ex = new RuntimeException("Cause 1", ex2);
+        assertThat(ExceptionUtils.getExceptionMessage(ex))
+                .isEqualTo("Cause 1 -> Cause 2 -> IllegalAccessException");
+    }
+
+    @Test
+    void testGetExceptionMessage_onlyTwo() {
+        var ex2 = new RuntimeException("Cause 2");
+        var ex = new RuntimeException("Cause 1", ex2);
+        assertThat(ExceptionUtils.getExceptionMessage(ex)).isEqualTo("Cause 1 -> Cause 2");
+    }
+
+    @Test
+    void testGetExceptionMessage_moreThanThree() {
+        var ex4 = new RuntimeException("Cause 4");
+        var ex3 = new RuntimeException("Cause 3", ex4);
+        var ex2 = new IllegalStateException(null, ex3);
+        var ex = new RuntimeException("Cause 1", ex2);
+        assertThat(ExceptionUtils.getExceptionMessage(ex))
+                .isEqualTo("Cause 1 -> IllegalStateException -> Cause 3");
+    }
+
+    @Test
+    void testGetExceptionMessage_serializedThrowable() {
+        var serializedException = new SerializedThrowable(new Exception("Serialized Exception"));
+        assertThat(ExceptionUtils.getExceptionMessage(serializedException))
+                .isEqualTo("Serialized Exception");
+    }
+
+    @Test
+    void testGetExceptionMessage_serializedThrowableWithDoubleSerializedException() {
+        var firstSerialized = new SerializedThrowable(new IndexOutOfBoundsException("4>3"));
+        var serializedException = new SerializedThrowable(firstSerialized);
+        assertThat(ExceptionUtils.getExceptionMessage(serializedException)).isEqualTo("4>3");
+    }
+
+    @Test
+    void testGetExceptionMessage_serializedThrowableWithRegularException() {
+        var serializedException = new SerializedThrowable(new Exception("Serialized Exception"));
+        var ex = new RuntimeException("Cause 1", serializedException);
+        assertThat(ExceptionUtils.getExceptionMessage(ex))
+                .isEqualTo("Cause 1 -> Serialized Exception");
+    }
+
+    @Test
+    void testGetExceptionMessage_serializedThrowableAndAnotherCause() {
+        var ex = new RuntimeException("Cause 1");
+        var serializedException =
+                new SerializedThrowable(new RuntimeException("Serialized Exception", ex));
+        assertThat(ExceptionUtils.getExceptionMessage(serializedException))
+                .isEqualTo("Serialized Exception -> Cause 1");
+    }
+
+    @Test
+    void testGetExceptionMessage_moreThanThreeWithSerializedAnnRegularOnes() {
+        var ex4 = new RuntimeException("Cause 4");
+        var ex3 = new RuntimeException("Cause 3", ex4);
+        var ex2 = new RuntimeException("Cause 2", new SerializedThrowable(ex3));
+        var ex = new RuntimeException("Cause 1", ex2);
+        assertThat(ExceptionUtils.getExceptionMessage(ex))
+                .isEqualTo("Cause 1 -> Cause 2 -> Cause 3");
+    }
+
+    @Test
+    void testGetExceptionMessage_moreThanThreeWithSerializedAndNotWithDifferentOrdering() {
+        var ex4 = new RuntimeException("Cause 4");
+        var ex3 = new RuntimeException("Cause 3", ex4);
+        var ex2 = new RuntimeException("Cause 2", new SerializedThrowable(ex3));
+        var ex = new RuntimeException("Cause 1", new SerializedThrowable(ex2));
+        assertThat(ExceptionUtils.getExceptionMessage(ex))
+                .isEqualTo("Cause 1 -> Cause 2 -> Cause 3");
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtilsTest.java
@@ -21,6 +21,8 @@ import org.apache.flink.util.SerializedThrowable;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link ExceptionUtils}. */
@@ -32,52 +34,6 @@ public class ExceptionUtilsTest {
     }
 
     @Test
-    void testGetExceptionMessage_simpleException() {
-        var ex = new RuntimeException("My Exception");
-        assertThat(ExceptionUtils.getExceptionMessage(ex)).isEqualTo("My Exception");
-    }
-
-    @Test
-    void testGetExceptionMessage_simpleExceptionNullCause() {
-        var ex = new OutOfMemoryError(null);
-        assertThat(ExceptionUtils.getExceptionMessage(ex)).isEqualTo("OutOfMemoryError");
-    }
-
-    @Test
-    void testGetExceptionMessage_exceptionWithCause() {
-        var ex = new RuntimeException("Root Cause");
-        var exWrapped = new RuntimeException("Wrapped Exception", ex);
-        assertThat(ExceptionUtils.getExceptionMessage(exWrapped))
-                .isEqualTo("Wrapped Exception -> Root Cause");
-    }
-
-    @Test
-    void testGetExceptionMessage_exactlyThree() {
-        var ex3 = new IllegalAccessException(null);
-        var ex2 = new RuntimeException("Cause 2", ex3);
-        var ex = new RuntimeException("Cause 1", ex2);
-        assertThat(ExceptionUtils.getExceptionMessage(ex))
-                .isEqualTo("Cause 1 -> Cause 2 -> IllegalAccessException");
-    }
-
-    @Test
-    void testGetExceptionMessage_onlyTwo() {
-        var ex2 = new RuntimeException("Cause 2");
-        var ex = new RuntimeException("Cause 1", ex2);
-        assertThat(ExceptionUtils.getExceptionMessage(ex)).isEqualTo("Cause 1 -> Cause 2");
-    }
-
-    @Test
-    void testGetExceptionMessage_moreThanThree() {
-        var ex4 = new RuntimeException("Cause 4");
-        var ex3 = new RuntimeException("Cause 3", ex4);
-        var ex2 = new IllegalStateException(null, ex3);
-        var ex = new RuntimeException("Cause 1", ex2);
-        assertThat(ExceptionUtils.getExceptionMessage(ex))
-                .isEqualTo("Cause 1 -> IllegalStateException -> Cause 3");
-    }
-
-    @Test
     void testGetExceptionMessage_serializedThrowable() {
         var serializedException = new SerializedThrowable(new Exception("Serialized Exception"));
         assertThat(ExceptionUtils.getExceptionMessage(serializedException))
@@ -85,46 +41,25 @@ public class ExceptionUtilsTest {
     }
 
     @Test
-    void testGetExceptionMessage_serializedThrowableWithDoubleSerializedException() {
-        var firstSerialized = new SerializedThrowable(new IndexOutOfBoundsException("4>3"));
-        var serializedException = new SerializedThrowable(firstSerialized);
-        assertThat(ExceptionUtils.getExceptionMessage(serializedException)).isEqualTo("4>3");
-    }
-
-    @Test
-    void testGetExceptionMessage_serializedThrowableWithRegularException() {
-        var serializedException = new SerializedThrowable(new Exception("Serialized Exception"));
-        var ex = new RuntimeException("Cause 1", serializedException);
-        assertThat(ExceptionUtils.getExceptionMessage(ex))
-                .isEqualTo("Cause 1 -> Serialized Exception");
-    }
-
-    @Test
-    void testGetExceptionMessage_serializedThrowableAndAnotherCause() {
-        var ex = new RuntimeException("Cause 1");
-        var serializedException =
-                new SerializedThrowable(new RuntimeException("Serialized Exception", ex));
-        assertThat(ExceptionUtils.getExceptionMessage(serializedException))
-                .isEqualTo("Serialized Exception -> Cause 1");
-    }
-
-    @Test
-    void testGetExceptionMessage_moreThanThreeWithSerializedAnnRegularOnes() {
+    void testGetExceptionMessage_differentKindsOfExceptions() {
         var ex4 = new RuntimeException("Cause 4");
         var ex3 = new RuntimeException("Cause 3", ex4);
         var ex2 = new RuntimeException("Cause 2", new SerializedThrowable(ex3));
         var ex = new RuntimeException("Cause 1", ex2);
         assertThat(ExceptionUtils.getExceptionMessage(ex))
-                .isEqualTo("Cause 1 -> Cause 2 -> Cause 3");
+                .isEqualTo("Cause 1 -> Cause 2 -> Cause 3 -> Cause 4");
     }
 
     @Test
-    void testGetExceptionMessage_moreThanThreeWithSerializedAndNotWithDifferentOrdering() {
-        var ex4 = new RuntimeException("Cause 4");
-        var ex3 = new RuntimeException("Cause 3", ex4);
-        var ex2 = new RuntimeException("Cause 2", new SerializedThrowable(ex3));
-        var ex = new RuntimeException("Cause 1", new SerializedThrowable(ex2));
-        assertThat(ExceptionUtils.getExceptionMessage(ex))
-                .isEqualTo("Cause 1 -> Cause 2 -> Cause 3");
+    void testSerializedThrowableError() {
+        var serializedException = new SerializedThrowable(new NonSerializableException());
+        assertThat(ExceptionUtils.getExceptionMessage(serializedException))
+                .isEqualTo("Unknown Error (SerializedThrowable)");
+    }
+
+    private static class NonSerializableException extends Exception {
+        private void writeObject(java.io.ObjectOutputStream stream) throws IOException {
+            throw new IOException();
+        }
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The operator often hides the actual issue for deployment errors and do not correctly report the error events.

## Brief change log

We are reporting the first 3 possible exceptions in the exception hierarchy in the error events.
## Verifying this change
This change added tests and can be verified as follows:
- Added new unit tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:  no
  - Core observer or reconciler logic that is regularly executed:  no

## Documentation

  - Does this pull request introduce a new feature? no

