### PR TITLE
[FLINK-37406] Update examples to use yaml based configs

### DIFF
--- a/examples/advanced-ingress.yaml
+++ b/examples/advanced-ingress.yaml
@@ -29,7 +29,7 @@ spec:
     annotations:
       nginx.ingress.kubernetes.io/rewrite-target: "/$2"
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    taskmanager.numberOfTaskSlots: 2
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/autoscaling/autoscaling-dynamic.yaml
+++ b/examples/autoscaling/autoscaling-dynamic.yaml
@@ -24,11 +24,12 @@ spec:
   image: autoscaling-example
   flinkVersion: v1_20
   flinkConfiguration:
-    job.autoscaler.enabled: "true"
-    job.autoscaler.stabilization.interval: "1m"
-    job.autoscaler.metrics.window: "15m"
-    job.autoscaler.utilization.target: "0.5"
-    job.autoscaler.target.utilization.boundary: "0.3"
+    job.autoscaler:
+      enabled: "true"
+      stabilization.interval: "1m"
+      metrics.window: "15m"
+      utilization.target: "0.5"
+      target.utilization.boundary: "0.3"
     pipeline.max-parallelism: "32"
     taskmanager.numberOfTaskSlots: "4"
   serviceAccount: flink

--- a/examples/autoscaling/autoscaling-dynamic.yaml
+++ b/examples/autoscaling/autoscaling-dynamic.yaml
@@ -25,13 +25,13 @@ spec:
   flinkVersion: v1_20
   flinkConfiguration:
     job.autoscaler:
-      enabled: "true"
-      stabilization.interval: "1m"
-      metrics.window: "15m"
-      utilization.target: "0.5"
-      target.utilization.boundary: "0.3"
-    pipeline.max-parallelism: "32"
-    taskmanager.numberOfTaskSlots: "4"
+      enabled: true
+      stabilization.interval: 1m
+      metrics.window: 15m
+      utilization.target: 0.5
+      target.utilization.boundary: 0.3
+    pipeline.max-parallelism: 32
+    taskmanager.numberOfTaskSlots: 4
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/autoscaling/autoscaling.yaml
+++ b/examples/autoscaling/autoscaling.yaml
@@ -24,18 +24,21 @@ spec:
   image: autoscaling-example
   flinkVersion: v1_20
   flinkConfiguration:
-    job.autoscaler.enabled: "true"
-    job.autoscaler.stabilization.interval: "1m"
-    job.autoscaler.metrics.window: "3m"
+    job.autoscaler:
+      enabled: "true"
+      stabilization.interval: "1m"
+      metrics.window: "3m"
+      target.utilization.boundary: "0.1"
     pipeline.max-parallelism: "24"
     taskmanager.numberOfTaskSlots: "4"
-    state.savepoints.dir: file:///flink-data/savepoints
-    state.checkpoints.dir: file:///flink-data/checkpoints
-    high-availability.type: kubernetes
-    high-availability.storageDir: file:///flink-data/ha
+    state:
+      savepoints.dir: file:///flink-data/savepoints
+      checkpoints.dir: file:///flink-data/checkpoints
+    high-availability:
+      type: kubernetes
+      storageDir: file:///flink-data/ha
     execution.checkpointing.interval: "1m"
     jobmanager.scheduler: adaptive
-    job.autoscaler.target.utilization.boundary: "0.1"
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/autoscaling/autoscaling.yaml
+++ b/examples/autoscaling/autoscaling.yaml
@@ -25,19 +25,19 @@ spec:
   flinkVersion: v1_20
   flinkConfiguration:
     job.autoscaler:
-      enabled: "true"
-      stabilization.interval: "1m"
-      metrics.window: "3m"
-      target.utilization.boundary: "0.1"
-    pipeline.max-parallelism: "24"
-    taskmanager.numberOfTaskSlots: "4"
+      enabled: true
+      stabilization.interval: 1m
+      metrics.window: 3m
+      target.utilization.boundary: 0.1
+    pipeline.max-parallelism: 24
+    taskmanager.numberOfTaskSlots: 4
     state:
       savepoints.dir: file:///flink-data/savepoints
       checkpoints.dir: file:///flink-data/checkpoints
     high-availability:
       type: kubernetes
       storageDir: file:///flink-data/ha
