### PR TITLE
upgrade maven-shade-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,6 +443,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.1</version>
                 <configuration>
                     <transformers combine.children="append">
                         <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />


### PR DESCRIPTION
should fix remaining Reproducible Builds issues on 2 shaded files found for release 1.13.0
https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/flink/flink-kubernetes-operator/README.md