### PR TITLE
[FLINK-38293] Update Checkstyle version and related rules in Kubernetes Operator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.6.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -282,14 +282,6 @@ under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.6.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.puppycrawl.tools</groupId>
-                        <artifactId>checkstyle</artifactId>
-                        <!-- Note: match version with docs/flinkDev/ide_setup.md -->
-                        <version>10.17.0</version>
-                    </dependency>
-                </dependencies>
                 <executions>
                     <execution>
                         <id>validate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -281,13 +281,13 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.4.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
                         <!-- Note: match version with docs/flinkDev/ide_setup.md -->
-                        <version>8.14</version>
+                        <version>10.17.0</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -276,23 +276,15 @@ This file is based on the checkstyle file of Apache Beam.
 		<!-- Checks for Javadoc comments.                     -->
 		<!-- See http://checkstyle.sf.net/config_javadoc.html -->
 		<module name="JavadocMethod">
-			<property name="scope" value="protected"/>
 			<property name="severity" value="error"/>
-			<property name="allowMissingJavadoc" value="true"/>
 			<property name="allowMissingParamTags" value="true"/>
 			<property name="allowMissingReturnTag" value="true"/>
-			<property name="allowMissingThrowsTags" value="true"/>
-			<property name="allowThrowsTagsForSubclasses" value="true"/>
-			<property name="allowUndeclaredRTE" value="true"/>
-			<!-- This check sometimes failed for with "Unable to get class information for @throws tag" for custom exceptions -->
-			<property name="suppressLoadErrors" value="true"/>
 		</module>
 
 		<!-- Check that paragraph tags are used correctly in Javadoc. -->
 		<module name="JavadocParagraph"/>
 
 		<module name="JavadocType">
-			<property name="scope" value="protected"/>
 			<property name="severity" value="error"/>
 			<property name="allowMissingParamTags" value="true"/>
 		</module>

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -285,6 +285,7 @@ This file is based on the checkstyle file of Apache Beam.
 		<module name="JavadocParagraph"/>
 
 		<module name="JavadocType">
+			<property name="scope" value="protected"/>
 			<property name="severity" value="error"/>
 			<property name="allowMissingParamTags" value="true"/>
 		</module>


### PR DESCRIPTION
## What is the purpose of the change

Update checkstyle so it supports newer Java language features like text blocks, etc.

## Brief change log

Updated checkstyle maven plugin and related rules.

## Verifying this change

Run the build, it passes. Try to use a text block in a unit test for exmaple, now passes the build, unlike before.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes 
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
