### PR TITLE
[hotfix][autoscaler] Cover ScalingRealizer overrides with tests

### DIFF
--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.autoscaler;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.event.TestingEventCollector;
 import org.apache.flink.autoscaler.exceptions.NotReadyException;
@@ -293,6 +294,12 @@ public class JobAutoScalerImplTest {
         autoscaler.scale(context);
         assertParallelismOverrides(Map.of(v1, "1", v2, "2"));
 
+        // Test job not running: overrides must still be re-projected onto the spec so that an
+        // in-flight upgrade does not regress the autoscaler's last decision (self-heal).
+        var notRunningContext = context.toBuilder().jobStatus(JobStatus.INITIALIZING).build();
+        autoscaler.scale(notRunningContext);
+        assertParallelismOverrides(Map.of(v1, "1", v2, "2"));
+
         // Make sure cleanup removes everything
         assertTrue(stateStore.hasDataFor(context));
         autoscaler.cleanup(context);
@@ -352,6 +359,55 @@ public class JobAutoScalerImplTest {
     }
 
     @Test
+    void testOverridesAreReappliedWhenJobNotRunning() throws Exception {
+        // Regression guard for the self-heal contract: while the job is in an in-flight upgrade
+        // (JobStatus != RUNNING), the autoscaler must still re-project its persisted decisions
+        // onto the spec on every reconcile cycle. Skipping the realizer in this state (as an
+        // earlier "if (!waiting)" guard did) lets external resets of spec.flinkConfiguration go
+        // unhealed and triggers a spurious second upgrade once the reconciler diffs the spec
+        // against lastReconciledSpec.
+        context.getConfiguration().set(AutoScalerOptions.MEMORY_TUNING_ENABLED, true);
+
+        var v1 = new JobVertexID().toString();
+        stateStore.storeParallelismOverrides(context, Map.of(v1, "3"));
+        ConfigChanges configChanges = new ConfigChanges();
+        configChanges.addOverride(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 0.42f);
+        stateStore.storeConfigChanges(context, configChanges);
+        stateStore.flush(context);
+
+        var notRunningContext = context.toBuilder().jobStatus(JobStatus.INITIALIZING).build();
+        var autoscaler =
+                new JobAutoScalerImpl<>(
+                        new TestingMetricsCollector<>(new JobTopology()),
+                        null,
+                        null,
+                        eventCollector,
+                        scalingRealizer,
+                        stateStore);
+
+        autoscaler.scale(notRunningContext);
+
+        boolean sawParallelism = false;
+        boolean sawConfig = false;
+        for (var event : scalingRealizer.events) {
+            if (event.getParallelismOverrides() != null) {
+                sawParallelism = true;
+                assertEquals(Map.of(v1, "3"), event.getParallelismOverrides());
+            }
+            if (event.getConfigChanges() != null) {
+                sawConfig = true;
+                assertThat(event.getConfigChanges().getOverrides())
+                        .containsExactly(
+                                entry(TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(), "0.42"));
+            }
+        }
+        assertTrue(
+                sawParallelism,
+                "Parallelism overrides must be re-applied while job is not running");
+        assertTrue(sawConfig, "Config overrides must be re-applied while job is not running");
+    }
+
+    @Test
     void testApplyConfigOverrides() throws Exception {
         context.getConfiguration().set(AutoScalerOptions.MEMORY_TUNING_ENABLED, true);
         var autoscaler =
@@ -384,7 +440,7 @@ public class JobAutoScalerImplTest {
 
     @Test
     void testAutoscalerDisabled() throws Exception {
-        context.getConfiguration().setBoolean(AUTOSCALER_ENABLED, false);
+        context.getConfiguration().set(AUTOSCALER_ENABLED, false);
         context.getConfiguration().set(VERTEX_SCALING_HISTORY_AGE, Duration.ofMillis(200));
 
         var scalingHistory = new TreeMap<Instant, ScalingSummary>();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizerTest.java
@@ -69,6 +69,122 @@ public class KubernetesScalingRealizerTest {
     }
 
     @Test
+    public void testRealizeParallelismOverridesIsNoOpWhenSpecAlreadyMatches() {
+        // Required to keep the test config context on legacy Flink YAML converters.
+        GlobalConfiguration.setStandardYaml(false);
+
+        KubernetesJobAutoScalerContext ctx =
+                TestingKubernetesAutoscalerUtils.createContext("test", null);
+        FlinkDeployment resource = (FlinkDeployment) ctx.getResource();
+
+        // Pre-populate the spec with the exact override string the autoscaler would produce
+        // and persist it as the last reconciled spec so observeConfig is in sync.
+        resource.getSpec()
+                .getFlinkConfiguration()
+                .put(PipelineOptions.PARALLELISM_OVERRIDES.key(), "a:1,b:2");
+        resource.getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(resource.getSpec(), resource);
+
+        new KubernetesScalingRealizer()
+                .realizeParallelismOverrides(ctx, Map.of("a", "1", "b", "2"));
+
+        // Steady-state: realizer must short-circuit and leave the spec value byte-identical
+        // (no NOOP rewrite that could re-order keys or churn lastReconciledSpec).
+        assertThat(
+                        resource.getSpec()
+                                .getFlinkConfiguration()
+                                .asFlatMap()
+                                .get(PipelineOptions.PARALLELISM_OVERRIDES.key()))
+                .isEqualTo("a:1,b:2");
+    }
+
+    @Test
+    public void testRealizeParallelismOverridesReappliesWhenSpecDrifted() {
+        // Required to keep the test config context on legacy Flink YAML converters.
+        GlobalConfiguration.setStandardYaml(false);
+
+        KubernetesJobAutoScalerContext ctx =
+                TestingKubernetesAutoscalerUtils.createContext("test", null);
+        FlinkDeployment resource = (FlinkDeployment) ctx.getResource();
+
+        // Spec was clobbered with a stale value mid-upgrade (e.g. last-state recovery).
+        resource.getSpec()
+                .getFlinkConfiguration()
+                .put(PipelineOptions.PARALLELISM_OVERRIDES.key(), "a:1");
+        resource.getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(resource.getSpec(), resource);
+
+        new KubernetesScalingRealizer()
+                .realizeParallelismOverrides(ctx, Map.of("a", "1", "b", "2"));
+
+        // Drift was self-healed.
+        assertThat(
+                        resource.getSpec()
+                                .getFlinkConfiguration()
+                                .asFlatMap()
+                                .get(PipelineOptions.PARALLELISM_OVERRIDES.key()))
+                .isIn("a:1,b:2", "b:2,a:1");
+    }
+
+    @Test
+    public void testRealizeConfigOverridesIsNoOpWhenSpecAlreadyMatches() {
+        KubernetesJobAutoScalerContext ctx =
+                TestingKubernetesAutoscalerUtils.createContext("test", null);
+        FlinkDeployment resource = (FlinkDeployment) ctx.getResource();
+
+        // Pre-populate the spec so the override is already present and the removal target
+        // is already absent.
+        resource.getSpec()
+                .getFlinkConfiguration()
+                .put(TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(), "0.42");
+        String initialTmMemory = resource.getSpec().getTaskManager().getResource().getMemory();
+
+        ConfigChanges overrides = new ConfigChanges();
+        overrides.addOverride(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 0.42f);
+        overrides.addRemoval(TaskManagerOptions.TASK_HEAP_MEMORY);
+        new KubernetesScalingRealizer().realizeConfigOverrides(ctx, overrides);
+
+        assertThat(
+                        resource.getSpec()
+                                .getFlinkConfiguration()
+                                .asFlatMap()
+                                .get(TaskManagerOptions.MANAGED_MEMORY_FRACTION.key()))
+                .isEqualTo("0.42");
+        assertThat(resource.getSpec().getFlinkConfiguration().asFlatMap())
+                .doesNotContainKey(TaskManagerOptions.TASK_HEAP_MEMORY.key());
+        // TM memory must not be churned in steady-state (the value can only change if total
+        // memory tuning produced a new target; here the spec already reflects intent).
+        assertThat(resource.getSpec().getTaskManager().getResource().getMemory())
+                .isEqualTo(initialTmMemory);
+    }
+
+    @Test
+    public void testRealizeConfigOverridesReappliesWhenSpecDrifted() {
+        KubernetesJobAutoScalerContext ctx =
+                TestingKubernetesAutoscalerUtils.createContext("test", null);
+        FlinkDeployment resource = (FlinkDeployment) ctx.getResource();
+
+        // Spec was clobbered with a stale value.
+        resource.getSpec()
+                .getFlinkConfiguration()
+                .put(TaskManagerOptions.MANAGED_MEMORY_FRACTION.key(), "0.10");
+
+        ConfigChanges overrides = new ConfigChanges();
+        overrides.addOverride(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 0.42f);
+        new KubernetesScalingRealizer().realizeConfigOverrides(ctx, overrides);
+
+        // Drift was self-healed.
+        assertThat(
+                        resource.getSpec()
+                                .getFlinkConfiguration()
+                                .asFlatMap()
+                                .get(TaskManagerOptions.MANAGED_MEMORY_FRACTION.key()))
+                .isEqualTo("0.42");
+    }
+
+    @Test
     public void testApplyMemoryOverrides() {
         KubernetesJobAutoScalerContext ctx =
                 TestingKubernetesAutoscalerUtils.createContext("test", null);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

`JobAutoScalerImpl#scale` invokes `applyParallelismOverrides` and `applyConfigOverrides` from its `finally` block on every reconciliation cycle, so that the autoscaler's persisted decisions are continuously re-projected onto `spec.flinkConfiguration`. This is intentional: the unconditional projection doubles as a self-heal hook against in-flight upgrades that may externally reset the spec (last-state recovery, blue/green promotion, manual `kubectl edit`, JOSDK informer cache lag).

This contract was previously not pinned by tests. Earlier review on PR #1075 surfaced the concern that skipping the override application while the job is not yet `RUNNING` would cause the reconciler to detect a spec change and trigger a spurious second upgrade, but no regression guard existed to catch a future change re-introducing that skip.

This pull request adds the missing test coverage. No production code changes.

## Brief change log

- *[flink-autoscaler]* `JobAutoScalerImplTest#testOverridesAreReappliedWhenJobNotRunning`, regression guard asserting that while `JobStatus == INITIALIZING`, both `applyParallelismOverrides` and `applyConfigOverrides` are still invoked from `scale()`'s `finally` block, so the realizer keeps re-projecting the autoscaler's persisted state onto `spec.flinkConfiguration`.
- *[flink-kubernetes-operator]* `KubernetesScalingRealizerTest`, additional tests around `realizeParallelismOverrides` and `realizeConfigOverrides` covering the apply path on a fresh spec, the re-apply path when the spec already carries the intended values, and the drift path when the spec was externally reset.

## Verifying this change
This change is test-only. Production behavior is unchanged.

- `mvn -pl flink-autoscaler -Dtest=JobAutoScalerImplTest test` -> `BUILD SUCCESS`.
- `mvn -pl flink-kubernetes-operator -Dtest=KubernetesScalingRealizerTest test` -> `BUILD SUCCESS`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
