### PR TITLE
[FLINK-37869][Observer] Fix finished bounded stream jobs can't be cle…

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -560,6 +560,12 @@ public abstract class AbstractFlinkService implements FlinkService {
                     && e.getMessage().contains("Checkpointing has not been enabled")) {
                 LOG.warn("Checkpointing not enabled for job {}", jobId, e);
                 return Optional.empty();
+            } else if (e instanceof ExecutionException
+                    && e.getMessage() != null
+                    && e.getMessage()
+                            .contains(String.format("Job %s not found", jobId.toString()))) {
+                LOG.warn("Job {} not found", jobId, e);
+                return Optional.empty();
             }
             throw new ReconciliationException("Could not observe latest savepoint information", e);
         }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -148,6 +148,7 @@ public class TestingFlinkService extends AbstractFlinkService {
     @Getter private final Map<String, Boolean> checkpointTriggers = new HashMap<>();
     private final Map<Long, String> checkpointStats = new HashMap<>();
     @Setter private boolean throwCheckpointingDisabledError = false;
+    @Setter private boolean throwJobNotFoundError = false;
     @Setter private Throwable jobFailedErr;
 
     @Getter private int desiredReplicas = 0;
@@ -644,6 +645,13 @@ public class TestingFlinkService extends AbstractFlinkService {
             throw new ExecutionException(
                     new RestClientException(
                             "Checkpointing has not been enabled", HttpResponseStatus.BAD_REQUEST));
+        }
+
+        if (throwJobNotFoundError) {
+            throw new ExecutionException(
+                    new RestClientException(
+                            String.format("Job %s not found", jobId.toString()),
+                            HttpResponseStatus.NOT_FOUND));
         }
 
         if (checkpointInfo != null) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fix finished bounded stream jobs can't be cleanup by the Flink Kubernetes Operator [FLINK-37869](https://issues.apache.org/jira/browse/FLINK-37869)


**background**
1. When a job is observed by the observer, the `observer()` method in `AbstractFlinkResourceObserver` is triggered
2. Once the JM deployment is ready, `AbstractFlinkDeploymentObserver#observeFlinkCluster()` observes the Flink cluster
3. `SnapshotObserver#observeSavepointStatus()` monitors the savepoint status
4. `SnapshotObserver#observeLatestCheckpoint()` tracks the last checkpoint of jobs with a globally terminal state:
    - A "Job not found" exception occurs when calling `getLastCheckpoint()` for a FINISHED job.
    - In reality, the job can be retrieved via the `GET /jobs/:jobid` request, but the `GET /jobs/:jobid/checkpoints` request will throw a "Job not found" exception.

## Brief change log

 - *Catch the exception and add log when observing Flink cluster for FINISHED bounded stream job*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
This change added tests and can be verified as follows:

  - *Added unittest `getLastCheckpointShouldHandleJobNotFound`*
  - *Manually verified the change by running bounded stream job on Kubernetes cluster, the Flink cluster resource was deleted when the job finished*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
