### PR TITLE
[FLINK-37391][docs] Improve documentation for dynamic namespace watching configuration

### DIFF
--- a/docs/content.zh/docs/operations/configuration.md
+++ b/docs/content.zh/docs/operations/configuration.md
@@ -86,6 +86,18 @@ Verify whether the config value of `kubernetes.operator.reconcile.interval` is u
 2022-05-28 13:08:30,115 o.a.f.k.o.c.FlinkConfigManager [INFO ] Updating default configuration to {kubernetes.operator.reconcile.interval=PT30S}
 ```
 
+### Example: Enabling Dynamic Namespace Watching
+
+To allow the operator to react to changes in the `watchNamespaces` list dynamically, i.e., without restarting its pod, you must set both of the following in your configuration:
+
+```yaml
+# 1. Enable the global dynamic configuration feature
+kubernetes.operator.dynamic.config.enabled: true
+
+# 2. Enable the specific feature for dynamic namespaces
+kubernetes.operator.dynamic.namespaces.enabled: true
+```
+
 ## Leader Election and High Availability
 
 The operator supports high availability through leader election and standby operator instances. To enable leader election you need to add the following two mandatory operator configuration parameters.

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -96,7 +96,7 @@
             <td><h5>kubernetes.operator.dynamic.namespaces.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Enables dynamic change of watched/monitored namespaces.</td>
+            <td>Enables the operator to dynamically update the list of namespaces it watches. Requires dynamic.config.enabled to be set to true.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.events.exceptions.limit-per-reconciliation</h5></td>

--- a/docs/layouts/shortcodes/generated/system_section.html
+++ b/docs/layouts/shortcodes/generated/system_section.html
@@ -12,7 +12,7 @@
             <td><h5>kubernetes.operator.dynamic.namespaces.enabled</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>Enables dynamic change of watched/monitored namespaces.</td>
+            <td>Enables the operator to dynamically update the list of namespaces it watches. Requires dynamic.config.enabled to be set to true.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.exception.field.max.length</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -404,7 +404,8 @@ public class KubernetesOperatorConfigOptions {
             operatorConfig("dynamic.namespaces.enabled")
                     .booleanType()
                     .defaultValue(false)
-                    .withDescription("Enables dynamic change of watched/monitored namespaces.");
+                    .withDescription(
+                            "Enables the operator to dynamically update the list of namespaces it watches. Requires dynamic.config.enabled to be set to true.");
 
     @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Duration> OPERATOR_RETRY_INITIAL_INTERVAL =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The current documentation for dynamic namespace watching configuration was unclear and led to users raising a couple of tickets - FLINK-37887, FLINK-37391. This PR clarifies the same.

## Brief change log

- Add example configuration for enabling dynamic namespace watching
- Clarify that dynamic.namespaces.enabled requires dynamic.config.enabled to be true

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
