### PR TITLE
[FLINK-39618] FlinkDeployment deletion deadlocks when FlinkSessionJobs are running with default block-on-* options

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconciler.java
@@ -158,12 +158,20 @@ public class SessionJobReconciler
         var flinkDep = flinkDepOptional.get();
 
         // If the session cluster is being deleted, the job will not survive regardless,
-        // so there is no need to explicitly cancel it.
+        // so there is no need to explicitly cancel it, unless BLOCK_ON_SESSION_JOBS is
+        // enabled.
         var sessionLifecycleState = flinkDep.getStatus().getLifecycleState();
         if (sessionLifecycleState == ResourceLifecycleState.DELETING
                 || sessionLifecycleState == ResourceLifecycleState.DELETED) {
-            LOG.info("Session cluster is being deleted, skipping job cancellation");
-            return DeleteControl.defaultDelete();
+            var observeConfig = ctx.getObserveConfig();
+            var blockOnSessionJobs =
+                    observeConfig != null
+                            && observeConfig.get(
+                                    KubernetesOperatorConfigOptions.BLOCK_ON_SESSION_JOBS);
+            if (!blockOnSessionJobs) {
+                LOG.info("Session cluster is being deleted, skipping job cancellation");
+                return DeleteControl.defaultDelete();
+            }
         }
 
         if (!sessionClusterReady(flinkDepOptional)) {
@@ -189,9 +197,9 @@ public class SessionJobReconciler
         }
 
         try {
-            var observeConfig = ctx.getObserveConfig();
             var suspendMode =
-                    observeConfig.getBoolean(KubernetesOperatorConfigOptions.SAVEPOINT_ON_DELETION)
+                    ctx.getObserveConfig()
+                                    .get(KubernetesOperatorConfigOptions.SAVEPOINT_ON_DELETION)
                             ? SuspendMode.SAVEPOINT
                             : SuspendMode.STATELESS;
             if (cancelJob(ctx, suspendMode)) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -266,6 +266,24 @@ public class TestUtils extends BaseTestUtils {
         };
     }
 
+    public static <T extends HasMetadata>
+            Context<T> createContextWithReadyFlinkDeploymentInLifecycleState(
+                    ResourceLifecycleState lifecycleState, Map<String, String> flinkDepConfig) {
+        return new TestingContext<>() {
+            @Override
+            public Optional<T> getSecondaryResource(Class expectedType, String eventSourceName) {
+                var session = buildSessionCluster();
+                session.getStatus().setLifecycleState(lifecycleState);
+                session.getStatus().setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+                session.getSpec().getFlinkConfiguration().putAllFrom(flinkDepConfig);
+                session.getStatus()
+                        .getReconciliationStatus()
+                        .serializeAndSetLastReconciledSpec(session.getSpec(), session);
+                return (Optional<T>) Optional.of(session);
+            }
+        };
+    }
+
     public static <T extends HasMetadata> Context<T> createContextWithUnhealthyFlinkDeployment(
             boolean haEnabled) {
         return new TestingContext<>() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
@@ -48,6 +48,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -905,6 +906,63 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         assertTrue(deleteControl.isRemoveFinalizer());
         // No cancellation attempted, job still in RUNNING state
         assertEquals(RUNNING, flinkService.listJobs().get(0).f1.getJobState());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ResourceLifecycleState.class,
+            names = {"DELETING", "DELETED"})
+    public void testCleanupWithDeletingClusterBlockOnSessionJobsDisabled(
+            ResourceLifecycleState lifecycleState) throws Exception {
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
+        assertEquals(1, flinkService.listJobs().size());
+        verifyAndSetRunningJobsToStatus(
+                sessionJob, JobState.RUNNING, RECONCILING, null, flinkService.listJobs());
+
+        var ctx =
+                TestUtils.createContextWithReadyFlinkDeploymentInLifecycleState(
+                        lifecycleState,
+                        Map.of(
+                                KubernetesOperatorConfigOptions.BLOCK_ON_SESSION_JOBS.key(),
+                                "false"));
+        var deleteControl = reconciler.cleanup(sessionJob, ctx);
+
+        assertTrue(deleteControl.isRemoveFinalizer());
+        // Bypass fired: no cancellation attempted, job still RUNNING.
+        assertEquals(RUNNING, flinkService.listJobs().get(0).f1.getJobState());
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = ResourceLifecycleState.class,
+            names = {"DELETING", "DELETED"})
+    public void testCleanupWithDeletingClusterBlockOnSessionJobsEnabled(
+            ResourceLifecycleState lifecycleState) throws Exception {
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+
+        reconciler.reconcile(
+                sessionJob, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient));
+        assertEquals(1, flinkService.listJobs().size());
+        verifyAndSetRunningJobsToStatus(
+                sessionJob, JobState.RUNNING, RECONCILING, null, flinkService.listJobs());
+
+        var ctx =
+                TestUtils.createContextWithReadyFlinkDeploymentInLifecycleState(
+                        lifecycleState,
+                        Map.of(
+                                KubernetesOperatorConfigOptions.BLOCK_ON_SESSION_JOBS.key(),
+                                "true"));
+        var deleteControl = reconciler.cleanup(sessionJob, ctx);
+
+        // Cancellation was initiated: cancelJobOrError returns pending so the reconciler
+        // reschedules and holds the finalizer until the cancel is re-observed. The job has
+        // already transitioned to CANCELED on the cluster side (TestingFlinkService).
+        assertFalse(deleteControl.isRemoveFinalizer());
+        assertEquals(10_000L, deleteControl.getScheduleDelay().orElse(null));
+        assertEquals(CANCELED, flinkService.listJobs().get(0).f1.getJobState());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Fix a deletion deadlock between `SessionJobReconciler` and `SessionReconciler` introduced in 1.15 by [FLINK-39271]. When a `FlinkDeployment` in session mode is deleted while jobs are running, the operator can get permanently stuck: `SessionJobReconciler` skips cancelling the Flink job (assuming the cluster will tear down anyway), but `SessionReconciler` then refuses to remove the `FlinkDeployment` finalizer because `BLOCK_ON_UNMANAGED_JOBS` finds the still-running jobs on the JobManager. Both options default to `true`, so the deadlock occurs out of the box.

