### PR TITLE
[FLINK-38466] Bump derby from 10.15.2.0 to 10.17.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@ under the License.
 		     of entries in the form '[-]{2}add-[opens|exports]=<module>/<package>=ALL-UNNAMED'.-->
         <surefire.module.config/>
 
-        <derby.version>10.15.2.0</derby.version>
+        <derby.version>10.17.1.0</derby.version>
         <awaitility.version>4.2.2</awaitility.version>
 
         <!-- valid options can be checked at https://central.sonatype.com/search?q=kubernetes-httpclient- currently: okhttp, jdk, jetty, vertx -->


### PR DESCRIPTION
## What is the purpose of the change

Bump derby version to 10.17.1.0

## Brief change log

The current version 10.15.2.0 has a direct vulnerability - [CVE Record: CVE-2022-46337](https://www.cve.org/CVERecord?id=CVE-2022-46337).
To remediate this, we can upgrade this package to latest 10.17.1.0

**Current** - [Maven Repository: org.apache.derby » derby » 10.15.2.0](https://mvnrepository.com/artifact/org.apache.derby/derby/10.15.2.0)

**Latest** - [Maven Repository: org.apache.derby » derby » 10.17.1.0](https://mvnrepository.com/artifact/org.apache.derby/derby/10.17.1.0)

FYI:
The derby [release notes](https://db.apache.org/derby/releases/release-10_17_1_0.cgi#:~:text=10.17%20does%20NOT%20support%20Java%20releases%20prior%20to%20Java%20SE%2021.) mentioned that the support for java versions earlier than 21 were removed.
But the scope for derby is mainly for the Integration tests. I've run the tests in local and the build is successful.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable