### PR TITLE
[FLINK-37657] Fix default image repository in Helm chart

### DIFF
--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -23,7 +23,7 @@
 # watchNamespaces: ["flink"]
 
 image:
-  repository: flink-kubernetes-operator
+  repository: ghcr.io/apache/flink-kubernetes-operator
   pullPolicy: IfNotPresent
   tag: latest
   # If image digest is set then it takes precedence and the image tag will be ignored


### PR DESCRIPTION
## What is the purpose of the change

Fix default image repository in Helm chart.

## Brief change log

  - Fix default image repository in Helm chart

## Verifying this change

N/A.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable