### PR TITLE
[hotfix] Validate jarURI in DefaultValidator

### DIFF
--- a/docs/content.zh/docs/custom-resource/overview.md
+++ b/docs/content.zh/docs/custom-resource/overview.md
@@ -201,9 +201,11 @@ The job specification has the same structure in FlinkSessionJobs and FlinkDeploy
 It leverages the [Flink filesystem](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/) mechanism to download the jar and submit to the session cluster.
 So the FlinkSessionJob must be run with an existing session cluster managed by the FlinkDeployment.
 
-By default the operator only accepts `https` and `local` URI schemes for `jarURI` to prevent the operator pod from being coerced into fetching attacker-controlled resources (SSRF) or reading local files on its own filesystem.
-For `https`, hosts that resolve to loopback, link-local, site-local or wildcard addresses (e.g. cloud metadata services such as `169.254.169.254`) are also rejected.
+By default the FlinkSessionJob `jarURI` is restricted to the `https` scheme.
+For `https`, hosts that resolve to loopback, link-local, site-local, wildcard or multicast addresses (e.g. cloud metadata services such as `169.254.169.254`) are also rejected.
 If you need to fetch artifacts via additional schemes such as `s3` or `hdfs`, extend the allowlist via `kubernetes.operator.user.artifacts.allowed-schemes` (and review `kubernetes.operator.user.artifacts.disallow-restricted-hosts` if you legitimately need to reach private addresses).
+Both options are operator-level and can only be set in the operator configuration; values supplied in a CR's `flinkConfiguration` are ignored for these keys.
+The check applies only to FlinkSessionJob — FlinkDeployment `jarURI` is not validated, since application clusters typically reference a JAR shipped inside the image (e.g. `local://`) and the operator does not fetch it.
 
 To support jar from different filesystems, you should extend the base docker image as below, and put the related filesystem jar to the plugin dir and deploy the operator.
 For example, to support the hadoop fs resource:

--- a/docs/content.zh/docs/custom-resource/overview.md
+++ b/docs/content.zh/docs/custom-resource/overview.md
@@ -201,6 +201,10 @@ The job specification has the same structure in FlinkSessionJobs and FlinkDeploy
 It leverages the [Flink filesystem](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/) mechanism to download the jar and submit to the session cluster.
 So the FlinkSessionJob must be run with an existing session cluster managed by the FlinkDeployment.
 
+By default the operator only accepts `https` and `local` URI schemes for `jarURI` to prevent the operator pod from being coerced into fetching attacker-controlled resources (SSRF) or reading local files on its own filesystem.
+For `https`, hosts that resolve to loopback, link-local, site-local or wildcard addresses (e.g. cloud metadata services such as `169.254.169.254`) are also rejected.
+If you need to fetch artifacts via additional schemes such as `s3` or `hdfs`, extend the allowlist via `kubernetes.operator.user.artifacts.allowed-schemes` (and review `kubernetes.operator.user.artifacts.disallow-restricted-hosts` if you legitimately need to reach private addresses).
+
 To support jar from different filesystems, you should extend the base docker image as below, and put the related filesystem jar to the plugin dir and deploy the operator.
 For example, to support the hadoop fs resource:
 

--- a/docs/content/docs/custom-resource/overview.md
+++ b/docs/content/docs/custom-resource/overview.md
@@ -204,6 +204,10 @@ The job specification has the same structure in FlinkSessionJobs and FlinkDeploy
 It leverages the [Flink filesystem](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/) mechanism to download the jar and submit to the session cluster.
 So the FlinkSessionJob must be run with an existing session cluster managed by the FlinkDeployment.
 
+By default the operator only accepts `https` and `local` URI schemes for `jarURI` to prevent the operator pod from being coerced into fetching attacker-controlled resources (SSRF) or reading local files on its own filesystem.
+For `https`, hosts that resolve to loopback, link-local, site-local or wildcard addresses (e.g. cloud metadata services such as `169.254.169.254`) are also rejected.
+If you need to fetch artifacts via additional schemes such as `s3` or `hdfs`, extend the allowlist via `kubernetes.operator.user.artifacts.allowed-schemes` (and review `kubernetes.operator.user.artifacts.disallow-restricted-hosts` if you legitimately need to reach private addresses).
+
 To support jar from different filesystems, you should extend the base docker image as below, and put the related filesystem jar to the plugin dir and deploy the operator.
 For example, to support the hadoop fs resource:
 

--- a/docs/content/docs/custom-resource/overview.md
+++ b/docs/content/docs/custom-resource/overview.md
@@ -204,9 +204,11 @@ The job specification has the same structure in FlinkSessionJobs and FlinkDeploy
 It leverages the [Flink filesystem](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/filesystems/overview/) mechanism to download the jar and submit to the session cluster.
 So the FlinkSessionJob must be run with an existing session cluster managed by the FlinkDeployment.
 
-By default the operator only accepts `https` and `local` URI schemes for `jarURI` to prevent the operator pod from being coerced into fetching attacker-controlled resources (SSRF) or reading local files on its own filesystem.
-For `https`, hosts that resolve to loopback, link-local, site-local or wildcard addresses (e.g. cloud metadata services such as `169.254.169.254`) are also rejected.
+By default the FlinkSessionJob `jarURI` is restricted to the `https` scheme.
+For `https`, hosts that resolve to loopback, link-local, site-local, wildcard or multicast addresses (e.g. cloud metadata services such as `169.254.169.254`) are also rejected.
 If you need to fetch artifacts via additional schemes such as `s3` or `hdfs`, extend the allowlist via `kubernetes.operator.user.artifacts.allowed-schemes` (and review `kubernetes.operator.user.artifacts.disallow-restricted-hosts` if you legitimately need to reach private addresses).
