### PR TITLE
[FLINK-39165] Prevent concurrent FlinkSessionJob / FlinkDeployment update

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -71,16 +71,12 @@ public class SessionReconciler
         if (!Objects.equals(
                 deployment.getMetadata().getGeneration(),
                 deployment.getStatus().getObservedGeneration())) {
-            boolean hasUpgradingSessionJob =
+            var deploymentName = deployment.getMetadata().getName();
+            boolean hasTransitioningSessionJob =
                     ctx.getJosdkContext().getSecondaryResources(FlinkSessionJob.class).stream()
-                            .filter(
-                                    job ->
-                                            deployment
-                                                    .getMetadata()
-                                                    .getName()
-                                                    .equals(job.getSpec().getDeploymentName()))
+                            .filter(job -> deploymentName.equals(job.getSpec().getDeploymentName()))
                             .anyMatch(SessionReconciler::isSessionJobTransitioning);
-            if (hasUpgradingSessionJob) {
+            if (hasTransitioningSessionJob) {
                 LOG.info(
                         "Deferring session cluster upgrade: associated session jobs are being upgraded");
                 return false;

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -27,6 +27,7 @@ import org.apache.flink.kubernetes.operator.api.diff.DiffType;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkDeploymentSpec;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
@@ -42,6 +43,7 @@ import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -64,7 +66,40 @@ public class SessionReconciler
 
     @Override
     protected boolean readyToReconcile(FlinkResourceContext<FlinkDeployment> ctx) {
+        var deployment = ctx.getResource();
+        // Only check when there is a pending spec change on the deployment itself
+        if (!Objects.equals(
+                deployment.getMetadata().getGeneration(),
+                deployment.getStatus().getObservedGeneration())) {
+            boolean hasUpgradingSessionJob =
+                    ctx.getJosdkContext().getSecondaryResources(FlinkSessionJob.class).stream()
+                            .filter(
+                                    job ->
+                                            deployment
+                                                    .getMetadata()
+                                                    .getName()
+                                                    .equals(job.getSpec().getDeploymentName()))
+                            .anyMatch(SessionReconciler::isSessionJobTransitioning);
+            if (hasUpgradingSessionJob) {
+                LOG.info(
+                        "Deferring session cluster upgrade: associated session jobs are being upgraded");
+                return false;
+            }
+        }
         return true;
+    }
+
+    private static boolean isSessionJobTransitioning(FlinkSessionJob job) {
+        var reconStatus = job.getStatus().getReconciliationStatus();
+        // New session jobs state is UPGRADING by default before first deployment. Treating them as
+        // transitioning would deadlock: the deployment can't
+        // start because it waits for the job, and the job can't start because it waits for the
+        // cluster.
+        if (reconStatus.isBeforeFirstDeployment()) {
+            return false;
+        }
+        var state = reconStatus.getState();
+        return state == ReconciliationState.UPGRADING || state == ReconciliationState.ROLLING_BACK;
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -27,6 +27,7 @@ import org.apache.flink.kubernetes.operator.api.spec.FlinkSessionJobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.autoscaler.KubernetesJobAutoScalerContext;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
@@ -43,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
+import java.util.Objects;
 import java.util.Optional;
 
 /** The reconciler for the {@link FlinkSessionJob}. */
@@ -186,9 +188,33 @@ public class SessionJobReconciler
                         "Session cluster deployment is in {} status, not ready for serve",
                         jobmanagerDeploymentStatus);
                 return false;
-            } else {
-                return true;
             }
+
+            // Block while FlinkDeployment is in reconciliation state
+            var reconciliationState = flinkdep.getStatus().getReconciliationStatus().getState();
+            if (reconciliationState != ReconciliationState.DEPLOYED
+                    && reconciliationState != ReconciliationState.ROLLED_BACK) {
+                LOG.info(
+                        "Session cluster deployment reconciliation state is {}, not ready for sync",
+                        reconciliationState);
+                return false;
+            }
+
+            // Block while a FlinkDeployment spec change is pending. This make sure that
+            // FlinkSessionJob updates will be
+            // applied only after all changes for this generation got applied
+            if (!Objects.equals(
+                    flinkdep.getMetadata().getGeneration(),
+                    flinkdep.getStatus().getObservedGeneration())) {
+                LOG.info(
+                        "Session cluster deployment has pending spec changes "
+                                + "(generation={}, observedGeneration={}), not ready for sync",
+                        flinkdep.getMetadata().getGeneration(),
+                        flinkdep.getStatus().getObservedGeneration());
+                return false;
+            }
+
+            return true;
         } else {
             LOG.warn("Session cluster deployment is not found");
             return false;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.kubernetes.operator.api.spec.FlinkSessionJobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobStatus;
+import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobStatus;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType;
@@ -40,8 +41,10 @@ import org.apache.flink.kubernetes.operator.service.SuspendMode;
 import org.apache.flink.kubernetes.operator.utils.SnapshotUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
 import lombok.Getter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -54,6 +57,7 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
@@ -860,5 +864,135 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
                 sessionJob.getStatus().getReconciliationStatus().getState());
         // New jobID recorded despite failure
         Assertions.assertNotEquals(jobID, sessionJob.getStatus().getJobStatus().getJobId());
+    }
+
+    @Test
+    public void testSessionClusterNotReadyWhenUpgrading() throws Exception {
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+
+        // Create a context where the deployment is JM=READY but reconciliation state=UPGRADING
+        Context<HasMetadata> upgradingContext =
+                new TestUtils.TestingContext<>() {
+                    @Override
+                    public Optional<HasMetadata> getSecondaryResource(
+                            Class expectedType, String eventSourceName) {
+                        var session = TestUtils.buildSessionCluster();
+                        session.getStatus()
+                                .setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+                        session.getStatus()
+                                .getReconciliationStatus()
+                                .serializeAndSetLastReconciledSpec(session.getSpec(), session);
+                        // Leave state as UPGRADING (the default)
+                        return Optional.of(session);
+                    }
+
+                    @Override
+                    public KubernetesClient getClient() {
+                        return kubernetesClient;
+                    }
+                };
+
+        reconciler.reconcile(sessionJob, upgradingContext);
+        assertEquals(0, flinkService.listJobs().size());
+    }
+
+    @Test
+    public void testSessionClusterNotReadyWhenGenerationMismatch() throws Exception {
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+
+        // Create a context where JM=READY, state=DEPLOYED, but generation != observedGeneration
+        Context<HasMetadata> mismatchContext =
+                new TestUtils.TestingContext<>() {
+                    @Override
+                    public Optional<HasMetadata> getSecondaryResource(
+                            Class expectedType, String eventSourceName) {
+                        var session = TestUtils.buildSessionCluster();
+                        session.getStatus()
+                                .setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+                        session.getStatus()
+                                .getReconciliationStatus()
+                                .serializeAndSetLastReconciledSpec(session.getSpec(), session);
+                        session.getStatus()
+                                .getReconciliationStatus()
+                                .setState(ReconciliationState.DEPLOYED);
+                        // Simulate a pending spec change: bump generation
+                        session.getMetadata().setGeneration(2L);
+                        return Optional.of(session);
+                    }
+
+                    @Override
+                    public KubernetesClient getClient() {
+                        return kubernetesClient;
+                    }
+                };
+
+        reconciler.reconcile(sessionJob, mismatchContext);
+        assertEquals(0, flinkService.listJobs().size());
+    }
+
+    @Test
+    public void testSessionClusterReadyWhenRolledBack() throws Exception {
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+
+        // Create a context where JM=READY, state=ROLLED_BACK, generation matches
+        Context<HasMetadata> rolledBackContext =
+                new TestUtils.TestingContext<>() {
+                    @Override
+                    public Optional<HasMetadata> getSecondaryResource(
+                            Class expectedType, String eventSourceName) {
+                        var session = TestUtils.buildSessionCluster();
+                        session.getStatus()
+                                .setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+                        session.getStatus()
+                                .getReconciliationStatus()
+                                .serializeAndSetLastReconciledSpec(session.getSpec(), session);
+                        session.getStatus().getReconciliationStatus().markReconciledSpecAsStable();
+                        session.getStatus()
+                                .getReconciliationStatus()
+                                .setState(ReconciliationState.ROLLED_BACK);
+                        return Optional.of(session);
+                    }
+
+                    @Override
+                    public KubernetesClient getClient() {
+                        return kubernetesClient;
+                    }
+                };
+
+        reconciler.reconcile(sessionJob, rolledBackContext);
+        assertEquals(1, flinkService.listJobs().size());
+    }
+
+    @Test
+    public void testSessionClusterReadyWhenDeployed() throws Exception {
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+
+        // Create a context where JM=READY, state=DEPLOYED, generation matches
+        Context<HasMetadata> rolledBackContext =
+                new TestUtils.TestingContext<>() {
+                    @Override
+                    public Optional<HasMetadata> getSecondaryResource(
+                            Class expectedType, String eventSourceName) {
+                        var session = TestUtils.buildSessionCluster();
+                        session.getStatus()
+                                .setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+                        session.getStatus()
+                                .getReconciliationStatus()
+                                .serializeAndSetLastReconciledSpec(session.getSpec(), session);
+                        session.getStatus().getReconciliationStatus().markReconciledSpecAsStable();
+                        session.getStatus()
+                                .getReconciliationStatus()
+                                .setState(ReconciliationState.DEPLOYED);
+                        return Optional.of(session);
+                    }
+
+                    @Override
+                    public KubernetesClient getClient() {
+                        return kubernetesClient;
+                    }
+                };
+
+        reconciler.reconcile(sessionJob, rolledBackContext);
+        assertEquals(1, flinkService.listJobs().size());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change                                                                                                                                                                                       
https://issues.apache.org/jira/browse/FLINK-39165
                                                                                                                                           
When a user updates both a `FlinkDeployment` (session cluster) and its `FlinkSessionJob `at the same time, both resources get reconciled concurrently. The deployment deletes and recreates the cluster while the session job tries to take a savepoint and resubmit, at some point job will be "lost" and "Job Not Found error", or submitted several times

## Brief change log

- `SessionJobReconciler.sessionClusterReady()`: Added reconciliation state check on top of the existing JM READY check, state must be `DEPLOYED` or `ROLLED_BACK`
- `SessionJobReconciler.noDeploymentChangesPending()`: New method called only from `readyToReconcile()`. Blocks when `metadata.generation != status.observedGeneration`, meaning a deployment spec change is pending but the reconciler hasn't picked it up yet. This is separated from `sessionClusterReady()` so it does not affect cleanup path.
- `SessionReconciler.readyToReconcile()`: When the deployment has a pending spec change, checks if any of its session jobs are mid-upgrade (`UPGRADING` or `ROLLING_BACK`). If so, waits for them to finish before updating the cluster. Session jobs that haven't been deployed yet are skipped to avoid a deadlock where the cluster waits for the job and the job waits for the cluster.

## Verifying this change
Added a few unit tests, as well as tested manually: deployed a session cluster with a session job and HA enabled, changed both specs at the same time, confirmed the session job waited for the cluster to finish upgrading and then upgraded itself with a savepoint on the new stable cluster. Checked that deletion is working as expected as well.

### Test Scenario:
1 session cluster `FlinkDeployment` and 3 `FlinkSessionJob`-s

1. New deployment (first time using `helm install`).  Logs: https://pastebin.com/HutrD3F2
2. Concurrent update. E.g. bumped `restartNonce` for all `FlinkSessionJob` and `FlinkDeployment`
(via `helm upgrade`). Logs: https://pastebin.com/xuPdS8kQ
3. Deletion (e.g. `helm uninstall`), all jobs were deleted in correct order, first `FlinkSessionJobs`, then `FlinkDeployment`: https://pastebin.com/GyuPnwg0


## Does this pull request potentially affect one of the following parts

- Dependencies: no
- The public API, i.e., is any changes to the CustomResourceDescriptors: no
- Core observer or reconciler logic that is regularly executed: yes. `sessionClusterReady()` runs on every session job reconciliation and `readyToReconcile()` runs on every session deployment reconciliation. The session job lookup on the deployment side only happens when the deployment has a pending spec change.

## Documentation
Does this pull request introduce a new feature? no