### PR TITLE
[FLINK-37470] Improve JobManager Deployment / Pod error handling

### DIFF
--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -185,6 +185,13 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kube-api-test-client-inject</artifactId>
+            <version>${fabric8.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver</artifactId>
             <version>${okhttp.version}</version>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -183,8 +183,7 @@ public abstract class AbstractFlinkDeploymentObserver
                     .forEach(AbstractFlinkDeploymentObserver::checkContainerError);
 
             // No obvious errors were found, check for volume mount issues
-            EventUtils.checkForVolumeMountErrors(
-                    pod, () -> EventUtils.getPodEvents(ctx.getKubernetesClient(), pod));
+            EventUtils.checkForVolumeMountErrors(ctx.getKubernetesClient(), pod);
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -30,9 +30,9 @@ import org.apache.flink.kubernetes.operator.exception.MissingJobManagerException
 import org.apache.flink.kubernetes.operator.observer.AbstractFlinkResourceObserver;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+import org.apache.flink.kubernetes.operator.utils.EventUtils;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 
-import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
+import java.util.stream.Stream;
 
 /** Base observer for session and application clusters. */
 public abstract class AbstractFlinkDeploymentObserver
@@ -135,7 +135,7 @@ public abstract class AbstractFlinkDeploymentObserver
             try {
                 checkFailedCreate(status);
                 // checking the pod is expensive; only do it when the deployment isn't ready
-                checkContainerBackoff(ctx);
+                checkContainerErrors(ctx);
             } catch (DeploymentFailedException dfe) {
                 // throw only when not already in error status to allow for spec update
                 deploymentStatus.getJobStatus().setState(JobStatus.RECONCILING);
@@ -172,21 +172,29 @@ public abstract class AbstractFlinkDeploymentObserver
         }
     }
 