+Both options are operator-level and can only be set in the operator configuration; values supplied in a CR's `flinkConfiguration` are ignored for these keys.
+The check applies only to FlinkSessionJob — FlinkDeployment `jarURI` is not validated, since application clusters typically reference a JAR shipped inside the image (e.g. `local://`) and the operator does not fetch it.
 
 To support jar from different filesystems, you should extend the base docker image as below, and put the related filesystem jar to the plugin dir and deploy the operator.
 For example, to support the hadoop fs resource:

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -213,18 +213,6 @@
             <td>Create new FlinkStateSnapshot resources for storing snapshots. Disable if you wish to use the deprecated mode and save snapshot results to FlinkDeployment/FlinkSessionJob status fields. The Operator will fallback to legacy mode during runtime if the CRD is not found, even if this value is true.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.user.artifacts.allowed-schemes</h5></td>
-            <td style="word-wrap: break-word;">"https";<wbr>"local"</td>
-            <td>List&lt;String&gt;</td>
-            <td>Comma separated list of URI schemes that are allowed for the job's jarURI. By default only 'https' and 'local' are allowed to prevent SSRF and local file disclosure via user-supplied URIs (e.g. 'http', 'file', 's3', 'hdfs', 'gs'). The 'local' scheme is preserved for application clusters that ship the JAR inside the image and is never fetched by the operator. Operators that need to fetch artifacts via other schemes (such as 's3' or 'hdfs') can extend this list. Scheme matching is case-insensitive.</td>
-        </tr>
-        <tr>
-            <td><h5>kubernetes.operator.user.artifacts.disallow-restricted-hosts</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>If enabled, jarURI hosts that resolve to loopback, link-local, site-local or wildcard addresses are rejected during validation. This prevents the operator from being coerced into issuing requests against cloud metadata services (e.g. 169.254.169.254) or other in-cluster services. Disable only if the operator legitimately needs to fetch from such addresses.</td>
-        </tr>
-        <tr>
             <td><h5>kubernetes.operator.user.artifacts.http.header</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>

--- a/docs/layouts/shortcodes/generated/dynamic_section.html
+++ b/docs/layouts/shortcodes/generated/dynamic_section.html
@@ -213,6 +213,18 @@
             <td>Create new FlinkStateSnapshot resources for storing snapshots. Disable if you wish to use the deprecated mode and save snapshot results to FlinkDeployment/FlinkSessionJob status fields. The Operator will fallback to legacy mode during runtime if the CRD is not found, even if this value is true.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.user.artifacts.allowed-schemes</h5></td>
+            <td style="word-wrap: break-word;">"https";<wbr>"local"</td>
+            <td>List&lt;String&gt;</td>
+            <td>Comma separated list of URI schemes that are allowed for the job's jarURI. By default only 'https' and 'local' are allowed to prevent SSRF and local file disclosure via user-supplied URIs (e.g. 'http', 'file', 's3', 'hdfs', 'gs'). The 'local' scheme is preserved for application clusters that ship the JAR inside the image and is never fetched by the operator. Operators that need to fetch artifacts via other schemes (such as 's3' or 'hdfs') can extend this list. Scheme matching is case-insensitive.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.user.artifacts.disallow-restricted-hosts</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>If enabled, jarURI hosts that resolve to loopback, link-local, site-local or wildcard addresses are rejected during validation. This prevents the operator from being coerced into issuing requests against cloud metadata services (e.g. 169.254.169.254) or other in-cluster services. Disable only if the operator legitimately needs to fetch from such addresses.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.user.artifacts.http.header</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -460,9 +460,9 @@
         </tr>
         <tr>
             <td><h5>kubernetes.operator.user.artifacts.allowed-schemes</h5></td>
-            <td style="word-wrap: break-word;">"https";<wbr>"local"</td>
+            <td style="word-wrap: break-word;">"https"</td>
             <td>List&lt;String&gt;</td>
-            <td>Comma separated list of URI schemes that are allowed for the job's jarURI. By default only 'https' and 'local' are allowed to prevent SSRF and local file disclosure via user-supplied URIs (e.g. 'http', 'file', 's3', 'hdfs', 'gs'). The 'local' scheme is preserved for application clusters that ship the JAR inside the image and is never fetched by the operator. Operators that need to fetch artifacts via other schemes (such as 's3' or 'hdfs') can extend this list. Scheme matching is case-insensitive.</td>
+            <td>Comma separated list of URI schemes that are allowed for the FlinkSessionJob jarURI. Only 'https' is allowed by default. Operators that need to fetch artifacts via other schemes (such as 's3' or 'hdfs') can extend this list. Scheme matching is case-insensitive.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.user.artifacts.base.dir</h5></td>
@@ -474,7 +474,7 @@
             <td><h5>kubernetes.operator.user.artifacts.disallow-restricted-hosts</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