## Brief change log

  - In `SessionJobReconciler.cleanupInternal`, gate the "skip cancellation when the session cluster is being deleted" bypass on `BLOCK_ON_SESSION_JOBS`. When that option is enabled (default), fall through to the regular cancel path so the Flink job is actually stopped, allowing `SessionReconciler` to release the finalizer and complete the cluster teardown.
  - Read `observeConfig` lazily inside the `DELETING`/`DELETED` branch (it can be `null` when the JobManager is unreachable, e.g. for unhealthy clusters); when `null`, take the bypass since no JM-side guard can fire anyway.
  - Move the existing `observeConfig` access inside the `try` block back to a `ctx.getObserveConfig()` call, and replace the deprecated `Configuration#getBoolean(ConfigOption)` calls with `Configuration#get(ConfigOption)`.

## Verifying this change

This change added tests and can be verified as follows:

  - Added `SessionJobReconcilerTest#testCleanupWithDeletingClusterBlockOnSessionJobsDisabled` (parameterized over `DELETING` and `DELETED`): asserts the bypass still fires when `BLOCK_ON_SESSION_JOBS=false`, the finalizer is removed, and the job is left untouched.
  - Added `SessionJobReconcilerTest#testCleanupWithDeletingClusterBlockOnSessionJobsEnabled` (parameterized over `DELETING` and `DELETED`): asserts that with `BLOCK_ON_SESSION_JOBS=true` the cancel path is taken, the cluster-side job transitions to `CANCELED`, and the reconciler reschedules with the finalizer held until cancellation is re-observed — the exact path that breaks the deadlock.
  - Added `TestUtils#createContextWithReadyFlinkDeploymentInLifecycleState` so tests can produce a context with a `READY` JobManager in a given lifecycle state with a custom flink configuration; the pre-existing `createContextWithFlinkDeploymentInLifecycleState` always sets the JM to `MISSING`, which short-circuits the new gate via `observeConfig == null` and so cannot exercise it.
  - Existing `testCleanupWithDeletingSessionCluster`, `testCleanupWithDeletedSessionCluster`, and `testCleanupWithUnhealthySessionClusterNoHa` continue to pass — they cover the third path of the new gate (`observeConfig == null` when the JM is `MISSING`).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable