### PR TITLE
[FLINK-38208] Use new Fabric8 client CRD generator in Flink Operator

### DIFF
--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -70,7 +70,7 @@ under the License.
         <!-- Fabric 8 -->
         <dependency>
             <groupId>io.fabric8</groupId>
-            <artifactId>crd-generator-apt</artifactId>
+            <artifactId>crd-generator-api-v2</artifactId>
             <version>${fabric8.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -284,6 +284,18 @@ under the License.
                     <execution>
                         <goals>
                             <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.fabric8</groupId>
+                <artifactId>crd-generator-maven-plugin</artifactId>
+                <version>${fabric8.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION

## What is the purpose of the change

The old CRD generator is deprecated and will eventually be removed from fabric8 .
see also: https://github.com/fabric8io/kubernetes-client/blob/main/doc/CRD-generator-migration-v2.md


## Brief change log

Update maven pom to use new CRD generator

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes 
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 