-            <td>If enabled, jarURI hosts that resolve to loopback, link-local, site-local or wildcard addresses are rejected during validation. This prevents the operator from being coerced into issuing requests against cloud metadata services (e.g. 169.254.169.254) or other in-cluster services. Disable only if the operator legitimately needs to fetch from such addresses.</td>
+            <td>If enabled, FlinkSessionJob jarURI hosts that resolve to loopback, link-local, site-local, wildcard or multicast addresses are rejected during validation. Disable only if the operator legitimately needs to fetch from such addresses.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.user.artifacts.http.header</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -459,10 +459,22 @@
             <td>Operator shutdown timeout before reconciliation threads are killed.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.user.artifacts.allowed-schemes</h5></td>
+            <td style="word-wrap: break-word;">"https";<wbr>"local"</td>
+            <td>List&lt;String&gt;</td>
+            <td>Comma separated list of URI schemes that are allowed for the job's jarURI. By default only 'https' and 'local' are allowed to prevent SSRF and local file disclosure via user-supplied URIs (e.g. 'http', 'file', 's3', 'hdfs', 'gs'). The 'local' scheme is preserved for application clusters that ship the JAR inside the image and is never fetched by the operator. Operators that need to fetch artifacts via other schemes (such as 's3' or 'hdfs') can extend this list. Scheme matching is case-insensitive.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.user.artifacts.base.dir</h5></td>
             <td style="word-wrap: break-word;">"/opt/flink/artifacts"</td>
             <td>String</td>
             <td>The base dir to put the session job artifacts.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.user.artifacts.disallow-restricted-hosts</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>If enabled, jarURI hosts that resolve to loopback, link-local, site-local or wildcard addresses are rejected during validation. This prevents the operator from being coerced into issuing requests against cloud metadata services (e.g. 169.254.169.254) or other in-cluster services. Disable only if the operator legitimately needs to fetch from such addresses.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.user.artifacts.http.header</h5></td>

--- a/docs/layouts/shortcodes/generated/system_section.html
+++ b/docs/layouts/shortcodes/generated/system_section.html
@@ -141,10 +141,22 @@
             <td>Max interval of retries on unhandled controller errors.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.user.artifacts.allowed-schemes</h5></td>
