### PR TITLE
[FLINK-37455] Create error Event when job goes into FAILED state

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -121,13 +121,7 @@ public class FlinkSessionJobController
             statusRecorder.patchAndCacheStatus(flinkSessionJob, ctx.getKubernetesClient());
             reconciler.reconcile(ctx);
         } catch (Exception e) {
-            eventRecorder.triggerEvent(
-                    flinkSessionJob,
-                    EventRecorder.Type.Warning,
-                    "SessionJobException",
-                    ExceptionUtils.getExceptionMessage(e),
-                    EventRecorder.Component.Job,
-                    josdkContext.getClient());
+            triggerErrorEvent(ctx, e);
             throw new ReconciliationException(e);
         }
         statusRecorder.patchAndCacheStatus(flinkSessionJob, ctx.getKubernetesClient());
@@ -165,6 +159,16 @@ public class FlinkSessionJobController
             statusRecorder.patchAndCacheStatus(sessionJob, ctx.getKubernetesClient());
         }
         return deleteControl;
+    }
+
+    private void triggerErrorEvent(FlinkResourceContext<?> ctx, Exception e) {
+        eventRecorder.triggerEvent(
+                ctx.getResource(),
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.Error.name(),
+                ExceptionUtils.getExceptionMessage(e),
+                EventRecorder.Component.Job,
+                ctx.getKubernetesClient());
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -314,6 +314,7 @@ public class EventRecorder {
         Scaling,
         UnsupportedFlinkVersion,
         SnapshotError,
-        SnapshotAbandoned
+        SnapshotAbandoned,
+        Error
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtils.java
@@ -93,11 +93,12 @@ public class ExceptionUtils {
         }
 
         if (throwable instanceof SerializedThrowable) {
+            var serialized = ((SerializedThrowable) throwable);
             var deserialized =
-                    ((SerializedThrowable) throwable)
-                            .deserializeError(Thread.currentThread().getContextClassLoader());
+                    serialized.deserializeError(Thread.currentThread().getContextClassLoader());
             if (deserialized == throwable) {
-                return "Unknown Error (SerializedThrowable)";
+                var msg = serialized.getMessage();
+                return msg != null ? msg : serialized.getOriginalErrorClassName();
             } else {
                 return getExceptionMessage(deserialized, level);
             }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtils.java
@@ -75,7 +75,7 @@ public class ExceptionUtils {
      *     &rarr; cause3"
      */
     public static String getExceptionMessage(Throwable throwable) {
-        return getExceptionMessage(throwable, 0);
+        return getExceptionMessage(throwable, 1);
     }
 
     /**

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -981,7 +981,7 @@ public class FlinkDeploymentControllerTest {
         var event = testController.flinkResourceEvents().remove();
         assertEquals("Submit", event.getReason());
         event = testController.flinkResourceEvents().remove();
-        assertEquals("ClusterDeploymentException", event.getReason());
+        assertEquals("Error", event.getReason());
         assertEquals("Deployment failure", event.getMessage());
     }
 
@@ -1006,7 +1006,7 @@ public class FlinkDeploymentControllerTest {
         var event = testController.flinkResourceEvents().remove();
         assertEquals("Submit", event.getReason());
         event = testController.flinkResourceEvents().remove();
-        assertEquals("ClusterDeploymentException", event.getReason());
+        assertEquals("Error", event.getReason());
         assertEquals(
                 "Deployment Failure -> IllegalStateException -> actual failure reason",
                 event.getMessage());
@@ -1112,7 +1112,7 @@ public class FlinkDeploymentControllerTest {
         var event = testController.flinkResourceEvents().remove();
         assertEquals("Submit", event.getReason());
         event = testController.flinkResourceEvents().remove();
-        assertEquals("ClusterDeploymentException", event.getReason());
+        assertEquals("Error", event.getReason());
         assertEquals(
                 "Deployment Failure -> IllegalStateException -> actual failure reason",
                 event.getMessage());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
@@ -103,7 +103,7 @@ class FlinkSessionJobControllerTest {
 
         var event = testController.events().remove();
         Assertions.assertEquals(EventRecorder.Type.Warning.toString(), event.getType());
-        Assertions.assertEquals("SessionJobException", event.getReason());
+        Assertions.assertEquals("Error", event.getReason());
 
         testController.cleanup(sessionJob, context);
     }
@@ -635,7 +635,7 @@ class FlinkSessionJobControllerTest {
         var event = testController.events().remove();
         assertEquals("Submit", event.getReason());
         event = testController.events().remove();
-        assertEquals("SessionJobException", event.getReason());
+        assertEquals("Error", event.getReason());
         assertEquals(
                 "Deployment Failure -> IllegalStateException -> actual failure reason",
                 event.getMessage());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtilsTest.java
@@ -52,12 +52,25 @@ public class ExceptionUtilsTest {
 
     @Test
     void testSerializedThrowableError() {
-        var serializedException = new SerializedThrowable(new NonSerializableException());
-        assertThat(ExceptionUtils.getExceptionMessage(serializedException))
-                .isEqualTo("Unknown Error (SerializedThrowable)");
+        assertThat(
+                        ExceptionUtils.getExceptionMessage(
+                                new SerializedThrowable(new NonSerializableException("Message"))))
+                .isEqualTo(String.format("%s: Message", NonSerializableException.class.getName()));
+
+        assertThat(
+                        ExceptionUtils.getExceptionMessage(
+                                new SerializedThrowable(new NonSerializableException())))
+                .isEqualTo(NonSerializableException.class.getName());
     }
 
     private static class NonSerializableException extends Exception {
+
+        public NonSerializableException(String message) {
+            super(message);
+        }
+
+        public NonSerializableException() {}
+
         private void writeObject(java.io.ObjectOutputStream stream) throws IOException {
             throw new IOException();
         }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ExceptionUtilsTest.java
@@ -47,7 +47,7 @@ public class ExceptionUtilsTest {
         var ex2 = new RuntimeException("Cause 2", new SerializedThrowable(ex3));
         var ex = new RuntimeException("Cause 1", ex2);
         assertThat(ExceptionUtils.getExceptionMessage(ex))
-                .isEqualTo("Cause 1 -> Cause 2 -> Cause 3 -> Cause 4");
+                .isEqualTo("Cause 1 -> Cause 2 -> Cause 3");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Currently we set the error status when the job terminally fails but no event is triggered. We use the recently improved exception utilities to present a nice error message.

## Brief change log

  - *Trigger event on failed jobs*
  - *Use recent improvements in error message handling to improve other event reporting* 
  
## Verifying this change

Unit and manual tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes
