### PR TITLE
[hotfix][docs] typo Adaptvie/Adaptive and booleans in autoscaler docs

### DIFF
--- a/docs/content.zh/docs/custom-resource/autoscaler.md
+++ b/docs/content.zh/docs/custom-resource/autoscaler.md
@@ -247,7 +247,7 @@ Flink cluster, includes:
 You can start a Flink Streaming job with the following ConfigOptions.
 
 ```
-# Enable Adaptvie scheduler to play the in-place rescaling.
+# Enable Adaptive scheduler to play the in-place rescaling.
 jobmanager.scheduler : adaptive
 
 # Enable autoscale and scaling

--- a/docs/content.zh/docs/custom-resource/autoscaler.md
+++ b/docs/content.zh/docs/custom-resource/autoscaler.md
@@ -246,13 +246,13 @@ Flink cluster, includes:
 
 You can start a Flink Streaming job with the following ConfigOptions.
 
-```
+```yaml
 # Enable Adaptive scheduler to play the in-place rescaling.
 jobmanager.scheduler : adaptive
 
 # Enable autoscale and scaling
-job.autoscaler.enabled : true
-job.autoscaler.scaling.enabled : true
+job.autoscaler.enabled : "true"
+job.autoscaler.scaling.enabled : "true"
 job.autoscaler.stabilization.interval : 1m
 job.autoscaler.metrics.window : 3m
 ```

--- a/docs/content/docs/custom-resource/autoscaler.md
+++ b/docs/content/docs/custom-resource/autoscaler.md
@@ -247,7 +247,7 @@ Flink cluster, includes:
 You can start a Flink Streaming job with the following ConfigOptions.
 
 ```
-# Enable Adaptvie scheduler to play the in-place rescaling.
+# Enable Adaptive scheduler to play the in-place rescaling.
 jobmanager.scheduler : adaptive
 
 # Enable autoscale and scaling

--- a/docs/content/docs/custom-resource/autoscaler.md
+++ b/docs/content/docs/custom-resource/autoscaler.md
@@ -246,13 +246,13 @@ Flink cluster, includes:
 
 You can start a Flink Streaming job with the following ConfigOptions.
 
-```
+```yaml
 # Enable Adaptive scheduler to play the in-place rescaling.
 jobmanager.scheduler : adaptive
 
 # Enable autoscale and scaling
-job.autoscaler.enabled : true
-job.autoscaler.scaling.enabled : true
+job.autoscaler.enabled : "true"
+job.autoscaler.scaling.enabled : "true"
 job.autoscaler.stabilization.interval : 1m
 job.autoscaler.metrics.window : 3m
 ```


### PR DESCRIPTION
## What is the purpose of the change

Fix typos


## Brief change log

- Fix typos in autoscaler docs

## Verifying this change

Trivial work

## Does this pull request potentially affect one of the following parts:

It only affects documentation.

## Documentation

  - Does this pull request introduce a new feature? **No**
  - If yes, how is the feature documented? **Not applicable**
