### PR TITLE
[ci] PRs should not cancel each others or traget branches CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ on:
       - release-*
   pull_request:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Currently there is only one instance of a workflow runs against a given target branch. 

This means merges to main for example cancel all current in progress PRs open against main. And one PR cancels the others CI runs against the same branch.

This pr changes the concurrency to one per workflow per PR by using: `github.ref_name` 

Definition:
```
The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, feature-branch-1.

For pull requests, the format is <pr_number>/merge.
```