### PR TITLE
[FLINK-39967] Fix `backoffLimit=-1` to mean unlimited retries in FlinkStateSnapshot

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
@@ -128,7 +128,8 @@ public class FlinkStateSnapshotController
                 resource.getStatus().getError(),
                 ctx.getKubernetesClient());
 
-        if (resource.getStatus().getFailures() > resource.getSpec().getBackoffLimit()) {
+        var backoffLimit = resource.getSpec().getBackoffLimit();
+        if (backoffLimit >= 0 && resource.getStatus().getFailures() > backoffLimit) {
             LOG.info(
                     "Snapshot {} failed and won't be retried as failure count exceeded the backoff limit",
                     resource.getMetadata().getName());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
@@ -168,7 +168,9 @@ public class FlinkStateSnapshotControllerTest {
         for (int i = 0; i < 10; i++) {
             controller.updateErrorStatus(snapshot, context, new Exception());
             assertThat(snapshot.getStatus().getState())
-                    .as("Snapshot with backoffLimit=-1 should retry indefinitely, but failed after attempt %d", i + 1)
+                    .as(
+                            "Snapshot with backoffLimit=-1 should retry indefinitely, but failed after attempt %d",
+                            i + 1)
                     .isEqualTo(TRIGGER_PENDING);
         }
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
@@ -154,6 +154,25 @@ public class FlinkStateSnapshotControllerTest {
         assertThat(snapshot.getStatus().getState()).isEqualTo(FAILED);
     }
 
+    @Test
+    public void testReconcileBackoffUnlimited() {
+        var deployment = createDeployment();
+        context = TestUtils.createSnapshotContext(client, deployment);
+        // Default backoffLimit is -1, meaning unlimited retries
+        var snapshot = createSavepoint(deployment, false, -1);
+        snapshot.setStatus(new FlinkStateSnapshotStatus());
+
+        flinkService.setTriggerSavepointFailure(true);
+
+        // With unlimited retries, the snapshot should never transition to FAILED
+        for (int i = 0; i < 10; i++) {
+            controller.updateErrorStatus(snapshot, context, new Exception());
+            assertThat(snapshot.getStatus().getState())
+                    .as("Snapshot with backoffLimit=-1 should retry indefinitely, but failed after attempt %d", i + 1)
+                    .isEqualTo(TRIGGER_PENDING);
+        }
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testReconcileSavepointAlreadyExists(boolean jobReferenced) {


### PR DESCRIPTION
## What is the purpose of the change

`FlinkStateSnapshotSpec.backoffLimit` defaults to `-1`, documented as meaning "unlimited" retries. However, the retry decision in `FlinkStateSnapshotController` did a plain numeric comparison `failures > backoffLimit`. With the default `-1`, after the first failure `failures` is `1`, so `1 > -1` is always `true` and the snapshot was immediately marked failed with no retry - the exact opposite of the documented behavior.

This PR fixes the comparison so that a negative `backoffLimit` (the `-1` sentinel) correctly means "retry indefinitely", while `0` means no retries and `N` means up to `N` retries.

## Brief change log

  - Treat `backoffLimit < 0` as "unlimited retries" in `FlinkStateSnapshotController`, so the documented `-1` default actually retries indefinitely instead of failing on the first error.
  - Added a test proving the bug and verifying the fix (snapshot with default `backoffLimit=-1` is retried after a failure rather than immediately failing).

## Verifying this change

This change added tests and can be verified as follows:

  - `FlinkStateSnapshotControllerTest` covers a snapshot failure with the default `backoffLimit=-1` and asserts the snapshot is rescheduled for retry (with exponential backoff) instead of being marked failed with no retry.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes (snapshot reconciler retry handling)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable