### PR TITLE
[FLINK-37193] Ingress recreated after perform a change to CR FlinkDeployment

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -91,6 +91,11 @@ public class FlinkOperator {
     private final Configuration baseConfig;
 
     public FlinkOperator(@Nullable Configuration conf) {
+        this(conf, null);
+    }
+
+    @VisibleForTesting
+    FlinkOperator(@Nullable Configuration conf, KubernetesClient client) {
         this.configManager =
                 conf != null
                         ? new FlinkConfigManager(conf) // For testing only
@@ -100,9 +105,13 @@ public class FlinkOperator {
 
         baseConfig = configManager.getDefaultConfig();
         this.metricGroup = OperatorMetricUtils.initOperatorMetrics(baseConfig);
-        this.client =
-                KubernetesClientUtils.getKubernetesClient(
-                        configManager.getOperatorConfiguration(), this.metricGroup);
+        if (client == null) {
+            this.client =
+                    KubernetesClientUtils.getKubernetesClient(
+                            configManager.getOperatorConfiguration(), this.metricGroup);
+        } else {
+            this.client = client;
+        }
         this.operator = createOperator();
         this.validators = ValidatorUtils.discoverValidators(configManager);
         this.listeners = ListenerUtils.discoverListeners(configManager);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -184,7 +184,7 @@ public class FlinkDeploymentController
         List<EventSource<?, FlinkDeployment>> eventSources = new ArrayList<>();
         eventSources.add(EventSourceUtils.getSessionJobInformerEventSource(context));
         eventSources.add(EventSourceUtils.getDeploymentInformerEventSource(context));
-
+        eventSources.add(EventSourceUtils.getIngressInformerEventSource(context));
         if (KubernetesClientUtils.isCrdInstalled(FlinkStateSnapshot.class)) {
             eventSources.add(
                     EventSourceUtils.getStateSnapshotForFlinkResourceInformerEventSource(context));
@@ -192,7 +192,6 @@ public class FlinkDeploymentController
             LOG.warn(
                     "Could not initialize informer for snapshots as the CRD has not been installed!");
         }
-
         return eventSources;
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -190,7 +190,7 @@ public class ApplicationReconciler
         status.getJobStatus().setState(org.apache.flink.api.common.JobStatus.RECONCILING);
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
 
-        IngressUtils.updateIngressRules(ctx, spec, deployConfig, ctx.getKubernetesClient(), true);
+        IngressUtils.updateIngressRules(ctx, spec, deployConfig, ctx.getKubernetesClient());
     }
 
     private void setJobIdIfNecessary(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -190,8 +190,7 @@ public class ApplicationReconciler
         status.getJobStatus().setState(org.apache.flink.api.common.JobStatus.RECONCILING);
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
 
-        IngressUtils.updateIngressRules(
-                relatedResource.getMetadata(), spec, deployConfig, ctx.getKubernetesClient());
+        IngressUtils.updateIngressRules(ctx, spec, deployConfig, ctx.getKubernetesClient(), true);
     }
 
     private void setJobIdIfNecessary(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconciler.java
@@ -190,7 +190,7 @@ public class ApplicationReconciler
         status.getJobStatus().setState(org.apache.flink.api.common.JobStatus.RECONCILING);
         status.setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
 
-        IngressUtils.updateIngressRules(ctx, spec, deployConfig, ctx.getKubernetesClient());
+        IngressUtils.reconcileIngress(ctx, spec, deployConfig, ctx.getKubernetesClient());
     }
 
     private void setJobIdIfNecessary(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -106,8 +106,7 @@ public class SessionReconciler
         setOwnerReference(cr, deployConfig);
         ctx.getFlinkService().submitSessionCluster(deployConfig);
         cr.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
-        IngressUtils.updateIngressRules(
-                cr.getMetadata(), spec, deployConfig, ctx.getKubernetesClient());
+        IngressUtils.updateIngressRules(ctx, spec, deployConfig, ctx.getKubernetesClient(), false);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -106,7 +106,7 @@ public class SessionReconciler
         setOwnerReference(cr, deployConfig);
         ctx.getFlinkService().submitSessionCluster(deployConfig);
         cr.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
-        IngressUtils.updateIngressRules(ctx, spec, deployConfig, ctx.getKubernetesClient(), false);
+        IngressUtils.updateIngressRules(ctx, spec, deployConfig, ctx.getKubernetesClient());
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -106,7 +106,7 @@ public class SessionReconciler
         setOwnerReference(cr, deployConfig);
         ctx.getFlinkService().submitSessionCluster(deployConfig);
         cr.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);
-        IngressUtils.updateIngressRules(ctx, spec, deployConfig, ctx.getKubernetesClient());
+        IngressUtils.reconcileIngress(ctx, spec, deployConfig, ctx.getKubernetesClient());
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
@@ -51,6 +51,8 @@ import static org.apache.flink.kubernetes.operator.utils.IngressUtils.ingressInN
 /** Utility class to locate secondary resources. */
 public class EventSourceUtils {
 
+    public static final String LABEL_COMPONENT_INGRESS = "ingress";
+
     private static final String FLINK_DEPLOYMENT_IDX = FlinkDeploymentController.class.getName();
     private static final String FLINK_SESSIONJOB_IDX = FlinkSessionJobController.class.getName();
     private static final String FLINK_STATE_SNAPSHOT_IDX = FlinkStateSnapshot.class.getName();
@@ -107,13 +109,10 @@ public class EventSourceUtils {
 
     public static InformerEventSource<?, FlinkDeployment> getIngressInformerEventSource(
             EventSourceContext<FlinkDeployment> context) {
-        //        final String labelSelector =
-        //                Map.of(Constants.LABEL_COMPONENT_KEY,
-        // Constants.LABEL_COMPONENT_JOB_MANAGER)
-        //                        .entrySet()
-        //                        .stream()
-        //                        .map(Object::toString)
-        //                        .collect(Collectors.joining(","));
+        final String labelSelector =
+                Map.of(Constants.LABEL_COMPONENT_KEY, LABEL_COMPONENT_INGRESS).entrySet().stream()
+                        .map(Object::toString)
+                        .collect(Collectors.joining(","));
 
         var ingressClass =
                 ingressInNetworkingV1(context.getClient())
@@ -122,7 +121,7 @@ public class EventSourceUtils {
 
         var configuration =
                 InformerEventSourceConfiguration.from(ingressClass, FlinkDeployment.class)
-                        //                        .withLabelSelector(labelSelector)
+                        .withLabelSelector(labelSelector)
                         .withNamespacesInheritedFromController()
                         .withFollowControllerNamespacesChanges(true)
                         .build();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
-import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.CrdConstants;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
@@ -31,6 +30,7 @@ import org.apache.flink.kubernetes.utils.Constants;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
 import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/IngressUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/IngressUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
+import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.util.Preconditions;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -45,10 +46,13 @@ import java.lang.module.ModuleDescriptor;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import static org.apache.flink.kubernetes.operator.utils.EventSourceUtils.LABEL_COMPONENT_INGRESS;
 
 /** Ingress utilities. */
 public class IngressUtils {
@@ -98,10 +102,12 @@ public class IngressUtils {
             FlinkDeploymentSpec spec,
             Configuration effectiveConfig,
             KubernetesClient client) {
+        var labels = new HashMap<>(spec.getIngress().getLabels());
+        labels.put(Constants.LABEL_COMPONENT_KEY, LABEL_COMPONENT_INGRESS);
         if (ingressInNetworkingV1(client)) {
             return new IngressBuilder()
                     .withNewMetadata()
-                    .withLabels(spec.getIngress().getLabels())
+                    .withLabels(labels)
                     .withAnnotations(spec.getIngress().getAnnotations())
                     .withName(objectMeta.getName())
                     .withNamespace(objectMeta.getNamespace())
@@ -133,7 +139,7 @@ public class IngressUtils {
             return new io.fabric8.kubernetes.api.model.networking.v1beta1.IngressBuilder()
                     .withNewMetadata()
                     .withAnnotations(spec.getIngress().getAnnotations())
-                    .withLabels(spec.getIngress().getLabels())
+                    .withLabels(labels)
                     .withName(objectMeta.getName())
                     .withNamespace(objectMeta.getNamespace())
                     .endMetadata()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/IngressUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/IngressUtils.java
@@ -48,6 +48,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -102,7 +103,10 @@ public class IngressUtils {
             FlinkDeploymentSpec spec,
             Configuration effectiveConfig,
             KubernetesClient client) {
-        var labels = new HashMap<>(spec.getIngress().getLabels());
+        Map<String, String> labels =
+                spec.getIngress().getLabels() == null
+                        ? new HashMap<>()
+                        : new HashMap<>(spec.getIngress().getLabels());
         labels.put(Constants.LABEL_COMPONENT_KEY, LABEL_COMPONENT_INGRESS);
         if (ingressInNetworkingV1(client)) {
             return new IngressBuilder()

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/IngressUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/IngressUtils.java
@@ -69,7 +69,7 @@ public class IngressUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(IngressUtils.class);
 
-    public static void updateIngressRules(
+    public static void reconcileIngress(
             FlinkResourceContext<?> ctx,
             FlinkDeploymentSpec spec,
             Configuration effectiveConfig,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptio
 
 import io.fabric8.kubeapitest.junit.EnableKubeAPIServer;
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.RegisteredController;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.rate.LinearRateLimiter;
@@ -39,8 +40,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *     ConfigurationServiceProvider) we write multiple tests as a single function, please provide
  *     ample comments.
  */
-@EnableKubeAPIServer(updateKubeConfigFile = true)
+@EnableKubeAPIServer
 class FlinkOperatorTest {
+
+    static KubernetesClient kubernetesClient;
 
     @Test
     void testConfigurationPassedToJOSDK() {
@@ -61,7 +64,7 @@ class FlinkOperatorTest {
         operatorConfig.set(
                 KubernetesOperatorConfigOptions.OPERATOR_LEADER_ELECTION_LEASE_NAME, testLeaseName);
 
-        var testOperator = new FlinkOperator(operatorConfig);
+        var testOperator = new FlinkOperator(operatorConfig, kubernetesClient);
         testOperator.registerDeploymentController();
         testOperator.registerSessionJobController();
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/FlinkOperatorTest.java
@@ -21,12 +21,12 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 
+import io.fabric8.kubeapitest.junit.EnableKubeAPIServer;
 import io.fabric8.kubernetes.client.Config;
 import io.javaoperatorsdk.operator.RegisteredController;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.processing.event.rate.LinearRateLimiter;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ThreadPoolExecutor;
@@ -39,14 +39,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *     ConfigurationServiceProvider) we write multiple tests as a single function, please provide
  *     ample comments.
  */
-public class FlinkOperatorTest {
-    @BeforeAll
-    public static void setAutoTryKubeConfig() {
-        System.setProperty(Config.KUBERNETES_AUTH_TRYKUBECONFIG_SYSTEM_PROPERTY, "false");
-    }
+@EnableKubeAPIServer(updateKubeConfigFile = true)
+class FlinkOperatorTest {
 
     @Test
-    public void testConfigurationPassedToJOSDK() {
+    void testConfigurationPassedToJOSDK() {
         var testParallelism = 42;
         var testSelector = "flink=enabled";
         var testLeaseName = "test-lease";
@@ -99,7 +96,7 @@ public class FlinkOperatorTest {
     }
 
     @Test
-    public void testLeaderElectionConfig() {
+    void testLeaderElectionConfig() {
         var operatorConfig = new Configuration();
         operatorConfig.set(KubernetesOperatorConfigOptions.OPERATOR_LEADER_ELECTION_ENABLED, true);
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -934,6 +934,7 @@ public class FlinkDeploymentControllerTest {
         assertTrue(testController.getContextFactory().getMetricGroups().isEmpty());
     }
 
+    // todo add test here
     @Test
     public void testIngressLifeCycle() throws Exception {
         FlinkDeployment appNoIngress = TestUtils.buildApplicationCluster();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -68,6 +68,7 @@ import static org.apache.flink.kubernetes.operator.TestUtils.MAX_RECONCILE_TIMES
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_JOB_UPGRADE_LAST_STATE_FALLBACK_ENABLED;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED;
 import static org.apache.flink.kubernetes.operator.utils.EventRecorder.Reason.ValidationError;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -934,7 +935,6 @@ public class FlinkDeploymentControllerTest {
         assertTrue(testController.getContextFactory().getMetricGroups().isEmpty());
     }
 
-    // todo add test here
     @Test
     public void testIngressLifeCycle() throws Exception {
         FlinkDeployment appNoIngress = TestUtils.buildApplicationCluster();
@@ -984,6 +984,9 @@ public class FlinkDeploymentControllerTest {
                                 appWithIngress.getMetadata().getName(),
                                 appWithIngress.getMetadata().getNamespace())
                         .getHost());
+        assertThat(ingress.getMetadata().getOwnerReferences()).hasSize(1);
+        assertThat(ingress.getMetadata().getOwnerReferences().get(0).getKind())
+                .isEqualTo(FlinkDeployment.class.getSimpleName());
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -75,7 +75,7 @@ public class SessionReconcilerTest extends OperatorTestBase {
     public void testStartSession() throws Exception {
         var count = new AtomicInteger(0);
         flinkService =
-                new TestingFlinkService() {
+                new TestingFlinkService(kubernetesClient) {
                     @Override
                     public void submitSessionCluster(Configuration conf) throws Exception {
                         super.submitSessionCluster(conf);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
@@ -18,30 +18,8 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.kubernetes.operator.TestUtils;
-import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
-import org.apache.flink.kubernetes.operator.api.spec.IngressSpec;
-import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
-import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
-
-import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
-import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
-import io.fabric8.kubernetes.api.model.networking.v1.IngressTLS;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.Test;
-
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test class for {@link IngressUtils}. */
 @EnableKubernetesMockClient(crud = true)
@@ -49,474 +27,486 @@ public class IngressUtilsTest {
 
     KubernetesClient client;
 
-    @Test
-    public void testIngress() {
-        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
-        Configuration config =
-                new FlinkConfigManager(new Configuration())
-                        .getDeployConfig(appCluster.getMetadata(), appCluster.getSpec());
-
-        // no ingress when ingressDomain is empty
-        IngressUtils.updateIngressRules(
-                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            assertNull(
-                    client.network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get());
-        } else {
-            assertNull(
-                    client.network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get());
-        }
-
-        // host based routing
-        IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
-        builder.template("{{name}}.{{namespace}}.example.com");
-        appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(
-                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-        Ingress ingress = null;
-        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingressV1beta1 = null;
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            ingress =
-                    client.network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        } else {
-            ingressV1beta1 =
-                    client.network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        }
-
-        List<IngressRule> rules = null;
-        List<io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule> rulesV1beta1 = null;
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            rules = ingress.getSpec().getRules();
-        } else {
-            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
-        }
-        assertEquals(
-                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() : rulesV1beta1.size());
-        assertEquals(
-                appCluster.getMetadata().getName()
-                        + "."
-                        + appCluster.getMetadata().getNamespace()
-                        + ".example.com",
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? rules.get(0).getHost()
-                        : rulesV1beta1.get(0).getHost());
-        assertNull(
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
-                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
-
-        // path based routing
-        builder.template("/{{namespace}}/{{name}}(/|$)(.*)");
-        builder.className("nginx");
-        builder.annotations(Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"));
-        appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(
-                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            ingress =
-                    client.network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-            rules = ingress.getSpec().getRules();
-        } else {
-            ingressV1beta1 =
-                    client.network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
-        }
-
-        assertEquals(
-                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() : rulesV1beta1.size());
-        assertNull(
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? rules.get(0).getHost()
-                        : rulesV1beta1.get(0).getHost());
-        assertEquals(
-                1,
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? rules.get(0).getHttp().getPaths().size()
-                        : rulesV1beta1.get(0).getHttp().getPaths().size());
-        assertEquals(
-                "/"
-                        + appCluster.getMetadata().getNamespace()
-                        + "/"
-                        + appCluster.getMetadata().getName()
-                        + "(/|$)(.*)",
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
-                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
-        assertEquals(
-                Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"),
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? ingress.getMetadata().getAnnotations()
-                        : ingressV1beta1.getMetadata().getAnnotations());
-        assertEquals(
-                "nginx",
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? ingress.getSpec().getIngressClassName()
-                        : ingressV1beta1.getSpec().getIngressClassName());
-
-        // host + path based routing
-        builder.template("example.com/{{namespace}}/{{name}}(/|$)(.*)");
-        builder.className("nginx");
-        appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(
-                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            ingress =
-                    client.network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-            rules = ingress.getSpec().getRules();
-        } else {
-            ingressV1beta1 =
-                    client.network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
-        }
-        assertEquals(
-                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() : rulesV1beta1.size());
-        assertEquals(
-                1,
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? rules.get(0).getHttp().getPaths().size()
-                        : rulesV1beta1.get(0).getHttp().getPaths().size());
-        assertEquals(
-                "/"
-                        + appCluster.getMetadata().getNamespace()
-                        + "/"
-                        + appCluster.getMetadata().getName()
-                        + "(/|$)(.*)",
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
-                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
-        assertEquals(
-                Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"),
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? ingress.getMetadata().getAnnotations()
-                        : ingressV1beta1.getMetadata().getAnnotations());
-        assertEquals(
-                "nginx",
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? ingress.getSpec().getIngressClassName()
-                        : ingressV1beta1.getSpec().getIngressClassName());
-    }
-
-    @Test
-    public void testIngressUrl() {
-        String template = "flink.k8s.io/{{namespace}}/{{name}}";
-        URL url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
-        assertEquals("flink.k8s.io", url.getHost());
-        assertEquals("/default/basic-ingress", url.getPath());
-
-        template = "/{{namespace}}/{{name}}";
-        url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
-        assertTrue(StringUtils.isBlank(url.getHost()));
-        assertEquals("/default/basic-ingress", url.getPath());
-
-        template = "{{name}}.{{namespace}}.flink.k8s.io";
-        url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
-
-        assertEquals("basic-ingress.default.flink.k8s.io", url.getHost());
-        assertTrue(StringUtils.isBlank(url.getPath()));
-
-        assertThrows(
-                ReconciliationException.class,
-                () -> IngressUtils.getIngressUrl("example.com:port", "basic-ingress", "default"));
-    }
-
-    @Test
-    public void testIngressTls() {
-        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
-        Configuration config =
-                new FlinkConfigManager(new Configuration())
-                        .getDeployConfig(appCluster.getMetadata(), appCluster.getSpec());
-
-        // no tls when tls spec is empty
-        IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
-        builder.template("{{name}}.{{namespace}}.example.com");
-        builder.tls(new ArrayList<>());
-        appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(
-                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-        Ingress ingress = null;
-        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingressV1beta1 = null;
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            ingress =
-                    client.network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        } else {
-            ingressV1beta1 =
-                    client.network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        }
-        List<IngressTLS> tls = null;
-        List<io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLS> tlsV1beta1 = null;
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            tls = ingress.getSpec().getTls();
-        } else {
-            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-        }
-        assertEquals(
-                0, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
-
-        // no tls when hosts spec is empty
-        builder.template("{{name}}.{{namespace}}.example.com");
-        IngressTLS ingressTlsSpecSecretOnly = new IngressTLS();
-        ingressTlsSpecSecretOnly.setSecretName("secret");
-        builder.tls(List.of(ingressTlsSpecSecretOnly));
-        appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(
-                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            ingress =
-                    client.network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        } else {
-            ingressV1beta1 =
-                    client.network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        }
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            tls = ingress.getSpec().getTls();
-        } else {
-            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-        }
-        assertEquals(
-                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
-        assertEquals(
-                "secret",
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? tls.get(0).getSecretName()
-                        : tlsV1beta1.get(0).getSecretName());
-
-        // tls with no secretName
-        builder.template("{{name}}.{{namespace}}.example.com");
-        IngressTLS ingressTlsSpecHostsOnly = new IngressTLS();
-        ingressTlsSpecHostsOnly.setHosts(List.of("example.com"));
-        builder.tls(List.of(ingressTlsSpecHostsOnly));
-        appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(
-                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            ingress =
-                    client.network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        } else {
-            ingressV1beta1 =
-                    client.network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        }
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            tls = ingress.getSpec().getTls();
-        } else {
-            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-        }
-        assertEquals(
-                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
-        assertEquals(
-                "example.com",
-                IngressUtils.ingressInNetworkingV1(client)
-                        ? tls.get(0).getHosts().get(0)
-                        : tlsV1beta1.get(0).getHosts().get(0));
-
-        // tls with secretName and hosts
-        builder.template("{{name}}.{{namespace}}.example.com");
-        IngressTLS ingressTlsSpecSingleTLSWithHost =
-                new IngressTLS(List.of("example.com"), "secret");
-        builder.tls(List.of(ingressTlsSpecSingleTLSWithHost));
-        appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(
-                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            ingress =
-                    client.network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        } else {
-            ingressV1beta1 =
-                    client.network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        }
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            tls = ingress.getSpec().getTls();
-        } else {
-            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-        }
-        assertEquals(
-                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            assertEquals("secret", tls.get(0).getSecretName());
-            assertEquals(1, tls.get(0).getHosts().size());
-            assertEquals("example.com", tls.get(0).getHosts().get(0));
-        } else {
-            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
-            assertEquals(1, tlsV1beta1.get(0).getHosts().size());
-            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
-        }
-
-        // tls with secretName and multiple hosts
-        builder.template("{{name}}.{{namespace}}.example.com");
-        IngressTLS ingressTlsSpecSingleTLSWithHosts =
-                new IngressTLS(List.of("example.com", "example2.com"), "secret");
-        builder.tls(List.of(ingressTlsSpecSingleTLSWithHosts));
-        appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(
-                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            ingress =
-                    client.network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        } else {
-            ingressV1beta1 =
-                    client.network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        }
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            tls = ingress.getSpec().getTls();
-        } else {
-            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-        }
-        assertEquals(
-                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            assertEquals("secret", tls.get(0).getSecretName());
-            assertEquals(2, tls.get(0).getHosts().size());
-            assertEquals("example.com", tls.get(0).getHosts().get(0));
-            assertEquals("example2.com", tls.get(0).getHosts().get(1));
-        } else {
-            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
-            assertEquals(2, tlsV1beta1.get(0).getHosts().size());
-            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
-            assertEquals("example2.com", tlsV1beta1.get(0).getHosts().get(1));
-        }
-
-        // tls with secretName and multiple hosts and multiple tls
-        builder.template("{{name}}.{{namespace}}.example.com");
-        IngressTLS ingressTlsSpecMultipleTLSWithHosts1 =
-                new IngressTLS(List.of("example.com", "example2.com"), "secret");
-        IngressTLS ingressTlsSpecMultipleTLSWithHosts2 =
-                new IngressTLS(List.of("example3.com", "example4.com"), "secret2");
-        builder.tls(
-                List.of(ingressTlsSpecMultipleTLSWithHosts1, ingressTlsSpecMultipleTLSWithHosts2));
-        appCluster.getSpec().setIngress(builder.build());
-        IngressUtils.updateIngressRules(
-                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            ingress =
-                    client.network()
-                            .v1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        } else {
-            ingressV1beta1 =
-                    client.network()
-                            .v1beta1()
-                            .ingresses()
-                            .inNamespace(appCluster.getMetadata().getNamespace())
-                            .withName(appCluster.getMetadata().getName())
-                            .get();
-        }
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            tls = ingress.getSpec().getTls();
-        } else {
-            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-        }
-        assertEquals(
-                2, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
-        if (IngressUtils.ingressInNetworkingV1(client)) {
-            assertEquals("secret", tls.get(0).getSecretName());
-            assertEquals(2, tls.get(0).getHosts().size());
-            assertEquals("example.com", tls.get(0).getHosts().get(0));
-            assertEquals("example2.com", tls.get(0).getHosts().get(1));
-            assertEquals("secret2", tls.get(1).getSecretName());
-            assertEquals(2, tls.get(1).getHosts().size());
-            assertEquals("example3.com", tls.get(1).getHosts().get(0));
-            assertEquals("example4.com", tls.get(1).getHosts().get(1));
-        } else {
-            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
-            assertEquals(2, tlsV1beta1.get(0).getHosts().size());
-            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
-            assertEquals("example2.com", tlsV1beta1.get(0).getHosts().get(1));
-            assertEquals("secret2", tlsV1beta1.get(1).getSecretName());
-            assertEquals(2, tlsV1beta1.get(1).getHosts().size());
-            assertEquals("example3.com", tlsV1beta1.get(1).getHosts().get(0));
-            assertEquals("example4.com", tlsV1beta1.get(1).getHosts().get(1));
-        }
-    }
+    //    @Test
+    //    public void testIngress() {
+    //        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
+    //        Configuration config =
+    //                new FlinkConfigManager(new Configuration())
+    //                        .getDeployConfig(appCluster.getMetadata(), appCluster.getSpec());
+    //
+    //        // no ingress when ingressDomain is empty
+    //        IngressUtils.updateIngressRules(
+    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            assertNull(
+    //                    client.network()
+    //                            .v1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get());
+    //        } else {
+    //            assertNull(
+    //                    client.network()
+    //                            .v1beta1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get());
+    //        }
+    //
+    //        // host based routing
+    //        IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
+    //        builder.template("{{name}}.{{namespace}}.example.com");
+    //        appCluster.getSpec().setIngress(builder.build());
+    //        IngressUtils.updateIngressRules(
+    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+    //        Ingress ingress = null;
+    //        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingressV1beta1 = null;
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            ingress =
+    //                    client.network()
+    //                            .v1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        } else {
+    //            ingressV1beta1 =
+    //                    client.network()
+    //                            .v1beta1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        }
+    //
+    //        List<IngressRule> rules = null;
+    //        List<io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule> rulesV1beta1 =
+    // null;
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            rules = ingress.getSpec().getRules();
+    //        } else {
+    //            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
+    //        }
+    //        assertEquals(
+    //                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() :
+    // rulesV1beta1.size());
+    //        assertEquals(
+    //                appCluster.getMetadata().getName()
+    //                        + "."
+    //                        + appCluster.getMetadata().getNamespace()
+    //                        + ".example.com",
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? rules.get(0).getHost()
+    //                        : rulesV1beta1.get(0).getHost());
+    //        assertNull(
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
+    //                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
+    //
+    //        // path based routing
+    //        builder.template("/{{namespace}}/{{name}}(/|$)(.*)");
+    //        builder.className("nginx");
+    //        builder.annotations(Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"));
+    //        appCluster.getSpec().setIngress(builder.build());
+    //        IngressUtils.updateIngressRules(
+    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            ingress =
+    //                    client.network()
+    //                            .v1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //            rules = ingress.getSpec().getRules();
+    //        } else {
+    //            ingressV1beta1 =
+    //                    client.network()
+    //                            .v1beta1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
+    //        }
+    //
+    //        assertEquals(
+    //                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() :
+    // rulesV1beta1.size());
+    //        assertNull(
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? rules.get(0).getHost()
+    //                        : rulesV1beta1.get(0).getHost());
+    //        assertEquals(
+    //                1,
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? rules.get(0).getHttp().getPaths().size()
+    //                        : rulesV1beta1.get(0).getHttp().getPaths().size());
+    //        assertEquals(
+    //                "/"
+    //                        + appCluster.getMetadata().getNamespace()
+    //                        + "/"
+    //                        + appCluster.getMetadata().getName()
+    //                        + "(/|$)(.*)",
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
+    //                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
+    //        assertEquals(
+    //                Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"),
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? ingress.getMetadata().getAnnotations()
+    //                        : ingressV1beta1.getMetadata().getAnnotations());
+    //        assertEquals(
+    //                "nginx",
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? ingress.getSpec().getIngressClassName()
+    //                        : ingressV1beta1.getSpec().getIngressClassName());
+    //
+    //        // host + path based routing
+    //        builder.template("example.com/{{namespace}}/{{name}}(/|$)(.*)");
+    //        builder.className("nginx");
+    //        appCluster.getSpec().setIngress(builder.build());
+    //        IngressUtils.updateIngressRules(
+    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            ingress =
+    //                    client.network()
+    //                            .v1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //            rules = ingress.getSpec().getRules();
+    //        } else {
+    //            ingressV1beta1 =
+    //                    client.network()
+    //                            .v1beta1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
+    //        }
+    //        assertEquals(
+    //                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() :
+    // rulesV1beta1.size());
+    //        assertEquals(
+    //                1,
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? rules.get(0).getHttp().getPaths().size()
+    //                        : rulesV1beta1.get(0).getHttp().getPaths().size());
+    //        assertEquals(
+    //                "/"
+    //                        + appCluster.getMetadata().getNamespace()
+    //                        + "/"
+    //                        + appCluster.getMetadata().getName()
+    //                        + "(/|$)(.*)",
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
+    //                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
+    //        assertEquals(
+    //                Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"),
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? ingress.getMetadata().getAnnotations()
+    //                        : ingressV1beta1.getMetadata().getAnnotations());
+    //        assertEquals(
+    //                "nginx",
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? ingress.getSpec().getIngressClassName()
+    //                        : ingressV1beta1.getSpec().getIngressClassName());
+    //    }
+    //
+    //    @Test
+    //    public void testIngressUrl() {
+    //        String template = "flink.k8s.io/{{namespace}}/{{name}}";
+    //        URL url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
+    //        assertEquals("flink.k8s.io", url.getHost());
+    //        assertEquals("/default/basic-ingress", url.getPath());
+    //
+    //        template = "/{{namespace}}/{{name}}";
+    //        url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
+    //        assertTrue(StringUtils.isBlank(url.getHost()));
+    //        assertEquals("/default/basic-ingress", url.getPath());
+    //
+    //        template = "{{name}}.{{namespace}}.flink.k8s.io";
+    //        url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
+    //
+    //        assertEquals("basic-ingress.default.flink.k8s.io", url.getHost());
+    //        assertTrue(StringUtils.isBlank(url.getPath()));
+    //
+    //        assertThrows(
+    //                ReconciliationException.class,
+    //                () -> IngressUtils.getIngressUrl("example.com:port", "basic-ingress",
+    // "default"));
+    //    }
+    //
+    //    @Test
+    //    public void testIngressTls() {
+    //        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
+    //        Configuration config =
+    //                new FlinkConfigManager(new Configuration())
+    //                        .getDeployConfig(appCluster.getMetadata(), appCluster.getSpec());
+    //
+    //        // no tls when tls spec is empty
+    //        IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
+    //        builder.template("{{name}}.{{namespace}}.example.com");
+    //        builder.tls(new ArrayList<>());
+    //        appCluster.getSpec().setIngress(builder.build());
+    //        IngressUtils.updateIngressRules(
+    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+    //        Ingress ingress = null;
+    //        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingressV1beta1 = null;
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            ingress =
+    //                    client.network()
+    //                            .v1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        } else {
+    //            ingressV1beta1 =
+    //                    client.network()
+    //                            .v1beta1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        }
+    //        List<IngressTLS> tls = null;
+    //        List<io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLS> tlsV1beta1 = null;
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            tls = ingress.getSpec().getTls();
+    //        } else {
+    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+    //        }
+    //        assertEquals(
+    //                0, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
+    // tlsV1beta1.size());
+    //
+    //        // no tls when hosts spec is empty
+    //        builder.template("{{name}}.{{namespace}}.example.com");
+    //        IngressTLS ingressTlsSpecSecretOnly = new IngressTLS();
+    //        ingressTlsSpecSecretOnly.setSecretName("secret");
+    //        builder.tls(List.of(ingressTlsSpecSecretOnly));
+    //        appCluster.getSpec().setIngress(builder.build());
+    //        IngressUtils.updateIngressRules(
+    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            ingress =
+    //                    client.network()
+    //                            .v1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        } else {
+    //            ingressV1beta1 =
+    //                    client.network()
+    //                            .v1beta1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        }
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            tls = ingress.getSpec().getTls();
+    //        } else {
+    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+    //        }
+    //        assertEquals(
+    //                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
+    // tlsV1beta1.size());
+    //        assertEquals(
+    //                "secret",
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? tls.get(0).getSecretName()
+    //                        : tlsV1beta1.get(0).getSecretName());
+    //
+    //        // tls with no secretName
+    //        builder.template("{{name}}.{{namespace}}.example.com");
+    //        IngressTLS ingressTlsSpecHostsOnly = new IngressTLS();
+    //        ingressTlsSpecHostsOnly.setHosts(List.of("example.com"));
+    //        builder.tls(List.of(ingressTlsSpecHostsOnly));
+    //        appCluster.getSpec().setIngress(builder.build());
+    //        IngressUtils.updateIngressRules(
+    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            ingress =
+    //                    client.network()
+    //                            .v1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        } else {
+    //            ingressV1beta1 =
+    //                    client.network()
+    //                            .v1beta1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        }
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            tls = ingress.getSpec().getTls();
+    //        } else {
+    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+    //        }
+    //        assertEquals(
+    //                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
+    // tlsV1beta1.size());
+    //        assertEquals(
+    //                "example.com",
+    //                IngressUtils.ingressInNetworkingV1(client)
+    //                        ? tls.get(0).getHosts().get(0)
+    //                        : tlsV1beta1.get(0).getHosts().get(0));
+    //
+    //        // tls with secretName and hosts
+    //        builder.template("{{name}}.{{namespace}}.example.com");
+    //        IngressTLS ingressTlsSpecSingleTLSWithHost =
+    //                new IngressTLS(List.of("example.com"), "secret");
+    //        builder.tls(List.of(ingressTlsSpecSingleTLSWithHost));
+    //        appCluster.getSpec().setIngress(builder.build());
+    //        IngressUtils.updateIngressRules(
+    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            ingress =
+    //                    client.network()
+    //                            .v1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        } else {
+    //            ingressV1beta1 =
+    //                    client.network()
+    //                            .v1beta1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        }
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            tls = ingress.getSpec().getTls();
+    //        } else {
+    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+    //        }
+    //        assertEquals(
+    //                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
+    // tlsV1beta1.size());
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            assertEquals("secret", tls.get(0).getSecretName());
+    //            assertEquals(1, tls.get(0).getHosts().size());
+    //            assertEquals("example.com", tls.get(0).getHosts().get(0));
+    //        } else {
+    //            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
+    //            assertEquals(1, tlsV1beta1.get(0).getHosts().size());
+    //            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
+    //        }
+    //
+    //        // tls with secretName and multiple hosts
+    //        builder.template("{{name}}.{{namespace}}.example.com");
+    //        IngressTLS ingressTlsSpecSingleTLSWithHosts =
+    //                new IngressTLS(List.of("example.com", "example2.com"), "secret");
+    //        builder.tls(List.of(ingressTlsSpecSingleTLSWithHosts));
+    //        appCluster.getSpec().setIngress(builder.build());
+    //        IngressUtils.updateIngressRules(
+    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            ingress =
+    //                    client.network()
+    //                            .v1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        } else {
+    //            ingressV1beta1 =
+    //                    client.network()
+    //                            .v1beta1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        }
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            tls = ingress.getSpec().getTls();
+    //        } else {
+    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+    //        }
+    //        assertEquals(
+    //                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
+    // tlsV1beta1.size());
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            assertEquals("secret", tls.get(0).getSecretName());
+    //            assertEquals(2, tls.get(0).getHosts().size());
+    //            assertEquals("example.com", tls.get(0).getHosts().get(0));
+    //            assertEquals("example2.com", tls.get(0).getHosts().get(1));
+    //        } else {
+    //            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
+    //            assertEquals(2, tlsV1beta1.get(0).getHosts().size());
+    //            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
+    //            assertEquals("example2.com", tlsV1beta1.get(0).getHosts().get(1));
+    //        }
+    //
+    //        // tls with secretName and multiple hosts and multiple tls
+    //        builder.template("{{name}}.{{namespace}}.example.com");
+    //        IngressTLS ingressTlsSpecMultipleTLSWithHosts1 =
+    //                new IngressTLS(List.of("example.com", "example2.com"), "secret");
+    //        IngressTLS ingressTlsSpecMultipleTLSWithHosts2 =
+    //                new IngressTLS(List.of("example3.com", "example4.com"), "secret2");
+    //        builder.tls(
+    //                List.of(ingressTlsSpecMultipleTLSWithHosts1,
+    // ingressTlsSpecMultipleTLSWithHosts2));
+    //        appCluster.getSpec().setIngress(builder.build());
+    //        IngressUtils.updateIngressRules(
+    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            ingress =
+    //                    client.network()
+    //                            .v1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        } else {
+    //            ingressV1beta1 =
+    //                    client.network()
+    //                            .v1beta1()
+    //                            .ingresses()
+    //                            .inNamespace(appCluster.getMetadata().getNamespace())
+    //                            .withName(appCluster.getMetadata().getName())
+    //                            .get();
+    //        }
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            tls = ingress.getSpec().getTls();
+    //        } else {
+    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+    //        }
+    //        assertEquals(
+    //                2, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
+    // tlsV1beta1.size());
+    //        if (IngressUtils.ingressInNetworkingV1(client)) {
+    //            assertEquals("secret", tls.get(0).getSecretName());
+    //            assertEquals(2, tls.get(0).getHosts().size());
+    //            assertEquals("example.com", tls.get(0).getHosts().get(0));
+    //            assertEquals("example2.com", tls.get(0).getHosts().get(1));
+    //            assertEquals("secret2", tls.get(1).getSecretName());
+    //            assertEquals(2, tls.get(1).getHosts().size());
+    //            assertEquals("example3.com", tls.get(1).getHosts().get(0));
+    //            assertEquals("example4.com", tls.get(1).getHosts().get(1));
+    //        } else {
+    //            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
+    //            assertEquals(2, tlsV1beta1.get(0).getHosts().size());
+    //            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
+    //            assertEquals("example2.com", tlsV1beta1.get(0).getHosts().get(1));
+    //            assertEquals("secret2", tlsV1beta1.get(1).getSecretName());
+    //            assertEquals(2, tlsV1beta1.get(1).getHosts().size());
+    //            assertEquals("example3.com", tlsV1beta1.get(1).getHosts().get(0));
+    //            assertEquals("example4.com", tlsV1beta1.get(1).getHosts().get(1));
+    //        }
+    //    }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
@@ -18,495 +18,512 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.spec.IngressSpec;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentContext;
+import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
+import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
+
+import io.fabric8.kubernetes.api.model.networking.v1.Ingress;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressRule;
+import io.fabric8.kubernetes.api.model.networking.v1.IngressTLS;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test class for {@link IngressUtils}. */
 @EnableKubernetesMockClient(crud = true)
-public class IngressUtilsTest {
+class IngressUtilsTest {
 
     KubernetesClient client;
 
-    //    @Test
-    //    public void testIngress() {
-    //        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
-    //        Configuration config =
-    //                new FlinkConfigManager(new Configuration())
-    //                        .getDeployConfig(appCluster.getMetadata(), appCluster.getSpec());
-    //
-    //        // no ingress when ingressDomain is empty
-    //        IngressUtils.updateIngressRules(
-    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            assertNull(
-    //                    client.network()
-    //                            .v1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get());
-    //        } else {
-    //            assertNull(
-    //                    client.network()
-    //                            .v1beta1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get());
-    //        }
-    //
-    //        // host based routing
-    //        IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
-    //        builder.template("{{name}}.{{namespace}}.example.com");
-    //        appCluster.getSpec().setIngress(builder.build());
-    //        IngressUtils.updateIngressRules(
-    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-    //        Ingress ingress = null;
-    //        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingressV1beta1 = null;
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            ingress =
-    //                    client.network()
-    //                            .v1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        } else {
-    //            ingressV1beta1 =
-    //                    client.network()
-    //                            .v1beta1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        }
-    //
-    //        List<IngressRule> rules = null;
-    //        List<io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule> rulesV1beta1 =
-    // null;
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            rules = ingress.getSpec().getRules();
-    //        } else {
-    //            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
-    //        }
-    //        assertEquals(
-    //                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() :
-    // rulesV1beta1.size());
-    //        assertEquals(
-    //                appCluster.getMetadata().getName()
-    //                        + "."
-    //                        + appCluster.getMetadata().getNamespace()
-    //                        + ".example.com",
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? rules.get(0).getHost()
-    //                        : rulesV1beta1.get(0).getHost());
-    //        assertNull(
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
-    //                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
-    //
-    //        // path based routing
-    //        builder.template("/{{namespace}}/{{name}}(/|$)(.*)");
-    //        builder.className("nginx");
-    //        builder.annotations(Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"));
-    //        appCluster.getSpec().setIngress(builder.build());
-    //        IngressUtils.updateIngressRules(
-    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            ingress =
-    //                    client.network()
-    //                            .v1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //            rules = ingress.getSpec().getRules();
-    //        } else {
-    //            ingressV1beta1 =
-    //                    client.network()
-    //                            .v1beta1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
-    //        }
-    //
-    //        assertEquals(
-    //                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() :
-    // rulesV1beta1.size());
-    //        assertNull(
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? rules.get(0).getHost()
-    //                        : rulesV1beta1.get(0).getHost());
-    //        assertEquals(
-    //                1,
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? rules.get(0).getHttp().getPaths().size()
-    //                        : rulesV1beta1.get(0).getHttp().getPaths().size());
-    //        assertEquals(
-    //                "/"
-    //                        + appCluster.getMetadata().getNamespace()
-    //                        + "/"
-    //                        + appCluster.getMetadata().getName()
-    //                        + "(/|$)(.*)",
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
-    //                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
-    //        assertEquals(
-    //                Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"),
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? ingress.getMetadata().getAnnotations()
-    //                        : ingressV1beta1.getMetadata().getAnnotations());
-    //        assertEquals(
-    //                "nginx",
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? ingress.getSpec().getIngressClassName()
-    //                        : ingressV1beta1.getSpec().getIngressClassName());
-    //
-    //        // host + path based routing
-    //        builder.template("example.com/{{namespace}}/{{name}}(/|$)(.*)");
-    //        builder.className("nginx");
-    //        appCluster.getSpec().setIngress(builder.build());
-    //        IngressUtils.updateIngressRules(
-    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            ingress =
-    //                    client.network()
-    //                            .v1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //            rules = ingress.getSpec().getRules();
-    //        } else {
-    //            ingressV1beta1 =
-    //                    client.network()
-    //                            .v1beta1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
-    //        }
-    //        assertEquals(
-    //                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() :
-    // rulesV1beta1.size());
-    //        assertEquals(
-    //                1,
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? rules.get(0).getHttp().getPaths().size()
-    //                        : rulesV1beta1.get(0).getHttp().getPaths().size());
-    //        assertEquals(
-    //                "/"
-    //                        + appCluster.getMetadata().getNamespace()
-    //                        + "/"
-    //                        + appCluster.getMetadata().getName()
-    //                        + "(/|$)(.*)",
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
-    //                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
-    //        assertEquals(
-    //                Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"),
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? ingress.getMetadata().getAnnotations()
-    //                        : ingressV1beta1.getMetadata().getAnnotations());
-    //        assertEquals(
-    //                "nginx",
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? ingress.getSpec().getIngressClassName()
-    //                        : ingressV1beta1.getSpec().getIngressClassName());
-    //    }
-    //
-    //    @Test
-    //    public void testIngressUrl() {
-    //        String template = "flink.k8s.io/{{namespace}}/{{name}}";
-    //        URL url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
-    //        assertEquals("flink.k8s.io", url.getHost());
-    //        assertEquals("/default/basic-ingress", url.getPath());
-    //
-    //        template = "/{{namespace}}/{{name}}";
-    //        url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
-    //        assertTrue(StringUtils.isBlank(url.getHost()));
-    //        assertEquals("/default/basic-ingress", url.getPath());
-    //
-    //        template = "{{name}}.{{namespace}}.flink.k8s.io";
-    //        url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
-    //
-    //        assertEquals("basic-ingress.default.flink.k8s.io", url.getHost());
-    //        assertTrue(StringUtils.isBlank(url.getPath()));
-    //
-    //        assertThrows(
-    //                ReconciliationException.class,
-    //                () -> IngressUtils.getIngressUrl("example.com:port", "basic-ingress",
-    // "default"));
-    //    }
-    //
-    //    @Test
-    //    public void testIngressTls() {
-    //        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
-    //        Configuration config =
-    //                new FlinkConfigManager(new Configuration())
-    //                        .getDeployConfig(appCluster.getMetadata(), appCluster.getSpec());
-    //
-    //        // no tls when tls spec is empty
-    //        IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
-    //        builder.template("{{name}}.{{namespace}}.example.com");
-    //        builder.tls(new ArrayList<>());
-    //        appCluster.getSpec().setIngress(builder.build());
-    //        IngressUtils.updateIngressRules(
-    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-    //        Ingress ingress = null;
-    //        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingressV1beta1 = null;
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            ingress =
-    //                    client.network()
-    //                            .v1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        } else {
-    //            ingressV1beta1 =
-    //                    client.network()
-    //                            .v1beta1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        }
-    //        List<IngressTLS> tls = null;
-    //        List<io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLS> tlsV1beta1 = null;
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            tls = ingress.getSpec().getTls();
-    //        } else {
-    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-    //        }
-    //        assertEquals(
-    //                0, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
-    // tlsV1beta1.size());
-    //
-    //        // no tls when hosts spec is empty
-    //        builder.template("{{name}}.{{namespace}}.example.com");
-    //        IngressTLS ingressTlsSpecSecretOnly = new IngressTLS();
-    //        ingressTlsSpecSecretOnly.setSecretName("secret");
-    //        builder.tls(List.of(ingressTlsSpecSecretOnly));
-    //        appCluster.getSpec().setIngress(builder.build());
-    //        IngressUtils.updateIngressRules(
-    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            ingress =
-    //                    client.network()
-    //                            .v1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        } else {
-    //            ingressV1beta1 =
-    //                    client.network()
-    //                            .v1beta1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        }
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            tls = ingress.getSpec().getTls();
-    //        } else {
-    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-    //        }
-    //        assertEquals(
-    //                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
-    // tlsV1beta1.size());
-    //        assertEquals(
-    //                "secret",
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? tls.get(0).getSecretName()
-    //                        : tlsV1beta1.get(0).getSecretName());
-    //
-    //        // tls with no secretName
-    //        builder.template("{{name}}.{{namespace}}.example.com");
-    //        IngressTLS ingressTlsSpecHostsOnly = new IngressTLS();
-    //        ingressTlsSpecHostsOnly.setHosts(List.of("example.com"));
-    //        builder.tls(List.of(ingressTlsSpecHostsOnly));
-    //        appCluster.getSpec().setIngress(builder.build());
-    //        IngressUtils.updateIngressRules(
-    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            ingress =
-    //                    client.network()
-    //                            .v1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        } else {
-    //            ingressV1beta1 =
-    //                    client.network()
-    //                            .v1beta1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        }
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            tls = ingress.getSpec().getTls();
-    //        } else {
-    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-    //        }
-    //        assertEquals(
-    //                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
-    // tlsV1beta1.size());
-    //        assertEquals(
-    //                "example.com",
-    //                IngressUtils.ingressInNetworkingV1(client)
-    //                        ? tls.get(0).getHosts().get(0)
-    //                        : tlsV1beta1.get(0).getHosts().get(0));
-    //
-    //        // tls with secretName and hosts
-    //        builder.template("{{name}}.{{namespace}}.example.com");
-    //        IngressTLS ingressTlsSpecSingleTLSWithHost =
-    //                new IngressTLS(List.of("example.com"), "secret");
-    //        builder.tls(List.of(ingressTlsSpecSingleTLSWithHost));
-    //        appCluster.getSpec().setIngress(builder.build());
-    //        IngressUtils.updateIngressRules(
-    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            ingress =
-    //                    client.network()
-    //                            .v1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        } else {
-    //            ingressV1beta1 =
-    //                    client.network()
-    //                            .v1beta1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        }
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            tls = ingress.getSpec().getTls();
-    //        } else {
-    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-    //        }
-    //        assertEquals(
-    //                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
-    // tlsV1beta1.size());
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            assertEquals("secret", tls.get(0).getSecretName());
-    //            assertEquals(1, tls.get(0).getHosts().size());
-    //            assertEquals("example.com", tls.get(0).getHosts().get(0));
-    //        } else {
-    //            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
-    //            assertEquals(1, tlsV1beta1.get(0).getHosts().size());
-    //            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
-    //        }
-    //
-    //        // tls with secretName and multiple hosts
-    //        builder.template("{{name}}.{{namespace}}.example.com");
-    //        IngressTLS ingressTlsSpecSingleTLSWithHosts =
-    //                new IngressTLS(List.of("example.com", "example2.com"), "secret");
-    //        builder.tls(List.of(ingressTlsSpecSingleTLSWithHosts));
-    //        appCluster.getSpec().setIngress(builder.build());
-    //        IngressUtils.updateIngressRules(
-    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            ingress =
-    //                    client.network()
-    //                            .v1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        } else {
-    //            ingressV1beta1 =
-    //                    client.network()
-    //                            .v1beta1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        }
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            tls = ingress.getSpec().getTls();
-    //        } else {
-    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-    //        }
-    //        assertEquals(
-    //                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
-    // tlsV1beta1.size());
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            assertEquals("secret", tls.get(0).getSecretName());
-    //            assertEquals(2, tls.get(0).getHosts().size());
-    //            assertEquals("example.com", tls.get(0).getHosts().get(0));
-    //            assertEquals("example2.com", tls.get(0).getHosts().get(1));
-    //        } else {
-    //            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
-    //            assertEquals(2, tlsV1beta1.get(0).getHosts().size());
-    //            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
-    //            assertEquals("example2.com", tlsV1beta1.get(0).getHosts().get(1));
-    //        }
-    //
-    //        // tls with secretName and multiple hosts and multiple tls
-    //        builder.template("{{name}}.{{namespace}}.example.com");
-    //        IngressTLS ingressTlsSpecMultipleTLSWithHosts1 =
-    //                new IngressTLS(List.of("example.com", "example2.com"), "secret");
-    //        IngressTLS ingressTlsSpecMultipleTLSWithHosts2 =
-    //                new IngressTLS(List.of("example3.com", "example4.com"), "secret2");
-    //        builder.tls(
-    //                List.of(ingressTlsSpecMultipleTLSWithHosts1,
-    // ingressTlsSpecMultipleTLSWithHosts2));
-    //        appCluster.getSpec().setIngress(builder.build());
-    //        IngressUtils.updateIngressRules(
-    //                appCluster.getMetadata(), appCluster.getSpec(), config, client);
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            ingress =
-    //                    client.network()
-    //                            .v1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        } else {
-    //            ingressV1beta1 =
-    //                    client.network()
-    //                            .v1beta1()
-    //                            .ingresses()
-    //                            .inNamespace(appCluster.getMetadata().getNamespace())
-    //                            .withName(appCluster.getMetadata().getName())
-    //                            .get();
-    //        }
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            tls = ingress.getSpec().getTls();
-    //        } else {
-    //            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
-    //        }
-    //        assertEquals(
-    //                2, IngressUtils.ingressInNetworkingV1(client) ? tls.size() :
-    // tlsV1beta1.size());
-    //        if (IngressUtils.ingressInNetworkingV1(client)) {
-    //            assertEquals("secret", tls.get(0).getSecretName());
-    //            assertEquals(2, tls.get(0).getHosts().size());
-    //            assertEquals("example.com", tls.get(0).getHosts().get(0));
-    //            assertEquals("example2.com", tls.get(0).getHosts().get(1));
-    //            assertEquals("secret2", tls.get(1).getSecretName());
-    //            assertEquals(2, tls.get(1).getHosts().size());
-    //            assertEquals("example3.com", tls.get(1).getHosts().get(0));
-    //            assertEquals("example4.com", tls.get(1).getHosts().get(1));
-    //        } else {
-    //            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
-    //            assertEquals(2, tlsV1beta1.get(0).getHosts().size());
-    //            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
-    //            assertEquals("example2.com", tlsV1beta1.get(0).getHosts().get(1));
-    //            assertEquals("secret2", tlsV1beta1.get(1).getSecretName());
-    //            assertEquals(2, tlsV1beta1.get(1).getHosts().size());
-    //            assertEquals("example3.com", tlsV1beta1.get(1).getHosts().get(0));
-    //            assertEquals("example4.com", tlsV1beta1.get(1).getHosts().get(1));
-    //        }
-    //    }
+    private FlinkResourceContext<?> createResourceContext(FlinkDeployment appCluster) {
+        // todo
+        return new FlinkDeploymentContext(appCluster, null, null, null, null, null);
+    }
+
+    @Test
+    void testIngress() {
+        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
+        Configuration config =
+                new FlinkConfigManager(new Configuration())
+                        .getDeployConfig(appCluster.getMetadata(), appCluster.getSpec());
+
+        // no ingress when ingressDomain is empty
+        IngressUtils.updateIngressRules(
+                createResourceContext(appCluster), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            assertNull(
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get());
+        } else {
+            assertNull(
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get());
+        }
+
+        // host based routing
+        IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
+        builder.template("{{name}}.{{namespace}}.example.com");
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                createResourceContext(appCluster), appCluster.getSpec(), config, client);
+        Ingress ingress = null;
+        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingressV1beta1 = null;
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+
+        List<IngressRule> rules = null;
+        List<io.fabric8.kubernetes.api.model.networking.v1beta1.IngressRule> rulesV1beta1 = null;
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            rules = ingress.getSpec().getRules();
+        } else {
+            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
+        }
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() : rulesV1beta1.size());
+        assertEquals(
+                appCluster.getMetadata().getName()
+                        + "."
+                        + appCluster.getMetadata().getNamespace()
+                        + ".example.com",
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? rules.get(0).getHost()
+                        : rulesV1beta1.get(0).getHost());
+        assertNull(
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
+                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
+
+        // path based routing
+        builder.template("/{{namespace}}/{{name}}(/|$)(.*)");
+        builder.className("nginx");
+        builder.annotations(Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                createResourceContext(appCluster), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+            rules = ingress.getSpec().getRules();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
+        }
+
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() : rulesV1beta1.size());
+        assertNull(
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? rules.get(0).getHost()
+                        : rulesV1beta1.get(0).getHost());
+        assertEquals(
+                1,
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? rules.get(0).getHttp().getPaths().size()
+                        : rulesV1beta1.get(0).getHttp().getPaths().size());
+        assertEquals(
+                "/"
+                        + appCluster.getMetadata().getNamespace()
+                        + "/"
+                        + appCluster.getMetadata().getName()
+                        + "(/|$)(.*)",
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
+                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
+        assertEquals(
+                Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"),
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? ingress.getMetadata().getAnnotations()
+                        : ingressV1beta1.getMetadata().getAnnotations());
+        assertEquals(
+                "nginx",
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? ingress.getSpec().getIngressClassName()
+                        : ingressV1beta1.getSpec().getIngressClassName());
+
+        // host + path based routing
+        builder.template("example.com/{{namespace}}/{{name}}(/|$)(.*)");
+        builder.className("nginx");
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                createResourceContext(appCluster), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+            rules = ingress.getSpec().getRules();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+            rulesV1beta1 = ingressV1beta1.getSpec().getRules();
+        }
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? rules.size() : rulesV1beta1.size());
+        assertEquals(
+                1,
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? rules.get(0).getHttp().getPaths().size()
+                        : rulesV1beta1.get(0).getHttp().getPaths().size());
+        assertEquals(
+                "/"
+                        + appCluster.getMetadata().getNamespace()
+                        + "/"
+                        + appCluster.getMetadata().getName()
+                        + "(/|$)(.*)",
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? rules.get(0).getHttp().getPaths().get(0).getPath()
+                        : rulesV1beta1.get(0).getHttp().getPaths().get(0).getPath());
+        assertEquals(
+                Map.of("nginx.ingress.kubernetes.io/rewrite-target", "/$2"),
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? ingress.getMetadata().getAnnotations()
+                        : ingressV1beta1.getMetadata().getAnnotations());
+        assertEquals(
+                "nginx",
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? ingress.getSpec().getIngressClassName()
+                        : ingressV1beta1.getSpec().getIngressClassName());
+    }
+
+    @Test
+    public void testIngressUrl() {
+        String template = "flink.k8s.io/{{namespace}}/{{name}}";
+        URL url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
+        assertEquals("flink.k8s.io", url.getHost());
+        assertEquals("/default/basic-ingress", url.getPath());
+
+        template = "/{{namespace}}/{{name}}";
+        url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
+        assertTrue(StringUtils.isBlank(url.getHost()));
+        assertEquals("/default/basic-ingress", url.getPath());
+
+        template = "{{name}}.{{namespace}}.flink.k8s.io";
+        url = IngressUtils.getIngressUrl(template, "basic-ingress", "default");
+
+        assertEquals("basic-ingress.default.flink.k8s.io", url.getHost());
+        assertTrue(StringUtils.isBlank(url.getPath()));
+
+        assertThrows(
+                ReconciliationException.class,
+                () -> IngressUtils.getIngressUrl("example.com:port", "basic-ingress", "default"));
+    }
+
+    @Test
+    public void testIngressTls() {
+        FlinkDeployment appCluster = TestUtils.buildApplicationCluster();
+        Configuration config =
+                new FlinkConfigManager(new Configuration())
+                        .getDeployConfig(appCluster.getMetadata(), appCluster.getSpec());
+
+        // no tls when tls spec is empty
+        IngressSpec.IngressSpecBuilder builder = IngressSpec.builder();
+        builder.template("{{name}}.{{namespace}}.example.com");
+        builder.tls(new ArrayList<>());
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                createResourceContext(appCluster), appCluster.getSpec(), config, client);
+        Ingress ingress = null;
+        io.fabric8.kubernetes.api.model.networking.v1beta1.Ingress ingressV1beta1 = null;
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        List<IngressTLS> tls = null;
+        List<io.fabric8.kubernetes.api.model.networking.v1beta1.IngressTLS> tlsV1beta1 = null;
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                0, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+
+        // no tls when hosts spec is empty
+        builder.template("{{name}}.{{namespace}}.example.com");
+        IngressTLS ingressTlsSpecSecretOnly = new IngressTLS();
+        ingressTlsSpecSecretOnly.setSecretName("secret");
+        builder.tls(List.of(ingressTlsSpecSecretOnly));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                createResourceContext(appCluster), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+        assertEquals(
+                "secret",
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? tls.get(0).getSecretName()
+                        : tlsV1beta1.get(0).getSecretName());
+
+        // tls with no secretName
+        builder.template("{{name}}.{{namespace}}.example.com");
+        IngressTLS ingressTlsSpecHostsOnly = new IngressTLS();
+        ingressTlsSpecHostsOnly.setHosts(List.of("example.com"));
+        builder.tls(List.of(ingressTlsSpecHostsOnly));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                createResourceContext(appCluster), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+        assertEquals(
+                "example.com",
+                IngressUtils.ingressInNetworkingV1(client)
+                        ? tls.get(0).getHosts().get(0)
+                        : tlsV1beta1.get(0).getHosts().get(0));
+
+        // tls with secretName and hosts
+        builder.template("{{name}}.{{namespace}}.example.com");
+        IngressTLS ingressTlsSpecSingleTLSWithHost =
+                new IngressTLS(List.of("example.com"), "secret");
+        builder.tls(List.of(ingressTlsSpecSingleTLSWithHost));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                createResourceContext(appCluster), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            assertEquals("secret", tls.get(0).getSecretName());
+            assertEquals(1, tls.get(0).getHosts().size());
+            assertEquals("example.com", tls.get(0).getHosts().get(0));
+        } else {
+            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
+            assertEquals(1, tlsV1beta1.get(0).getHosts().size());
+            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
+        }
+
+        // tls with secretName and multiple hosts
+        builder.template("{{name}}.{{namespace}}.example.com");
+        IngressTLS ingressTlsSpecSingleTLSWithHosts =
+                new IngressTLS(List.of("example.com", "example2.com"), "secret");
+        builder.tls(List.of(ingressTlsSpecSingleTLSWithHosts));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                createResourceContext(appCluster), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                1, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            assertEquals("secret", tls.get(0).getSecretName());
+            assertEquals(2, tls.get(0).getHosts().size());
+            assertEquals("example.com", tls.get(0).getHosts().get(0));
+            assertEquals("example2.com", tls.get(0).getHosts().get(1));
+        } else {
+            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
+            assertEquals(2, tlsV1beta1.get(0).getHosts().size());
+            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
+            assertEquals("example2.com", tlsV1beta1.get(0).getHosts().get(1));
+        }
+
+        // tls with secretName and multiple hosts and multiple tls
+        builder.template("{{name}}.{{namespace}}.example.com");
+        IngressTLS ingressTlsSpecMultipleTLSWithHosts1 =
+                new IngressTLS(List.of("example.com", "example2.com"), "secret");
+        IngressTLS ingressTlsSpecMultipleTLSWithHosts2 =
+                new IngressTLS(List.of("example3.com", "example4.com"), "secret2");
+        builder.tls(
+                List.of(ingressTlsSpecMultipleTLSWithHosts1, ingressTlsSpecMultipleTLSWithHosts2));
+        appCluster.getSpec().setIngress(builder.build());
+        IngressUtils.updateIngressRules(
+                createResourceContext(appCluster), appCluster.getSpec(), config, client);
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            ingress =
+                    client.network()
+                            .v1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        } else {
+            ingressV1beta1 =
+                    client.network()
+                            .v1beta1()
+                            .ingresses()
+                            .inNamespace(appCluster.getMetadata().getNamespace())
+                            .withName(appCluster.getMetadata().getName())
+                            .get();
+        }
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            tls = ingress.getSpec().getTls();
+        } else {
+            tlsV1beta1 = ingressV1beta1.getSpec().getTls();
+        }
+        assertEquals(
+                2, IngressUtils.ingressInNetworkingV1(client) ? tls.size() : tlsV1beta1.size());
+        if (IngressUtils.ingressInNetworkingV1(client)) {
+            assertEquals("secret", tls.get(0).getSecretName());
+            assertEquals(2, tls.get(0).getHosts().size());
+            assertEquals("example.com", tls.get(0).getHosts().get(0));
+            assertEquals("example2.com", tls.get(0).getHosts().get(1));
+            assertEquals("secret2", tls.get(1).getSecretName());
+            assertEquals(2, tls.get(1).getHosts().size());
+            assertEquals("example3.com", tls.get(1).getHosts().get(0));
+            assertEquals("example4.com", tls.get(1).getHosts().get(1));
+        } else {
+            assertEquals("secret", tlsV1beta1.get(0).getSecretName());
+            assertEquals(2, tlsV1beta1.get(0).getHosts().size());
+            assertEquals("example.com", tlsV1beta1.get(0).getHosts().get(0));
+            assertEquals("example2.com", tlsV1beta1.get(0).getHosts().get(1));
+            assertEquals("secret2", tlsV1beta1.get(1).getSecretName());
+            assertEquals(2, tlsV1beta1.get(1).getHosts().size());
+            assertEquals("example3.com", tlsV1beta1.get(1).getHosts().get(0));
+            assertEquals("example4.com", tlsV1beta1.get(1).getHosts().get(1));
+        }
+    }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/IngressUtilsTest.java
@@ -53,7 +53,8 @@ class IngressUtilsTest {
 
     private FlinkResourceContext<?> createResourceContext(FlinkDeployment appCluster) {
         // todo
-        return new FlinkDeploymentContext(appCluster, null, null, null, null, null);
+        return new FlinkDeploymentContext(
+                appCluster, new TestingJosdkContext<>(client, Map.of()), null, null, null, null);
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/TestingJosdkContext.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/TestingJosdkContext.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.IndexedResourceCache;
+import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ManagedWorkflowAndDependentResourceContext;
+import io.javaoperatorsdk.operator.processing.event.EventSourceRetriever;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * JOSDK Context for unit testing.
+ *
+ * @param <P>
+ */
+public class TestingJosdkContext<P extends HasMetadata> implements Context<P> {
+
+    private final KubernetesClient kubernetesClient;
+    private final Map<Class<?>, List<Object>> secondaryResources;
+
+    public TestingJosdkContext(
+            KubernetesClient kubernetesClient, Map<Class<?>, List<Object>> secondaryResources) {
+        this.kubernetesClient = kubernetesClient;
+        this.secondaryResources = secondaryResources;
+    }
+
+    @Override
+    public Optional<RetryInfo> getRetryInfo() {
+        return Optional.empty();
+    }
+
+    @Override
+    public <R> Set<R> getSecondaryResources(Class<R> expectedType) {
+        var res = secondaryResources.get(expectedType);
+        if (res == null) {
+            return Set.of();
+        }
+        return (Set<R>) Set.of(res);
+    }
+
+    @Override
+    public <R> Optional<R> getSecondaryResource(Class<R> expectedType, String eventSourceName) {
+        var resources = getSecondaryResources(expectedType);
+        if (resources.isEmpty()) {
+            return Optional.empty();
+        } else if (resources.size() == 1) {
+            return Optional.of(resources.iterator().next());
+        } else {
+            throw new IllegalStateException("Multiple secondary resources found: " + resources);
+        }
+    }
+
+    @Override
+    public ControllerConfiguration<P> getControllerConfiguration() {
+        return null;
+    }
+
+    @Override
+    public ManagedWorkflowAndDependentResourceContext managedWorkflowAndDependentResourceContext() {
+        return null;
+    }
+
+    @Override
+    public EventSourceRetriever<P> eventSourceRetriever() {
+        return null;
+    }
+
+    @Override
+    public KubernetesClient getClient() {
+        return null;
+    }
+
+    @Override
+    public ExecutorService getWorkflowExecutorService() {
+        return null;
+    }
+
+    @Override
+    public P getPrimaryResource() {
+        return null;
+    }
+
+    @Override
+    public IndexedResourceCache<P> getPrimaryCache() {
+        return null;
+    }
+
+    @Override
+    public boolean isNextReconciliationImminent() {
+        return false;
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/TestingJosdkContext.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/TestingJosdkContext.java
@@ -26,11 +26,14 @@ import io.javaoperatorsdk.operator.api.reconciler.IndexedResourceCache;
 import io.javaoperatorsdk.operator.api.reconciler.RetryInfo;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.managed.ManagedWorkflowAndDependentResourceContext;
 import io.javaoperatorsdk.operator.processing.event.EventSourceRetriever;
+import lombok.Setter;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -40,11 +43,21 @@ import java.util.concurrent.ExecutorService;
  */
 public class TestingJosdkContext<P extends HasMetadata> implements Context<P> {
 
-    private final KubernetesClient kubernetesClient;
-    private final Map<Class<?>, List<Object>> secondaryResources;
+    @Setter private KubernetesClient kubernetesClient;
+
+    @Setter
+    private Map<Class<? extends HasMetadata>, List<? extends HasMetadata>> secondaryResources =
+            new ConcurrentHashMap<>();
+
+    public TestingJosdkContext() {}
+
+    public TestingJosdkContext(KubernetesClient kubernetesClient) {
+        this.kubernetesClient = kubernetesClient;
+    }
 
     public TestingJosdkContext(
-            KubernetesClient kubernetesClient, Map<Class<?>, List<Object>> secondaryResources) {
+            KubernetesClient kubernetesClient,
+            Map<Class<? extends HasMetadata>, List<? extends HasMetadata>> secondaryResources) {
         this.kubernetesClient = kubernetesClient;
         this.secondaryResources = secondaryResources;
     }
@@ -60,7 +73,7 @@ public class TestingJosdkContext<P extends HasMetadata> implements Context<P> {
         if (res == null) {
             return Set.of();
         }
-        return (Set<R>) Set.of(res);
+        return (Set<R>) new HashSet<>(res);
     }
 
     @Override
@@ -92,7 +105,7 @@ public class TestingJosdkContext<P extends HasMetadata> implements Context<P> {
 
     @Override
     public KubernetesClient getClient() {
-        return null;
+        return kubernetesClient;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

In this alternative, ingress is bound to the CR, not to the job, for proper deletion of the added informer.

Note that this has a side effect, that if job is suspended, the ingress still will be present. What actually might not be a bad thing. (If the users intention is to resume the job)

There are cases where we might want to re-create, for example, in `className` changes. But we can take care of this if needed in a subsequent PR.


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:  no
  - Core observer or reconciler logic that is regularly executed: yes /

## Documentation

  - Does this pull request introduce a new feature?   no
  - If yes, how is the feature documented? not applicable
