### PR TITLE
[FLINK-39306][flink-autoscaler] Align the busy-time TRUE_PROCESSING_RATE numerator estimator with the busy-time aggregator

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
@@ -484,6 +484,10 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                     .findAny(allMetricNames)
                     .ifPresent(
                             m -> filteredMetrics.put(m, FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT));
+        } else {
+            FlinkMetric.NUM_RECORDS_IN_PER_SEC
+                    .findAny(allMetricNames)
+                    .ifPresent(m -> filteredMetrics.put(m, FlinkMetric.NUM_RECORDS_IN_PER_SEC));
         }
 
         for (FlinkMetric flinkMetric : requiredMetrics) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricEvaluator.java
@@ -158,7 +158,11 @@ public class ScalingMetricEvaluator {
                 TRUE_PROCESSING_RATE,
                 EvaluatedScalingMetric.avg(
                         computeTrueProcessingRate(
-                                busyTimeAvg, inputRateAvg, metricsHistory, vertex, conf)));
+                                busyTimeAvg,
+                                computeTprInputRate(conf, vertex, metricsHistory),
+                                metricsHistory,
+                                vertex,
+                                conf)));
 
         evaluatedMetrics.put(LOAD, EvaluatedScalingMetric.avg(busyTimeAvg / 1000.));
 
@@ -492,6 +496,42 @@ public class ScalingMetricEvaluator {
             return anyInfinite ? Double.POSITIVE_INFINITY : Double.NaN;
         }
         return n < minElements ? Double.NaN : sum / n;
