### PR TITLE
[FLINK-38148][FlinkService] Support Flink v1.17 when listing job exceptions

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
@@ -37,7 +37,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * Copied from Flink 2.0 to handle removed changes, with small modifications like: FLINK-38148 that
- * allows nullable `failureLabels` to support Flink v1.17
+ * allows nullable `failureLabels` to support Flink v1.17.
  */
 public class JobExceptionsInfoWithHistory implements ResponseBody {
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
@@ -35,7 +35,10 @@ import java.util.StringJoiner;
 import static org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
-/** Copied from Flink 2.0 to handle removed changes. */
+/**
+ * Copied from Flink 2.0 to handle removed changes, with small modifications like: FLINK-38148 that
+ * allows nullable `failureLabels` to support Flink v1.17
+ */
 public class JobExceptionsInfoWithHistory implements ResponseBody {
 
     public static final String FIELD_NAME_EXCEPTION_HISTORY = "exceptionHistory";
@@ -189,14 +192,15 @@ public class JobExceptionsInfoWithHistory implements ResponseBody {
                 @JsonProperty(FIELD_NAME_EXCEPTION_NAME) String exceptionName,
                 @JsonProperty(FIELD_NAME_EXCEPTION_STACKTRACE) String stacktrace,
                 @JsonProperty(FIELD_NAME_EXCEPTION_TIMESTAMP) long timestamp,
-                @JsonProperty(FIELD_NAME_FAILURE_LABELS) Map<String, String> failureLabels,
+                @JsonProperty(FIELD_NAME_FAILURE_LABELS) @Nullable
+                        Map<String, String> failureLabels,
                 @JsonProperty(FIELD_NAME_TASK_NAME) @Nullable String taskName,
                 @JsonProperty(FIELD_NAME_ENDPOINT) @Nullable String endpoint,
                 @JsonProperty(FIELD_NAME_TASK_MANAGER_ID) @Nullable String taskManagerId) {
             this.exceptionName = checkNotNull(exceptionName);
             this.stacktrace = checkNotNull(stacktrace);
             this.timestamp = timestamp;
-            this.failureLabels = checkNotNull(failureLabels);
+            this.failureLabels = failureLabels;
             this.taskName = taskName;
             this.endpoint = endpoint;
             this.taskManagerId = taskManagerId;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -112,6 +112,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -148,6 +149,7 @@ import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConf
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1318,32 +1320,47 @@ public class AbstractFlinkServiceTest {
 
     @Test
     public void listingJobExceptionsIsCompatibleWihFlinkV1_17Test() throws Exception {
-        JobExceptionsInfoWithHistory exceptionInfoWithNullFailureLabels =
-                new JobExceptionsInfoWithHistory(
-                        new JobExceptionsInfoWithHistory.JobExceptionHistory(
-                                java.util.Collections.singletonList(
-                                        new JobExceptionsInfoWithHistory.RootExceptionInfo(
-                                                "org.apache.flink.util.FlinkExpectedException",
-                                                "The TaskExecutor is shutting down.",
-                                                1755998006623L,
-                                                null,
-                                                "Source: Events Generator Source (2/2) - execution #0",
-                                                "10.244.0.105:44401",
-                                                "basic-example-taskmanager-1-1",
-                                                java.util.Collections.emptyList())),
-                                false));
-
+        var flinkV117JsonResponse =
+                "{\n"
+                        + "  \"root-exception\": \"org.apache.flink.util.FlinkExpectedException: The TaskExecutor is shutting down.\\n\\tat org.apache.flink.runtime.taskexecutor.TaskExecutor.onStop(TaskExecutor.java:476)\\n\\tat org.apache.flink.runtime.rpc.RpcEndpoint.internalCallOnStop(RpcEndpoint.java:239)\\n\\tat org.apache.flink.runtime.rpc.akka.AkkaRpcActor$StartedState.lambda$terminate$0(AkkaRpcActor.java:578)\\n\\tat org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.runWithContextClassLoader(ClassLoadingUtils.java:83)\\n\\tat org.apache.flink.runtime.rpc.akka.AkkaRpcActor$StartedState.terminate(AkkaRpcActor.java:577)\\n\\tat org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleControlMessage(AkkaRpcActor.java:196)\\n\\tat akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:24)\\n\\tat akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:20)\\n\\tat scala.PartialFunction.applyOrElse(PartialFunction.scala:127)\\n\\tat scala.PartialFunction.applyOrElse$(PartialFunction.scala:126)\\n\\tat akka.japi.pf.UnitCaseStatement.applyOrElse(CaseStatements.scala:20)\\n\\tat scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:175)\\n\\tat scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:176)\\n\\tat akka.actor.Actor.aroundReceive(Actor.scala:537)\\n\\tat akka.actor.Actor.aroundReceive$(Actor.scala:535)\\n\\tat akka.actor.AbstractActor.aroundReceive(AbstractActor.scala:220)\\n\\tat akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)\\n\\tat akka.actor.ActorCell.invoke(ActorCell.scala:547)\\n\\tat akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)\\n\\tat akka.dispatch.Mailbox.run(Mailbox.scala:231)\\n\\tat akka.dispatch.Mailbox.exec(Mailbox.scala:243)\\n\\tat java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)\\n\\tat java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)\\n\\tat java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)\\n\\tat java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)\\n\\tat java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)\\n\",\n"
+                        + "  \"timestamp\": 1755995361447,\n"
+                        + "  \"all-exceptions\": [],\n"
+                        + "  \"truncated\": false,\n"
+                        + "  \"exceptionHistory\": {\n"
+                        + "    \"entries\": [\n"
+                        + "      {\n"
+                        + "        \"exceptionName\": \"org.apache.flink.util.FlinkExpectedException\",\n"
+                        + "        \"stacktrace\": \"org.apache.flink.util.FlinkExpectedException: The TaskExecutor is shutting down.\\n\\tat org.apache.flink.runtime.taskexecutor.TaskExecutor.onStop(TaskExecutor.java:476)\\n\\tat org.apache.flink.runtime.rpc.RpcEndpoint.internalCallOnStop(RpcEndpoint.java:239)\\n\\tat org.apache.flink.runtime.rpc.akka.AkkaRpcActor$StartedState.lambda$terminate$0(AkkaRpcActor.java:578)\\n\\tat org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.runWithContextClassLoader(ClassLoadingUtils.java:83)\\n\\tat org.apache.flink.runtime.rpc.akka.AkkaRpcActor$StartedState.terminate(AkkaRpcActor.java:577)\\n\\tat org.apache.flink.runtime.rpc.akka.AkkaRpcActor.handleControlMessage(AkkaRpcActor.java:196)\\n\\tat akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:24)\\n\\tat akka.japi.pf.UnitCaseStatement.apply(CaseStatements.scala:20)\\n\\tat scala.PartialFunction.applyOrElse(PartialFunction.scala:127)\\n\\tat scala.PartialFunction.applyOrElse$(PartialFunction.scala:126)\\n\\tat akka.japi.pf.UnitCaseStatement.applyOrElse(CaseStatements.scala:20)\\n\\tat scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:175)\\n\\tat scala.PartialFunction$OrElse.applyOrElse(PartialFunction.scala:176)\\n\\tat akka.actor.Actor.aroundReceive(Actor.scala:537)\\n\\tat akka.actor.Actor.aroundReceive$(Actor.scala:535)\\n\\tat akka.actor.AbstractActor.aroundReceive(AbstractActor.scala:220)\\n\\tat akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)\\n\\tat akka.actor.ActorCell.invoke(ActorCell.scala:547)\\n\\tat akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)\\n\\tat akka.dispatch.Mailbox.run(Mailbox.scala:231)\\n\\tat akka.dispatch.Mailbox.exec(Mailbox.scala:243)\\n\\tat java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)\\n\\tat java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)\\n\\tat java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)\\n\\tat java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)\\n\\tat java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)\\n\",\n"
+                        + "        \"timestamp\": 1755995361447,\n"
+                        + "        \"taskName\": \"Source: Custom Source (2/2) - execution #0\",\n"
+                        + "        \"location\": \"10.244.0.93:37079\",\n"
+                        + "        \"taskManagerId\": \"basic-example-taskmanager-1-1\",\n"
+                        + "        \"concurrentExceptions\": []\n"
+                        + "      }\n"
+                        + "    ],\n"
+                        + "    \"truncated\": false\n"
+                        + "  }\n"
+                        + "}";
         var flinkService =
                 getTestingService(
                         (messageHeaders, messageParameters, requestBody) ->
                                 CompletableFuture.completedFuture(
-                                        exceptionInfoWithNullFailureLabels));
-        assertDoesNotThrow(
-                () ->
-                        flinkService.getJobExceptions(
-                                TestUtils.buildApplicationCluster(),
-                                new JobID(),
-                                new Configuration()));
+                                        parseExceptionsJsonResponse(flinkV117JsonResponse)));
+
+        var jobExceptions =
+                flinkService.getJobExceptions(
+                        TestUtils.buildApplicationCluster(), new JobID(), new Configuration());
+        assertNotNull(jobExceptions);
+        assertEquals(1, jobExceptions.getExceptionHistory().getEntries().size());
+    }
+
+    @SneakyThrows
+    private static JobExceptionsInfoWithHistory parseExceptionsJsonResponse(
+            String flinkV117JsonResponse) {
+        var jsonNode = RestMapperUtils.getStrictObjectMapper().readTree(flinkV117JsonResponse);
+        var jsonParser = RestMapperUtils.getStrictObjectMapper().treeAsTokens(jsonNode);
+        return RestMapperUtils.getFlexibleObjectMapper()
+                .readValue(jsonParser, JobExceptionsInfoWithHistory.class);
     }
 
     class TestingService extends AbstractFlinkService {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR adds fixes compatibility issue when listing exceptions for Flink v.1.17 jobs


## Brief change log

- Allow nullable `failureLabels` in `JobExceptionsInfoWithHistory`

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->

This change added tests and can be verified as follows:
- Added additional unit test in `AbstractFlinkServiceTest` that simulates Flink v1.17 API response

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