-    execution.checkpointing.interval: "1m"
+    execution.checkpointing.interval: 1m
     jobmanager.scheduler: adaptive
   serviceAccount: flink
   jobManager:

--- a/examples/basic-checkpoint-ha.yaml
+++ b/examples/basic-checkpoint-ha.yaml
@@ -25,10 +25,12 @@ spec:
   flinkVersion: v1_20
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
-    state.savepoints.dir: file:///flink-data/savepoints
-    state.checkpoints.dir: file:///flink-data/checkpoints
-    high-availability.type: kubernetes
-    high-availability.storageDir: file:///flink-data/ha
+    state:
+      savepoints.dir: file:///flink-data/savepoints
+      checkpoints.dir: file:///flink-data/checkpoints
+    high-availability:
+      type: kubernetes
+      storageDir: file:///flink-data/ha
     kubernetes.operator.savepoint.format.type: NATIVE
   serviceAccount: flink
   jobManager:

--- a/examples/basic-checkpoint-ha.yaml
+++ b/examples/basic-checkpoint-ha.yaml
@@ -24,7 +24,7 @@ spec:
   image: flink:1.20
   flinkVersion: v1_20
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    taskmanager.numberOfTaskSlots: 2
     state:
       savepoints.dir: file:///flink-data/savepoints
       checkpoints.dir: file:///flink-data/checkpoints

--- a/examples/basic-ingress.yaml
+++ b/examples/basic-ingress.yaml
@@ -26,7 +26,7 @@ spec:
   ingress:
     template: "{{name}}.{{namespace}}.flink.k8s.io"
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    taskmanager.numberOfTaskSlots: 2
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/basic-reactive.yaml
+++ b/examples/basic-reactive.yaml
@@ -25,7 +25,7 @@ spec:
   flinkVersion: v1_20
   flinkConfiguration:
     scheduler-mode: REACTIVE
-    taskmanager.numberOfTaskSlots: "2"
+    taskmanager.numberOfTaskSlots: 2
     state:
       savepoints.dir: file:///flink-data/savepoints
       checkpoints.dir: file:///flink-data/checkpoints

--- a/examples/basic-reactive.yaml
+++ b/examples/basic-reactive.yaml
@@ -26,10 +26,12 @@ spec:
   flinkConfiguration:
     scheduler-mode: REACTIVE
     taskmanager.numberOfTaskSlots: "2"
-    state.savepoints.dir: file:///flink-data/savepoints
-    state.checkpoints.dir: file:///flink-data/checkpoints
-    high-availability: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
-    high-availability.storageDir: file:///flink-data/ha
+    state:
+      savepoints.dir: file:///flink-data/savepoints
+      checkpoints.dir: file:///flink-data/checkpoints
+    high-availability:
+      type: org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory
+      storageDir: file:///flink-data/ha
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/basic-session-deployment-only.yaml
+++ b/examples/basic-session-deployment-only.yaml
@@ -24,7 +24,7 @@ spec:
   image: flink:1.20
   flinkVersion: v1_20
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    taskmanager.numberOfTaskSlots: 2
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/basic.yaml
+++ b/examples/basic.yaml
@@ -24,7 +24,7 @@ spec:
   image: flink:1.20
   flinkVersion: v1_20
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    taskmanager.numberOfTaskSlots: 2
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/custom-logging.yaml
+++ b/examples/custom-logging.yaml
@@ -24,7 +24,7 @@ spec:
   image: flink:1.20
   flinkVersion: v1_20
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    taskmanager.numberOfTaskSlots: 2
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/flink-beam-example/beam-example.yaml
+++ b/examples/flink-beam-example/beam-example.yaml
@@ -24,7 +24,7 @@ spec:
   image: flink-beam-example:latest
   flinkVersion: v1_19
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "1"
+    taskmanager.numberOfTaskSlots: 1
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/flink-python-example/python-example.yaml
+++ b/examples/flink-python-example/python-example.yaml
@@ -24,7 +24,7 @@ spec:
   image: flink-python-example:latest
   flinkVersion: v1_20
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "1"
+    taskmanager.numberOfTaskSlots: 1
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/flink-sql-runner-example/sql-example.yaml
+++ b/examples/flink-sql-runner-example/sql-example.yaml
@@ -24,7 +24,7 @@ spec:
   image: flink-sql-runner-example:latest
   flinkVersion: v1_20
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "1"
+    taskmanager.numberOfTaskSlots: 1
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/flink-tls-example/basic-secure-deployment-only.yaml
+++ b/examples/flink-tls-example/basic-secure-deployment-only.yaml
@@ -27,7 +27,7 @@ spec:
     taskmanager.numberOfTaskSlots: "2"
     security.ssl:
       internal:
