### PR TITLE
[FLINK-38051] Fix flaky test JobAutoScalerImplTest

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -456,7 +456,10 @@ public class ScalingMetricEvaluator {
             return Double.NaN;
         }
 
-        return 1000 * (last - first) / Duration.between(firstTs, lastTs).toMillis();
+        long tsDiff = Duration.between(firstTs, lastTs).toMillis();
+        tsDiff = Math.max(tsDiff, 1);
+
+        return 1000 * (last - first) / tsDiff;
     }
 
     public static double getAverage(


### PR DESCRIPTION
## What is the purpose of the change

I often had `JobAutoScalerImplTest#testMetricReporting` fail on my local computer, this happens when there is less than 1ms between the two metrics point being added, and thus `ScalingMetricEvaluator#getRate` trying to divide with 0.

I think it makes sense round up the duration to 1 ms in this case, even though it's not really expected to happen in a real scenario.

## Brief change log

- Update `ScalingMetricEvaluator#getRate` to round up the difference between the first and last timestamps to 1 ms.

## Verifying this change

- Verified locally that the test is no longer flaky on my machine.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
