### PR TITLE
[hotfix][docs] Fix Custom Flink Resource Mutators documentation code section

### DIFF
--- a/docs/content.zh/docs/operations/plugins.md
+++ b/docs/content.zh/docs/operations/plugins.md
@@ -131,33 +131,30 @@ That folder is added to classpath upon initialization.
 The following steps demonstrate how to develop and use a custom mutator.
 
 1. Implement `FlinkResourceMutator` interface:
-    ```java
-    package org.apache.flink.mutator;
+   ```java
+   package org.apache.flink.mutator;
 
    import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
    import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
    import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
-
+   
    import java.util.Optional;
-
+   
    /** Custom Flink Mutator. */
    public class CustomFlinkMutator implements FlinkResourceMutator {
-
-    @Override
-    public FlinkDeployment mutateDeployment(FlinkDeployment deployment) {
-
+   
+      @Override
+      public FlinkDeployment mutateDeployment(FlinkDeployment deployment) {
         return deployment;
-    }
-
-    @Override
-    public FlinkSessionJob mutateSessionJob(
+      }
+   
+      @Override
+      public FlinkSessionJob mutateSessionJob(
             FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
-
         return sessionJob;
-    }
-}
-
-    ```
+      }
+   }
+   ```
 
 2. Create service definition file `org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator` in `META-INF/services`.   With custom `FlinkResourceMutator` implementation, the service definition describes as follows:
     ```text

--- a/docs/content/docs/operations/plugins.md
+++ b/docs/content/docs/operations/plugins.md
@@ -131,33 +131,30 @@ That folder is added to classpath upon initialization.
 The following steps demonstrate how to develop and use a custom mutator.
 
 1. Implement `FlinkResourceMutator` interface:
-    ```java
-    package org.apache.flink.mutator;
+   ```java
+   package org.apache.flink.mutator;
 
    import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
    import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
    import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
-
+   
    import java.util.Optional;
-
+   
    /** Custom Flink Mutator. */
    public class CustomFlinkMutator implements FlinkResourceMutator {
-
-    @Override
-    public FlinkDeployment mutateDeployment(FlinkDeployment deployment) {
-
+   
+      @Override
+      public FlinkDeployment mutateDeployment(FlinkDeployment deployment) {
         return deployment;
-    }
-
-    @Override
-    public FlinkSessionJob mutateSessionJob(
+      }
+   
+      @Override
+      public FlinkSessionJob mutateSessionJob(
             FlinkSessionJob sessionJob, Optional<FlinkDeployment> session) {
-
         return sessionJob;
-    }
-}
-
-    ```
+      }
+   }
+   ```
 
 2. Create service definition file `org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator` in `META-INF/services`.   With custom `FlinkResourceMutator` implementation, the service definition describes as follows:
     ```text


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fixture of a documentation broken table:

Previously:
<img width="913" height="696" alt="image" src="https://github.com/user-attachments/assets/ccc6be62-7b2b-4d5d-b8f6-6674d47721e3" />

After the fix:
<img width="871" height="573" alt="image" src="https://github.com/user-attachments/assets/f96eac16-f814-47ba-a804-da0cfd9dcf9b" />


## Brief change log

Only the `docs/content/docs/operations/plugins.md` and `docs/content.zh/docs/operations/plugins.md` files were updated for the main documentation.

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
This change is a small hotfix and can be checked within the documentation page.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