-    private void checkContainerBackoff(FlinkResourceContext<FlinkDeployment> ctx) {
+    private void checkContainerErrors(FlinkResourceContext<FlinkDeployment> ctx) {
         PodList jmPods =
                 ctx.getFlinkService().getJmPodList(ctx.getResource(), ctx.getObserveConfig());
         for (Pod pod : jmPods.getItems()) {
-            for (ContainerStatus cs : pod.getStatus().getContainerStatuses()) {
-                ContainerStateWaiting csw = cs.getState().getWaiting();
-                if (csw != null
-                        && Set.of(
-                                        DeploymentFailedException.REASON_CRASH_LOOP_BACKOFF,
-                                        DeploymentFailedException.REASON_IMAGE_PULL_BACKOFF,
-                                        DeploymentFailedException.REASON_ERR_IMAGE_PULL)
-                                .contains(csw.getReason())) {
-                    throw new DeploymentFailedException(csw);
-                }
-            }
+            var podStatus = pod.getStatus();
+            Stream.concat(
+                            podStatus.getContainerStatuses().stream(),
+                            podStatus.getInitContainerStatuses().stream())
+                    .forEach(AbstractFlinkDeploymentObserver::checkContainerError);
+
+            // No obvious errors were found, check for volume mount issues
+            EventUtils.checkForVolumeMountErrors(
+                    pod, () -> EventUtils.getPodEvents(ctx.getKubernetesClient(), pod));
+        }
+    }
+
+    private static void checkContainerError(ContainerStatus cs) {
+        if (cs.getState() == null || cs.getState().getWaiting() == null) {
+            return;
+        }
+        if (DeploymentFailedException.CONTAINER_ERROR_REASONS.contains(
+                cs.getState().getWaiting().getReason())) {
+            throw DeploymentFailedException.forContainerStatus(cs);
         }
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -17,11 +17,16 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
+
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodCondition;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.slf4j.Logger;
@@ -32,10 +37,15 @@ import javax.annotation.Nullable;
 import java.net.HttpURLConnection;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * The util to generate an event for the target resource. It is copied from
@@ -182,13 +192,7 @@ public class EventUtils {
             String eventName) {
         return new EventBuilder()
                 .withApiVersion("v1")
-                .withInvolvedObject(
-                        new ObjectReferenceBuilder()
-                                .withKind(target.getKind())
-                                .withUid(target.getMetadata().getUid())
-                                .withName(target.getMetadata().getName())
-                                .withNamespace(target.getMetadata().getNamespace())
-                                .build())
+                .withInvolvedObject(getObjectReference(target))
                 .withType(type.name())
                 .withReason(reason)
                 .withFirstTimestamp(Instant.now().toString())
@@ -234,5 +238,79 @@ public class EventUtils {
             }
         }
         return Optional.empty();
+    }
+
+    public static List<Event> getPodEvents(KubernetesClient client, Pod pod) {
+        var ref = getObjectReference(pod);
+
+        var eventList =
+                client.v1()
+                        .events()
+                        .inNamespace(pod.getMetadata().getNamespace())
+                        .withInvolvedObject(ref)
+                        .list();
+
+        if (eventList == null) {
+            return new ArrayList<>();
+        }
+
+        var items = eventList.getItems();
+        if (items == null) {
+            return new ArrayList<>();
+        }
+        return items;
+    }
+
+    @VisibleForTesting
+    protected static ObjectReference getObjectReference(HasMetadata resource) {
+        var ref = new ObjectReference();
+        ref.setApiVersion(resource.getApiVersion());
+        ref.setKind(resource.getKind());
+        ref.setName(resource.getMetadata().getName());
+        ref.setNamespace(resource.getMetadata().getNamespace());
+        ref.setUid(resource.getMetadata().getUid());
+        return ref;
+    }
+
+    /**
+     * Check that pod is stuck during volume mount stage and throw {@link DeploymentFailedException}
+     * with the right reason message if that's the case.
+     *
+     * @param pod Pod to be checked
+     * @param podEventSupplier supplier for Pod event list. For easy testability
+     */
+    public static void checkForVolumeMountErrors(Pod pod, Supplier<List<Event>> podEventSupplier) {
+        var conditions = pod.getStatus().getConditions();
+        if (conditions == null) {
+            return;
+        }
+        var conditionMap =
+                conditions.stream()
+                        .collect(Collectors.toMap(PodCondition::getType, Function.identity()));
+
+        // We use PodReadyToStartContainers if available otherwise use Initialized, but it's only
+        // there k8s 1.29+
+        boolean failedInitialization =
+                checkStatusWasAlways(
+                        pod,
+                        conditionMap.getOrDefault(
+                                "PodReadyToStartContainers", conditionMap.get("Initialized")),
+                        "False");
+
+        boolean notReady = checkStatusWasAlways(pod, conditionMap.get("Ready"), "False");
+
+        if (notReady && failedInitialization) {
+            podEventSupplier.get().stream()
+                    .filter(e -> e.getReason().equals("FailedMount"))
+                    .findAny()
+                    .ifPresent(
+                            e -> {
+                                throw new DeploymentFailedException(e.getMessage(), e.getReason());
+                            });
+        }
+    }
+
+    private static boolean checkStatusWasAlways(Pod pod, PodCondition condition, String status) {
+        return condition != null && condition.getStatus().equals(status);
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -97,6 +97,24 @@ public class TestUtils extends BaseTestUtils {
     public static PodList createFailedPodList(String crashLoopMessage, String reason) {
         ContainerStatus cs =
                 new ContainerStatusBuilder()
+                        .withName("c1")
+                        .withNewState()
+                        .withNewWaiting()
+                        .withReason(reason)
+                        .withMessage(crashLoopMessage)
+                        .endWaiting()
+                        .endState()
+                        .build();
+
+        Pod pod = getTestPod("host", "apiVersion", Collections.emptyList());
+        pod.setStatus(new PodStatusBuilder().withContainerStatuses(cs).build());
+        return new PodListBuilder().withItems(pod).build();
+    }
+
+    public static PodList createFailedInitContainerPodList(String crashLoopMessage, String reason) {
+        ContainerStatus cs =
+                new ContainerStatusBuilder()
+                        .withName("c1")
                         .withNewState()
                         .withNewWaiting()
                         .withReason(reason)
@@ -108,7 +126,8 @@ public class TestUtils extends BaseTestUtils {
         Pod pod = getTestPod("host", "apiVersion", Collections.emptyList());
         pod.setStatus(
                 new PodStatusBuilder()
-                        .withContainerStatuses(Collections.singletonList(cs))
+                        .withContainerStatuses(new ContainerStatusBuilder().withReady().build())
+                        .withInitContainerStatuses(cs)
                         .build());
         return new PodListBuilder().withItems(pod).build();
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedExceptionTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/exception/DeploymentFailedExceptionTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.exception;
+
+import io.fabric8.kubernetes.api.model.ContainerState;
+import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
+import io.fabric8.kubernetes.api.model.ContainerStateWaiting;
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for {@link DeploymentFailedException}. */
+public class DeploymentFailedExceptionTest {
+
+    @Test
+    public void testErrorFromContainerStatus() {
+        var containerStatus = new ContainerStatus();
+        containerStatus.setName("c1");
+        var state = new ContainerState();
+        var waiting = new ContainerStateWaiting();
+        waiting.setMessage("msg");
+        waiting.setReason("r");
+        state.setWaiting(waiting);
+
+        containerStatus.setState(state);
+
+        var ex = DeploymentFailedException.forContainerStatus(containerStatus);
+        assertEquals("[c1] msg", ex.getMessage());
+        assertEquals("r", ex.getReason());
+
+        waiting.setReason("CrashLoopBackOff");
+        waiting.setMessage("backing off");
+        ex = DeploymentFailedException.forContainerStatus(containerStatus);
+        assertEquals("[c1] backing off", ex.getMessage());
+        assertEquals("CrashLoopBackOff", ex.getReason());
+
+        // Last state set but not terminated
+        var lastState = new ContainerState();
+        containerStatus.setLastState(lastState);
+
+        ex = DeploymentFailedException.forContainerStatus(containerStatus);
+        assertEquals("[c1] backing off", ex.getMessage());
+        assertEquals("CrashLoopBackOff", ex.getReason());
+
+        var terminated = new ContainerStateTerminated();
+        terminated.setMessage("crash");
+        lastState.setTerminated(terminated);
+
+        ex = DeploymentFailedException.forContainerStatus(containerStatus);
+        assertEquals("[c1] CrashLoop - crash", ex.getMessage());
+        assertEquals("CrashLoopBackOff", ex.getReason());
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventUtilsTest.java
@@ -18,9 +18,14 @@
 package org.apache.flink.kubernetes.operator.utils;
 
 import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.EventBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodCondition;
+import io.fabric8.kubernetes.api.model.PodConditionBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
@@ -33,9 +38,16 @@ import javax.annotation.Nullable;
 
 import java.net.HttpURLConnection;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** Test for {@link EventUtils}. */
 @EnableKubernetesMockClient(crud = true)
@@ -571,5 +583,109 @@ public class EventUtilsTest {
                         null,
                         null));
         Assertions.assertNull(eventConsumed);
+    }
+
+    @Test
+    public void testVolumeMountErrors() {
+        var pod =
+                new PodBuilder()
+                        .withNewMetadata()
+                        .withName("test")
+                        .withNamespace("default")
+                        .endMetadata()
+                        .withNewStatus()
+                        .endStatus()
+                        .build();
+
+        var events =
+                List.of(
+                        createPodEvent("e1", "reason1", "msg1", pod),
+                        createPodEvent("e2", "FailedMount", "mountErr", pod));
+
+        // No conditions, no error expected
+        EventUtils.checkForVolumeMountErrors(pod, () -> events);
+
+        var conditions = new ArrayList<PodCondition>();
+        pod.getStatus().setConditions(conditions);
+
+        // No conditions, no error expected
+        EventUtils.checkForVolumeMountErrors(pod, () -> events);
+
+        var conditionMap = new HashMap<String, String>();
+
+        // Pod initialized completely, shouldn't check events
+        conditionMap.put("Initialized", "True");
+        conditionMap.put("Ready", "False");
+
+        conditions.clear();
+        conditionMap.forEach(
+                (t, s) ->
+                        conditions.add(
+                                new PodConditionBuilder().withType(t).withStatus(s).build()));
+        EventUtils.checkForVolumeMountErrors(pod, () -> events);
+
+        // Pod initialized completely, shouldn't check events
+        conditionMap.put("PodReadyToStartContainers", "True");
+        conditionMap.put("Initialized", "False");
+
+        conditions.clear();
+        conditionMap.forEach(
+                (t, s) ->
+                        conditions.add(
+                                new PodConditionBuilder().withType(t).withStatus(s).build()));
+        EventUtils.checkForVolumeMountErrors(pod, () -> events);
+
+        // Check event only when not ready to start
+        conditionMap.put("PodReadyToStartContainers", "False");
+        conditions.clear();
+        conditionMap.forEach(
+                (t, s) ->
+                        conditions.add(
+                                new PodConditionBuilder().withType(t).withStatus(s).build()));
+
+        try {
+            EventUtils.checkForVolumeMountErrors(pod, () -> events);
+            fail("Exception not thrown");
+        } catch (DeploymentFailedException dfe) {
+            assertEquals("FailedMount", dfe.getReason());
+            assertEquals("mountErr", dfe.getMessage());
+        }
+
+        // Old kubernetes without PodReadyToStartContainers
+        conditionMap.remove("PodReadyToStartContainers");
+        conditionMap.put("Initialized", "False");
+        conditions.clear();
+        conditionMap.forEach(
+                (t, s) ->
+                        conditions.add(
+                                new PodConditionBuilder().withType(t).withStatus(s).build()));
+
+        try {
+            EventUtils.checkForVolumeMountErrors(pod, () -> events);
+            fail("Exception not thrown");
+        } catch (DeploymentFailedException dfe) {
+            assertEquals("FailedMount", dfe.getReason());
+            assertEquals("mountErr", dfe.getMessage());
+        }
+    }
+
+    private Event createPodEvent(String name, String reason, String msg, Pod pod) {
+        return new EventBuilder()
+                .withApiVersion("v1")
+                .withInvolvedObject(EventUtils.getObjectReference(pod))
+                .withType("type")
+                .withReason(reason)
+                .withFirstTimestamp(Instant.now().toString())
+                .withLastTimestamp(Instant.now().toString())
+                .withNewSource()
+                .withComponent("pod")
+                .endSource()
+                .withCount(1)
+                .withMessage(msg)
+                .withNewMetadata()
+                .withName(name)
+                .withNamespace(pod.getMetadata().getNamespace())
+                .endMetadata()
+                .build();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/PodErrorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/PodErrorTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
+
+import io.fabric8.kubeapitest.junit.EnableKubeAPIServer;
+import io.fabric8.kubernetes.api.model.EventBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodCondition;
+import io.fabric8.kubernetes.api.model.PodConditionBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/** Test for {@link EventUtils}. */
+@EnableKubeAPIServer
+public class PodErrorTest {
+
+    static KubernetesClient client;
+
+    @Test
+    public void testVolumeMountErrors() {
+        var pod =
+                new PodBuilder()
+                        .withNewMetadata()
+                        .withName("test")
+                        .withNamespace("default")
+                        .endMetadata()
+                        .withNewStatus()
+                        .endStatus()
+                        .build();
+
+        // No conditions, no error expected
+        EventUtils.checkForVolumeMountErrors(client, pod);
+
+        var conditions = new ArrayList<PodCondition>();
+        pod.getStatus().setConditions(conditions);
+
+        // No conditions, no error expected
+        EventUtils.checkForVolumeMountErrors(client, pod);
+
+        // Create error events
+        createPodEvent("e1", "reason1", "msg1", pod);
+        createPodEvent("e2", "FailedMount", "mountErr", pod);
+
+        var conditionMap = new HashMap<String, String>();
+
+        // Pod initialized completely, shouldn't check events
+        conditionMap.put("Initialized", "True");
+        conditionMap.put("Ready", "False");
+
+        conditions.clear();
+        conditionMap.forEach(
+                (t, s) ->
+                        conditions.add(
+                                new PodConditionBuilder().withType(t).withStatus(s).build()));
+        EventUtils.checkForVolumeMountErrors(client, pod);
+
+        // Pod initialized completely, shouldn't check events
+        conditionMap.put("PodReadyToStartContainers", "True");
+        conditionMap.put("Initialized", "False");
+
+        conditions.clear();
+        conditionMap.forEach(
+                (t, s) ->
+                        conditions.add(
+                                new PodConditionBuilder().withType(t).withStatus(s).build()));
+        EventUtils.checkForVolumeMountErrors(client, pod);
+
+        // Check event only when not ready to start
+        conditionMap.put("PodReadyToStartContainers", "False");
+        conditions.clear();
+        conditionMap.forEach(
+                (t, s) ->
+                        conditions.add(
+                                new PodConditionBuilder().withType(t).withStatus(s).build()));
+
+        try {
+            EventUtils.checkForVolumeMountErrors(client, pod);
+            fail("Exception not thrown");
+        } catch (DeploymentFailedException dfe) {
+            assertEquals("FailedMount", dfe.getReason());
+            assertEquals("mountErr", dfe.getMessage());
+        }
+
+        // Old kubernetes without PodReadyToStartContainers
+        conditionMap.remove("PodReadyToStartContainers");
+        conditionMap.put("Initialized", "False");
+        conditions.clear();
+        conditionMap.forEach(
+                (t, s) ->
+                        conditions.add(
+                                new PodConditionBuilder().withType(t).withStatus(s).build()));
+
+        try {
+            EventUtils.checkForVolumeMountErrors(client, pod);
+            fail("Exception not thrown");
+        } catch (DeploymentFailedException dfe) {
+            assertEquals("FailedMount", dfe.getReason());
+            assertEquals("mountErr", dfe.getMessage());
+        }
+    }
+
+    private void createPodEvent(String name, String reason, String msg, Pod pod) {
+        var event =
+                new EventBuilder()
+                        .withApiVersion("v1")
+                        .withInvolvedObject(EventUtils.getObjectReference(pod))
+                        .withType("type")
+                        .withReason(reason)
+                        .withFirstTimestamp(Instant.now().toString())
+                        .withLastTimestamp(Instant.now().toString())
+                        .withNewSource()
+                        .withComponent("pod")
+                        .endSource()
+                        .withCount(1)
+                        .withMessage(msg)
+                        .withNewMetadata()
+                        .withName(name)
+                        .withNamespace(pod.getMetadata().getNamespace())
+                        .endMetadata()
+                        .build();
+        client.resource(event).create();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

The operator correctly reacts to certain type of pod errors such as image pull/crash loop when they happen on main / sidecar containers. 

However these errors are ignored on initcontainers. Furthermore, volume mount errors which do not manifest in clear container error statueses are not recorded at all. 

This PR aims to collectively fix this and greatly improve startup error handling

## Brief change log

  - *Check and catch all container and init container error statuses*
  - *Add special logic to handle common volume mount errors based on pod events in case of failed startup*

## Verifying this change

New unit tests + manually verified on different local and prod envs

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
