### PR TITLE
[FLINK-39439] Fix savepoint history entry removed from status before dispose succeeds

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
@@ -368,10 +368,14 @@ public class SnapshotObserver<
         var lastSavepoint = savepointHistory.get(savepointHistory.size() - 1);
 
         while (savepointHistory.size() > maxCount) {
-            // remove oldest entries
-            var sp = savepointHistory.remove(0);
-            if (savepointCleanupEnabled) {
-                disposeSavepointQuietly(ctx, sp.getLocation());
+            // Remove oldest entry only after successful dispose to avoid orphaning files.
+            // Break on failure — entries are ordered oldest-first so we cannot skip this one
+            // and remove a newer entry instead, as that would leave the oldest orphaned.
+            var sp = savepointHistory.get(0);
+            if (!savepointCleanupEnabled || disposeSavepointQuietly(ctx, sp.getLocation())) {
+                savepointHistory.remove(0);
+            } else {
+                break;
             }
         }
 
@@ -382,21 +386,27 @@ public class SnapshotObserver<
                 continue;
             }
             if (sp.getTimeStamp() < maxTms) {
-                it.remove();
-                if (savepointCleanupEnabled) {
-                    disposeSavepointQuietly(ctx, sp.getLocation());
+                // Remove entry only after successful dispose to avoid orphaning files.
+                // Each entry is independent here so we continue on failure rather than breaking.
+                if (!savepointCleanupEnabled || disposeSavepointQuietly(ctx, sp.getLocation())) {
+                    it.remove();
                 }
             }
         }
     }
 
