### PR TITLE
[hotfix][examples] Update example JAR URLs from Flink 1.16.1 to Flink 2.2.0

### DIFF
--- a/examples/basic-session-deployment-and-job.yaml
+++ b/examples/basic-session-deployment-and-job.yaml
@@ -40,7 +40,7 @@ metadata:
 spec:
   deploymentName: basic-session-deployment-example
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.16.1/flink-examples-streaming_2.12-1.16.1-TopSpeedWindowing.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming/2.2.0/flink-examples-streaming-2.2.0-TopSpeedWindowing.jar
     parallelism: 4
     upgradeMode: stateless
 
@@ -52,7 +52,7 @@ metadata:
 spec:
   deploymentName: basic-session-deployment-example
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.16.1/flink-examples-streaming_2.12-1.16.1.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming/2.2.0/flink-examples-streaming-2.2.0.jar
     parallelism: 2
     upgradeMode: stateless
     entryClass: org.apache.flink.streaming.examples.statemachine.StateMachineExample

--- a/examples/basic-session-job-only.yaml
+++ b/examples/basic-session-job-only.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   deploymentName: basic-session-deployment-only-example
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.16.1/flink-examples-streaming_2.12-1.16.1-TopSpeedWindowing.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming/2.2.0/flink-examples-streaming-2.2.0-TopSpeedWindowing.jar
     parallelism: 4
     upgradeMode: stateless
 

--- a/examples/flink-tls-example/basic-secure-session-job-only.yaml
+++ b/examples/flink-tls-example/basic-secure-session-job-only.yaml
@@ -39,7 +39,7 @@ spec:
     kubernetes.secrets: basic-secure-cert:/opt/flink/tls-cert
   deploymentName: basic-secure-deployment-only
   job:
-    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.16.1/flink-examples-streaming_2.12-1.16.1-TopSpeedWindowing.jar
+    jarURI: https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming/2.2.0/flink-examples-streaming-2.2.0-TopSpeedWindowing.jar
     parallelism: 4
     upgradeMode: stateless
 

--- a/examples/pod-template.yaml
+++ b/examples/pod-template.yaml
@@ -65,7 +65,7 @@ spec:
             - /bin/sh
             - -c
             - "wget -O /opt/flink/downloads/flink-examples-streaming.jar \
-              https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming_2.12/1.16.1/flink-examples-streaming_2.12-1.16.1.jar"
+              https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming/2.2.0/flink-examples-streaming-2.2.0.jar"
   taskManager:
     resource:
       memory: "2048m"


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The example YAML files reference Flink 1.16.1 streaming example JARs (`flink-examples-streaming_2.12-1.16.1`) while using `flinkVersion: v2_2` and `image: flink:2.2`. These JARs were compiled against the old `SourceFunction` API which was removed in Flink 2.x, causing runtime failures when deploying the examples as-is.

This hotfix updates all affected JAR URLs to the Flink 2.2.0 artifacts (`flink-examples-streaming-2.2.0`), which no longer carry the Scala suffix and are compatible with the Flink 2.2 runtime.

> **Note:** Some references to the 1.16.1 version still remain in the repository and documentation (e.g., `flink-python-example/python-example.yaml`) because those examples are combined with `flinkVersion: v1_20` and are therefore not affected by this incompatibility.

## Brief change log

- Updated JAR URLs in 4 example files from `flink-examples-streaming_2.12/1.16.1/flink-examples-streaming_2.12-1.16.1` to `flink-examples-streaming/2.2.0/flink-examples-streaming-2.2.0`

**Affected files:**
- `examples/basic-session-deployment-and-job.yaml`
- `examples/basic-session-job-only.yaml`
- `examples/pod-template.yaml`
- `examples/flink-tls-example/basic-secure-session-job-only.yaml`

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
This change only updates documentation/example YAML files. The updated URLs have been verified to resolve successfully on Maven Central.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
