### PR TITLE
[FLINK-39549][flink-autoscaler] Compute OBSERVED_TPR for non-source vertices behind a feature flag

### DIFF
--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -129,6 +129,18 @@
             <td>Minimum nr of observations used when estimating / switching to observed true processing rate.</td>
         </tr>
         <tr>
+            <td><h5>job.autoscaler.observed-true-processing-rate.non-source.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether to also compute the observed (backpressure-derived) true processing rate for non-source vertices. When enabled, OBSERVED_TPR is populated for any vertex whose engagement (busy + backpressured time) crosses the configured threshold, mirroring the source-side behavior gated on lag. Default off for backward compatibility.</td>
+        </tr>
+        <tr>
+            <td><h5>job.autoscaler.observed-true-processing-rate.non-source.engagement-threshold</h5></td>
+            <td style="word-wrap: break-word;">0.9</td>
+            <td>Double</td>
+            <td>Engagement threshold (between 0 and 1) for triggering observed true processing rate computation on non-source vertices. Computed as (busyTimeMsPerSecond + backPressuredTimeMsPerSecond) / 1000. The vertex is considered fully engaged (and therefore not input-starved) when this value crosses the threshold, which is the non-source analogue of the source 'has lag' condition.</td>
+        </tr>
+        <tr>
             <td><h5>job.autoscaler.observed-true-processing-rate.switch-threshold</h5></td>
             <td style="word-wrap: break-word;">0.15</td>
             <td>Double</td>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
@@ -439,6 +439,7 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
     @SneakyThrows
     private Map<JobVertexID, Map<String, FlinkMetric>> queryFilteredMetricNames(
             Context ctx, JobTopology topology, Stream<JobVertexID> vertexStream) {
+        var conf = ctx.getConfiguration();
         try (var restClient = ctx.getRestClusterClient()) {
             return vertexStream
                     .filter(v -> !topology.getFinishedVertices().contains(v))
@@ -447,7 +448,11 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                                     v -> v,
                                     v ->
                                             getFilteredVertexMetricNames(
-                                                    restClient, ctx.getJobID(), v, topology)));
+                                                    restClient,
+                                                    ctx.getJobID(),
+                                                    v,
+                                                    topology,
+                                                    conf)));
         }
     }
 
@@ -456,7 +461,8 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
             RestClusterClient<?> restClient,
             JobID jobID,
             JobVertexID jobVertexID,
