### PR TITLE
[FLINK-39432] Add option to delete with session running session jobs

### DIFF
--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -195,6 +195,12 @@
             <td>The interval before a savepoint trigger attempt is marked as unsuccessful.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.session.block-on-session-jobs</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Block FlinkDeployment deletion if managed jobs are running in the session cluster.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.session.block-on-unmanaged-jobs</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -195,13 +195,13 @@
             <td>The interval before a savepoint trigger attempt is marked as unsuccessful.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.session.block-on-session-jobs</h5></td>
+            <td><h5>kubernetes.operator.session.deletion.block-on-session-jobs</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Block FlinkDeployment deletion if managed jobs are running in the session cluster.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.session.block-on-unmanaged-jobs</h5></td>
+            <td><h5>kubernetes.operator.session.deletion.block-on-unmanaged-jobs</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Block FlinkDeployment deletion if unmanaged jobs (jobs not managed by FlinkSessionJob resources) are running in the session cluster. Example: Jobs submitted via CLI.</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -429,13 +429,13 @@
             <td>The interval before a savepoint trigger attempt is marked as unsuccessful.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.session.block-on-session-jobs</h5></td>
+            <td><h5>kubernetes.operator.session.deletion.block-on-session-jobs</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Block FlinkDeployment deletion if managed jobs are running in the session cluster.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.session.block-on-unmanaged-jobs</h5></td>
+            <td><h5>kubernetes.operator.session.deletion.block-on-unmanaged-jobs</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>Block FlinkDeployment deletion if unmanaged jobs (jobs not managed by FlinkSessionJob resources) are running in the session cluster. Example: Jobs submitted via CLI.</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -429,6 +429,12 @@
             <td>The interval before a savepoint trigger attempt is marked as unsuccessful.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.session.block-on-session-jobs</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Block FlinkDeployment deletion if managed jobs are running in the session cluster.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.session.block-on-unmanaged-jobs</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -663,6 +663,14 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Block FlinkDeployment deletion if unmanaged jobs (jobs not managed by FlinkSessionJob resources) are running in the session cluster. Example: Jobs submitted via CLI.");
 
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> BLOCK_ON_SESSION_JOBS =
+            operatorConfig("session.block-on-session-jobs")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Block FlinkDeployment deletion if managed jobs are running in the session cluster.");
+
     @Documentation.Section(SECTION_ADVANCED)
     public static final ConfigOption<Duration> REFRESH_CLUSTER_RESOURCE_VIEW =
             operatorConfig("cluster.resource-view.refresh-interval")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -657,15 +657,16 @@ public class KubernetesOperatorConfigOptions {
 
     @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> BLOCK_ON_UNMANAGED_JOBS =
-            operatorConfig("session.block-on-unmanaged-jobs")
+            operatorConfig("session.deletion.block-on-unmanaged-jobs")
                     .booleanType()
                     .defaultValue(true)
+                    .withDeprecatedKeys(operatorConfigKey("session.block-on-unmanaged-jobs"))
                     .withDescription(
                             "Block FlinkDeployment deletion if unmanaged jobs (jobs not managed by FlinkSessionJob resources) are running in the session cluster. Example: Jobs submitted via CLI.");
 
     @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> BLOCK_ON_SESSION_JOBS =
-            operatorConfig("session.block-on-session-jobs")
+            operatorConfig("session.deletion.block-on-session-jobs")
                     .booleanType()
                     .defaultValue(true)
                     .withDescription(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -160,10 +160,14 @@ public class SessionReconciler
 
     @Override
     public DeleteControl cleanupInternal(FlinkResourceContext<FlinkDeployment> ctx) {
-        Set<FlinkSessionJob> sessionJobs =
-                ctx.getJosdkContext().getSecondaryResources(FlinkSessionJob.class);
+        var sessionJobs = ctx.getJosdkContext().getSecondaryResources(FlinkSessionJob.class);
         var deployment = ctx.getResource();
-        if (!sessionJobs.isEmpty()) {
+
+        boolean blockOnSessionJobs =
+                ctx.getObserveConfig()
+                        .getBoolean(KubernetesOperatorConfigOptions.BLOCK_ON_SESSION_JOBS);
+
+        if (blockOnSessionJobs && !sessionJobs.isEmpty()) {
             var error =
                     String.format(
                             "The session jobs %s should be deleted first",
@@ -188,7 +192,7 @@ public class SessionReconciler
         boolean blockOnUnmanagedJobs =
                 ctx.getObserveConfig()
                         .getBoolean(KubernetesOperatorConfigOptions.BLOCK_ON_UNMANAGED_JOBS);
-        if (blockOnUnmanagedJobs) {
+        if (blockOnSessionJobs && blockOnUnmanagedJobs) {
             Set<JobID> nonTerminalJobs = getNonTerminalJobs(ctx);
             if (!nonTerminalJobs.isEmpty()) {
                 var error =

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.client.JobStatusMessage;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
 import lombok.Getter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -304,5 +305,82 @@ public class SessionReconcilerTest extends OperatorTestBase {
                 0,
                 nonTerminalJobsAfterRemoval.size(),
                 "Should have no non-terminal jobs when only terminated jobs exist");
+    }
+
+    @Test
+    public void testDeleteSessionWithBlockOnSessionJobsFalse() throws Exception {
+        FlinkDeployment deployment = TestUtils.buildSessionCluster();
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(KubernetesOperatorConfigOptions.BLOCK_ON_SESSION_JOBS.key(), "false");
+
+        reconciler.reconcile(deployment, flinkService.getContext());
+
+        assertEquals(
+                ReconciliationState.DEPLOYED,
+                deployment.getStatus().getReconciliationStatus().getState());
+
+        // Create some running jobs
+        JobID managedJobId1 = new JobID();
+        JobID managedJobId2 = new JobID();
+        JobID unmanagedRunningJobId = new JobID();
+
+        flinkService
+                .listJobs()
+                .add(
+                        Tuple3.of(
+                                null,
+                                new JobStatusMessage(
+                                        managedJobId1,
+                                        "managed-job-1",
+                                        JobStatus.RUNNING,
+                                        System.currentTimeMillis()),
+                                new Configuration()));
+        flinkService
+                .listJobs()
+                .add(
+                        Tuple3.of(
+                                null,
+                                new JobStatusMessage(
+                                        managedJobId2,
+                                        "managed-job-2",
+                                        JobStatus.RUNNING,
+                                        System.currentTimeMillis()),
+                                new Configuration()));
+        flinkService
+                .listJobs()
+                .add(
+                        Tuple3.of(
+                                null,
+                                new JobStatusMessage(
+                                        unmanagedRunningJobId,
+                                        "unmanaged-running-job",
+                                        JobStatus.RUNNING,
+                                        System.currentTimeMillis()),
+                                new Configuration()));
+
+        // Create FlinkSessionJob resources for the managed jobs
+        FlinkSessionJob managedSessionJob1 = TestUtils.buildSessionJob();
+        managedSessionJob1.getMetadata().setName("managed-session-job-1");
+        managedSessionJob1.getStatus().getJobStatus().setJobId(managedJobId1.toHexString());
+        kubernetesClient.resource(managedSessionJob1).createOrReplace();
+
+        FlinkSessionJob managedSessionJob2 = TestUtils.buildSessionJob();
+        managedSessionJob2.getMetadata().setName("managed-session-job-2");
+        managedSessionJob2.getStatus().getJobStatus().setJobId(managedJobId2.toHexString());
+        kubernetesClient.resource(managedSessionJob2).createOrReplace();
+
+        // Test cleanup with BLOCK_ON_SESSION_JOBS=false
+        var context = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
+        var resourceContext = getResourceContext(deployment, context);
+
+        var sessionReconciler = (SessionReconciler) reconciler.getReconciler();
+        DeleteControl deleteControl = sessionReconciler.cleanupInternal(resourceContext);
+
+        // Verify that deletion proceeds immediately despite running jobs
+        assertTrue(
+                deleteControl.isRemoveFinalizer(),
+                "Session should be deleted immediately when BLOCK_ON_SESSION_JOBS is false");
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Add configuration to allow deletion of session clusters without blocking on session jobs. This allows the deletion and upgrade of clusters even in cases when the jobs cannot be deleted for some reason and may be desirable in some use-cases (where the session cluster upgrade is more important than the job health). The new config is disabled by default to preserve the existing behaviour

## Brief change log

- Introduce new config 
- New tests

## Verifying this change

Unit and manual testing

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? generated
