### PR TITLE
[FLINK-39559] Set ownerReferences on JM Deployment recreated during session cluster recovery

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -121,7 +121,14 @@ public class SessionReconciler
     }
 
     private void recoverSession(FlinkResourceContext<FlinkDeployment> ctx) throws Exception {
-        ctx.getFlinkService().submitSessionCluster(ctx.getObserveConfig());
+        var conf = ctx.getObserveConfig();
+        // Owner references must be re-applied on the deploy config used for recovery.
+        // Without this, the recreated JobManager Deployment is created with no
+        // ownerReferences, which prevents JOSDK from linking it back to the
+        // FlinkDeployment via getSecondaryResource(), leading to an unrecoverable
+        // MISSING / AlreadyExists loop.
+        setOwnerReference(ctx.getResource(), conf);
+        ctx.getFlinkService().submitSessionCluster(conf);
         ctx.getResource()
                 .getStatus()
                 .setJobManagerDeploymentStatus(JobManagerDeploymentStatus.DEPLOYING);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -149,6 +149,53 @@ public class SessionReconcilerTest extends OperatorTestBase {
         Assertions.assertEquals(expectedOwnerReferences, or);
     }
 
+    /**
+     * Regression test: the recovery path (recoverSession) must populate
+     * KubernetesConfigOptions.JOB_MANAGER_OWNER_REFERENCE on the configuration used to recreate the
+     * JobManager Deployment. Otherwise the recreated Deployment has no ownerReferences and JOSDK
+     * cannot link it back to the FlinkDeployment via getSecondaryResource(), causing an
+     * unrecoverable MISSING / AlreadyExists loop.
+     */
+    @Test
+    public void testRecoverSessionSetsOwnerReference() throws Exception {
+        var capturedConfigs = new java.util.ArrayList<Configuration>();
+        flinkService =
+                new TestingFlinkService(kubernetesClient) {
+                    @Override
+                    public void submitSessionCluster(Configuration conf) throws Exception {
+                        capturedConfigs.add(new Configuration(conf));
+                        super.submitSessionCluster(conf);
+                    }
+                };
+
+        FlinkDeployment deployment = TestUtils.buildSessionCluster();
+        // Initial deploy goes through SessionReconciler.deploy() which already sets ownerRef.
+        reconciler.reconcile(deployment, flinkService.getContext());
+        assertEquals(1, capturedConfigs.size());
+
+        // Simulate the JM Deployment going missing (e.g. node failure / informer cache miss).
+        // shouldRecoverDeployment() requires HA to be enabled (it is by default for the test
+        // session cluster) and the JM status to be MISSING for a non-terminal deployment.
+        deployment.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.MISSING);
+        capturedConfigs.clear();
+
+        reconciler.reconcile(deployment, flinkService.getContext());
+
+        assertEquals(
+                1,
+                capturedConfigs.size(),
+                "recoverSession should have invoked submitSessionCluster exactly once");
+        Configuration recoverConfig = capturedConfigs.get(0);
+        List<Map<String, String>> ownerRefs =
+                recoverConfig.get(KubernetesConfigOptions.JOB_MANAGER_OWNER_REFERENCE);
+        Assertions.assertEquals(
+                List.of(TestUtils.generateTestOwnerReferenceMap(deployment)),
+                ownerRefs,
+                "recoverSession must populate JOB_MANAGER_OWNER_REFERENCE so the recreated"
+                        + " JobManager Deployment carries ownerReferences linking it to the"
+                        + " FlinkDeployment CR");
+    }
+
     @Test
     public void testGetNonTerminalJobs() throws Exception {
         FlinkDeployment deployment = TestUtils.buildSessionCluster();


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes a deterministic, unrecoverable loop on session clusters whose JobManager Deployment goes missing.

`SessionReconciler.recoverSession()` calls `submitSessionCluster()` with `ctx.getObserveConfig()` but does not first invoke `setOwnerReference()`. Because the `kubernetes.jobmanager.owner.reference` Flink config option is set transiently per-deploy and is never persisted to `spec.flinkConfiguration`, the observe config never carries it. As a result, the JM Deployment recreated by recovery has no `ownerReferences`.

JOSDK's default secondary-to-primary mapper for the JM Deployment uses `ownerReferences` to link a Deployment back to its `FlinkDeployment` primary (registered in `EventSourceUtils#getDeploymentInformerEventSource` via `InformerEventSourceConfiguration.from(Deployment.class, FlinkDeployment.class)` without a custom mapper). Without ownerReferences, `getSecondaryResource(Deployment.class)` returns empty on the next observe, the operator sets `jobManagerDeploymentStatus = MISSING`, recovery runs again and fails with `409 AlreadyExists`, the catch path in `KubernetesClusterDescriptor` calls `stopAndCleanupCluster()` which deletes the orphan Deployment, and the cycle repeats indefinitely.

This is a regression of the same fix applied for the `deploy()` path in [FLINK-28979](https://issues.apache.org/jira/browse/FLINK-28979) (commit 62eb68c8) — the `recoverSession()` path was missed when ownerReferences were originally introduced. The corresponding test `SessionReconcilerTest#testSetOwnerReference` only exercises `deploy()`, so the gap was never caught.

`ApplicationReconciler` is unaffected because its recovery path routes through `resubmitJob → restoreJob → deploy()`, and `ApplicationReconciler#deploy()` already calls `setOwnerReference()`.

## Brief change log

  - `SessionReconciler#recoverSession` now calls `setOwnerReference()` on the observe config before submitting the session cluster, mirroring the `deploy()` path.
  - Added regression test `SessionReconcilerTest#testRecoverSessionSetsOwnerReference` that exercises `reconcileOtherChanges → recoverSession` and asserts the configuration passed to `submitSessionCluster()` carries the expected `JOB_MANAGER_OWNER_REFERENCE` entry.

## Verifying this change

This change added a regression test and can be verified as follows:

  - `SessionReconcilerTest#testRecoverSessionSetsOwnerReference` brings a session cluster to READY, marks the JM `MISSING`, triggers reconcile, captures the configuration handed to `submitSessionCluster()`, and asserts the expected ownerReferences are present.
  - Confirmed the test fails on master (no ownerReferences set) and passes with the fix applied.
  - Full operator module suite (`mvn -pl flink-kubernetes-operator test`) passes locally — 2134 tests, 0 failures, 0 errors, 0 skipped.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes — but only the session-cluster recovery branch (`SessionReconciler#recoverSession`); behaviour aligns with the existing `deploy()` path.

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable