### PR TITLE
[FLINK-32033][Kubernetes-Operator] Fix Lifecycle Status of FlinkDeployment Resource in case of MISSING/ERROR JM status

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
@@ -90,6 +90,30 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
             return ResourceLifecycleState.FAILED;
         }
 
+        // Check for unrecoverable deployments that should be marked as FAILED
+        if (this instanceof FlinkDeploymentStatus) {
+            FlinkDeploymentStatus deploymentStatus = (FlinkDeploymentStatus) this;
+            var jmStatus = deploymentStatus.getJobManagerDeploymentStatus();
+
+            // ERROR deployments are in terminal error state and should always be FAILED
+            if (jmStatus == JobManagerDeploymentStatus.ERROR) {
+                return ResourceLifecycleState.FAILED;
+            }
+
+            // MISSING deployments should be FAILED if they're clearly unrecoverable
+            if (jmStatus == JobManagerDeploymentStatus.MISSING) {
+                // Mark as FAILED if error message clearly indicates deployment failure (any time)
+                if (StringUtils.isNotEmpty(error)) {
+                    return ResourceLifecycleState.FAILED;
+                }
+                // Also mark as FAILED if stable deployment is missing without any error
+                // (indicating it was deleted externally)
+                else if (reconciliationStatus.isLastReconciledSpecStable()) {
+                    return ResourceLifecycleState.FAILED;
+                }
+            }
+        }
+
         if (reconciliationStatus.getState() == ReconciliationState.ROLLED_BACK) {
             return ResourceLifecycleState.ROLLED_BACK;
         } else if (reconciliationStatus.isLastReconciledSpecStable()) {

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
@@ -100,7 +100,14 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
             if ((jmDeployStatus == JobManagerDeploymentStatus.MISSING
                             || jmDeployStatus == JobManagerDeploymentStatus.ERROR)
                     && StringUtils.isNotEmpty(error)
-                    && error.contains("configmaps have been deleted")) {
+                    && (error.toLowerCase()
+                                    .contains(
+                                            "it is possible that the job has finished or terminally failed, or the configmaps have been deleted")
+                            || error.toLowerCase().contains("manual restore required")
+                            || error.toLowerCase().contains("ha metadata not available")
+                            || error.toLowerCase()
+                                    .contains(
+                                            "ha data is not available to make stateful upgrades"))) {
                 return ResourceLifecycleState.FAILED;
             }
         }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
@@ -37,8 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 @SuperBuilder
 public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
 
-    // Error message constants for deployment failure classification
-    // Full error message constants for deployment failure reporting
+    // Frequent error message constants for deployment failure reporting
     public static final String MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED =
             "It is possible that the job has finished or terminally failed, or the configmaps have been deleted.";
     public static final String MSG_HA_METADATA_NOT_AVAILABLE = "HA metadata is not available";

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/CommonStatus.java
@@ -37,7 +37,7 @@ import org.apache.commons.lang3.StringUtils;
 @SuperBuilder
 public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
 
-    // Frequent error message constants for deployment failure reporting
+    // Frequent error message constants for resource failure reporting
     public static final String MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED =
             "It is possible that the job has finished or terminally failed, or the configmaps have been deleted.";
     public static final String MSG_HA_METADATA_NOT_AVAILABLE = "HA metadata is not available";
@@ -96,7 +96,8 @@ public abstract class CommonStatus<SPEC extends AbstractFlinkSpec> {
             return ResourceLifecycleState.FAILED;
         }
 