+    }
+
+    /**
+     * Estimate the input record rate used as the {@link ScalingMetric#TRUE_PROCESSING_RATE}
+     * numerator. The busy-time TPR is {@code rate / busyTime}, so to keep the ratio internally
+     * consistent the numerator must be estimated the same way as the busy-time denominator (see
+     * {@link #computeBusyTimeAvg}). The default {@code MAX} (and {@code MIN}) busy-time aggregator
+     * derives busy time from the per-second {@code LOAD} gauge averaged over the window, so we use
+     * the averaged per-second record-rate gauge here too. The {@code AVG} aggregator derives busy
+     * time from the cumulative accumulated busy-time counter via {@link #getRate}, so we keep the
+     * cumulative {@code getRate} in that case.
+     */
+    @VisibleForTesting
+    static double computeTprInputRate(
+            Configuration conf,
+            JobVertexID vertex,
+            SortedMap<Instant, CollectedMetrics> metricsHistory) {
+        if (conf.get(AutoScalerOptions.BUSY_TIME_AGGREGATOR) == MetricAggregator.AVG) {
+            return getRate(ScalingMetric.NUM_RECORDS_IN, vertex, metricsHistory);
+        }
+        return getAverageWithRateFallback(
+                ScalingMetric.NUM_RECORDS_IN_PER_SECOND,
+                ScalingMetric.NUM_RECORDS_IN,
+                vertex,
+                metricsHistory);
+    }
+
+    public static double getAverageWithRateFallback(
+            ScalingMetric metric,
+            ScalingMetric fallbackMetric,
+            @Nullable JobVertexID jobVertexId,
+            SortedMap<Instant, CollectedMetrics> metricsHistory) {
+        double average = getAverage(metric, jobVertexId, metricsHistory);
+        return Double.isInfinite(average) || Double.isNaN(average)
+                ? getRate(fallbackMetric, jobVertexId, metricsHistory)
+                : average;
     }
 
     /**

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
@@ -40,6 +40,7 @@ public enum FlinkMetric {
     SOURCE_TASK_NUM_RECORDS_IN(s -> s.startsWith("Source__") && s.endsWith(".numRecordsIn")),
     PENDING_RECORDS(s -> s.endsWith(".pendingRecords")),
     BACKPRESSURE_TIME_PER_SEC(s -> s.equals("backPressuredTimeMsPerSecond")),
+    NUM_RECORDS_IN_PER_SEC(s -> s.equals("numRecordsInPerSecond")),
 
     HEAP_MEMORY_MAX(s -> s.equals("Status.JVM.Memory.Heap.Max")),
     HEAP_MEMORY_USED(s -> s.equals("Status.JVM.Memory.Heap.Used")),

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
@@ -68,6 +68,8 @@ public enum ScalingMetric {
 
     NUM_RECORDS_IN(false),
 
+    NUM_RECORDS_IN_PER_SECOND(false),
+
     NUM_RECORDS_OUT(false),
 
     ACCUMULATED_BUSY_TIME(false),

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -98,6 +98,11 @@ public class ScalingMetrics {
                                 .orElseGet(observedTprAvg);
                 scalingMetrics.put(ScalingMetric.OBSERVED_TPR, observedTprOpt);
             }
+        } else {
+            var inPerSec = flinkMetrics.get(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
+            if (inPerSec != null) {
+                scalingMetrics.put(ScalingMetric.NUM_RECORDS_IN_PER_SECOND, inPerSec.getSum());
+            }
         }
     }
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
@@ -47,8 +47,10 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -113,9 +115,12 @@ public class JobAutoScalerImplTest {
                         scalingRealizer,
                         stateStore);
 
+        var now = Instant.now();
+        autoscaler.setClock(Clock.fixed(now, ZoneId.systemDefault()));
         autoscaler.scale(context);
 
         metricsCollector.updateMetrics(jobVertexID, m -> m.setNumRecordsIn(100));
+        autoscaler.setClock(Clock.fixed(now.plus(Duration.ofSeconds(10)), ZoneId.systemDefault()));
         autoscaler.scale(context);
 
         MetricGroup metricGroup = autoscaler.flinkMetrics.get(context.getJobKey()).getMetricGroup();

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricEvaluatorTest.java
@@ -806,6 +806,52 @@ public class ScalingMetricEvaluatorTest {
         assertEquals(Double.NaN, ScalingMetricEvaluator.getRate(m2, v2, history));
     }
 
+    @Test
+    public void computeTprInputRateTest() {
+        var vertex = new JobVertexID();
+        var cumulative = ScalingMetric.NUM_RECORDS_IN;
+        var perSecond = ScalingMetric.NUM_RECORDS_IN_PER_SECOND;
+
+        // Cumulative getRate = 1000 * (100 - 0) / 1000ms = 100/s.
+        // Per-second average = (40 + 60) / 2 = 50/s. The two intentionally differ so we can tell
+        // which estimator is used.
+        var history = new TreeMap<Instant, CollectedMetrics>();
+        history.put(
+                Instant.ofEpochMilli(1000),
+                new CollectedMetrics(Map.of(vertex, Map.of(cumulative, 0., perSecond, 40.)), null));
+        history.put(
+                Instant.ofEpochMilli(2000),
+                new CollectedMetrics(
+                        Map.of(vertex, Map.of(cumulative, 100., perSecond, 60.)), null));
+
+        // The default MAX (and MIN) aggregator derives busy time from the per-second LOAD gauge
+        // mean, so the TPR numerator uses the per-second record-rate gauge mean to stay consistent.
+        for (var aggregator : new MetricAggregator[] {MetricAggregator.MAX, MetricAggregator.MIN}) {
+            var conf = new Configuration();
+            conf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, aggregator);
+            assertEquals(50., ScalingMetricEvaluator.computeTprInputRate(conf, vertex, history));
+        }
+
+        // The AVG aggregator derives busy time from the cumulative counter via getRate, so the TPR
+        // numerator keeps the cumulative getRate.
+        var avgConf = new Configuration();
+        avgConf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.AVG);
+        assertEquals(100., ScalingMetricEvaluator.computeTprInputRate(avgConf, vertex, history));
+
+        // When the per-second gauge is unavailable, MAX falls back to the cumulative getRate.
+        var noPerSecond = new TreeMap<Instant, CollectedMetrics>();
+        noPerSecond.put(
+                Instant.ofEpochMilli(1000),
+                new CollectedMetrics(Map.of(vertex, Map.of(cumulative, 0.)), null));
+        noPerSecond.put(
+                Instant.ofEpochMilli(2000),
+                new CollectedMetrics(Map.of(vertex, Map.of(cumulative, 100.)), null));
+        var maxConf = new Configuration();
+        maxConf.set(AutoScalerOptions.BUSY_TIME_AGGREGATOR, MetricAggregator.MAX);
+        assertEquals(
+                100., ScalingMetricEvaluator.computeTprInputRate(maxConf, vertex, noPerSecond));
+    }
+
     private Tuple2<Double, Double> getThresholds(
             double inputTargetRate, double catchUpRate, Configuration conf) {
         return getThresholds(inputTargetRate, catchUpRate, conf, false);


### PR DESCRIPTION
## What is the purpose of the change

The busy-time `TRUE_PROCESSING_RATE` is a ratio, `busyTimeTpr = inputRate / (busyTimeAvg / 1000)`, but its two halves are estimated over the metric window with different methods. The denominator `busyTimeAvg` follows the configured busy-time aggregator, while the numerator `inputRate` always uses `getRate(NUM_RECORDS_IN)`. Under the default `MAX` aggregator the denominator is a per-second gauge mean (`getAverage(LOAD) * 1000`) while the numerator is a cumulative endpoint rate, so the ratio mixes two different temporal estimators.

`getRate` (time-weighted average) and `getAverage` of a per-second gauge (unweighted sample mean) agree under uniform sampling but diverge under non-uniform sampling. Because `busyTimeTpr` is a ratio of two co-varying quantities, using one shared estimator for both lets the common sampling weighting cancel, while mixing them leaves the denominator's sampling artifact in the result.

This change makes the numerator follow the same estimator as the denominator: per-second gauge mean under `MAX`/`MIN`, cumulative `getRate` under `AVG`. It is an internal-consistency fix scoped to the busy-time TPR numerator. It is not an accuracy claim about the underlying capacity model.

## Brief change log

  - Added `computeTprInputRate(conf, vertex, metricsHistory)` in `ScalingMetricEvaluator`: returns `getAverage(NUM_RECORDS_IN_PER_SECOND)` under `MAX`/`MIN` (matching the per-second `busyTimeAvg`) and `getRate(NUM_RECORDS_IN)` under `AVG` (matching the cumulative `busyTimeAvg`), with a fallback to `getRate(NUM_RECORDS_IN)` when the per-second gauge is unavailable (older Flink, missing metric).
  - `computeTrueProcessingRate` now takes its numerator from `computeTprInputRate`. The demand path (`computeTargetDataRate`), backlog detection, and the edge data-rate / output-ratio propagation are unchanged and keep the exact `getRate`, since they are not part of this ratio.
  - Collected and stored the `numRecordsInPerSecond` task metric for non-source vertices (`FlinkMetric.NUM_RECORDS_IN_PER_SEC`, `ScalingMetric.NUM_RECORDS_IN_PER_SECOND`, `ScalingMetricCollector`, `ScalingMetrics`).
  - Fixed a flaky `JobAutoScalerImplTest` by injecting a deterministic `Clock`, so successive metric collections get distinct timestamps and the metric history does not collapse to a single sample.

## Verifying this change

This change added tests and can be verified as follows:

  - `ScalingMetricEvaluatorTest#computeTprInputRateTest` asserts the gating: `MAX`/`MIN` use the per-second gauge mean, `AVG` uses the cumulative `getRate`, and the per-second-unavailable case falls back to `getRate`.
  - Existing `ScalingMetricEvaluatorTest`, `MetricsCollectionAndEvaluationTest`, and `BacklogBasedScalingTest` continue to pass. Behavior is unchanged under `AVG` and under uniform sampling.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes (autoscaler metric evaluation), but only the busy-time TPR numerator, and only under non-uniform sampling with the default/`MAX` aggregator

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable