### PR TITLE
[FLINK-39509][flink-kubernetes-webhook] Fix mutating webhook producing spurious object modifications on no-op patches

### DIFF
--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/mutator/FlinkMutator.java
@@ -66,9 +66,10 @@ public class FlinkMutator implements Mutator<HasMetadata> {
         return resource;
     }
 
-    private FlinkSessionJob mutateSessionJob(HasMetadata resource) {
+    private HasMetadata mutateSessionJob(HasMetadata resource) {
         try {
             var sessionJob = mapper.convertValue(resource, FlinkSessionJob.class);
+            var originalSessionJob = mapper.valueToTree(sessionJob);
             var namespace = sessionJob.getMetadata().getNamespace();
             var deploymentName = sessionJob.getSpec().getDeploymentName();
             var key = Cache.namespaceKeyFunc(namespace, deploymentName);
@@ -78,18 +79,30 @@ public class FlinkMutator implements Mutator<HasMetadata> {
             for (FlinkResourceMutator mutator : mutators) {
                 sessionJob = mutator.mutateSessionJob(sessionJob, Optional.ofNullable(deployment));
             }
-
+            // Return the original resource if no mutation was applied to avoid
+            // the serialization round-trip producing a different object, which causes
+            // kubectl to inconsistently omit the "(no change)" suffix on patch responses
+            if (originalSessionJob.equals(mapper.valueToTree(sessionJob))) {
+                return resource;
+            }
             return sessionJob;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
-    private FlinkDeployment mutateDeployment(HasMetadata resource) {
+    private HasMetadata mutateDeployment(HasMetadata resource) {
         try {
             var flinkDeployment = mapper.convertValue(resource, FlinkDeployment.class);
+            var originalFlinkDeployment = mapper.valueToTree(flinkDeployment);
             for (FlinkResourceMutator mutator : mutators) {
                 flinkDeployment = mutator.mutateDeployment(flinkDeployment);
+            }
+            // Return the original resource if no mutation was applied to avoid
+            // the serialization round-trip producing a different object, which causes
+            // kubectl to inconsistently omit the "(no change)" suffix on patch responses
+            if (originalFlinkDeployment.equals(mapper.valueToTree(flinkDeployment))) {
+                return resource;
             }
             return flinkDeployment;
         } catch (Exception e) {
@@ -97,11 +110,18 @@ public class FlinkMutator implements Mutator<HasMetadata> {
         }
     }
 
-    private FlinkStateSnapshot mutateStateSnapshot(HasMetadata resource) {
+    private HasMetadata mutateStateSnapshot(HasMetadata resource) {
         try {
             var snapshot = mapper.convertValue(resource, FlinkStateSnapshot.class);
+            var originalSnapshot = mapper.valueToTree(snapshot);
             for (var mutator : mutators) {
                 snapshot = mutator.mutateStateSnapshot(snapshot);
+            }
+            // Return the original resource if no mutation was applied to avoid
+            // the serialization round-trip producing a different object, which causes
+            // kubectl to inconsistently omit the "(no change)" suffix on patch responses
+            if (originalSnapshot.equals(mapper.valueToTree(snapshot))) {
+                return resource;
             }
             return snapshot;
         } catch (Exception e) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The mutating webhook's `FlinkMutator` always performs a Jackson `convertValue` serialization round-trip (`HasMetadata` -> typed class -> back) on every CREATE/UPDATE admission request. When no `FlinkResourceMutator` actually modifies the resource, the round-tripped object can serialize differently from the original input (e.g., field ordering, null handling), causing the webhook to return a JSON patch to the API server even though nothing was logically changed.

This leads to inconsistent behavior where `kubectl patch` reports `patched` instead of `patched (no change)` for resources like `FlinkDeployment`, even when the patch contains no effective change (e.g., setting `restartNonce` to its current value). While this does not trigger an actual reconciliation (the operator correctly detects no spec diff), it is confusing and causes unnecessary `resourceVersion` bumps on the Kubernetes object.

## Brief change log

  - For each `mutate*` method in `FlinkMutator`, capture a snapshot of the typed object **before** running mutators via `mapper.valueToTree()`, then compare it against the state **after** mutators run
  - If nothing changed, return the **original** `HasMetadata` resource, bypassing the serialization round-trip entirely
  - Applied consistently to all three resource types: `FlinkDeployment`, `FlinkSessionJob`, `FlinkStateSnapshot`

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
This change is a trivial rework / code cleanup without any test coverage.

Manually verified the change by:
  - Deploying the operator with the fix to a minikube cluster
  - Patching a `FlinkDeployment` with an identical `restartNonce` value and confirming `kubectl` now correctly reports `patched (no change)`
  - Patching a `FlinkSessionJob` with an identical `restartNonce` value and confirming the same `patched (no change)` output
  - Verifying that patches with actual changes (new `restartNonce` values) still correctly report `patched` and trigger reconciliation

Concretely, this change can be manually verified the change by deploying the `basic-session-deployment-and-job.yaml` example and patching with an already-applied `restartNonce` value:

**Before (without fix):**
```
$ kubectl patch flinkdeployment basic-session-deployment-example --type=merge -p '{"spec":{"restartNonce": 1}}'
flinkdeployment.flink.apache.org/basic-session-deployment-example patched
```

**After (with fix):**
```
$ kubectl patch flinkdeployment basic-session-deployment-example --type=merge -p '{"spec":{"restartNonce": 1}}'
flinkdeployment.flink.apache.org/basic-session-deployment-example patched (no change)
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
