### PR TITLE
Clear stale savepointTriggerId on B/G transition abort

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -685,6 +685,7 @@ public class BlueGreenDeploymentService {
         FlinkBlueGreenDeploymentState previousState =
                 getPreviousState(nextState, context.getDeployments());
         context.getDeploymentStatus().setBlueGreenState(previousState);
+        context.getDeploymentStatus().setSavepointTriggerId(null);
 
         var error =
                 String.format(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -546,6 +546,9 @@ public class FlinkBlueGreenDeploymentControllerTest {
                 ReconciliationState.UPGRADING,
                 flinkDeployments.get(1).getStatus().getReconciliationStatus().getState());
         assertTrue(instantStrToMillis(rs.reconciledStatus.getAbortTimestamp()) > 0);
+        // savepointTriggerId must be cleared on abort so the next transition
+        // triggers a fresh savepoint instead of reusing a stale triggerId
+        assertNull(rs.reconciledStatus.getSavepointTriggerId());
 
         // Simulate another change in the spec to trigger a redeployment
         customValue = UUID.randomUUID().toString();


### PR DESCRIPTION
This is a bug fix that has prevented subsequent transitions to B/G from previous jobs aborting

## Summary
- Clear `savepointTriggerId` from B/G CR status in `abortDeployment()` so subsequent transition attempts trigger a fresh savepoint instead of reusing a stale triggerId
- The triggerId is tracked by the Flink CheckpointCoordinator for a specific job execution — if the job restarts (e.g. TM OOM), the new execution's CheckpointCoordinator won't know about it, causing `configureInitialSavepoint()` to fail with "Could not fetch savepoint with triggerId"
- Add assertion in `verifyFailureDuringTransition` test confirming triggerId is null after abort

## Test plan
- [x] `verifyFailureDuringTransition` passes with new assertion