### PR TITLE
[helm] Move inline ConfigMap to dedicated template and add checksum annotation

### DIFF
--- a/helm/flink-kubernetes-operator/templates/configmap.yaml
+++ b/helm/flink-kubernetes-operator/templates/configmap.yaml
@@ -1,0 +1,70 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+---
+{{- if .Values.defaultConfiguration.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flink-operator-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flink-operator.labels" . | nindent 4 }}
+data:
+  config.yaml: |+
+{{- if .Values.defaultConfiguration.append }}
+  {{- $.Files.Get "conf/flink-conf.yaml"  | nindent 4 -}}
+{{- end }}
+{{- if hasKey (.Values.defaultConfiguration) "config.yaml" }}
+  {{- index (.Values.defaultConfiguration) "config.yaml" | nindent 4 -}}
+{{- end }}
+{{- if .Values.watchNamespaces }}
+    kubernetes.operator.watched.namespaces: {{ join "," .Values.watchNamespaces  }}
+{{- end }}
+{{- if index .Values "operatorHealth" }}
+    kubernetes.operator.health.probe.enabled: true
+    kubernetes.operator.health.probe.port: {{ .Values.operatorHealth.port }}
+{{- end }}
+  flink-conf.yaml: |+
+{{- if .Values.defaultConfiguration.append }}
+  {{- $.Files.Get "conf/flink-conf.yaml"  | nindent 4 -}}
+{{- end }}
+{{- if hasKey (.Values.defaultConfiguration) "flink-conf.yaml" }}
+  {{- index (.Values.defaultConfiguration) "flink-conf.yaml" | nindent 4 -}}
+{{- end }}
+{{- if .Values.watchNamespaces }}
+    kubernetes.operator.watched.namespaces: {{ join "," .Values.watchNamespaces  }}
+{{- end }}
+{{- if index .Values "operatorHealth" }}
+    kubernetes.operator.health.probe.enabled: true
+    kubernetes.operator.health.probe.port: {{ .Values.operatorHealth.port }}
+{{- end }}
+  log4j-operator.properties: |+
+{{- if .Values.defaultConfiguration.append }}
+  {{- $.Files.Get "conf/log4j-operator.properties"  | nindent 4 -}}
+{{- end }}
+{{- if index (.Values.defaultConfiguration) "log4j-operator.properties" }}
+  {{- index (.Values.defaultConfiguration) "log4j-operator.properties" | nindent 4 -}}
+{{- end }}
+  log4j-console.properties: |+
+{{- if .Values.defaultConfiguration.append }}
+  {{- $.Files.Get "conf/log4j-console.properties"  | nindent 4 -}}
+{{- end }}
+{{- if index (.Values.defaultConfiguration) "log4j-console.properties" }}
+  {{- index (.Values.defaultConfiguration) "log4j-console.properties" | nindent 4 -}}
+{{- end }}
+{{- end }}

--- a/helm/flink-kubernetes-operator/templates/flink-operator.yaml
+++ b/helm/flink-kubernetes-operator/templates/flink-operator.yaml
@@ -46,6 +46,9 @@ spec:
         {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
+        {{- if .Values.defaultConfiguration.create }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- if index (.Values.operatorPod) "annotations" }}
           {{- with .Values.operatorPod.annotations }}
             {{- toYaml . | nindent 8 }}
@@ -273,56 +276,3 @@ spec:
             secretName: {{ .Values.tls.secretName }}
             optional: true
         {{- end }}
----
-{{- if .Values.defaultConfiguration.create }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: flink-operator-config
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "flink-operator.labels" . | nindent 4 }}
-data:
-  config.yaml: |+
-{{- if .Values.defaultConfiguration.append }}
-  {{- $.Files.Get "conf/flink-conf.yaml"  | nindent 4 -}}
-{{- end }}
-{{- if hasKey (.Values.defaultConfiguration) "config.yaml" }}
-  {{- index (.Values.defaultConfiguration) "config.yaml" | nindent 4 -}}
-{{- end }}
-{{- if .Values.watchNamespaces }}
-    kubernetes.operator.watched.namespaces: {{ join "," .Values.watchNamespaces  }}
-{{- end }}
-{{- if index .Values "operatorHealth" }}
-    kubernetes.operator.health.probe.enabled: true
-    kubernetes.operator.health.probe.port: {{ .Values.operatorHealth.port }}
-{{- end }}
-  flink-conf.yaml: |+
-{{- if .Values.defaultConfiguration.append }}
-  {{- $.Files.Get "conf/flink-conf.yaml"  | nindent 4 -}}
-{{- end }}
-{{- if hasKey (.Values.defaultConfiguration) "flink-conf.yaml" }}
-  {{- index (.Values.defaultConfiguration) "flink-conf.yaml" | nindent 4 -}}
-{{- end }}
-{{- if .Values.watchNamespaces }}
-    kubernetes.operator.watched.namespaces: {{ join "," .Values.watchNamespaces  }}
-{{- end }}
-{{- if index .Values "operatorHealth" }}
-    kubernetes.operator.health.probe.enabled: true
-    kubernetes.operator.health.probe.port: {{ .Values.operatorHealth.port }}
-{{- end }}
-  log4j-operator.properties: |+
-{{- if .Values.defaultConfiguration.append }}
-  {{- $.Files.Get "conf/log4j-operator.properties"  | nindent 4 -}}
-{{- end }}
-{{- if index (.Values.defaultConfiguration) "log4j-operator.properties" }}
-  {{- index (.Values.defaultConfiguration) "log4j-operator.properties" | nindent 4 -}}
-{{- end }}
-  log4j-console.properties: |+
-{{- if .Values.defaultConfiguration.append }}
-  {{- $.Files.Get "conf/log4j-console.properties"  | nindent 4 -}}
-{{- end }}
-{{- if index (.Values.defaultConfiguration) "log4j-console.properties" }}
-  {{- index (.Values.defaultConfiguration) "log4j-console.properties" | nindent 4 -}}
-{{- end }}
-{{- end }}


### PR DESCRIPTION
## What is the purpose of the change

This pull request extracts the inline `ConfigMap` definition from `flink-operator.yaml` into a dedicated `configmap.yaml` file under `templates/`.

Additionally, it introduces a `checksum/config` annotation in the `Deployment` metadata to ensure that the operator pod restarts automatically when the configuration changes.

This improves modularity, readability, and enables safe rolling upgrades via Helm when using `defaultConfiguration.create: true`.

## Brief change log

- Extracted the `flink-operator-config` ConfigMap into `templates/configmap.yaml`
- Added `checksum/config` annotation to the operator `Deployment` template
- The checksum is computed using `include "..." | sha256sum`
- Rendering and annotation are conditional on `.Values.defaultConfiguration.create`

## Verifying this change

This change is a trivial Helm chart refactor and does not require test coverage.

Manually verified via `helm template` that:

- The `ConfigMap` is rendered as expected
- `Deployment` includes `checksum/config` annotation
- Checksum changes when config content changes

## Does this pull request potentially affect one of the following parts

- **Dependencies** (does it add or upgrade a dependency): **no**
- **Public API** (i.e., any changes to the `CustomResourceDescriptors`): **no**
- **Core observer or reconciler logic that is regularly executed**: **no**

## Documentation

- **Does this pull request introduce a new feature?** **no**
- **If yes, how is the feature documented?** _not applicable_
