### PR TITLE
[FLINK-38207] Update Flink Operator to use JOSDK 5.1.2

### DIFF
--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -48,8 +48,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.fabric8:kubernetes-model-scheduling:jar:7.3.0
 - io.fabric8:kubernetes-model-storageclass:jar:7.3.0
 - io.fabric8:zjsonpatch:jar:7.3.0
-- io.javaoperatorsdk:operator-framework-core:jar:5.1.0
-- io.javaoperatorsdk:operator-framework:jar:5.1.0
+- io.javaoperatorsdk:operator-framework-core:jar:5.1.2
+- io.javaoperatorsdk:operator-framework:jar:5.1.2
 - org.apache.commons:commons-compress:jar:1.26.0
 - org.apache.commons:commons-lang3:jar:3.16.0
 - org.apache.commons:commons-math3:jar:3.6.1

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -147,7 +147,7 @@ operatorSecurityContext: {}
 webhookSecurityContext: {}
 
 webhook:
-  create: false
+  create: true
   # validator:
   #   create: true
   # mutator:

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -147,7 +147,7 @@ operatorSecurityContext: {}
 webhookSecurityContext: {}
 
 webhook:
-  create: true
+  create: false
   # validator:
   #   create: true
   # mutator:

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@ under the License.
         <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
         <git-commit-id-maven-plugin.version>5.0.0</git-commit-id-maven-plugin.version>
 
-        <operator.sdk.version>5.1.1</operator.sdk.version>
+        <operator.sdk.version>5.1.2</operator.sdk.version>
         <operator.sdk.webhook-framework.version>3.0.0</operator.sdk.webhook-framework.version>
 
         <fabric8.version>7.3.1</fabric8.version>


### PR DESCRIPTION
This release fixes an issue with resource indexing on startup:

https://github.com/operator-framework/java-operator-sdk/pull/2881

What does not necessarily create issues in practice, but can lead to inconsistent behavior 

## What is the purpose of the change

Bump JOSDK version to 5.1.2

## Brief change log

Bump JOSDK version to 5.1.2

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes 
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 