-        enabled: 'true'
+        enabled: true
         keystore: /opt/flink/tls-cert/keystore.jks
         keystore-password: password1234
         truststore: /opt/flink/tls-cert/truststore.jks
@@ -40,7 +40,7 @@ spec:
         truststore: /opt/flink/tls-cert/truststore.jks
         key-password: password1234
         truststore-password: password1234
-    kubernetes.secrets: 'basic-secure-cert:/opt/flink/tls-cert'
+    kubernetes.secrets: basic-secure-cert:/opt/flink/tls-cert
   serviceAccount: flink
   jobManager:
     resource:

--- a/examples/flink-tls-example/basic-secure-deployment-only.yaml
+++ b/examples/flink-tls-example/basic-secure-deployment-only.yaml
@@ -25,18 +25,21 @@ spec:
   flinkVersion: v1_20
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
-    security.ssl.internal.enabled: 'true'
-    security.ssl.internal.keystore: /opt/flink/tls-cert/keystore.jks
-    security.ssl.internal.keystore-password: password1234
-    security.ssl.internal.truststore: /opt/flink/tls-cert/truststore.jks
-    security.ssl.internal.key-password: password1234
-    security.ssl.internal.truststore-password: password1234
-    security.ssl.rest.enabled: 'true'
-    security.ssl.rest.keystore: /opt/flink/tls-cert/keystore.jks
-    security.ssl.rest.keystore-password: password1234
-    security.ssl.rest.truststore: /opt/flink/tls-cert/truststore.jks
-    security.ssl.rest.key-password: password1234
-    security.ssl.rest.truststore-password: password1234
+    security.ssl:
+      internal:
+        enabled: 'true'
+        keystore: /opt/flink/tls-cert/keystore.jks
+        keystore-password: password1234
+        truststore: /opt/flink/tls-cert/truststore.jks
+        key-password: password1234
+        truststore-password: password1234
+      rest:
+        enabled: 'true'
+        keystore: /opt/flink/tls-cert/keystore.jks
+        keystore-password: password1234
+        truststore: /opt/flink/tls-cert/truststore.jks
+        key-password: password1234
+        truststore-password: password1234
     kubernetes.secrets: 'basic-secure-cert:/opt/flink/tls-cert'
   serviceAccount: flink
   jobManager:

--- a/examples/flink-tls-example/basic-secure-session-job-only.yaml
+++ b/examples/flink-tls-example/basic-secure-session-job-only.yaml
@@ -21,18 +21,21 @@ metadata:
   name: basic-secure-session-job-only
 spec:
   flinkConfiguration:
-    security.ssl.internal.enabled: 'true'
-    security.ssl.internal.keystore: /opt/flink/tls-cert/keystore.jks
-    security.ssl.internal.keystore-password: password1234
-    security.ssl.internal.truststore: /opt/flink/tls-cert/truststore.jks
-    security.ssl.internal.key-password: password1234
-    security.ssl.internal.truststore-password: password1234
-    security.ssl.rest.keystore: /opt/flink/tls-cert/keystore.jks
-    security.ssl.rest.truststore: /opt/flink/tls-cert/truststore.jks
-    security.ssl.rest.key-password: password1234
-    security.ssl.rest.truststore-password: password1234
-    security.ssl.rest.enabled: 'true'
-    security.ssl.rest.keystore-password: password1234
+    security.ssl:
+      internal:
+        enabled: 'true'
+        keystore: /opt/flink/tls-cert/keystore.jks
+        keystore-password: password1234
+        truststore: /opt/flink/tls-cert/truststore.jks
+        key-password: password1234
+        truststore-password: password1234
+      rest:
+        keystore: /opt/flink/tls-cert/keystore.jks
+        truststore: /opt/flink/tls-cert/truststore.jks
+        key-password: password1234
+        truststore-password: password1234
+        enabled: 'true'
+        keystore-password: password1234
     kubernetes.secrets: 'basic-secure-cert:/opt/flink/tls-cert'
   deploymentName: basic-secure-deployment-only
   job:

