### PR TITLE
[FLINK-31406] Do not delete jobgraph on scale only last-state upgrades

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -119,7 +119,7 @@ public abstract class AbstractFlinkResourceReconciler<
             updateStatusBeforeFirstDeployment(
                     cr, spec, deployConfig, status, ctx.getKubernetesClient());
 
-            deploy(ctx, spec, deployConfig, getInitialSnapshotPath(spec), false);
+            deploy(ctx, spec, deployConfig, getInitialSnapshotPath(spec), false, false);
 
             ReconciliationUtils.updateStatusForDeployedSpec(cr, deployConfig, clock);
             return;
@@ -304,6 +304,8 @@ public abstract class AbstractFlinkResourceReconciler<
      * @param deployConfig Flink conf for the deployment.
      * @param savepoint Optional savepoint path for applications and session jobs.
      * @param requireHaMetadata Flag used by application deployments to validate HA metadata
+     * @param retainJobGraph Flag used by application deployments to decide if job graph should be
+     *     deleted while submitting application.
      * @throws Exception Error during deployment.
      */
     @VisibleForTesting
@@ -312,7 +314,8 @@ public abstract class AbstractFlinkResourceReconciler<
             SPEC spec,
             Configuration deployConfig,
             Optional<String> savepoint,
-            boolean requireHaMetadata)
+            boolean requireHaMetadata,
+            boolean retainJobGraph)
             throws Exception;
 
     /**

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -136,7 +136,8 @@ public class ApplicationReconciler
             FlinkDeploymentSpec spec,
             Configuration deployConfig,
             Optional<String> savepoint,
-            boolean requireHaMetadata)
+            boolean requireHaMetadata,
+            boolean retainJobGraph)
             throws Exception {
 
         var relatedResource = ctx.getResource();
@@ -180,7 +181,8 @@ public class ApplicationReconciler
                 EventRecorder.Component.JobManagerDeployment,
                 MSG_SUBMIT,
                 ctx.getKubernetesClient());
-        flinkService.submitApplicationCluster(spec.getJob(), deployConfig, requireHaMetadata);
+        flinkService.submitApplicationCluster(
+                spec.getJob(), deployConfig, requireHaMetadata, retainJobGraph);
         status.getJobStatus().setState(org.apache.flink.api.common.JobStatus.RECONCILING);
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -74,7 +74,7 @@ public class SessionReconciler
         ReconciliationUtils.updateStatusBeforeDeploymentAttempt(deployment, deployConfig, clock);
         statusRecorder.patchAndCacheStatus(deployment, ctx.getKubernetesClient());
 
-        deploy(ctx, deployment.getSpec(), deployConfig, Optional.empty(), false);
+        deploy(ctx, deployment.getSpec(), deployConfig, Optional.empty(), false, false);
         ReconciliationUtils.updateStatusForDeployedSpec(deployment, deployConfig, clock);
         return true;
     }
@@ -93,7 +93,8 @@ public class SessionReconciler
             FlinkDeploymentSpec spec,
             Configuration deployConfig,
             Optional<String> savepoint,
-            boolean requireHaMetadata)
+            boolean requireHaMetadata,
+            boolean retainJobGraph)
             throws Exception {
         var cr = ctx.getResource();
         setOwnerReference(cr, deployConfig);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -70,7 +70,8 @@ public class SessionJobReconciler
             FlinkSessionJobSpec sessionJobSpec,
             Configuration deployConfig,
             Optional<String> savepoint,
-            boolean requireHaMetadata)
+            boolean requireHaMetadata,
+            boolean retainJobGraph)
             throws Exception {
 
         eventRecorder.triggerEvent(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -51,7 +51,8 @@ public interface FlinkService {
 
     KubernetesClient getKubernetesClient();
 
-    void submitApplicationCluster(JobSpec jobSpec, Configuration conf, boolean requireHaMetadata)
+    void submitApplicationCluster(
+            JobSpec jobSpec, Configuration conf, boolean requireHaMetadata, boolean retainJobGraph)
             throws Exception;
 
     boolean isHaMetadataAvailable(Configuration conf);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -205,7 +205,8 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     @Override
     public void submitApplicationCluster(
-            JobSpec jobSpec, Configuration conf, boolean requireHaMetadata) throws Exception {
+            JobSpec jobSpec, Configuration conf, boolean requireHaMetadata, boolean retainJobGraph)
+            throws Exception {
 
         if (requireHaMetadata) {
             validateHaMetadataExists(conf);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
@@ -103,7 +103,10 @@ public class JobStatusObserverTest extends OperatorTestBase {
                         .getState());
         FlinkResourceContext<AbstractFlinkResource<?, ?>> ctx = getResourceContext(deployment);
         flinkService.submitApplicationCluster(
-                deployment.getSpec().getJob(), ctx.getDeployConfig(deployment.getSpec()), false);
+                deployment.getSpec().getJob(),
+                ctx.getDeployConfig(deployment.getSpec()),
+                false,
+                false);
         flinkService.cancelJob(JobID.fromHexString(jobStatus.getJobId()), false);
         observer.observe(ctx);
         assertEquals(
@@ -126,7 +129,10 @@ public class JobStatusObserverTest extends OperatorTestBase {
         jobStatus.setState(JobStatus.RUNNING);
         FlinkResourceContext<AbstractFlinkResource<?, ?>> ctx = getResourceContext(deployment);
         flinkService.submitApplicationCluster(
-                deployment.getSpec().getJob(), ctx.getDeployConfig(deployment.getSpec()), false);
+                deployment.getSpec().getJob(),
+                ctx.getDeployConfig(deployment.getSpec()),
+                false,
+                false);
 
         // Mark failed
         flinkService.setJobFailedErr(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -98,7 +98,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
         observer.observe(deployment, TestUtils.createEmptyContext());
         assertNull(deployment.getStatus().getReconciliationStatus().getLastStableSpec());
 
-        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false, false);
         ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
 
         // Validate port check logic
@@ -194,7 +194,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
     public void testEventGeneratedWhenStatusChanged() throws Exception {
         Configuration conf =
                 configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
-        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false, false);
 
         ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
@@ -225,7 +225,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
     public void testErrorForwardToStatusWhenJobFailed() throws Exception {
         Configuration conf =
                 configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
-        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false, false);
 
         ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
         deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
@@ -250,7 +250,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
                 .getSpec()
                 .getFlinkConfiguration()
                 .put(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED.key(), "false");
-        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false, false);
         bringToReadyStatus(deployment);
         assertTrue(ReconciliationUtils.isJobRunning(deployment.getStatus()));
 
@@ -539,7 +539,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
         deployment.getSpec().getJob().setCheckpointTriggerNonce(timedOutNonce);
         Configuration conf =
                 configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
-        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false, false);
         bringToReadyStatus(deployment);
         assertTrue(ReconciliationUtils.isJobRunning(deployment.getStatus()));
 
@@ -678,7 +678,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
     public void testSavepointFormat() throws Exception {
         Configuration conf =
                 configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
-        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false, false);
         bringToReadyStatus(deployment);
         assertTrue(ReconciliationUtils.isJobRunning(deployment.getStatus()));
 
@@ -896,7 +896,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
     public void jobStatusNotOverwrittenWhenTerminal() throws Exception {
         Configuration conf =
                 configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
-        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false, false);
         bringToReadyStatus(deployment);
 
         deployment
@@ -918,7 +918,7 @@ public class ApplicationObserverTest extends OperatorTestBase {
     public void getLastCheckpointShouldHandleCheckpointingNotEnabled() throws Exception {
         Configuration conf =
                 configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
-        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false, false);
         bringToReadyStatus(deployment);
 
         deployment

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -131,7 +131,13 @@ public class SessionReconcilerTest extends OperatorTestBase {
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
         reconciler
                 .getReconciler()
-                .deploy(getResourceContext(flinkApp), spec, deployConfig, Optional.empty(), false);
+                .deploy(
+                        getResourceContext(flinkApp),
+                        spec,
+                        deployConfig,
+                        Optional.empty(),
+                        false,
+                        false);
 
         final List<Map<String, String>> expectedOwnerReferences =
                 List.of(TestUtils.generateTestOwnerReferenceMap(flinkApp));

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/NativeFlinkServiceTest.java
@@ -230,7 +230,8 @@ public class NativeFlinkServiceTest {
 
         var flinkService = (NativeFlinkService) createFlinkService(testingClusterClient);
         var testingService = new TestingNativeFlinkService(flinkService);
-        testingService.submitApplicationCluster(deployment.getSpec().getJob(), deployConfig, false);
+        testingService.submitApplicationCluster(
+                deployment.getSpec().getJob(), deployConfig, false, false);
         assertFalse(
                 testingService.getRuntimeConfig().containsKey(OPERATOR_HEALTH_PROBE_PORT.key()));
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/SecureFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/SecureFlinkServiceTest.java
@@ -120,7 +120,7 @@ public class SecureFlinkServiceTest {
                         () -> {
                             final FlinkDeployment deployment = TestUtils.buildApplicationCluster();
                             testService.submitApplicationCluster(
-                                    deployment.getSpec().getJob(), deployConfig, false);
+                                    deployment.getSpec().getJob(), deployConfig, false, false);
                         });
         assertInstanceOf(ClusterRetrieveException.class, thrown.getCause());
     }
@@ -248,7 +248,7 @@ public class SecureFlinkServiceTest {
         try {
             final FlinkDeployment deployment = TestUtils.buildApplicationCluster();
             testService.submitApplicationCluster(
-                    deployment.getSpec().getJob(), deployConfig, false);
+                    deployment.getSpec().getJob(), deployConfig, false, false);
         } finally {
             TestUtils.setEnv(originalEnv);
         }
@@ -302,7 +302,11 @@ public class SecureFlinkServiceTest {
 
         @Override
         public void submitApplicationCluster(
-                JobSpec jobSpec, Configuration conf, boolean requireHaMetadata) throws Exception {
+                JobSpec jobSpec,
+                Configuration conf,
+                boolean requireHaMetadata,
+                boolean retainJobGraph)
+                throws Exception {
             try {
                 getClusterClient(conf);
             } catch (ConfigurationException e) {


### PR DESCRIPTION
### What is the purpose of the change

Retain job graph on Scale only last state upgrades.

### Brief change log

Add mechanism to detect upgrade for SCALE only diff using lastStableSpec. retain job graph if Scale only last state upgrade. 

### Verifying this change

New unit tests added to cover this

### Does this pull request potentially affect one of the following parts:

Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changes to the CustomResourceDescriptors: no
Core observer or reconciler logic that is regularly executed: yes


