### PR TITLE
[FLINK-37406] Fix config array serialization

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,7 +23,6 @@ github:
     release-1.10: {}
     release-1.11: {}
     release-1.12: {}
-
 notifications:
   commits:      commits@flink.apache.org
   issues:       issues@flink.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,6 +23,7 @@ github:
     release-1.10: {}
     release-1.11: {}
     release-1.12: {}
+
 notifications:
   commits:      commits@flink.apache.org
   issues:       issues@flink.apache.org

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/spec/ConfigObjectNodeTest.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/spec/ConfigObjectNodeTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.api.spec;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigObjectNodeTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+    @BeforeEach
+    void setup() {
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(ConfigObjectNode.class, new ConfigObjectNodeDeserializer());
+        objectMapper.registerModule(module);
+    }
+
+    @Test
+    void deserializeArray() throws JsonProcessingException {
+        var value = "a: 1\n" + "b:\n" + " c: [1,2]";
+
+        var flatMap = objectMapper.readValue(value, ConfigObjectNode.class).asFlatMap();
+
+        assertThat(flatMap).containsExactlyInAnyOrderEntriesOf(Map.of("a", "1", "b.c", "1;2"));
+    }
+
+    @Test
+    void deserializeStringArray() throws JsonProcessingException {
+        var value = "a: 1\n" + "b:\n" + " c: [\"1\",\"2\"]";
+
+        var flatMap = objectMapper.readValue(value, ConfigObjectNode.class).asFlatMap();
+
+        assertThat(flatMap).containsExactlyInAnyOrderEntriesOf(Map.of("a", "1", "b.c", "1;2"));
+    }
+}


### PR DESCRIPTION

## What is the purpose of the change

Fixes serialization of array values:

```yaml
a: 1
b: 
  c: [1,2]
```

now becomes:

```
a: 1
b.c: 1;2
```
This change added tests;

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:  no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable