### PR TITLE
[FLINK-39646][examples] Update python example to Flink 2.2

### DIFF
--- a/examples/flink-python-example/Dockerfile
+++ b/examples/flink-python-example/Dockerfile
@@ -16,27 +16,22 @@
 # limitations under the License.
 ################################################################################
 # Check https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/standalone/docker/#using-flink-python-on-docker for more details
-FROM flink:1.16
+FROM flink:2.2
 
-# install python3: it has updated Python to 3.9 in Debian 11 and so install Python 3.7 from source, \
-# it currently only supports Python 3.6, 3.7 and 3.8 in PyFlink officially.
+# The flink:2.x base image runs as the non-root `flink` user; switch to root
+# to install system packages, then drop privileges again before adding the job.
+USER root
 
+# install python3 and pip3
 RUN apt-get update -y && \
-apt-get install -y build-essential libssl-dev zlib1g-dev libbz2-dev libffi-dev && \
-wget https://www.python.org/ftp/python/3.7.9/Python-3.7.9.tgz && \
-tar -xvf Python-3.7.9.tgz && \
-cd Python-3.7.9 && \
-./configure --without-tests --enable-shared && \
-make -j6 && \
-make install && \
-ldconfig /usr/local/lib && \
-cd .. && rm -f Python-3.7.9.tgz && rm -rf Python-3.7.9 && \
-ln -s /usr/local/bin/python3 /usr/local/bin/python && \
-apt-get clean && \
-rm -rf /var/lib/apt/lists/*
+    apt-get install -y python3 python3-pip python3-dev && \
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/bin/python3 /usr/bin/python
 
-# install PyFlink
-RUN pip3 install "apache-flink>=1.16.0,<1.17.1"
+# install PyFlink (PyFlink 2.2 supports Python 3.9, 3.10, 3.11, 3.12).
+# --break-system-packages is required because the base image is Ubuntu 24.04
+# (Noble), which enforces PEP 668.
+RUN pip3 install --break-system-packages apache-flink==2.2.0
 
 # add python script
 USER flink

--- a/examples/flink-python-example/README.md
+++ b/examples/flink-python-example/README.md
@@ -46,11 +46,11 @@ user-defined arguments should be placed in the end. Check the [doc](https://nigh
 
 A working example would be:
 ```yaml
-args: ["-pyfs", "/opt/flink/usrlib/pythonjob/python_demo.py", "-pyclientexec", "/usr/bin/python3", "-py", "/opt/flink/usrlib/pythonjob/python_demo.py", "-myarg", "123"]
+args: ["-pyfs", "/opt/flink/usrlib/python_demo.py", "-pyclientexec", "/usr/bin/python3", "-py", "/opt/flink/usrlib/python_demo.py", "-myarg", "123"]
 ```
 But the following will throw exception:
 ```yaml
-args: ["-myarg", "123", "-pyfs", "/opt/flink/usrlib/pythonjob/python_demo.py", "-pyclientexec", "/usr/bin/python3", "-py", "/opt/flink/usrlib/pythonjob/python_demo.py"]
+args: ["-myarg", "123", "-pyfs", "/opt/flink/usrlib/python_demo.py", "-pyclientexec", "/usr/bin/python3", "-py", "/opt/flink/usrlib/python_demo.py"]
 ```
 
 ## Usage
@@ -65,13 +65,13 @@ Dockerfile
 
 Check this [doc](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/standalone/docker/#using-flink-python-on-docker) for more details about building a PyFlink image. The included Dockerfile is based on `flink:2.2` and installs PyFlink 2.2.0 (which supports Python 3.9, 3.10, 3.11 and 3.12).
 
-Note: PyFlink's `pemja` dependency only ships pre-built Linux wheels for `x86_64`. On other architectures (e.g. Apple Silicon) the build falls back to compiling from source, which fails because `flink:2.2` ships a JRE-only image. Build for `linux/amd64` explicitly in that case (`docker build --platform linux/amd64 ...`).
+Note: PyFlink's `pemja` dependency only ships pre-built Linux wheels for `x86_64`, and the `flink:2.2` base image is JRE-only, so building from source on other architectures fails. Build for `linux/amd64` explicitly - the resulting image runs natively on x86 and on Apple Silicon via Docker Desktop's emulation.
 
 ```bash
 # Uncomment when building for local minikube env:
 # eval $(minikube docker-env)
 
-DOCKER_BUILDKIT=1 docker build . -t flink-python-example:latest
+DOCKER_BUILDKIT=1 docker build --platform linux/amd64 . -t flink-python-example:latest
 ```
 This step will create an image based on an official Flink base image including the Python scripts.
 

--- a/examples/flink-python-example/README.md
+++ b/examples/flink-python-example/README.md
@@ -35,7 +35,7 @@ This is an end-to-end example of running Flink Python jobs using the Flink Kuber
 Flink supports Python jobs in application mode by utilizing `org.apache.flink.client.python.PythonDriver` class as the 
 entry class. With the Flink Kubernetes Operator, we can reuse this class to run Python jobs as well. 
 
-The class is packaged in flink-python_${scala_version}-${flink_version}.jar which is in the default Flink image.
+The class is packaged in flink-python-${flink_version}.jar which is in the default Flink image.
 So we do not need to create a new job jar. Instead, we just set `entryClass` of the job crd to 
 `org.apache.flink.client.python.PythonDriver`. After applying the job yaml, the launched job manager pod will run the `main()` 
 method of PythonDriver and parse arguments declared in the `args` field of the job crd.
@@ -46,11 +46,11 @@ user-defined arguments should be placed in the end. Check the [doc](https://nigh
 
 A working example would be:
 ```yaml
-args: ["-pyfs", "/opt/flink/usrlib/pythonjob/python_demo.py", "-pyclientexec", "/usr/local/bin/python3", "-py", "/opt/flink/usrlib/pythonjob/python_demo.py", "-myarg", "123"]
+args: ["-pyfs", "/opt/flink/usrlib/pythonjob/python_demo.py", "-pyclientexec", "/usr/bin/python3", "-py", "/opt/flink/usrlib/pythonjob/python_demo.py", "-myarg", "123"]
 ```
 But the following will throw exception:
 ```yaml
-args: ["-myarg", "123", "-pyfs", "/opt/flink/usrlib/pythonjob/python_demo.py", "-pyclientexec", "/usr/local/bin/python3", "-py", "/opt/flink/usrlib/pythonjob/python_demo.py"]
+args: ["-myarg", "123", "-pyfs", "/opt/flink/usrlib/pythonjob/python_demo.py", "-pyclientexec", "/usr/bin/python3", "-py", "/opt/flink/usrlib/pythonjob/python_demo.py"]
 ```
 
 ## Usage
@@ -63,7 +63,10 @@ Dockerfile
 
 **Step 2**: Build docker image
 
-Check this [doc](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/standalone/docker/#using-flink-python-on-docker) for more details about building Pyflink image. Note, Pyflink 1.15.3 is only supported on x86 arch.  
+Check this [doc](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/standalone/docker/#using-flink-python-on-docker) for more details about building a PyFlink image. The included Dockerfile is based on `flink:2.2` and installs PyFlink 2.2.0 (which supports Python 3.9, 3.10, 3.11 and 3.12).
+
+Note: PyFlink's `pemja` dependency only ships pre-built Linux wheels for `x86_64`. On other architectures (e.g. Apple Silicon) the build falls back to compiling from source, which fails because `flink:2.2` ships a JRE-only image. Build for `linux/amd64` explicitly in that case (`docker build --platform linux/amd64 ...`).
+
 ```bash
 # Uncomment when building for local minikube env:
 # eval $(minikube docker-env)
@@ -72,7 +75,7 @@ DOCKER_BUILDKIT=1 docker build . -t flink-python-example:latest
 ```
 This step will create an image based on an official Flink base image including the Python scripts.
 
-**Step 4**: Create FlinkDeployment Yaml and Submit
+**Step 3**: Create FlinkDeployment Yaml and Submit
 
 Edit the included `python-example.yaml` so that the `job.args` section points to the Python script that you wish to execute, then submit it.
 

--- a/examples/flink-python-example/python-example.yaml
+++ b/examples/flink-python-example/python-example.yaml
@@ -22,7 +22,7 @@ metadata:
   name: python-example
 spec:
   image: flink-python-example:latest
-  flinkVersion: v1_20
+  flinkVersion: v2_2
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: 1
   serviceAccount: flink
@@ -35,8 +35,8 @@ spec:
       memory: "2048m"
       cpu: 1
   job:
-    jarURI: local:///opt/flink/opt/flink-python_2.12-1.16.1.jar # Note, this jarURI is actually a placeholder
+    jarURI: local:///opt/flink/opt/flink-python-2.2.0.jar # Note, this jarURI is actually a placeholder
     entryClass: "org.apache.flink.client.python.PythonDriver"
-    args: ["-pyclientexec", "/usr/local/bin/python3", "-py", "/opt/flink/usrlib/python_demo.py"]
+    args: ["-pyclientexec", "/usr/bin/python3", "-py", "/opt/flink/usrlib/python_demo.py"]
     parallelism: 1
     upgradeMode: stateless


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Bring `examples/flink-python-example/` in line with the rest of the examples directory, which targets Flink 2.2.


## Brief change log

  - **Dockerfile**: bump base image `flink:1.16` → `flink:2.2`
  - **python-example.yaml**: `flinkVersion: v1_20` → `v2_2` (matches every other example YAML).
  - **README.md**: refresh the PyFlink/Python compatibility note

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
This change has been verified manually on a local minikube cluster.
With Flink Kubernetes Operator 1.14.0 + cert-manager installed, `kubectl apply -f python-example.yaml` (with `imagePullPolicy: Never` for the local image) brings the FlinkDeployment to `STABLE / READY / RUNNING`. The JM logs confirm the operator invokes `PythonDriver` with the new `-pyclientexec /usr/bin/python3` and `pipeline.jars=local:///opt/flink/opt/flink-python-2.2.0.jar`. The TaskManager's `print` sink emits records from the `datagen` source continuously, with no restarts over a multi-hour run.

This change is **a documentation/example-only change** it does not modify any production code paths.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no, changes inside an example image only)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
