### PR TITLE
[hotfix][javadocs] Fix typo in the Javadoc for the load value in LoadSimulationPipeline

### DIFF
--- a/examples/autoscaling/src/main/java/autoscaling/LoadSimulationPipeline.java
+++ b/examples/autoscaling/src/main/java/autoscaling/LoadSimulationPipeline.java
@@ -55,7 +55,7 @@ import java.time.temporal.ChronoUnit;
  *
  *                    A concrete example: "1;2;4\n4;2;1"
  *                      Two branches are created with three tasks each. On the first branch, the tasks have
- *                      a load of 1, 2, and 3 respectively. On the second branch, the tasks have the load reversed.
+ *                      a load of 1, 2, and 4 respectively. On the second branch, the tasks have the load reversed.
  *                      This means, that at peak Flink Autoscaling at target utilization of 0.5, the parallelisms of
  *                      the tasks will be 2, 4, 8 for branch one and vise-versa for branch two.
  * </pre>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In the provided example, the max load of the third task in the first branch is 4 (not 3)

```
A concrete example: "1;2;4\n4;2;1
```
## Brief change log

  - fixes a typo in LoadSimulationPipeline's javadoc

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
*(Please pick either of the following options)*

This change is a trivial rework

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / **no**)
  - Core observer or reconciler logic that is regularly executed: (yes / **no**)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
