### PR TITLE
[FLINK-38285] Allow to override config options with environment variables

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -473,14 +473,9 @@ public class FlinkConfigManager {
         envVars.forEach(
                 (k, v) -> {
                     if (k.startsWith(ENV_VAR_PREFIX)) {
-                        res.setString(envVarToKey(k), envVarValueToValue(v));
+                        res.setString(envVarToKey(k), v);
                     }
                 });
-    }
-
-    @VisibleForTesting
-    static String envVarValueToValue(String v) {
-        return v.replace("_", " ");
     }
 
     @VisibleForTesting

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -53,6 +53,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_WATCHED_NAMESPACES;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -427,5 +428,19 @@ public class FlinkConfigManagerTest {
         assertTrue(completed1.get());
         assertTrue(completed2.get());
         assertTrue(completed3.get());
+    }
+
+    @Test
+    void envVarToFlinkConfig() {
+        assertThat(
+                        FlinkConfigManager.envVarToKey(
+                                "FLINK_CONF_RESTART__STRATEGY_FAILURE__RATE_DELAY"))
+                .isEqualTo("restart-strategy.failure-rate.delay");
+    }
+
+    @Test
+    void envVarValueToFlinkConfigValue() {
+        assertThat(FlinkConfigManager.envVarValueToValue("1")).isEqualTo("1");
+        assertThat(FlinkConfigManager.envVarValueToValue("1_m")).isEqualTo("1 m");
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManagerTest.java
@@ -437,10 +437,4 @@ public class FlinkConfigManagerTest {
                                 "FLINK_CONF_RESTART__STRATEGY_FAILURE__RATE_DELAY"))
                 .isEqualTo("restart-strategy.failure-rate.delay");
     }
-
-    @Test
-    void envVarValueToFlinkConfigValue() {
-        assertThat(FlinkConfigManager.envVarValueToValue("1")).isEqualTo("1");
-        assertThat(FlinkConfigManager.envVarValueToValue("1_m")).isEqualTo("1 m");
-    }
 }

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -147,7 +147,7 @@ operatorSecurityContext: {}
 webhookSecurityContext: {}
 
 webhook:
-  create: false
+  create: true
   # validator:
   #   create: true
   # mutator:

--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -147,7 +147,7 @@ operatorSecurityContext: {}
 webhookSecurityContext: {}
 
 webhook:
-  create: true
+  create: false
   # validator:
   #   create: true
   # mutator:


### PR DESCRIPTION

## What is the purpose of the change

Allow to override config options with environment variables


## Brief change log

*(for example:)*
  - *Periodic savepoint trigger is introduced to the custom resource*
  - *The operator checks on reconciliation whether the required time has passed*
  - *The JobManager's dispose savepoint API is used to clean up obsolete savepoints*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed:  no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  docs 
