### PR TITLE
[hotfix][docs] Pull request to update documentation for Flink 2.0 support.

### DIFF
--- a/docs/content.zh/docs/concepts/overview.md
+++ b/docs/content.zh/docs/concepts/overview.md
@@ -44,7 +44,7 @@ Flink Kubernetes Operator 旨在承担人工操作 Flink 部署的职责。 人�
   - 有状态和无状态应用程序升级
   - 保存点的触发和管理
   - 处理错误，回滚失败的升级
-- 多 Flink 版本支持：v1.16, v1.17, v1.18, v1.19, v1.20
+- 多 Flink 版本支持：v1.16, v1.17, v1.18, v1.19, v1.20, v2.0
 - [Deployment Modes]({{< ref "docs/custom-resource/overview#application-deployments" >}}):
   - Application 集群
   - Session 集群

--- a/docs/content/docs/concepts/overview.md
+++ b/docs/content/docs/concepts/overview.md
@@ -36,7 +36,7 @@ Flink Kubernetes Operator aims to capture the responsibilities of a human operat
   - Stateful and stateless application upgrades
   - Triggering and managing savepoints
   - Handling errors, rolling-back broken upgrades
-- Multiple Flink version support: v1.16, v1.17, v1.18, v1.19, v1.20
+- Multiple Flink version support: v1.16, v1.17, v1.18, v1.19, v1.20, v2.0
 - [Deployment Modes]({{< ref "docs/custom-resource/overview#application-deployments" >}}):
   - Application cluster
   - Session cluster


### PR DESCRIPTION

  

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.


## What is the purpose of the change

*In Flink Kubernetes Operator version 1.12, the contents overview does not specify support for Flink 2.0. Therefore, I have added v2_0 to the doc files at the following two paths.*

* /flink-kubernetes-operator/docs/content/docs/concepts/overview.md
* /flink-kubernetes-operator/docs/content.zh/docs/concepts/overview.md

## Brief change log

<img width="2510" height="1858" alt="image" src="https://github.com/user-attachments/assets/48b8b2b0-f0b1-4922-9def-0ded8756c6b6" />
> when playing 2.1 version error message

<img width="2010" height="1328" alt="image" src="https://github.com/user-attachments/assets/777be448-8214-4526-9ed5-41fa40b20855" />
> flink kubernetes operator 1.12 spec  FlinkVersion code 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`:  no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
