### PR TITLE
[FLINK-37769] Include cause in event when restarting unhealthy job

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/ClusterHealthInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/ClusterHealthInfo.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.health;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.kubernetes.operator.observer.ClusterHealthResult;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -47,7 +48,7 @@ public class ClusterHealthInfo {
     private long numCompletedCheckpointsIncreasedTimeStamp;
 
     /** Calculated field whether the cluster is healthy or not. */
-    private boolean healthy;
+    private ClusterHealthResult healthResult;
 
     public ClusterHealthInfo() {
         this(Clock.systemDefaultZone());
@@ -55,7 +56,7 @@ public class ClusterHealthInfo {
 
     public ClusterHealthInfo(Clock clock) {
         timeStamp = clock.millis();
-        healthy = true;
+        healthResult = ClusterHealthResult.healthy();
     }
 
     public static boolean isValid(ClusterHealthInfo clusterHealthInfo) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/ClusterHealthResult.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/ClusterHealthResult.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.observer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** Cluster Health Result. */
+@Value
+public class ClusterHealthResult {
+    boolean healthy;
+    String error;
+
+    @JsonCreator
+    public ClusterHealthResult(
+            @JsonProperty("healthy") boolean healthy, @JsonProperty("error") String error) {
+        this.healthy = healthy;
+        this.error = error;
+    }
+
+    public static ClusterHealthResult error(String error) {
+        return new ClusterHealthResult(false, error);
+    }
+
+    public static ClusterHealthResult healthy() {
+        return new ClusterHealthResult(true, null);
+    }
+
+    public ClusterHealthResult join(ClusterHealthResult clusterHealthResult) {
+        boolean isHealthy = this.healthy && clusterHealthResult.healthy;
+        String error =
+                Stream.of(this.error, clusterHealthResult.getError())
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.joining("|"));
+
+        return new ClusterHealthResult(isHealthy, error);
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/ClusterHealthInfoTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/health/ClusterHealthInfoTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.kubernetes.operator.health;
 
+import org.apache.flink.kubernetes.operator.observer.ClusterHealthResult;
+
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
@@ -43,11 +45,13 @@ class ClusterHealthInfoTest {
 
     @Test
     public void deserializeWithOldVersionShouldDeserializeCorrectly() {
-        var clusterHealthInfoJson = "{\"timeStamp\":1,\"numRestarts\":2,\"healthy\":true}";
+        var clusterHealthInfoJson =
+                "{\"timeStamp\":1,\"numRestarts\":2,\"healthResult\": {\"healthy\":false, \"error\":\"test-error\"}}}}";
         var clusterHealthInfoFromJson = ClusterHealthInfo.deserialize(clusterHealthInfoJson);
         assertEquals(1, clusterHealthInfoFromJson.getTimeStamp());
         assertEquals(2, clusterHealthInfoFromJson.getNumRestarts());
-        assertTrue(clusterHealthInfoFromJson.isHealthy());
+        assertFalse(clusterHealthInfoFromJson.getHealthResult().isHealthy());
+        assertEquals("test-error", clusterHealthInfoFromJson.getHealthResult().getError());
     }
 
     @Test
@@ -58,7 +62,7 @@ class ClusterHealthInfoTest {
         clusterHealthInfo.setNumRestartsEvaluationTimeStamp(3);
         clusterHealthInfo.setNumCompletedCheckpoints(4);
         clusterHealthInfo.setNumCompletedCheckpointsIncreasedTimeStamp(5);
-        clusterHealthInfo.setHealthy(false);
+        clusterHealthInfo.setHealthResult(ClusterHealthResult.error("error"));
         var clusterHealthInfoJson = ClusterHealthInfo.serialize(clusterHealthInfo);
 
         var clusterHealthInfoFromJson = ClusterHealthInfo.deserialize(clusterHealthInfoJson);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/ClusterHealthEvaluatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/ClusterHealthEvaluatorTest.java
@@ -358,6 +358,6 @@ class ClusterHealthEvaluatorTest {
         var lastValidClusterHealthInfo =
                 ClusterHealthEvaluator.getLastValidClusterHealthInfo(clusterInfo);
         assertNotNull(lastValidClusterHealthInfo);
-        assertEquals(healthy, lastValidClusterHealthInfo.isHealthy());
+        assertEquals(healthy, lastValidClusterHealthInfo.getHealthResult().isHealthy());
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/ClusterHealthResultTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/ClusterHealthResultTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.observer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClusterHealthResultTest {
+
+    @Test
+    void error() {
+        ClusterHealthResult clusterHealthResult = ClusterHealthResult.error("test-error");
+
+        assertFalse(clusterHealthResult.isHealthy());
+        assertEquals("test-error", clusterHealthResult.getError());
+    }
+
+    @Test
+    void healthy() {
+        ClusterHealthResult clusterHealthResult = ClusterHealthResult.healthy();
+
+        assertTrue(clusterHealthResult.isHealthy());
+        assertNull(clusterHealthResult.getError());
+    }
+
+    @Test
+    void join() {
+        ClusterHealthResult clusterHealthResult =
+                ClusterHealthResult.healthy()
+                        .join(ClusterHealthResult.error("test-error-1"))
+                        .join(ClusterHealthResult.error("test-error-2"));
+
+        assertFalse(clusterHealthResult.isHealthy());
+        assertEquals("test-error-1|test-error-2", clusterHealthResult.getError());
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -65,6 +65,7 @@ import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptio
 import org.apache.flink.kubernetes.operator.exception.UpgradeFailureException;
 import org.apache.flink.kubernetes.operator.health.ClusterHealthInfo;
 import org.apache.flink.kubernetes.operator.observer.ClusterHealthEvaluator;
+import org.apache.flink.kubernetes.operator.observer.ClusterHealthResult;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.SnapshotType;
 import org.apache.flink.kubernetes.operator.reconciler.TestReconcilerAdapter;
@@ -128,7 +129,6 @@ import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.CHECK
 import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.SAVEPOINT;
 import static org.apache.flink.kubernetes.operator.reconciler.deployment.AbstractFlinkResourceReconciler.MSG_SUBMIT;
 import static org.apache.flink.kubernetes.operator.reconciler.deployment.ApplicationReconciler.MSG_RECOVERY;
-import static org.apache.flink.kubernetes.operator.reconciler.deployment.ApplicationReconciler.MSG_RESTART_UNHEALTHY;
 import static org.apache.flink.kubernetes.operator.utils.SnapshotUtils.getLastSnapshotStatus;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -1223,12 +1223,11 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
         var clusterHealthInfo = new ClusterHealthInfo();
         clusterHealthInfo.setTimeStamp(System.currentTimeMillis());
         clusterHealthInfo.setNumRestarts(2);
-        clusterHealthInfo.setHealthy(false);
+        clusterHealthInfo.setHealthResult(ClusterHealthResult.error("error"));
         ClusterHealthEvaluator.setLastValidClusterHealthInfo(
                 deployment.getStatus().getClusterInfo(), clusterHealthInfo);
         reconciler.reconcile(deployment, context);
-        Assertions.assertEquals(
-                MSG_RESTART_UNHEALTHY, flinkResourceEventCollector.events.remove().getMessage());
+        Assertions.assertEquals("error", flinkResourceEventCollector.events.remove().getMessage());
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR is a feature improvement to include cause in event when restarting unhealthy job:

Before:
```
2025-05-15 14:08:52,863 o.a.f.k.o.l.AuditUtils         [INFO ][default/basic-example] >>> Event[Job]       | Warning | RESTARTUNHEALTHYJOB | Restarting unhealthy job
```

After:
```
2025-05-15 14:08:52,863 o.a.f.k.o.l.AuditUtils         [INFO ][default/basic-example] >>> Event[Job]       | Warning | RESTARTUNHEALTHYJOB | Restart count hit threshold: 1
```

## Brief change log

- A new class `ClusterHealthResult` is introduced to store information about the job health and error message

## Verifying this change

This change added unit tests and can be verified as follows:

  - Manually built image and run on local `minikube`
  - Verified `ClusterHealthResult` is serialised and deserialised correctly by observer
```
2025-05-15 14:09:50,968 o.a.f.k.o.o.ClusterHealthObserver [DEBUG][default/basic-example] Observed cluster health: ClusterHealthInfo(timeStamp=1747318190968, numRestarts=0, numRestartsEvaluationTimeStamp=0, numCompletedCheckpoints=0, numCompletedCheckpointsIncreasedTimeStamp=0, healthResult=ClusterHealthResult(healthy=true, error=null))
```
  - Verified Event created contains caused of unhealthy job
```
2025-05-15 14:08:52,863 o.a.f.k.o.l.AuditUtils         [INFO ][default/basic-example] >>> Event[Job]       | Warning | RESTARTUNHEALTHYJOB | Restart count hit threshold: 1
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
