### PR TITLE
[WIP][FLINK-37406] Add support for structured YAML config in FlinkDeployment CRD

### DIFF
--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -138,6 +138,13 @@ under the License.
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.operator.api.diff.DiffType;
 import org.apache.flink.kubernetes.operator.api.diff.Diffable;
 import org.apache.flink.kubernetes.operator.api.diff.SpecDiff;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -58,4 +59,6 @@ public abstract class AbstractFlinkSpec implements Diffable<AbstractFlinkSpec> {
                 mode = KubernetesDeploymentMode.NATIVE)
     })
     private Map<String, String> flinkConfiguration;
+
+    private JsonNode config;
 }

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/utils/SpecUtils.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/utils/SpecUtils.java
@@ -23,15 +23,29 @@ import org.apache.flink.kubernetes.operator.api.reconciler.ReconciliationMetadat
 import org.apache.flink.kubernetes.operator.api.spec.AbstractFlinkSpec;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.schema.CoreSchema;
 
 import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /** Spec utilities. */
 public class SpecUtils {
     public static final String INTERNAL_METADATA_JSON_KEY = "resource_metadata";
     private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper yamlObjectMapper = new ObjectMapper(new YAMLFactory());
+
+    private static final Load loader =
+            new Load(LoadSettings.builder().setSchema(new CoreSchema()).build());
 
     /**
      * Deserializes the spec and custom metadata object from JSON.
@@ -118,6 +132,45 @@ public class SpecUtils {
                             objectMapper.writeValueAsString(object), object.getClass());
         } catch (JsonProcessingException e) {
             throw new IllegalStateException(e);
+        }
+    }
+
+    public static void moveConfigToFlinkConfiguration(AbstractFlinkSpec abstractFlinkSpec) {
+        if (abstractFlinkSpec.getConfig() != null && !abstractFlinkSpec.getConfig().isEmpty()) {
+            var props = parseConfigToStringMap(abstractFlinkSpec.getConfig());
+            abstractFlinkSpec.setConfig(null);
+            if (abstractFlinkSpec.getFlinkConfiguration() == null) {
+                abstractFlinkSpec.setFlinkConfiguration(new HashMap<>(props));
+            } else {
+                abstractFlinkSpec.getFlinkConfiguration().putAll(props);
+            }
+        }
+    }
+
+    public static Map<String, String> parseConfigToStringMap(JsonNode node) {
+        Map<String, String> flatMap = new LinkedHashMap<>();
+        flattenHelper(node, "", flatMap);
+        return flatMap;
+    }
+
+    private static void flattenHelper(
+            JsonNode node, String parentKey, Map<String, String> flatMap) {
+        if (node.isObject()) {
+            Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> field = fields.next();
+                String newKey =
+                        parentKey.isEmpty() ? field.getKey() : parentKey + "." + field.getKey();
+                flattenHelper(field.getValue(), newKey, flatMap);
+            }
+        } else if (node.isArray()) {
+            for (int i = 0; i < node.size(); i++) {
+                String newKey = parentKey + "[" + i + "]";
+                flattenHelper(node.get(i), newKey, flatMap);
+            }
+        } else {
+            // Store values as strings
+            flatMap.put(parentKey, node.asText());
         }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
 import org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.api.utils.SpecUtils;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.kubernetes.operator.exception.UpgradeFailureException;
@@ -122,7 +123,7 @@ public class FlinkDeploymentController
     @Override
     public UpdateControl<FlinkDeployment> reconcile(FlinkDeployment flinkApp, Context josdkContext)
             throws Exception {
-
+        SpecUtils.moveConfigToFlinkConfiguration(flinkApp.getSpec());
         if (canaryResourceManager.handleCanaryResourceReconciliation(
                 flinkApp, josdkContext.getClient())) {
             return UpdateControl.noUpdate();
@@ -132,6 +133,8 @@ public class FlinkDeploymentController
 
         statusRecorder.updateStatusFromCache(flinkApp);
         FlinkDeployment previousDeployment = ReconciliationUtils.clone(flinkApp);
+        SpecUtils.moveConfigToFlinkConfiguration(previousDeployment.getSpec());
+
         var ctx = ctxFactory.getResourceContext(flinkApp, josdkContext);
 
         // If we get an unsupported Flink version, trigger event and exit

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -22,6 +22,7 @@ import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
 import org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState;
 import org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobStatus;
+import org.apache.flink.kubernetes.operator.api.utils.SpecUtils;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.kubernetes.operator.health.CanaryResourceManager;
 import org.apache.flink.kubernetes.operator.observer.Observer;
@@ -88,7 +89,7 @@ public class FlinkSessionJobController
     @Override
     public UpdateControl<FlinkSessionJob> reconcile(
             FlinkSessionJob flinkSessionJob, Context josdkContext) {
-
+        SpecUtils.moveConfigToFlinkConfiguration(flinkSessionJob.getSpec());
         if (canaryResourceManager.handleCanaryResourceReconciliation(
                 flinkSessionJob, josdkContext.getClient())) {
             return UpdateControl.noUpdate();
@@ -98,6 +99,7 @@ public class FlinkSessionJobController
 
         statusRecorder.updateStatusFromCache(flinkSessionJob);
         FlinkSessionJob previousJob = ReconciliationUtils.clone(flinkSessionJob);
+        SpecUtils.moveConfigToFlinkConfiguration(previousJob.getSpec());
         var ctx = ctxFactory.getResourceContext(flinkSessionJob, josdkContext);
 
         // If we get an unsupported Flink version, trigger event and exit

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -31,6 +31,8 @@ spec:
         properties:
           spec:
             properties:
+              config:
+                x-kubernetes-preserve-unknown-fields: true
               flinkConfiguration:
                 additionalProperties:
                   type: string

--- a/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinksessionjobs.flink.apache.org-v1.yml
@@ -31,6 +31,8 @@ spec:
         properties:
           spec:
             properties:
+              config:
+                x-kubernetes-preserve-unknown-fields: true
               deploymentName:
                 type: string
               flinkConfiguration:


### PR DESCRIPTION

## What is the purpose of the change

This change introduces `config` field for `FlinkDeployment` and `FlinkSessionJob` as an alternative to `flinkConfiguration`.  While `flinkConfiguration` accepts string key-value pairs, the new field accepts arbitrary yaml input, as defined in [flink configuration](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/config/#flink-configuration-file) documentation.

While this change allows adding values to both `flinkConfiguration` and `config`, if there is a value with same key the one from `config` will take precedence. However, it is the users resposibility to make sure that there are no overlapping keys, thus keys with deprecated names and with actual key names, in that case behavior is not deterministic. 

TODO: Flip

## Brief change log

- adds `config` to CRD
- backfills `flinkConfiguration` from `config` 

## Verifying this change

TODO describe tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes
  - Core observer or reconciler logic that is regularly executed: yes 

## Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented?  docs and JavaDocs (TODO)