--- a/examples/flink-tls-example/basic-secure-session-job-only.yaml
+++ b/examples/flink-tls-example/basic-secure-session-job-only.yaml
@@ -23,7 +23,7 @@ spec:
   flinkConfiguration:
     security.ssl:
       internal:
-        enabled: 'true'
+        enabled: true
         keystore: /opt/flink/tls-cert/keystore.jks
         keystore-password: password1234
         truststore: /opt/flink/tls-cert/truststore.jks
@@ -34,9 +34,9 @@ spec:
         truststore: /opt/flink/tls-cert/truststore.jks
         key-password: password1234
         truststore-password: password1234
-        enabled: 'true'
+        enabled: true
         keystore-password: password1234
-    kubernetes.secrets: 'basic-secure-cert:/opt/flink/tls-cert'
+    kubernetes.secrets: basic-secure-cert:/opt/flink/tls-cert
   deploymentName: basic-secure-deployment-only
   job:
     jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.16.1/flink-examples-streaming_2.12-1.16.1-TopSpeedWindowing.jar

--- a/examples/flink-tls-example/basic-secure.yaml
+++ b/examples/flink-tls-example/basic-secure.yaml
@@ -25,12 +25,13 @@ spec:
   flinkVersion: v1_20
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "2"
-    security.ssl.enabled: 'true'
-    security.ssl.truststore: /opt/flink/tls-cert/truststore.jks
-    security.ssl.truststore-password: password1234
-    security.ssl.keystore: /opt/flink/tls-cert/keystore.jks
-    security.ssl.keystore-password: password1234
-    security.ssl.key-password: password1234
+    security.ssl:
+      enabled: 'true'
+      truststore: /opt/flink/tls-cert/truststore.jks
+      truststore-password: password1234
+      keystore: /opt/flink/tls-cert/keystore.jks
+      keystore-password: password1234
+      key-password: password1234
     kubernetes.secrets: 'basic-secure-cert:/opt/flink/tls-cert'
   serviceAccount: flink
   jobManager:

--- a/examples/flink-tls-example/basic-secure.yaml
+++ b/examples/flink-tls-example/basic-secure.yaml
@@ -24,7 +24,7 @@ spec:
   image: flink:1.20
   flinkVersion: v1_20
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    taskmanager.numberOfTaskSlots: 2
     security.ssl:
       enabled: 'true'
       truststore: /opt/flink/tls-cert/truststore.jks

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -24,7 +24,7 @@ spec:
   image: flink:1.20
   flinkVersion: v1_20
   flinkConfiguration:
-    taskmanager.numberOfTaskSlots: "2"
+    taskmanager.numberOfTaskSlots: 2
   serviceAccount: flink
   podTemplate:
     spec:

--- a/examples/snapshot/job-from-savepoint.yaml
+++ b/examples/snapshot/job-from-savepoint.yaml
@@ -37,8 +37,9 @@ spec:
   image: flink:1.20
   flinkVersion: v1_20
   flinkConfiguration:
-    state.checkpoints.dir: file:///flink-data/checkpoints
-    state.savepoints.dir: file:///flink-data/savepoints
+    state:
+      checkpoints.dir: file:///flink-data/checkpoints
+      savepoints.dir: file:///flink-data/savepoints
   serviceAccount: flink
   jobManager:
     resource:


### PR DESCRIPTION
## What is the purpose of the change

Update samples to use yaml based configs instead of key/value pairs

## Brief change log

Updates samples

Such change is already tested in e2e test in PR:
https://github.com/apache/flink-kubernetes-operator/pull/1013

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable 
