### PR TITLE
[FLINK-36577] Add compatibility check for FlinkStateSnapshot

### DIFF
--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -257,6 +257,23 @@ under the License.
                             </target>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>statesnapshot-crd-compatibility-check</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <java classname="org.apache.flink.kubernetes.operator.api.validation.CrdCompatibilityChecker"
+                                      fork="true" failonerror="true">
+                                    <classpath refid="maven.compile.classpath"/>
+                                    <arg value="file://${rootDir}/helm/flink-kubernetes-operator/crds/flinkstatesnapshots.flink.apache.org-v1.yml"/>
+                                    <arg value="https://raw.githubusercontent.com/apache/flink-kubernetes-operator/release-1.10.0/helm/flink-kubernetes-operator/crds/flinkstatesnapshots.flink.apache.org-v1.yml"/>
+                                </java>
+                            </target>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/validation/CrdCompatibilityCheckerTest.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/validation/CrdCompatibilityCheckerTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.api.validation;
 
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
+import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -269,6 +270,19 @@ public class CrdCompatibilityCheckerTest {
                 objectMapper.readValue(
                         new File("src/test/resources/test-deployment.yaml"), FlinkDeployment.class);
         assertEquals(flinkDeploymentWithUnknownFields.toString(), flinkDeployment.toString());
+    }
+
+    @Test
+    public void testCreateFlinkStateSnapshotIgnoreUnknownFields() throws IOException {
+        FlinkStateSnapshot flinkSnapshotWithUnknownFields =
+                objectMapper.readValue(
+                        new File("src/test/resources/test-snapshot-with-unknown-fields.yaml"),
+                        FlinkStateSnapshot.class);
+        FlinkStateSnapshot flinkSnapshot =
+                objectMapper.readValue(
+                        new File("src/test/resources/test-snapshot.yaml"),
+                        FlinkStateSnapshot.class);
+        assertEquals(flinkSnapshotWithUnknownFields.toString(), flinkSnapshot.toString());
     }
 
     @Test

--- a/flink-kubernetes-operator-api/src/test/resources/test-snapshot-with-unknown-fields.yaml
+++ b/flink-kubernetes-operator-api/src/test/resources/test-snapshot-with-unknown-fields.yaml
@@ -1,0 +1,30 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkStateSnapshot
+metadata:
+  name: example-savepoint
+spec:
+  backoffLimit: 0
+  jobReference:
+    kind: FlinkDeployment
+    name: example-deployment
+    unknownField: testUnknownField
+  savepoint:
+    unknownField: testUnknownField
+  unknownField: testUnknownField

--- a/flink-kubernetes-operator-api/src/test/resources/test-snapshot.yaml
+++ b/flink-kubernetes-operator-api/src/test/resources/test-snapshot.yaml
@@ -1,0 +1,27 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkStateSnapshot
+metadata:
+  name: example-savepoint
+spec:
+  backoffLimit: 0
+  jobReference:
+    kind: FlinkDeployment
+    name: example-deployment
+  savepoint: {}


### PR DESCRIPTION
## What is the purpose of the change

This adds a compatibility checks for the FlinkStateSnapshot CRD which will run the class `CrdCompatibilityChecker`.

## Brief change log

- Add a new execution next to the existing CRD checks for FlinkStateSnapshot which ensures backward compatibility with the CRD released in version 1.10.0
- Add new unit test to ensure FlinkStateSnapshot ignores unknown fields

## Verifying this change

- Changed one of the enum values of `FlinkStateSnapshot` locally and verified that it fails the test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