-    private void disposeSavepointQuietly(FlinkResourceContext<CR> ctx, String path) {
+    private boolean disposeSavepointQuietly(FlinkResourceContext<CR> ctx, String path) {
         try {
             LOG.info("Disposing savepoint {}", path);
             ctx.getFlinkService().disposeSavepoint(path, ctx.getObserveConfig());
+            return true;
         } catch (Exception e) {
             // savepoint dispose error should not affect the deployment
-            LOG.error("Exception while disposing savepoint {}", path, e);
+            LOG.error(
+                    "Exception while disposing savepoint {}, will retry on next reconcile",
+                    path,
+                    e);
+            return false;
         }
     }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverLegacyTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverLegacyTest.java
@@ -319,6 +319,137 @@ public class SnapshotObserverLegacyTest extends OperatorTestBase {
     }
 
     @Test
+    public void testCountBasedDisposeRetainsEntryOnFailure() {
+        var deployment = TestUtils.buildApplicationCluster();
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
+        Configuration conf = new Configuration();
+        conf.set(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED, false);
+        conf.set(KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT, 2);
+        configManager.updateDefaultConfig(conf);
+
+        var spInfo = deployment.getStatus().getJobStatus().getSavepointInfo();
+        long futureTs = System.currentTimeMillis() * 2;
+        var sp0 =
+                new Savepoint(
+                        futureTs,
+                        "sp0",
+                        SnapshotTriggerType.MANUAL,
+                        SavepointFormatType.CANONICAL,
+                        0L);
+        var sp1 =
+                new Savepoint(
+                        futureTs + 1,
+                        "sp1",
+                        SnapshotTriggerType.MANUAL,
+                        SavepointFormatType.CANONICAL,
+                        1L);
+        var sp2 =
+                new Savepoint(
+                        futureTs + 2,
+                        "sp2",
+                        SnapshotTriggerType.MANUAL,
+                        SavepointFormatType.CANONICAL,
+                        2L);
+        spInfo.updateLastSavepoint(sp0);
+        spInfo.updateLastSavepoint(sp1);
+        spInfo.updateLastSavepoint(sp2);
+
+        flinkService.setDisposeSavepointFailure(true);
+        observer.cleanupSavepointHistoryLegacy(getResourceContext(deployment), Set.of());
+
+        // sp0 must still be in history because dispose failed — removing it would orphan the files
+        assertThat(spInfo.getSavepointHistory()).containsExactly(sp0, sp1, sp2);
+        assertThat(flinkService.getDisposedSavepoints()).isEmpty();
+    }
+
+    @Test
+    public void testAgeBasedDisposeRetainsEntryOnFailure() {
+        var deployment = TestUtils.buildApplicationCluster();
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
+        Configuration conf = new Configuration();
+        conf.set(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED, false);
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE,
+                Duration.ofMillis(5));
+        configManager.updateDefaultConfig(conf);
+
+        var spInfo = deployment.getStatus().getJobStatus().getSavepointInfo();
+        var sp1 =
+                new Savepoint(
+                        1, "sp1", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 1L);
+        var sp2 =
+                new Savepoint(
+                        2, "sp2", SnapshotTriggerType.MANUAL, SavepointFormatType.CANONICAL, 2L);
+        spInfo.updateLastSavepoint(sp1);
+        spInfo.updateLastSavepoint(sp2);
+
+        flinkService.setDisposeSavepointFailure(true);
+        observer.cleanupSavepointHistoryLegacy(getResourceContext(deployment), Set.of());
+
+        // sp1 must still be in history because dispose failed — removing it would orphan the files
+        assertThat(spInfo.getSavepointHistory()).containsExactly(sp1, sp2);
+        assertThat(flinkService.getDisposedSavepoints()).isEmpty();
+    }
+
+    @Test
+    public void testDisposeRetryOnSubsequentReconcile() {
+        var deployment = TestUtils.buildApplicationCluster();
+        deployment
+                .getStatus()
+                .getReconciliationStatus()
+                .serializeAndSetLastReconciledSpec(deployment.getSpec(), deployment);
+        Configuration conf = new Configuration();
+        conf.set(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED, false);
+        conf.set(KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT, 2);
+        configManager.updateDefaultConfig(conf);
+
+        var spInfo = deployment.getStatus().getJobStatus().getSavepointInfo();
+        long futureTs = System.currentTimeMillis() * 2;
+        var sp0 =
+                new Savepoint(
+                        futureTs,
+                        "sp0",
+                        SnapshotTriggerType.MANUAL,
+                        SavepointFormatType.CANONICAL,
+                        0L);
+        var sp1 =
+                new Savepoint(
+                        futureTs + 1,
+                        "sp1",
+                        SnapshotTriggerType.MANUAL,
+                        SavepointFormatType.CANONICAL,
+                        1L);
+        var sp2 =
+                new Savepoint(
+                        futureTs + 2,
+                        "sp2",
+                        SnapshotTriggerType.MANUAL,
+                        SavepointFormatType.CANONICAL,
+                        2L);
+        spInfo.updateLastSavepoint(sp0);
+        spInfo.updateLastSavepoint(sp1);
+        spInfo.updateLastSavepoint(sp2);
+
+        // First reconcile: dispose fails (job is down), entry must be retained
+        flinkService.setDisposeSavepointFailure(true);
+        observer.cleanupSavepointHistoryLegacy(getResourceContext(deployment), Set.of());
+        assertThat(spInfo.getSavepointHistory()).containsExactly(sp0, sp1, sp2);
+        assertThat(flinkService.getDisposedSavepoints()).isEmpty();
+
+        // Second reconcile: dispose succeeds, entry must now be removed
+        flinkService.setDisposeSavepointFailure(false);
+        observer.cleanupSavepointHistoryLegacy(getResourceContext(deployment), Set.of());
+        assertThat(spInfo.getSavepointHistory()).containsExactly(sp1, sp2);
+        assertThat(flinkService.getDisposedSavepoints()).containsExactly(sp0.getLocation());
+    }
+
+    @Test
     public void testPeriodicSavepoint() throws Exception {
         var conf = new Configuration();
         conf.set(KubernetesOperatorConfigOptions.SNAPSHOT_RESOURCE_ENABLED, false);


### PR DESCRIPTION
## What is the purpose of the change

In legacy mode, `cleanupSavepointHistoryLegacy` removed the savepoint entry from the deployment status before calling the Flink dispose API. If the job was down at that moment, the dispose call failed silently and the entry was already gone - leaving the savepoint files on storage permanently with no path to cleanup.

Fix: invert the order - call dispose first, only remove the status entry on success. On failure the entry is retained and retried on the next reconcile cycle. For count-based eviction a break is used on failure since entries are oldest-first and skipping the oldest would still orphan it. For age-based eviction each entry is evaluated independently so cleanup continues on failure.

Tests added (SnapshotObserverLegacyTest):
- `testCountBasedDisposeRetainsEntryOnFailure` - entry kept when dispose fails (count path)
- `testAgeBasedDisposeRetainsEntryOnFailure` - entry kept when dispose fails (age path)
- `testDisposeRetryOnSubsequentReconcile` - entry successfully cleaned up on the next reconcile after dispose recovers

## Brief change log

Fixed the issue and added tests.

## Verifying this change

Existing + new automated tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
