### PR TITLE
[hotfix][docs] Fix broken stable docs URL in outdated/unreleased banner

### DIFF
--- a/docs/layouts/partials/docs/inject/content-before.html
+++ b/docs/layouts/partials/docs/inject/content-before.html
@@ -23,14 +23,14 @@ under the License.
 {{ if $.Site.Params.ShowOutDatedWarning }}
 <article class="markdown">
     <blockquote style="border-color:#f66">
-        {{ markdownify "This documentation is for an out-of-date version of Apache Flink Kubernetes Operator. We recommend you use the latest [stable version](https://ci.apache.org/projects/flink/flink-kubernetes-operator-docs-stable/)."}}
+        {{ markdownify "This documentation is for an out-of-date version of Apache Flink Kubernetes Operator. We recommend you use the latest [stable version](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/)."}}
     </blockquote>
 </article>
 {{ end }}
 {{ if (not $.Site.Params.IsStable) }}
 <article class="markdown">
     <blockquote style="border-color:#f66">
-        {{ markdownify "This documentation is for an unreleased version of the Apache Flink Kubernetes Operator. We recommend you use the latest [stable version](https://ci.apache.org/projects/flink/flink-kubernetes-operator-docs-stable/)."}}
+        {{ markdownify "This documentation is for an unreleased version of the Apache Flink Kubernetes Operator. We recommend you use the latest [stable version](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/)."}}
     </blockquote>
 </article>
 {{ end }}


### PR DESCRIPTION
## What is the purpose of the change

This hotfix updates the broken "stable version" link that appears in the outdated/unreleased documentation banner. The link pointed to the legacy `ci.apache.org` host, which now redirects to `ci2.apache.org` and returns `No Such Resource / File not found`. All other docs references in the repo already use `nightlies.apache.org` — this banner was missed during the original docs infra migration.

## Brief change log

  - Replace both occurrences of `https://ci.apache.org/projects/flink/flink-kubernetes-operator-docs-stable/` with `https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-stable/` in `docs/layouts/partials/docs/inject/content-before.html`.

<img width="1186" height="293" alt="image" src="https://github.com/user-attachments/assets/89da9fc0-0ae3-4128-bde1-2b479a7c1591" />
<br>
Clicking on the stable version link opens
<img width="899" height="198" alt="image" src="https://github.com/user-attachments/assets/95ba5f94-4634-4980-a5c6-1adf9d580288" />


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable