### PR TITLE
[hotfix] Fix missing log in AbstractFlinkService

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -730,7 +730,10 @@ public abstract class AbstractFlinkService implements FlinkService {
 
             var stats = response.get();
             if (stats == null) {
-                throw new IllegalStateException("Checkpoint ID %d for job %s does not exist!");
+                throw new IllegalStateException(
+                        String.format(
+                                "Checkpoint ID %d for job %s does not exist!",
+                                checkpointId, jobId));
             } else if (stats instanceof CheckpointStatistics.CompletedCheckpointStatistics) {
                 return CheckpointStatsResult.completed(
                         ((CheckpointStatistics.CompletedCheckpointStatistics) stats)


### PR DESCRIPTION
We found that the `fetchCheckpointStats` method does not log complete information when `stats` is null. Although this scenario is rare, we have improved the relevant log messages to provide more complete information.