### PR TITLE
Express is values.yaml that config.yaml can be used

### DIFF
--- a/helm/flink-kubernetes-operator/values.yaml
+++ b/helm/flink-kubernetes-operator/values.yaml
@@ -169,6 +169,16 @@ defaultConfiguration:
   # If set to false, loads just the overrides as in (2).
   # This option has not effect, if create is equal to false.
   append: true
+
+#  Uncomment to use the new config.yaml format, but also comment out the flink-config.yaml key.
+#  config.yaml:
+#    kubernetes.operator:
+#      metrics.reporter.slf4j:
+#        factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory
+#        interval: 5 MINUTE
+#      reconcile.interval: 15 s
+#      observer.progress-check.interval: 5 s
+
   flink-conf.yaml: |+
     # Flink Config Overrides
     kubernetes.operator.metrics.reporter.slf4j.factory.class: org.apache.flink.metrics.slf4j.Slf4jReporterFactory


### PR DESCRIPTION

## What is the purpose of the change

Add an commented out section to helm `values.yaml` that showcases how to use `config.yaml` instead of `flink-conf.yaml`.


## Verifying this change

The underlying mechanism was already implemented before, was just hard to find.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
