### PR TITLE
[FLINK-37744][Helm] Add Helm lint and test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,22 +16,86 @@
 # limitations under the License.
 ################################################################################
 
-
 # We need to specify repo related information here since Apache INFRA doesn't differentiate
 # between several workflows with the same names while preparing a report for GHA usage
 # https://infra-reports.apache.org/#ghactions
 name: Flink Kubernetes Operator CI
+
 on:
   push:
     branches:
       - main
       - release-*
   pull_request:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+env:
+  HELM_CHART_DIR: helm
+  FLINK_OPERATOR_CHART: flink-kubernetes-operator
+
 jobs:
+  helm_lint_test:
+    runs-on: ubuntu-latest
+
+    name: Helm Lint Test
+
+    steps:
+      - name: Determine branch name
+        id: get_branch
+        run: |
+          BRANCH=""
+          if [ "${{ github.event_name }}" == "push" ]; then
+            BRANCH=${{ github.ref_name }}
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            BRANCH=${{ github.base_ref }}
+          fi
+          echo "BRANCH=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.3.0
+        with:
+          version: v3.17.3
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        env:
+          BRANCH: ${{ steps.get_branch.outputs.BRANCH }}
+        run: |
+          changed=$(ct list-changed --target-branch $BRANCH --chart-dirs ${{ env.HELM_CHART_DIR }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Helm lint
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          helm lint ${{ env.HELM_CHART_DIR }}/${{ env.FLINK_OPERATOR_CHART }} --strict --debug
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        env:
+          BRANCH: ${{ steps.get_branch.outputs.BRANCH }}
+        run: ct lint --target-branch $BRANCH --chart-dirs ${{ env.HELM_CHART_DIR }} --check-version-increment=false --validate-maintainers=false
+
+      - name: Install Helm unittest plugin
+        if: steps.list-changed.outputs.changed == 'true'
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 0.8.1
+
+      - name: Run Helm unittest
+        if: steps.list-changed.outputs.changed == 'true'
+        run: helm unittest ${{ env.HELM_CHART_DIR }}/${{ env.FLINK_OPERATOR_CHART }} --file "tests/**/*_test.yaml" --strict --debug
+
   test_ci:
     runs-on: ubuntu-latest
     name: maven build
@@ -53,9 +117,6 @@ jobs:
             echo "Please generate the java doc via 'mvn clean install -DskipTests -Pgenerate-docs' again"
             exit 1
           fi
-      - name: Validate helm chart linting
-        run: |
-          helm lint helm/flink-kubernetes-operator
       - name: Tests in flink-kubernetes-operator
         run: |
           cd flink-kubernetes-operator


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request adds a new feature to periodically create and maintain savepoints through the `FlinkDeployment` custom resource.)*

- Add GitHub action workflow for Helm chart lint and test

## Brief change log

Add GitHub action workflow for Helm chart lint and test.

## Verifying this change

This change added tests and can be verified as follows:

  - Added Helm lint test and unit tests to the GitHub action workflow

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
