### PR TITLE
Stateless Flink State Snapshot

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
@@ -89,6 +89,9 @@ public class FlinkStateSnapshotController
     @Override
     public DeleteControl cleanup(
             FlinkStateSnapshot flinkStateSnapshot, Context<FlinkStateSnapshot> josdkContext) {
+        if (flinkStateSnapshot.getStatus() == null) {
+            return DeleteControl.defaultDelete();
+        }
         var ctx = ctxFactory.getFlinkStateSnapshotContext(flinkStateSnapshot, josdkContext);
         try {
             metricManager.onRemove(flinkStateSnapshot);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
@@ -729,6 +729,20 @@ public class FlinkStateSnapshotControllerTest {
         assertSnapshotMetrics(listener, TestUtils.TEST_NAMESPACE, Map.of(), Map.of());
     }
 
+    @Test
+    public void testCleanupWithNullStatus() {
+        var deployment = createDeployment();
+        context = TestUtils.createSnapshotContext(client, deployment);
+
+        var savepoint = createSavepoint(deployment);
+        savepoint.setStatus(null);
+        assertDeleteControl(controller.cleanup(savepoint, context), true, null);
+
+        var checkpoint = createCheckpoint(deployment, CheckpointType.FULL, 0);
+        checkpoint.setStatus(null);
+        assertDeleteControl(controller.cleanup(checkpoint, context), true, null);
+    }
+
     private FlinkStateSnapshot createSavepoint(FlinkDeployment deployment) {
         return createSavepoint(deployment, false, 7);
     }


### PR DESCRIPTION
## Problem

When a FlinkStateSnapshot CR is deleted before the FlinkStateSnapshotController has reconciled it, the cleanup() method throws a NullPointerException on getStatus().getState(). The exception is caught in a way that prevents the finalizer from being removed, causing the CR to be permanently stuck in a terminating state. This blocks namespace deletion. 

## Root Cause

FlinkStateSnapshotController.cleanup() and FlinkResourceContextFactory.getFlinkStateSnapshotContext() assume the status is non-null, but FlinkStateSnapshot CRs are created without a status (the status subresource is only populated when reconcile() runs). If the CR receives a deletion timestamp before reconcile() runs, JOSDK calls cleanup() directly — the only code path that initializes null status is in reconcile(), not cleanup().

The NPE propagates to JOSDK (or is caught by the controller's catch block returning noFinalizerRemoval()), causing an infinite retry loop where every attempt crashes the same way.

reconcile() already handles this case correctly:


```
// status might be null here
flinkStateSnapshot.setStatus(
        Objects.requireNonNullElseGet(
                flinkStateSnapshot.getStatus(), FlinkStateSnapshotStatus::new));
```
cleanup() and updateErrorStatus() are missing this guard.


## Impact

- FlinkStateSnapshot CRs with null status accumulate as zombie resources with finalizers that can never be cleared.
- Namespace deletion is blocked indefinitely

## Fix 

Add the same null-status initialization to cleanup() and updateErrorStatus() that already exists in reconcile(). A null-status snapshot was never triggered against Flink, so no data exists on storage and cleanup can safely proceed