-            JobTopology topology) {
+            JobTopology topology,
+            Configuration conf) {
 
         var allMetricNames = queryAggregatedMetricNames(restClient, jobID, jobVertexID);
         var filteredMetrics = new HashMap<String, FlinkMetric>();
@@ -484,6 +490,14 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                     .findAny(allMetricNames)
                     .ifPresent(
                             m -> filteredMetrics.put(m, FlinkMetric.SOURCE_TASK_NUM_RECORDS_OUT));
+        } else if (conf != null
+                && conf.get(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_NON_SOURCE_ENABLED)) {
+            FlinkMetric.BACKPRESSURE_TIME_PER_SEC
+                    .findAny(allMetricNames)
+                    .ifPresent(m -> filteredMetrics.put(m, FlinkMetric.BACKPRESSURE_TIME_PER_SEC));
+            FlinkMetric.NUM_RECORDS_IN_PER_SEC
+                    .findAny(allMetricNames)
+                    .ifPresent(m -> filteredMetrics.put(m, FlinkMetric.NUM_RECORDS_IN_PER_SEC));
         }
 
         for (FlinkMetric flinkMetric : requiredMetrics) {

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -243,6 +243,35 @@ public class AutoScalerOptions {
                     .withDescription(
                             "Minimum nr of observations used when estimating / switching to observed true processing rate.");
 
+    public static final ConfigOption<Boolean> OBSERVED_TRUE_PROCESSING_RATE_NON_SOURCE_ENABLED =
+            autoScalerConfig("observed-true-processing-rate.non-source.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withFallbackKeys(
+                            oldOperatorConfigKey(
+                                    "observed-true-processing-rate.non-source.enabled"))
+                    .withDescription(
+                            "Whether to also compute the observed (backpressure-derived) true processing rate "
+                                    + "for non-source vertices. When enabled, OBSERVED_TPR is populated for any vertex "
+                                    + "whose engagement (busy + backpressured time) crosses the configured threshold, "
+                                    + "mirroring the source-side behavior gated on lag. Default off for backward compatibility.");
+
+    public static final ConfigOption<Double>
+            OBSERVED_TRUE_PROCESSING_RATE_NON_SOURCE_ENGAGEMENT_THRESHOLD =
+                    autoScalerConfig(
+                                    "observed-true-processing-rate.non-source.engagement-threshold")
+                            .doubleType()
+                            .defaultValue(0.9)
+                            .withFallbackKeys(
+                                    oldOperatorConfigKey(
+                                            "observed-true-processing-rate.non-source.engagement-threshold"))
+                            .withDescription(
+                                    "Engagement threshold (between 0 and 1) for triggering observed true processing rate "
+                                            + "computation on non-source vertices. Computed as (busyTimeMsPerSecond + "
+                                            + "backPressuredTimeMsPerSecond) / 1000. The vertex is considered fully engaged "
+                                            + "(and therefore not input-starved) when this value crosses the threshold, "
+                                            + "which is the non-source analogue of the source 'has lag' condition.");
+
     public static final ConfigOption<Boolean> SCALING_EFFECTIVENESS_DETECTION_ENABLED =
             autoScalerConfig("scaling.effectiveness.detection.enabled")
                     .booleanType()

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/FlinkMetric.java
@@ -40,6 +40,7 @@ public enum FlinkMetric {
     SOURCE_TASK_NUM_RECORDS_IN(s -> s.startsWith("Source__") && s.endsWith(".numRecordsIn")),
     PENDING_RECORDS(s -> s.endsWith(".pendingRecords")),
     BACKPRESSURE_TIME_PER_SEC(s -> s.equals("backPressuredTimeMsPerSecond")),
+    NUM_RECORDS_IN_PER_SEC(s -> s.equals("numRecordsInPerSecond")),
 
     HEAP_MEMORY_MAX(s -> s.equals("Status.JVM.Memory.Heap.Max")),
     HEAP_MEMORY_USED(s -> s.equals("Status.JVM.Memory.Heap.Used")),

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetric.java
@@ -33,7 +33,15 @@ public enum ScalingMetric {
     /** Processing rate at full capacity (records/sec). */
     TRUE_PROCESSING_RATE(true),
 
-    /** Observed true processing rate for sources. */
+    /**
+     * Observed true processing rate, derived from backpressure. Always populated for source
+     * vertices when the source is catching up, based on source lag. Optionally populated for
+     * non-source vertices when {@code
+     * job.autoscaler.observed-true-processing-rate.non-source.enabled} is set, in which case it is
+     * gated on the vertex being fully engaged (busy plus backpressured time crosses the configured
+     * engagement threshold). That gate is the per vertex analogue of the source "has lag"
+     * condition.
+     */
     OBSERVED_TPR(true),
 
     /** Target processing rate of operators as derived from source inputs (records/sec). */

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/metrics/ScalingMetrics.java
@@ -98,6 +98,12 @@ public class ScalingMetrics {
                                 .orElseGet(observedTprAvg);
                 scalingMetrics.put(ScalingMetric.OBSERVED_TPR, observedTprOpt);
             }
+        } else if (conf.get(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_NON_SOURCE_ENABLED)) {
+            var nonSourceObservedTpr =
+                    getNonSourceObservedTpr(flinkMetrics, conf).orElseGet(observedTprAvg);
+            if (!Double.isNaN(nonSourceObservedTpr)) {
+                scalingMetrics.put(ScalingMetric.OBSERVED_TPR, nonSourceObservedTpr);
+            }
         }
     }
 
@@ -128,6 +134,60 @@ public class ScalingMetrics {
                         numRecordsInPerSecond,
                         flinkMetrics.get(FlinkMetric.BACKPRESSURE_TIME_PER_SEC).getAvg());
 
+        return Double.isNaN(observedTpr) ? Optional.empty() : Optional.of(observedTpr);
+    }
+
+    /**
+     * Compute the observed (backpressure-derived) true processing rate for a non-source vertex.
+     *
+     * <p>Triggered only when the vertex is "fully engaged", meaning it spends nearly all of its
+     * time either busy or backpressured. This mirrors the source side "has lag" gate in {@link
+     * #getObservedTpr}. A fully engaged vertex is not input starved by upstream, so its observed
+     * input rate represents its true capacity (modulo backpressure).
+     *
+     * <p>Returns {@link Optional#empty()} when the required metrics are unavailable, the vertex is
+     * not engaged enough, or the formula degenerates (e.g. {@code backpressure >= 1000ms/s}). In
+     * those cases the caller falls back to the historical observed TPR average (if any).
+     */
+    private static Optional<Double> getNonSourceObservedTpr(
+            Map<FlinkMetric, AggregatedMetric> flinkMetrics, Configuration conf) {
+
+        var backpressureMsPerSecond = flinkMetrics.get(FlinkMetric.BACKPRESSURE_TIME_PER_SEC);
+        var numRecordsInPerSecond = flinkMetrics.get(FlinkMetric.NUM_RECORDS_IN_PER_SEC);
+        var busyTimePerSecond = flinkMetrics.get(FlinkMetric.BUSY_TIME_PER_SEC);
+        if (backpressureMsPerSecond == null
+                || numRecordsInPerSecond == null
+                || busyTimePerSecond == null) {
+            return Optional.empty();
+        }
+
+        double busyMsPerSec = busyTimePerSecond.getAvg();
+        double bpMsPerSec = backpressureMsPerSecond.getAvg();
+        if (!Double.isFinite(busyMsPerSec) || !Double.isFinite(bpMsPerSec)) {
+            return Optional.empty();
+        }
+
+        double engagement = (Math.max(0, busyMsPerSec) + Math.max(0, bpMsPerSec)) / 1000.;
+        double engagementThreshold =
+                conf.get(
+                        AutoScalerOptions
+                                .OBSERVED_TRUE_PROCESSING_RATE_NON_SOURCE_ENGAGEMENT_THRESHOLD);
+        if (engagement < engagementThreshold) {
+            return Optional.empty();
+        }
+
+        double numRecordsInPerSecondSum = numRecordsInPerSecond.getSum();
+        if (Double.isNaN(numRecordsInPerSecondSum)) {
+            return Optional.empty();
+        }
+        // Mirror source-side semantics: zero input rate while engaged signals no work to do,
+        // allow scale down.
+        if (numRecordsInPerSecondSum == 0) {
+            return Optional.of(Double.POSITIVE_INFINITY);
+        }
+
+        double observedTpr =
+                computeObservedTprWithBackpressure(numRecordsInPerSecondSum, bpMsPerSec);
         return Double.isNaN(observedTpr) ? Optional.empty() : Optional.of(observedTpr);
     }
 

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
@@ -392,7 +392,11 @@ public class ScalingMetricCollectorTest {
                 new RestApiMetricsCollector<JobID, JobAutoScalerContext<JobID>>() {
                     @Override
                     protected Map<String, FlinkMetric> getFilteredVertexMetricNames(
-                            RestClusterClient<?> rc, JobID id, JobVertexID jvi, JobTopology t) {
+                            RestClusterClient<?> rc,
+                            JobID id,
+                            JobVertexID jvi,
+                            JobTopology t,
+                            Configuration conf) {
                         metricNameQueryCounter.compute(jvi, (j, c) -> c + 1);
                         return Map.of();
                     }
@@ -517,7 +521,8 @@ public class ScalingMetricCollectorTest {
             metricList.addAll(requiredMetrics);
             metricList.remove(m);
             try {
-                testCollector.getFilteredVertexMetricNames(null, new JobID(), vertex, topology);
+                testCollector.getFilteredVertexMetricNames(
+                        null, new JobID(), vertex, topology, new Configuration());
                 fail(m);
             } catch (Exception e) {
                 assertTrue(e.getMessage().startsWith("Could not find required metric "));
@@ -551,6 +556,6 @@ public class ScalingMetricCollectorTest {
                 MetricNotFoundException.class,
                 () ->
                         metricCollector.getFilteredVertexMetricNames(
-                                null, new JobID(), source, topology));
+                                null, new JobID(), source, topology, new Configuration()));
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/metrics/ScalingMetricsTest.java
@@ -287,8 +287,60 @@ public class ScalingMetricsTest {
                         conf));
     }
 
+    @Test
+    public void testNonSourceObservedTprDisabledByDefault() {
+        double tpr =
+                computeNonSourceObservedTpr(900., 100., 1000., new Configuration(), Double.NaN);
+
+        assertTrue(Double.isNaN(tpr));
+    }
+
+    @Test
+    public void testNonSourceObservedTprEnabled() {
+        var conf = new Configuration();
+        conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_NON_SOURCE_ENABLED, true);
+
+        assertTrue(Double.isNaN(computeNonSourceObservedTpr(700., 200., 1000., conf, Double.NaN)));
+        assertEquals(1000. / 0.8, computeNonSourceObservedTpr(800., 200., 1000., conf, Double.NaN));
+        assertEquals(
+                Double.POSITIVE_INFINITY,
+                computeNonSourceObservedTpr(950., 50., 0., conf, Double.NaN));
+        assertTrue(Double.isNaN(computeNonSourceObservedTpr(0., 1000., 1000., conf, Double.NaN)));
+        assertEquals(PREV_TPR, computeNonSourceObservedTpr(100., 100., 1000., conf, PREV_TPR));
+    }
+
+    @Test
+    public void testNonSourceObservedTprCustomEngagementThreshold() {
+        var conf = new Configuration();
+        conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_NON_SOURCE_ENABLED, true);
+        conf.set(
+                AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_NON_SOURCE_ENGAGEMENT_THRESHOLD,
+                0.5);
+
+        assertEquals(
+                500. / (1 - 0.1), computeNonSourceObservedTpr(500., 100., 500., conf, Double.NaN));
+        assertTrue(Double.isNaN(computeNonSourceObservedTpr(300., 100., 500., conf, Double.NaN)));
+    }
+
+    @Test
+    public void testNonSourceObservedTprMissingMetricsAreSilentlySkipped() {
+        var conf = new Configuration();
+        conf.set(AutoScalerOptions.OBSERVED_TRUE_PROCESSING_RATE_NON_SOURCE_ENABLED, true);
+
+        assertTrue(
+                Double.isNaN(
+                        computeNonSourceObservedTpr(900., Double.NaN, 1000., conf, Double.NaN)));
+        assertTrue(
+                Double.isNaN(
+                        computeNonSourceObservedTpr(900., 100., Double.NaN, conf, Double.NaN)));
+    }
+
     private static AggregatedMetric aggSum(double sum) {
         return new AggregatedMetric("", Double.NaN, Double.NaN, Double.NaN, sum, Double.NaN);
+    }
+
+    private static AggregatedMetric aggAvg(double avg) {
+        return new AggregatedMetric("", Double.NaN, Double.NaN, avg, Double.NaN, Double.NaN);
     }
 
     private static AggregatedMetric aggMax(double max) {
@@ -297,5 +349,34 @@ public class ScalingMetricsTest {
 
     private static AggregatedMetric aggAvgMax(double avg, double max) {
         return new AggregatedMetric("", Double.NaN, max, avg, Double.NaN, Double.NaN);
+    }
+
+    private static double computeNonSourceObservedTpr(
+            double busyAvg,
+            double bpAvg,
+            double inputRatePerSecSum,
+            Configuration conf,
+            double prevTpr) {
+        var source = new JobVertexID();
+        var sink = new JobVertexID();
+        var topology =
+                new JobTopology(
+                        new VertexInfo(
+                                source, Collections.emptyMap(), 1, 1, new IOMetrics(0, 0, 0)),
+                        new VertexInfo(
+                                sink, Map.of(source, REBALANCE), 1, 1, new IOMetrics(0, 0, 0)));
+
+        Map<ScalingMetric, Double> scalingMetrics = new HashMap<>();
+        var flinkMetrics = new HashMap<FlinkMetric, AggregatedMetric>();
+        flinkMetrics.put(FlinkMetric.BUSY_TIME_PER_SEC, aggAvg(busyAvg));
+        if (!Double.isNaN(bpAvg)) {
+            flinkMetrics.put(FlinkMetric.BACKPRESSURE_TIME_PER_SEC, aggAvg(bpAvg));
+        }
+        if (!Double.isNaN(inputRatePerSecSum)) {
+            flinkMetrics.put(FlinkMetric.NUM_RECORDS_IN_PER_SEC, aggSum(inputRatePerSecSum));
+        }
+        ScalingMetrics.computeDataRateMetrics(
+                sink, flinkMetrics, scalingMetrics, topology, conf, () -> prevTpr);
+        return scalingMetrics.getOrDefault(ScalingMetric.OBSERVED_TPR, Double.NaN);
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

> **Merge order: this PR should be merged after #1078 (FLINK-39306).** The two touch the same per-second metric plumbing (both introduce `FlinkMetric.NUM_RECORDS_IN_PER_SEC` and extend non-source metric collection), so they conflict and #1078 should land first. They are also complementary. #1078 makes the busy-time `TRUE_PROCESSING_RATE` ratio internally consistent for every vertex by aligning its numerator estimator with the busy-time denominator. The extra benefit of that alignment, comparability against `OBSERVED_TPR` inside `selectTprMetric`, only applies to non-source vertices once this PR populates `OBSERVED_TPR` for them. Together they make the non-source capacity decision coherent.

This pull request extends the autoscaler's *observed* (backpressure-derived) true processing rate computation, currently scoped to source vertices only, to **non-source vertices** as well, behind an opt-in feature flag.

Today, `OBSERVED_TPR` is populated only for sources, and every downstream vertex falls back exclusively to the busy-time based `TRUE_PROCESSING_RATE`. This creates an alignment asymmetry across the job graph: sources may be evaluated using a backpressure-aware capacity model while their downstream operators are evaluated purely from busy-time, which is known to be unreliable under sustained backpressure. When the real bottleneck of the pipeline is downstream, this asymmetry can produce inconsistent or suboptimal scaling decisions on the very vertex that matters most.

This change generalizes the observed-TPR path so that any vertex in the graph can, when locally appropriate conditions are met, be evaluated using the same capacity model as sources. The behavior is fully opt-in, defaults to off, and preserves existing behavior for all current deployments.

This improvement is especially well suited for backpressured downstream tasks, for example IO-dependent operators whose external dependency is the limiter. For a heavily backpressured vertex the busy-time estimate becomes hypersensitive, because dividing the rate by the small busy fraction amplifies any idle time and busy-time measurement noise, so it tends to overstate capacity. The backpressure-derived `OBSERVED_TPR` is anchored directly to the backpressure signal and stays stable in that regime, and `selectTprMetric` already prefers it precisely when the busy-time estimate runs too high. The benefit grows with the backpressure level.


## Brief change log

- A new `FlinkMetric.NUM_RECORDS_IN_PER_SEC` is introduced for the task-level `numRecordsInPerSecond` metric used by non-source vertices.
- `ScalingMetricCollector#getFilteredVertexMetricNames` is extended to thread `Configuration` through and, when the new flag is on, **best-effort** request `BACKPRESSURE_TIME_PER_SEC` and `NUM_RECORDS_IN_PER_SEC` for non-source vertices. Missing metrics are silently skipped (never throw `MetricNotFoundException`) so older Flink versions are not broken.
- `ScalingMetrics#computeDataRateMetrics` is split into the existing source path (unchanged) and a new non-source path that computes `OBSERVED_TPR` via a small helper `getNonSourceObservedTpr`. The helper reuses the existing `computeObservedTprWithBackpressure` formula and is gated on a per-vertex **engagement signal**, `(busyTimeMsPerSecond + backPressuredTimeMsPerSecond) / 1000 ≥ engagement-threshold`, which is the per-vertex semantic dual of the source-side "has lag" gate (a vertex that is fully engaged is, by definition, not input-starved by upstream).
- Two new opt-in `AutoScalerOptions`:
  - `job.autoscaler.observed-true-processing-rate.non-source.enabled` (default `false`)
  - `job.autoscaler.observed-true-processing-rate.non-source.engagement-threshold` (default `0.95`)
- `ScalingMetricEvaluator` is left unchanged: `selectTprMetric` is already vertex-agnostic and naturally picks up `OBSERVED_TPR` for non-sources once it is populated, without any additional wiring or risk.
- Javadoc on `ScalingMetric.OBSERVED_TPR` is updated to reflect the new generality.
- Generated config table (`auto_scaler_configuration.html`) updated with the two new options.

The feature is intentionally scoped tightly: gates remain **local and independent** per vertex (no cross-vertex coupling between source and non-source decisions). Independence is the right primitive here as the local engagement gate already implicitly suppresses non-source observed-TPR when the pipeline is idle, while still allowing it to fire in the most important target case (downstream bottleneck while sources have no lag).


## Verifying this change
This change added tests and can be verified as follows:

- New unit tests in `ScalingMetricsTest` covering the non-source path:
  - `testNonSourceObservedTprDisabledByDefault` - flag off ⇒ `OBSERVED_TPR` is never populated for non-sources, even with all metrics present and the vertex fully engaged.
  - `testNonSourceObservedTprEnabled` - covers below-threshold (no `OBSERVED_TPR` / fallback to historical avg), engaged with backpressure (formula yields `rate / (1 - bp/1000)`), zero input rate while engaged (`+Infinity`, mirroring source semantics), and the degenerate `bp ≥ 1000ms/s` case.
  - `testNonSourceObservedTprCustomEngagementThreshold` - verifies the engagement threshold option is honored.
  - `testNonSourceObservedTprMissingMetricsAreSilentlySkipped` - verifies graceful behavior when the deployed Flink version does not expose the per-vertex metrics.
- Existing `ScalingMetricCollectorTest` updated for the new `Configuration` parameter on `getFilteredVertexMetricNames`; existing required-metrics coverage preserved.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs & JavaDocs