+            <td style="word-wrap: break-word;">"https"</td>
+            <td>List&lt;String&gt;</td>
+            <td>Comma separated list of URI schemes that are allowed for the FlinkSessionJob jarURI. Only 'https' is allowed by default. Operators that need to fetch artifacts via other schemes (such as 's3' or 'hdfs') can extend this list. Scheme matching is case-insensitive.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.user.artifacts.base.dir</h5></td>
             <td style="word-wrap: break-word;">"/opt/flink/artifacts"</td>
             <td>String</td>
             <td>The base dir to put the session job artifacts.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.user.artifacts.disallow-restricted-hosts</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>If enabled, FlinkSessionJob jarURI hosts that resolve to loopback, link-local, site-local, wildcard or multicast addresses are rejected during validation. Disable only if the operator legitimately needs to fetch from such addresses.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.watched.namespaces</h5></td>

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
@@ -67,6 +67,7 @@ public class BaseTestUtils {
     public static final String IMAGE = String.format("flink:%s", FLINK_VERSION);
     public static final String IMAGE_POLICY = "IfNotPresent";
     public static final String SAMPLE_JAR = "local:///tmp/sample.jar";
+    public static final String SAMPLE_SESSION_JOB_JAR = "https://example.com/sample.jar";
 
     public static FlinkDeployment buildSessionCluster() {
         return buildSessionCluster(FlinkVersion.v1_17);
@@ -154,7 +155,7 @@ public class BaseTestUtils {
                         .deploymentName(TEST_DEPLOYMENT_NAME)
                         .job(
                                 JobSpec.builder()
-                                        .jarURI(SAMPLE_JAR)
+                                        .jarURI(SAMPLE_SESSION_JOB_JAR)
                                         .parallelism(1)
                                         .upgradeMode(UpgradeMode.STATELESS)
                                         .state(jobState)

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -34,6 +34,7 @@ import org.apache.commons.lang3.StringUtils;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -81,6 +82,8 @@ public class FlinkOperatorConfiguration {
     int reportedExceptionEventsMaxStackTraceLength;
     boolean manageIngress;
     Duration jobSubmissionTimeout;
+    List<String> jarUriAllowedSchemes;
+    boolean jarUriDisallowRestrictedHosts;
 
     public static FlinkOperatorConfiguration fromConfiguration(Configuration operatorConfig) {
         Duration reconcileInterval =
@@ -211,6 +214,13 @@ public class FlinkOperatorConfiguration {
         Duration jobSubmissionTimeout =
                 operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_JOB_SUBMISSION_TIMEOUT);
 
+        List<String> jarUriAllowedSchemes =
+                operatorConfig.get(KubernetesOperatorConfigOptions.JAR_URI_ALLOWED_SCHEMES);
+
+        boolean jarUriDisallowRestrictedHosts =
+                operatorConfig.get(
+                        KubernetesOperatorConfigOptions.JAR_URI_DISALLOW_RESTRICTED_HOSTS);
+
         return new FlinkOperatorConfiguration(
                 reconcileInterval,
                 reconcilerMaxParallelism,
@@ -244,7 +254,9 @@ public class FlinkOperatorConfiguration {
                 reportedExceptionEventsMaxCount,
                 reportedExceptionEventsMaxStackTraceLength,
                 manageIngress,
-                jobSubmissionTimeout);
+                jobSubmissionTimeout,
+                jarUriAllowedSchemes,
+                jarUriDisallowRestrictedHosts);
     }
 
     private static GenericRetry getRetryConfig(Configuration conf) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -31,6 +31,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Constants;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /** This class holds configuration constants used by flink operator. */
@@ -331,6 +332,34 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Custom HTTP header for HttpArtifactFetcher. The header will be applied when getting the session job artifacts. "
                                     + "Expected format: headerKey1:headerValue1,headerKey2:headerValue2.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<List<String>> JAR_URI_ALLOWED_SCHEMES =
+            operatorConfig("user.artifacts.allowed-schemes")
+                    .stringType()
+                    .asList()
+                    .defaultValues("https", "local")
+                    .withDescription(
+                            "Comma separated list of URI schemes that are allowed for the job's jarURI. "
+                                    + "By default only 'https' and 'local' are allowed to prevent SSRF and "
+                                    + "local file disclosure via user-supplied URIs (e.g. 'http', 'file', "
+                                    + "'s3', 'hdfs', 'gs'). The 'local' scheme is preserved for application "
+                                    + "clusters that ship the JAR inside the image and is never fetched by "
+                                    + "the operator. Operators that need to fetch artifacts via other "
+                                    + "schemes (such as 's3' or 'hdfs') can extend this list. "
+                                    + "Scheme matching is case-insensitive.");
+
+    @Documentation.Section(SECTION_DYNAMIC)
+    public static final ConfigOption<Boolean> JAR_URI_DISALLOW_RESTRICTED_HOSTS =
+            operatorConfig("user.artifacts.disallow-restricted-hosts")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "If enabled, jarURI hosts that resolve to loopback, link-local, site-local "
+                                    + "or wildcard addresses are rejected during validation. This prevents "
+                                    + "the operator from being coerced into issuing requests against cloud "
+                                    + "metadata services (e.g. 169.254.169.254) or other in-cluster services. "
+                                    + "Disable only if the operator legitimately needs to fetch from such addresses.");
 
     @Documentation.Section(SECTION_DYNAMIC)
     public static final ConfigOption<Boolean> SNAPSHOT_RESOURCE_ENABLED =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -333,32 +333,26 @@ public class KubernetesOperatorConfigOptions {
                             "Custom HTTP header for HttpArtifactFetcher. The header will be applied when getting the session job artifacts. "
                                     + "Expected format: headerKey1:headerValue1,headerKey2:headerValue2.");
 
-    @Documentation.Section(SECTION_DYNAMIC)
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<List<String>> JAR_URI_ALLOWED_SCHEMES =
             operatorConfig("user.artifacts.allowed-schemes")
                     .stringType()
                     .asList()
-                    .defaultValues("https", "local")
+                    .defaultValues("https")
                     .withDescription(
-                            "Comma separated list of URI schemes that are allowed for the job's jarURI. "
-                                    + "By default only 'https' and 'local' are allowed to prevent SSRF and "
-                                    + "local file disclosure via user-supplied URIs (e.g. 'http', 'file', "
-                                    + "'s3', 'hdfs', 'gs'). The 'local' scheme is preserved for application "
-                                    + "clusters that ship the JAR inside the image and is never fetched by "
-                                    + "the operator. Operators that need to fetch artifacts via other "
-                                    + "schemes (such as 's3' or 'hdfs') can extend this list. "
+                            "Comma separated list of URI schemes that are allowed for the FlinkSessionJob jarURI. "
+                                    + "Only 'https' is allowed by default. Operators that need to fetch artifacts "
+                                    + "via other schemes (such as 's3' or 'hdfs') can extend this list. "
                                     + "Scheme matching is case-insensitive.");
 
-    @Documentation.Section(SECTION_DYNAMIC)
+    @Documentation.Section(SECTION_SYSTEM)
     public static final ConfigOption<Boolean> JAR_URI_DISALLOW_RESTRICTED_HOSTS =
             operatorConfig("user.artifacts.disallow-restricted-hosts")
                     .booleanType()
                     .defaultValue(true)
                     .withDescription(
-                            "If enabled, jarURI hosts that resolve to loopback, link-local, site-local "
-                                    + "or wildcard addresses are rejected during validation. This prevents "
-                                    + "the operator from being coerced into issuing requests against cloud "
-                                    + "metadata services (e.g. 169.254.169.254) or other in-cluster services. "
+                            "If enabled, FlinkSessionJob jarURI hosts that resolve to loopback, link-local, "
+                                    + "site-local, wildcard or multicast addresses are rejected during validation. "
                                     + "Disable only if the operator legitimately needs to fetch from such addresses.");
 
     @Documentation.Section(SECTION_DYNAMIC)

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.validation;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.autoscaler.validation.AutoscalerValidator;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
@@ -57,11 +58,17 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /** Default validator implementation for {@link FlinkDeployment}. */
 public class DefaultValidator implements FlinkResourceValidator {
@@ -240,6 +247,11 @@ public class DefaultValidator implements FlinkResourceValidator {
 
         Configuration configuration = Configuration.fromMap(confMap);
 
+        Optional<String> jarUriError = validateJarURI(job.getJarURI(), configuration);
+        if (jarUriError.isPresent()) {
+            return jarUriError;
+        }
+
         if (job.getUpgradeMode() != UpgradeMode.STATELESS) {
             if (StringUtils.isNullOrWhitespaceOnly(
                     configuration.getString(CheckpointingOptions.CHECKPOINTS_DIRECTORY))) {
@@ -287,6 +299,60 @@ public class DefaultValidator implements FlinkResourceValidator {
             return Optional.of("Job parallelism must be larger than 0");
         }
 
+        return Optional.empty();
+    }
+
+    @VisibleForTesting
+    static Optional<String> validateJarURI(String jarURI, Configuration conf) {
+        if (jarURI == null) {
+            return Optional.empty();
+        }
+
+        URI uri;
+        try {
+            uri = new URI(jarURI);
+        } catch (URISyntaxException e) {
+            return Optional.of("jarURI is not a valid URI: " + e.getMessage());
+        }
+
+        String scheme = uri.getScheme();
+        if (scheme == null) {
+            return Optional.of("jarURI must include a scheme");
+        }
+
+        Set<String> allowedSchemes =
+                conf.get(KubernetesOperatorConfigOptions.JAR_URI_ALLOWED_SCHEMES).stream()
+                        .map(s -> s.toLowerCase(Locale.ROOT))
+                        .collect(Collectors.toSet());
+        if (!allowedSchemes.contains(scheme.toLowerCase(Locale.ROOT))) {
+            return Optional.of(
+                    String.format(
+                            "jarURI scheme '%s' is not in the allowlist %s. Configure '%s' to extend the allowlist.",
+                            scheme,
+                            allowedSchemes,
+                            KubernetesOperatorConfigOptions.JAR_URI_ALLOWED_SCHEMES.key()));
+        }
+
+        if (("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))
+                && conf.get(KubernetesOperatorConfigOptions.JAR_URI_DISALLOW_RESTRICTED_HOSTS)) {
+            String host = uri.getHost();
+            if (host == null || host.isEmpty()) {
+                return Optional.of("jarURI must include a host for http/https schemes");
+            }
+            InetAddress addr;
+            try {
+                addr = InetAddress.getByName(host);
+            } catch (UnknownHostException e) {
+                return Optional.of("jarURI host '" + host + "' cannot be resolved");
+            }
+            if (addr.isLoopbackAddress()
+                    || addr.isLinkLocalAddress()
+                    || addr.isSiteLocalAddress()
+                    || addr.isAnyLocalAddress()
+                    || addr.isMulticastAddress()) {
+                return Optional.of("jarURI host '" + host + "' resolves to a restricted address");
+            }
+        }
         return Optional.empty();
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -62,6 +62,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -247,11 +248,6 @@ public class DefaultValidator implements FlinkResourceValidator {
 
         Configuration configuration = Configuration.fromMap(confMap);
 
-        Optional<String> jarUriError = validateJarURI(job.getJarURI(), configuration);
-        if (jarUriError.isPresent()) {
-            return jarUriError;
-        }
-
         if (job.getUpgradeMode() != UpgradeMode.STATELESS) {
             if (StringUtils.isNullOrWhitespaceOnly(
                     configuration.getString(CheckpointingOptions.CHECKPOINTS_DIRECTORY))) {
@@ -303,7 +299,8 @@ public class DefaultValidator implements FlinkResourceValidator {
     }
 
     @VisibleForTesting
-    static Optional<String> validateJarURI(String jarURI, Configuration conf) {
+    static Optional<String> validateJarURI(
+            String jarURI, Collection<String> allowedSchemes, boolean disallowRestrictedHosts) {
         if (jarURI == null) {
             return Optional.empty();
         }
@@ -320,21 +317,21 @@ public class DefaultValidator implements FlinkResourceValidator {
             return Optional.of("jarURI must include a scheme");
         }
 
-        Set<String> allowedSchemes =
-                conf.get(KubernetesOperatorConfigOptions.JAR_URI_ALLOWED_SCHEMES).stream()
+        Set<String> normalizedAllowedSchemes =
+                allowedSchemes.stream()
                         .map(s -> s.toLowerCase(Locale.ROOT))
                         .collect(Collectors.toSet());
-        if (!allowedSchemes.contains(scheme.toLowerCase(Locale.ROOT))) {
+        if (!normalizedAllowedSchemes.contains(scheme.toLowerCase(Locale.ROOT))) {
             return Optional.of(
                     String.format(
                             "jarURI scheme '%s' is not in the allowlist %s. Configure '%s' to extend the allowlist.",
                             scheme,
-                            allowedSchemes,
+                            normalizedAllowedSchemes,
                             KubernetesOperatorConfigOptions.JAR_URI_ALLOWED_SCHEMES.key()));
         }
 
         if (("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))
-                && conf.get(KubernetesOperatorConfigOptions.JAR_URI_DISALLOW_RESTRICTED_HOSTS)) {
+                && disallowRestrictedHosts) {
             String host = uri.getHost();
             if (host == null || host.isEmpty()) {
                 return Optional.of("jarURI must include a host for http/https schemes");
@@ -354,6 +351,18 @@ public class DefaultValidator implements FlinkResourceValidator {
             }
         }
         return Optional.empty();
+    }
+
+    private Optional<String> validateSessionJobJarURI(FlinkSessionJob sessionJob) {
+        var jobSpec = sessionJob.getSpec().getJob();
+        if (jobSpec == null) {
+            return Optional.empty();
+        }
+        var operatorConfiguration = configManager.getOperatorConfiguration();
+        return validateJarURI(
+                jobSpec.getJarURI(),
+                operatorConfiguration.getJarUriAllowedSchemes(),
+                operatorConfiguration.isJarUriDisallowRestrictedHosts());
     }
 
     private Optional<String> validateJmSpec(JobManagerSpec jmSpec, Map<String, String> confMap) {
@@ -580,7 +589,8 @@ public class DefaultValidator implements FlinkResourceValidator {
         return firstPresent(
                 validateDeploymentName(sessionJob.getSpec().getDeploymentName()),
                 validateJobNotEmpty(sessionJob),
-                validateSpecChange(sessionJob));
+                validateSpecChange(sessionJob),
+                validateSessionJobJarURI(sessionJob));
     }
 
     private Optional<String> validateSessionJobWithCluster(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -601,6 +601,95 @@ public class DefaultValidatorTest {
                 "InitialSavepointPath must not be empty for savepoint redeploymen");
     }
 
+    @Test
+    public void testJarUriSchemeValidation() {
+        // Default allowlist permits 'https' and 'local'.
+        testSuccess(dep -> dep.getSpec().getJob().setJarURI("local:///tmp/sample.jar"));
+        testSuccess(dep -> dep.getSpec().getJob().setJarURI("https://example.com/path/to/job.jar"));
+        // Null jarURI is allowed (e.g. for entryClass-only jobs).
+        testSuccess(dep -> dep.getSpec().getJob().setJarURI(null));
+
+        // Schemes outside the default allowlist must be rejected.
+        testError(
+                dep -> dep.getSpec().getJob().setJarURI("http://example.com/job.jar"),
+                "jarURI scheme 'http' is not in the allowlist");
+        testError(
+                dep ->
+                        dep.getSpec()
+                                .getJob()
+                                .setJarURI(
+                                        "file:///var/run/secrets/kubernetes.io/serviceaccount/token"),
+                "jarURI scheme 'file' is not in the allowlist");
+        testError(
+                dep -> dep.getSpec().getJob().setJarURI("s3://my-bucket/job.jar"),
+                "jarURI scheme 's3' is not in the allowlist");
+
+        // Missing scheme is rejected.
+        testError(
+                dep -> dep.getSpec().getJob().setJarURI("/no/scheme/job.jar"),
+                "jarURI must include a scheme");
+
+        // Malformed URI is rejected.
+        testError(
+                dep -> dep.getSpec().getJob().setJarURI("ht tp://bad uri"),
+                "jarURI is not a valid URI");
+
+        // Operators can extend the allowlist via configuration.
+        testSuccess(
+                dep -> {
+                    dep.getSpec()
+                            .getFlinkConfiguration()
+                            .put(
+                                    KubernetesOperatorConfigOptions.JAR_URI_ALLOWED_SCHEMES.key(),
+                                    "https;s3;local");
+                    dep.getSpec().getJob().setJarURI("s3://my-bucket/job.jar");
+                });
+    }
+
+    @Test
+    public void testJarUriHostValidation() {
+        // Cloud-metadata link-local addresses must be rejected.
+        testError(
+                dep ->
+                        dep.getSpec()
+                                .getJob()
+                                .setJarURI(
+                                        "https://169.254.169.254/latest/meta-data/iam/security-credentials/"),
+                "jarURI host '169.254.169.254' resolves to a restricted address");
+
+        // Loopback addresses must be rejected.
+        testError(
+                dep -> dep.getSpec().getJob().setJarURI("https://127.0.0.1/job.jar"),
+                "jarURI host '127.0.0.1' resolves to a restricted address");
+        testError(
+                dep -> dep.getSpec().getJob().setJarURI("https://localhost/job.jar"),
+                "jarURI host 'localhost' resolves to a restricted address");
+
+        // Site-local (RFC 1918 private) addresses must be rejected.
+        testError(
+                dep -> dep.getSpec().getJob().setJarURI("https://10.0.0.1/job.jar"),
+                "jarURI host '10.0.0.1' resolves to a restricted address");
+        testError(
+                dep -> dep.getSpec().getJob().setJarURI("https://192.168.1.1/job.jar"),
+                "jarURI host '192.168.1.1' resolves to a restricted address");
+
+        // The host check only applies to http/https schemes.
+        testSuccess(dep -> dep.getSpec().getJob().setJarURI("local:///etc/passwd"));
+
+        // Disabling the restricted-host check via configuration must allow loopback.
+        testSuccess(
+                dep -> {
+                    dep.getSpec()
+                            .getFlinkConfiguration()
+                            .put(
+                                    KubernetesOperatorConfigOptions
+                                            .JAR_URI_DISALLOW_RESTRICTED_HOSTS
+                                            .key(),
+                                    "false");
+                    dep.getSpec().getJob().setJarURI("https://127.0.0.1/job.jar");
+                });
+    }
+
     @ParameterizedTest
     @EnumSource(UpgradeMode.class)
     public void testFlinkVersionChangeValidation(UpgradeMode toUpgradeMode) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -61,6 +61,7 @@ import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -603,91 +604,114 @@ public class DefaultValidatorTest {
 
     @Test
     public void testJarUriSchemeValidation() {
-        // Default allowlist permits 'https' and 'local'.
-        testSuccess(dep -> dep.getSpec().getJob().setJarURI("local:///tmp/sample.jar"));
-        testSuccess(dep -> dep.getSpec().getJob().setJarURI("https://example.com/path/to/job.jar"));
-        // Null jarURI is allowed (e.g. for entryClass-only jobs).
-        testSuccess(dep -> dep.getSpec().getJob().setJarURI(null));
+        var defaultAllowed = List.of("https");
 
-        // Schemes outside the default allowlist must be rejected.
-        testError(
-                dep -> dep.getSpec().getJob().setJarURI("http://example.com/job.jar"),
-                "jarURI scheme 'http' is not in the allowlist");
-        testError(
-                dep ->
-                        dep.getSpec()
-                                .getJob()
-                                .setJarURI(
-                                        "file:///var/run/secrets/kubernetes.io/serviceaccount/token"),
-                "jarURI scheme 'file' is not in the allowlist");
-        testError(
-                dep -> dep.getSpec().getJob().setJarURI("s3://my-bucket/job.jar"),
-                "jarURI scheme 's3' is not in the allowlist");
+        // Allowed scheme is accepted.
+        Assertions.assertEquals(
+                Optional.empty(),
+                DefaultValidator.validateJarURI(
+                        "https://example.com/path/to/job.jar", defaultAllowed, true));
+        // Null jarURI is allowed (e.g. for entryClass-only jobs).
+        Assertions.assertEquals(
+                Optional.empty(), DefaultValidator.validateJarURI(null, defaultAllowed, true));
+
+        // Disallowed schemes are rejected.
+        for (String disallowed :
+                List.of(
+                        "http://example.com/job.jar",
+                        "file:///var/run/secrets/kubernetes.io/serviceaccount/token",
+                        "s3://my-bucket/job.jar",
+                        "local:///tmp/sample.jar")) {
+            var error = DefaultValidator.validateJarURI(disallowed, defaultAllowed, true);
+            assertTrue(error.isPresent(), "expected error for " + disallowed);
+            assertTrue(
+                    error.get().startsWith("jarURI scheme '"),
+                    "unexpected message for " + disallowed + ": " + error.get());
+        }
 
         // Missing scheme is rejected.
-        testError(
-                dep -> dep.getSpec().getJob().setJarURI("/no/scheme/job.jar"),
-                "jarURI must include a scheme");
+        var noScheme = DefaultValidator.validateJarURI("/no/scheme/job.jar", defaultAllowed, true);
+        assertTrue(noScheme.isPresent());
+        assertTrue(noScheme.get().startsWith("jarURI must include a scheme"));
 
         // Malformed URI is rejected.
-        testError(
-                dep -> dep.getSpec().getJob().setJarURI("ht tp://bad uri"),
-                "jarURI is not a valid URI");
+        var malformed = DefaultValidator.validateJarURI("ht tp://bad uri", defaultAllowed, true);
+        assertTrue(malformed.isPresent());
+        assertTrue(malformed.get().startsWith("jarURI is not a valid URI"));
 
-        // Operators can extend the allowlist via configuration.
-        testSuccess(
-                dep -> {
-                    dep.getSpec()
-                            .getFlinkConfiguration()
-                            .put(
-                                    KubernetesOperatorConfigOptions.JAR_URI_ALLOWED_SCHEMES.key(),
-                                    "https;s3;local");
-                    dep.getSpec().getJob().setJarURI("s3://my-bucket/job.jar");
-                });
+        // Operators can extend the allowlist (case-insensitive matching).
+        Assertions.assertEquals(
+                Optional.empty(),
+                DefaultValidator.validateJarURI(
+                        "S3://my-bucket/job.jar", List.of("https", "s3"), true));
     }
 
     @Test
     public void testJarUriHostValidation() {
-        // Cloud-metadata link-local addresses must be rejected.
-        testError(
-                dep ->
-                        dep.getSpec()
-                                .getJob()
-                                .setJarURI(
-                                        "https://169.254.169.254/latest/meta-data/iam/security-credentials/"),
-                "jarURI host '169.254.169.254' resolves to a restricted address");
+        var defaultAllowed = List.of("https");
 
-        // Loopback addresses must be rejected.
-        testError(
-                dep -> dep.getSpec().getJob().setJarURI("https://127.0.0.1/job.jar"),
-                "jarURI host '127.0.0.1' resolves to a restricted address");
-        testError(
-                dep -> dep.getSpec().getJob().setJarURI("https://localhost/job.jar"),
-                "jarURI host 'localhost' resolves to a restricted address");
+        // Cloud-metadata link-local, loopback, site-local and wildcard addresses must be rejected.
+        for (String restricted :
+                List.of(
+                        "https://169.254.169.254/latest/meta-data/iam/security-credentials/",
+                        "https://127.0.0.1/job.jar",
+                        "https://localhost/job.jar",
+                        "https://10.0.0.1/job.jar",
+                        "https://192.168.1.1/job.jar")) {
+            var error = DefaultValidator.validateJarURI(restricted, defaultAllowed, true);
+            assertTrue(error.isPresent(), "expected error for " + restricted);
+            assertTrue(
+                    error.get().contains("resolves to a restricted address"),
+                    "unexpected message for " + restricted + ": " + error.get());
+        }
 
-        // Site-local (RFC 1918 private) addresses must be rejected.
-        testError(
-                dep -> dep.getSpec().getJob().setJarURI("https://10.0.0.1/job.jar"),
-                "jarURI host '10.0.0.1' resolves to a restricted address");
-        testError(
-                dep -> dep.getSpec().getJob().setJarURI("https://192.168.1.1/job.jar"),
-                "jarURI host '192.168.1.1' resolves to a restricted address");
+        // Disabling the restricted-host check allows loopback.
+        Assertions.assertEquals(
+                Optional.empty(),
+                DefaultValidator.validateJarURI(
+                        "https://127.0.0.1/job.jar", defaultAllowed, false));
+    }
 
-        // The host check only applies to http/https schemes.
-        testSuccess(dep -> dep.getSpec().getJob().setJarURI("local:///etc/passwd"));
+    @Test
+    public void testSessionJobJarUriValidationUsesOperatorConfig() {
+        // Operator-level config sets a custom allowlist; the CR cannot override it.
+        var operatorConf = new Configuration();
+        operatorConf.set(
+                KubernetesOperatorConfigOptions.JAR_URI_ALLOWED_SCHEMES, List.of("https", "s3"));
+        var customValidator = new DefaultValidator(new FlinkConfigManager(operatorConf));
 
-        // Disabling the restricted-host check via configuration must allow loopback.
-        testSuccess(
-                dep -> {
-                    dep.getSpec()
-                            .getFlinkConfiguration()
-                            .put(
-                                    KubernetesOperatorConfigOptions
-                                            .JAR_URI_DISALLOW_RESTRICTED_HOSTS
-                                            .key(),
-                                    "false");
-                    dep.getSpec().getJob().setJarURI("https://127.0.0.1/job.jar");
-                });
+        // s3 is allowed by operator config.
+        var s3Job = TestUtils.buildSessionJob();
+        s3Job.getSpec().getJob().setJarURI("s3://my-bucket/job.jar");
+        Assertions.assertEquals(
+                Optional.empty(), customValidator.validateSessionJob(s3Job, Optional.empty()));
+
+        // file:// is still rejected.
+        var fileJob = TestUtils.buildSessionJob();
+        fileJob.getSpec().getJob().setJarURI("file:///etc/passwd");
+        var fileError = customValidator.validateSessionJob(fileJob, Optional.empty());
+        assertTrue(fileError.isPresent());
+        assertTrue(fileError.get().startsWith("jarURI scheme 'file'"));
+
+        // A CR-supplied override of the allowlist is ignored — the operator-level config wins.
+        var overrideJob = TestUtils.buildSessionJob();
+        overrideJob
+                .getSpec()
+                .setFlinkConfiguration(
+                        Map.of(
+                                KubernetesOperatorConfigOptions.JAR_URI_ALLOWED_SCHEMES.key(),
+                                "https;file"));
+        overrideJob.getSpec().getJob().setJarURI("file:///etc/passwd");
+        var overrideError = customValidator.validateSessionJob(overrideJob, Optional.empty());
+        assertTrue(overrideError.isPresent());
+        assertTrue(overrideError.get().startsWith("jarURI scheme 'file'"));
+
+        // Default validator (https only) rejects the default https-but-link-local URI for sanity.
+        var loopbackJob = TestUtils.buildSessionJob();
+        loopbackJob.getSpec().getJob().setJarURI("https://169.254.169.254/job.jar");
+        var loopbackError = validator.validateSessionJob(loopbackJob, Optional.empty());
+        assertTrue(loopbackError.isPresent());
+        assertTrue(loopbackError.get().contains("resolves to a restricted address"));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What

Validate the `jarURI` field on **FlinkSessionJob** submission: reject malformed URIs, schemes outside an allowlist, and `http`/`https` URIs whose host resolves to loopback, link-local, site-local, wildcard or multicast addresses. FlinkDeployment is intentionally not validated, since application clusters reference a JAR shipped inside the image (e.g. `local://`) and the operator never fetches it.

## Config options

Both options are operator-level (`SECTION_SYSTEM`), resolved via `FlinkOperatorConfiguration` so a user-supplied `flinkConfiguration` in a CR cannot override them.

- `kubernetes.operator.user.artifacts.allowed-schemes` (`List<String>`, default `https`)
- `kubernetes.operator.user.artifacts.disallow-restricted-hosts` (`Boolean`, default `true`)

## Tests

- `mvn -pl flink-kubernetes-operator test` → 2133 / 0
- `mvn -pl flink-kubernetes-webhook test` → 105 / 0
- `mvn clean install -DskipTests` (full reactor) → BUILD SUCCESS

`DefaultValidatorTest` covers:
- `testJarUriSchemeValidation` and `testJarUriHostValidation` — direct unit tests on the static helper (allowed/disallowed schemes, malformed URIs, missing schemes, loopback/link-local/site-local/wildcard/multicast hosts, opt-out flag).
- `testSessionJobJarUriValidationUsesOperatorConfig` — verifies the validator reads the allowlist from the operator-level configuration and that a CR-supplied override of those keys is ignored.