-        // Check for unrecoverable deployments that should be marked as FAILED
+        // Check for unrecoverable deployments that should be marked as FAILED if the error contains
+        // the following substrings
         if (this instanceof FlinkDeploymentStatus) {
             FlinkDeploymentStatus deploymentStatus = (FlinkDeploymentStatus) this;
             var jmDeployStatus = deploymentStatus.getJobManagerDeploymentStatus();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -59,6 +59,8 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_HA_METADATA_NOT_AVAILABLE;
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_MANUAL_RESTORE_REQUIRED;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_JOB_RESTART_FAILED;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_JOB_UPGRADE_LAST_STATE_CHECKPOINT_MAX_AGE;
 import static org.apache.flink.kubernetes.operator.reconciler.SnapshotType.CHECKPOINT;
@@ -227,7 +229,8 @@ public abstract class AbstractJobReconciler<
 
             if (!SnapshotUtils.lastSavepointKnown(status)) {
                 throw new UpgradeFailureException(
-                        "Job is in terminal state but last checkpoint is unknown, possibly due to an unrecoverable restore error. Manual restore required.",
+                        "Job is in terminal state but last checkpoint is unknown, possibly due to an unrecoverable restore error. "
+                                + MSG_MANUAL_RESTORE_REQUIRED,
                         "UpgradeFailed");
             }
             LOG.info("Job is in terminal state, ready for upgrade from observed latest state");
@@ -360,7 +363,8 @@ public abstract class AbstractJobReconciler<
 
         var conf = ctx.getObserveConfig();
         if (!ctx.getFlinkService().isHaMetadataAvailable(conf)) {
-            LOG.info("HA metadata not available, cancel will be used instead of last-state");
+            LOG.info(
+                    "{}, cancel will be used instead of last-state", MSG_HA_METADATA_NOT_AVAILABLE);
             return true;
         }
         return conf.get(KubernetesOperatorConfigOptions.OPERATOR_JOB_UPGRADE_LAST_STATE_CANCEL_JOB);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -59,6 +59,9 @@ import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_HA_METADATA_NOT_AVAILABLE;
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED;
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_MANUAL_RESTORE_REQUIRED;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_CLUSTER_HEALTH_CHECK_ENABLED;
 
 /** Reconciler Flink Application deployments. */
@@ -114,9 +117,11 @@ public class ApplicationReconciler
                         || jmDeployStatus == JobManagerDeploymentStatus.ERROR)
                 && !flinkService.isHaMetadataAvailable(deployConfig)) {
             throw new UpgradeFailureException(
-                    "JobManager deployment is missing and HA data is not available to make stateful upgrades. "
-                            + "It is possible that the job has finished or terminally failed, or the configmaps have been deleted. "
-                            + "Manual restore required.",
+                    "JobManager deployment is missing and "
+                            + MSG_HA_METADATA_NOT_AVAILABLE
+                            + " to make stateful upgrades. "
+                            + MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED
+                            + MSG_MANUAL_RESTORE_REQUIRED,
                     "UpgradeFailed");
         }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -570,8 +570,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                         .getExternalPointer()
                         .equals(NonPersistentMetadataCheckpointStorageLocation.EXTERNAL_POINTER)) {
             throw new UpgradeFailureException(
-                    "Latest checkpoint not externally addressable, "
-                            + MSG_MANUAL_RESTORE_REQUIRED,
+                    "Latest checkpoint not externally addressable, " + MSG_MANUAL_RESTORE_REQUIRED,
                     "CheckpointNotFound");
         }
         return latestCheckpointOpt.map(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -155,6 +155,9 @@ import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_HA_METADATA_NOT_AVAILABLE;
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED;
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_MANUAL_RESTORE_REQUIRED;
 import static org.apache.flink.kubernetes.operator.config.FlinkConfigBuilder.FLINK_VERSION;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.K8S_OP_CONF_PREFIX;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
@@ -567,7 +570,8 @@ public abstract class AbstractFlinkService implements FlinkService {
                         .getExternalPointer()
                         .equals(NonPersistentMetadataCheckpointStorageLocation.EXTERNAL_POINTER)) {
             throw new UpgradeFailureException(
-                    "Latest checkpoint not externally addressable, manual recovery required.",
+                    "Latest checkpoint not externally addressable, "
+                            + MSG_MANUAL_RESTORE_REQUIRED,
                     "CheckpointNotFound");
         }
         return latestCheckpointOpt.map(
@@ -1022,8 +1026,9 @@ public abstract class AbstractFlinkService implements FlinkService {
     private void validateHaMetadataExists(Configuration conf) {
         if (!isHaMetadataAvailable(conf)) {
             throw new UpgradeFailureException(
-                    "HA metadata not available to restore from last state. "
-                            + "It is possible that the job has finished or terminally failed, or the configmaps have been deleted. ",
+                    MSG_HA_METADATA_NOT_AVAILABLE
+                            + " to restore from last state."
+                            + MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED,
                     "RestoreFailed");
         }
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -105,6 +105,10 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_HA_METADATA_NOT_AVAILABLE;
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED;
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_MANUAL_RESTORE_REQUIRED;
+
 /** Flink service mock for tests. */
 public class TestingFlinkService extends AbstractFlinkService {
 
@@ -244,9 +248,10 @@ public class TestingFlinkService extends AbstractFlinkService {
     protected void validateHaMetadataExists(Configuration conf) {
         if (!isHaMetadataAvailable(conf)) {
             throw new UpgradeFailureException(
-                    "HA metadata not available to restore from last state. "
-                            + "It is possible that the job has finished or terminally failed, or the configmaps have been deleted. "
-                            + "Manual restore required.",
+                    MSG_HA_METADATA_NOT_AVAILABLE
+                            + " to restore from last state. "
+                            + MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED
+                            + MSG_MANUAL_RESTORE_REQUIRED,
                     "RestoreFailed");
         }
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/DeploymentRecoveryTest.java
@@ -121,7 +121,7 @@ public class DeploymentRecoveryTest {
                             .getStatus()
                             .getError()
                             .contains(
-                                    "JobManager deployment is missing and HA data is not available to make stateful upgrades."));
+                                    "JobManager deployment is missing and HA metadata is not available"));
         } else {
             flinkService.setPortReady(true);
             testController.reconcile(appCluster, context);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -1054,7 +1054,7 @@ public class FlinkDeploymentControllerTest {
                         .flinkResourceEvents()
                         .poll()
                         .getMessage()
-                        .contains("HA metadata not available to restore from last state."));
+                        .contains("HA metadata is not available to restore from last state."));
 
         testController.flinkResourceEvents().clear();
         testController.reconcile(appCluster, context);
@@ -1068,7 +1068,7 @@ public class FlinkDeploymentControllerTest {
                         .flinkResourceEvents()
                         .poll()
                         .getMessage()
-                        .contains("HA metadata not available to restore from last state."));
+                        .contains("HA metadata is not available to restore from last state."));
 
         flinkService.setHaDataAvailable(true);
         testController.flinkResourceEvents().clear();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/ResourceLifecycleMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/lifecycle/ResourceLifecycleMetricsTest.java
@@ -53,6 +53,9 @@ import static org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecyc
 import static org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState.STABLE;
 import static org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState.SUSPENDED;
 import static org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState.UPGRADING;
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_HA_METADATA_NOT_AVAILABLE;
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED;
+import static org.apache.flink.kubernetes.operator.api.status.CommonStatus.MSG_MANUAL_RESTORE_REQUIRED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -352,9 +355,11 @@ public class ResourceLifecycleMetricsTest {
         application
                 .getStatus()
                 .setError(
-                        "JobManager deployment is missing and HA data is not available to make stateful upgrades. "
-                                + "It is possible that the job has finished or terminally failed, or the configmaps have been deleted. "
-                                + "Manual restore required.");
+                        "\"JobManager deployment is missing and  "
+                                + MSG_HA_METADATA_NOT_AVAILABLE
+                                + " to make stateful upgrades. "
+                                + MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED
+                                + MSG_MANUAL_RESTORE_REQUIRED);
         assertEquals(
                 FAILED,
                 application.getStatus().getLifecycleState(),
@@ -364,8 +369,9 @@ public class ResourceLifecycleMetricsTest {
         application
                 .getStatus()
                 .setError(
-                        "HA metadata not available to restore from last state. "
-                                + "It is possible that the job has finished or terminally failed, or the configmaps have been deleted. ");
+                        MSG_HA_METADATA_NOT_AVAILABLE
+                                + " to restore from last state. "
+                                + MSG_JOB_FINISHED_OR_CONFIGMAPS_DELETED);
         assertEquals(
                 FAILED,
                 application.getStatus().getLifecycleState(),


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Currently the lifecycle state shows STABLE even if an application deployment was deleted and stays in MISSING / reconciling state. This would fix the lifecycle status of the deployment which would be FAILED in cases when the JM is in MISSING/ERROR state with ERROR: `configmaps have been deleted` indicating TERMINAL error.*


## Brief change log
  - *Added logic to detect unrecoverable `FlinkDeployment `scenarios*
  - *Inserted after existing job status FAILED check*
  - *Checks for `JobManagerStatus`:
    - *MISSING JobManager Deployment with error `({"type":"org.apache.flink.kubernetes.operator.exception.UpgradeFailureException","message":"HA metadata not available to restore from last state. It is possible that the job has finished or terminally failed, or the configmaps have been deleted. ","additionalMetadata":{},"throwableList":[]})` → Return FAILED lifecycle state*
    - *MISSING JobManager Deployment (no error or recoverable error) → Return DEPLOYED lifecycle state*
    - *ERROR JobManager Deployment without terminal error -> Return DEPLOYED lifecycle state*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
This change added tests and can be verified as follows:
  - *Added Unit Tests in `ResourceLifecycleMetricsTest` to validate Lifecycle Status for `flinkDeployment`*
  - *Manually verified the change by running a cluster with 3 sets of Application Flink Clusters:*
    - *Application Deployment 1 -> with invalid image -> ERRORED JobManager Deployment Status -> DEPLOYED Lifecycle Status of `flinkDeployment`*
    - *Application Deployment 2 -> with valid image -> Deleted `JobManager Deployment` ->  Caused `Missing` JM Status -> FAILED Lifecycle Status of `flinkDeployment`*
    - *Application Deployment 3 -> with valid image ->with invalid node selector -> `Jobmanager Deployment Status:` `DEPLOYING` -> Hence the Lifecycle Status is `STABLE`*
    - 
<img width="720" height="148" alt="Screenshot 2025-07-13 at 4 35 19 AM" src="https://github.com/user-attachments/assets/cc0bd120-c8a3-48d9-a464-cc2fbbf92155" />
<img width="734" height="112" alt="Screenshot 2025-07-13 at 4 35 30 AM" src="https://github.com/user-attachments/assets/6ee888e1-bb47-4f51-9c45-1f7171d700d8" />
<img width="634" height="31" alt="Screenshot 2025-07-13 at 4 35 39 AM" src="https://github.com/user-attachments/assets/3c1ad0c7-218b-4724-8591-61c4d53a5840" />

<img width="726" height="206" alt="Screenshot 2025-07-13 at 1 02 20 PM" src="https://github.com/user-attachments/assets/140a2ab0-b063-4ebe-a1d0-ba78ed494a94" />
<img width="564" height="23" alt="Screenshot 2025-07-13 at 1 03 24 PM" src="https://github.com/user-attachments/assets/d9d81d14-b05f-4a68-abe1-141599174b0b" />



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
