### PR TITLE
[FLINK-39688] Share a single PluginManager across operator and webhook startup

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -21,7 +21,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.plugin.PluginManager;
-import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
@@ -53,6 +52,7 @@ import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
+import org.apache.flink.kubernetes.operator.utils.OperatorPluginUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
@@ -105,7 +105,8 @@ public class FlinkOperator {
                                 KubernetesClientUtils.isCrdInstalled(FlinkStateSnapshot.class));
 
         baseConfig = configManager.getDefaultConfig();
-        this.metricGroup = OperatorMetricUtils.initOperatorMetrics(baseConfig);
+        PluginManager pluginManager = OperatorPluginUtils.createPluginManager(baseConfig);
+        this.metricGroup = OperatorMetricUtils.initOperatorMetrics(baseConfig, pluginManager);
         if (client == null) {
             this.client =
                     KubernetesClientUtils.getKubernetesClient(
@@ -114,12 +115,12 @@ public class FlinkOperator {
             this.client = client;
         }
         this.operator = createOperator();
-        this.validators = ValidatorUtils.discoverValidators(configManager);
-        this.listeners = ListenerUtils.discoverListeners(configManager);
+        this.validators = ValidatorUtils.discoverValidators(configManager, pluginManager);
+        this.listeners = ListenerUtils.discoverListeners(configManager, pluginManager);
         this.eventRecorder = EventRecorder.create(client, listeners);
         this.ctxFactory =
                 new FlinkResourceContextFactory(configManager, metricGroup, eventRecorder);
-        PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(baseConfig);
+        LOG.info("Initializing file system factories from plugin directory.");
         FileSystem.initialize(baseConfig, pluginManager);
         this.operatorHealthService = OperatorHealthService.fromConfig(configManager);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/ListenerUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/ListenerUtils.java
@@ -26,7 +26,6 @@ import org.apache.flink.configuration.DelegatingConfiguration;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.kubernetes.operator.api.listener.FlinkResourceListener;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
-import org.apache.flink.kubernetes.operator.utils.OperatorPluginUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,16 +59,9 @@ public class ListenerUtils {
      * kubernetes.operator.plugins.listeners.test.k1: v1
      *
      * @param configManager {@link FlinkConfigManager} to access plugin configurations.
+     * @param pluginManager shared {@link PluginManager} used for plugin discovery.
      * @return Enabled listeners.
      */
-    @VisibleForTesting
-    public static Collection<FlinkResourceListener> discoverListeners(
-            FlinkConfigManager configManager) {
-        return discoverListeners(
-                configManager,
-                OperatorPluginUtils.createPluginManager(configManager.getDefaultConfig()));
-    }
-
     public static Collection<FlinkResourceListener> discoverListeners(
             FlinkConfigManager configManager, PluginManager pluginManager) {
         var listeners = new ArrayList<FlinkResourceListener>();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/ListenerUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/listener/ListenerUtils.java
@@ -22,21 +22,19 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.DelegatingConfiguration;
-import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.kubernetes.operator.api.listener.FlinkResourceListener;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.utils.OperatorPluginUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -53,8 +51,6 @@ public class ListenerUtils {
     private static final String SUFFIX = ".class";
     private static final Pattern PTN =
             Pattern.compile(Pattern.quote(PREFIX) + "([\\S&&[^.]]*)" + Pattern.quote(SUFFIX));
-    private static final List<String> EXTRA_PARENT_FIRST_PATTERNS =
-            List.of("io.fabric8", "com.fasterxml");
 
     /**
      * Load {@link FlinkResourceListener} implementations from the plugin directory. Only listeners
@@ -66,13 +62,22 @@ public class ListenerUtils {
      * @param configManager {@link FlinkConfigManager} to access plugin configurations.
      * @return Enabled listeners.
      */
+    @VisibleForTesting
     public static Collection<FlinkResourceListener> discoverListeners(
             FlinkConfigManager configManager) {
+        return discoverListeners(
+                configManager,
+                OperatorPluginUtils.createPluginManager(configManager.getDefaultConfig()));
+    }
+
+    public static Collection<FlinkResourceListener> discoverListeners(
+            FlinkConfigManager configManager, PluginManager pluginManager) {
         var listeners = new ArrayList<FlinkResourceListener>();
-        var conf = getListenerBaseConf(configManager);
+        var conf = configManager.getDefaultConfig();
 
         Map<String, Configuration> listenerConfigs = loadListenerConfigs(conf);
-        PluginUtils.createPluginManagerFromRootFolder(conf)
+        LOG.info("Loading FlinkResourceListener implementations from plugin directory.");
+        pluginManager
                 .load(FlinkResourceListener.class)
                 .forEachRemaining(
                         listener -> {
@@ -94,21 +99,6 @@ public class ListenerUtils {
                             }
                         });
         return listeners;
-    }
-
-    private static Configuration getListenerBaseConf(FlinkConfigManager configManager) {
-        var conf = new Configuration(configManager.getDefaultConfig());
-        List<String> additionalPatterns =
-                new ArrayList<>(
-                        conf.getOptional(
-                                        CoreOptions
-                                                .PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL)
-                                .orElse(Collections.emptyList()));
-        additionalPatterns.addAll(EXTRA_PARENT_FIRST_PATTERNS);
-        conf.set(
-                CoreOptions.PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
-                additionalPatterns);
-        return conf;
     }
 
     @VisibleForTesting

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/OperatorMetricUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/OperatorMetricUtils.java
@@ -20,11 +20,11 @@ package org.apache.flink.kubernetes.operator.metrics;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.plugin.PluginManager;
-import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
+import org.apache.flink.kubernetes.operator.utils.OperatorPluginUtils;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.HistogramStatistics;
@@ -55,10 +55,16 @@ public class OperatorMetricUtils {
     private static final String OPERATOR_METRICS_PREFIX = K8S_OP_CONF_PREFIX + "metrics.";
     private static final String METRICS_PREFIX = "metrics.";
 
+    @VisibleForTesting
     public static KubernetesOperatorMetricGroup initOperatorMetrics(Configuration defaultConfig) {
+        return initOperatorMetrics(
+                defaultConfig, OperatorPluginUtils.createPluginManager(defaultConfig));
+    }
+
+    public static KubernetesOperatorMetricGroup initOperatorMetrics(
+            Configuration defaultConfig, PluginManager pluginManager) {
         Configuration metricConfig = createMetricConfig(defaultConfig);
         LOG.info("Initializing operator metrics using conf: {}", metricConfig);
-        PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(metricConfig);
         MetricRegistry metricRegistry = createMetricRegistry(metricConfig, pluginManager);
         KubernetesOperatorMetricGroup operatorMetricGroup =
                 KubernetesOperatorMetricGroup.create(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/MutatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/MutatorUtils.java
@@ -17,8 +17,9 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.mutator.DefaultFlinkMutator;
 import org.apache.flink.kubernetes.operator.mutator.FlinkResourceMutator;
@@ -40,13 +41,22 @@ public final class MutatorUtils {
      * @param configManager Flink Config manager
      * @return Set of FlinkResourceMutator
      */
+    @VisibleForTesting
     public static Set<FlinkResourceMutator> discoverMutators(FlinkConfigManager configManager) {
+        return discoverMutators(
+                configManager,
+                OperatorPluginUtils.createPluginManager(configManager.getDefaultConfig()));
+    }
+
+    public static Set<FlinkResourceMutator> discoverMutators(
+            FlinkConfigManager configManager, PluginManager pluginManager) {
         var conf = configManager.getDefaultConfig();
         Set<FlinkResourceMutator> flinkmutator = new HashSet<>();
         DefaultFlinkMutator defaultFlinkMutator = new DefaultFlinkMutator();
         defaultFlinkMutator.configure(conf);
         flinkmutator.add(defaultFlinkMutator);
-        PluginUtils.createPluginManagerFromRootFolder(conf)
+        LOG.info("Loading FlinkResourceMutator implementations from plugin directory.");
+        pluginManager
                 .load(FlinkResourceMutator.class)
                 .forEachRemaining(
                         mutator -> {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/MutatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/MutatorUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
@@ -34,19 +33,6 @@ import java.util.Set;
 public final class MutatorUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(MutatorUtils.class);
-
-    /**
-     * discovers mutators.
-     *
-     * @param configManager Flink Config manager
-     * @return Set of FlinkResourceMutator
-     */
-    @VisibleForTesting
-    public static Set<FlinkResourceMutator> discoverMutators(FlinkConfigManager configManager) {
-        return discoverMutators(
-                configManager,
-                OperatorPluginUtils.createPluginManager(configManager.getDefaultConfig()));
-    }
 
     public static Set<FlinkResourceMutator> discoverMutators(
             FlinkConfigManager configManager, PluginManager pluginManager) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/OperatorPluginUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/OperatorPluginUtils.java
@@ -42,7 +42,7 @@ public final class OperatorPluginUtils {
     private OperatorPluginUtils() {}
 
     /** Returns a copy of {@code baseConf} with the operator's parent-first patterns merged in. */
-    public static Configuration enrichWithPluginParentFirstPatterns(Configuration baseConf) {
+    private static Configuration enrichWithPluginParentFirstPatterns(Configuration baseConf) {
         var conf = new Configuration(baseConf);
         var patterns =
                 new ArrayList<>(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/OperatorPluginUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/OperatorPluginUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.core.plugin.PluginUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Builds the single, process-wide {@link PluginManager} used by the operator and webhook for plugin
+ * discovery (metric reporters, file systems, validators, mutators, listeners).
+ *
+ * <p>Plugin classloaders delegate {@code io.fabric8} and {@code com.fasterxml} to the parent so all
+ * plugins share the operator's fabric8 client and Jackson, avoiding duplicate informers and version
+ * skew.
+ */
+public final class OperatorPluginUtils {
+
+    private static final List<String> EXTRA_PARENT_FIRST_PATTERNS =
+            List.of("io.fabric8", "com.fasterxml");
+
+    private OperatorPluginUtils() {}
+
+    /** Returns a copy of {@code baseConf} with the operator's parent-first patterns merged in. */
+    public static Configuration enrichWithPluginParentFirstPatterns(Configuration baseConf) {
+        var conf = new Configuration(baseConf);
+        var patterns =
+                new ArrayList<>(
+                        conf.getOptional(
+                                        CoreOptions
+                                                .PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL)
+                                .orElse(Collections.emptyList()));
+        for (var p : EXTRA_PARENT_FIRST_PATTERNS) {
+            if (!patterns.contains(p)) {
+                patterns.add(p);
+            }
+        }
+        conf.set(CoreOptions.PLUGIN_ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL, patterns);
+        return conf;
+    }
+
+    /** Creates the shared {@link PluginManager} from {@code baseConf}, enriching it as needed. */
+    public static PluginManager createPluginManager(Configuration baseConf) {
+        return PluginUtils.createPluginManagerFromRootFolder(
+                enrichWithPluginParentFirstPatterns(baseConf));
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
@@ -17,8 +17,9 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ConfigConstants;
-import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
@@ -36,13 +37,22 @@ public final class ValidatorUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlinkUtils.class);
 
+    @VisibleForTesting
     public static Set<FlinkResourceValidator> discoverValidators(FlinkConfigManager configManager) {
+        return discoverValidators(
+                configManager,
+                OperatorPluginUtils.createPluginManager(configManager.getDefaultConfig()));
+    }
+
+    public static Set<FlinkResourceValidator> discoverValidators(
+            FlinkConfigManager configManager, PluginManager pluginManager) {
         var conf = configManager.getDefaultConfig();
         Set<FlinkResourceValidator> resourceValidators = new HashSet<>();
         DefaultValidator defaultValidator = new DefaultValidator(configManager);
         defaultValidator.configure(conf);
         resourceValidators.add(defaultValidator);
-        PluginUtils.createPluginManagerFromRootFolder(conf)
+        LOG.info("Loading FlinkResourceValidator implementations from plugin directory.");
+        pluginManager
                 .load(FlinkResourceValidator.class)
                 .forEachRemaining(
                         validator -> {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.kubernetes.operator.api.spec.FlinkVersion;
@@ -36,13 +35,6 @@ import java.util.Set;
 public final class ValidatorUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlinkUtils.class);
-
-    @VisibleForTesting
-    public static Set<FlinkResourceValidator> discoverValidators(FlinkConfigManager configManager) {
-        return discoverValidators(
-                configManager,
-                OperatorPluginUtils.createPluginManager(configManager.getDefaultConfig()));
-    }
 
     public static Set<FlinkResourceValidator> discoverValidators(
             FlinkConfigManager configManager, PluginManager pluginManager) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
@@ -44,6 +44,7 @@ import org.apache.flink.kubernetes.operator.reconciler.snapshot.StateSnapshotRec
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.FlinkResourceEventCollector;
 import org.apache.flink.kubernetes.operator.utils.FlinkStateSnapshotEventCollector;
+import org.apache.flink.kubernetes.operator.utils.OperatorPluginUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 
@@ -122,7 +123,10 @@ public class FlinkStateSnapshotControllerTest {
         statusRecorder = new StatusRecorder<>(metricManager, statusUpdateCounter);
         controller =
                 new FlinkStateSnapshotController(
-                        ValidatorUtils.discoverValidators(configManager),
+                        ValidatorUtils.discoverValidators(
+                                configManager,
+                                OperatorPluginUtils.createPluginManager(
+                                        configManager.getDefaultConfig())),
                         ctxFactory,
                         new StateSnapshotReconciler(ctxFactory, eventRecorder),
                         new StateSnapshotObserver(ctxFactory, eventRecorder),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkDeploymentController.java
@@ -36,6 +36,7 @@ import org.apache.flink.kubernetes.operator.resources.ClusterResourceManager;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.FlinkResourceEventCollector;
 import org.apache.flink.kubernetes.operator.utils.FlinkStateSnapshotEventCollector;
+import org.apache.flink.kubernetes.operator.utils.OperatorPluginUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 
@@ -104,7 +105,10 @@ public class TestingFlinkDeploymentController
         canaryResourceManager = new CanaryResourceManager<>(configManager);
         flinkDeploymentController =
                 new FlinkDeploymentController(
-                        ValidatorUtils.discoverValidators(configManager),
+                        ValidatorUtils.discoverValidators(
+                                configManager,
+                                OperatorPluginUtils.createPluginManager(
+                                        configManager.getDefaultConfig())),
                         contextFactory,
                         reconcilerFactory,
                         new FlinkDeploymentObserverFactory(eventRecorder),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
@@ -35,6 +35,7 @@ import org.apache.flink.kubernetes.operator.reconciler.sessionjob.SessionJobReco
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.FlinkResourceEventCollector;
 import org.apache.flink.kubernetes.operator.utils.FlinkStateSnapshotEventCollector;
+import org.apache.flink.kubernetes.operator.utils.OperatorPluginUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 
@@ -90,7 +91,10 @@ public class TestingFlinkSessionJobController
 
         flinkSessionJobController =
                 new FlinkSessionJobController(
-                        ValidatorUtils.discoverValidators(configManager),
+                        ValidatorUtils.discoverValidators(
+                                configManager,
+                                OperatorPluginUtils.createPluginManager(
+                                        configManager.getDefaultConfig())),
                         ctxFactory,
                         new SessionJobReconciler(
                                 eventRecorder, statusRecorder, new NoopJobAutoscaler<>()),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/ListenerUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/listener/ListenerUtilsTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.utils.OperatorPluginUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -56,10 +57,11 @@ public class ListenerUtilsTest {
                     ConfigConstants.ENV_FLINK_PLUGINS_DIR,
                     TestUtils.getTestPluginsRootDir(temporaryFolder));
             TestUtils.setEnv(systemEnv);
+            var configManager = new FlinkConfigManager(Configuration.fromMap(testConfig));
+            var pluginManager =
+                    OperatorPluginUtils.createPluginManager(configManager.getDefaultConfig());
             var listeners =
-                    new ArrayList<>(
-                            ListenerUtils.discoverListeners(
-                                    new FlinkConfigManager(Configuration.fromMap(testConfig))));
+                    new ArrayList<>(ListenerUtils.discoverListeners(configManager, pluginManager));
             assertEquals(1, listeners.size());
 
             var testingListener = (TestingListener) listeners.get(0);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/MutatorUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/MutatorUtilsTest.java
@@ -52,13 +52,15 @@ public class MutatorUtilsTest {
                     ConfigConstants.ENV_FLINK_PLUGINS_DIR,
                     TestUtils.getTestPluginsRootDir(temporaryFolder));
             TestUtils.setEnv(systemEnv);
+            var configManager = new FlinkConfigManager(new Configuration());
+            var pluginManager =
+                    OperatorPluginUtils.createPluginManager(configManager.getDefaultConfig());
             assertEquals(
                     new HashSet<>(
                             Arrays.asList(
                                     DefaultFlinkMutator.class.getName(),
                                     TestMutator.class.getName())),
-                    MutatorUtils.discoverMutators(new FlinkConfigManager(new Configuration()))
-                            .stream()
+                    MutatorUtils.discoverMutators(configManager, pluginManager).stream()
                             .map(v -> v.getClass().getName())
                             .collect(Collectors.toSet()));
         } finally {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtilsTest.java
@@ -52,13 +52,15 @@ public class ValidatorUtilsTest {
                     ConfigConstants.ENV_FLINK_PLUGINS_DIR,
                     TestUtils.getTestPluginsRootDir(temporaryFolder));
             TestUtils.setEnv(systemEnv);
+            var configManager = new FlinkConfigManager(new Configuration());
+            var pluginManager =
+                    OperatorPluginUtils.createPluginManager(configManager.getDefaultConfig());
             assertEquals(
                     new HashSet<>(
                             Arrays.asList(
                                     DefaultValidator.class.getName(),
                                     TestValidator.class.getName())),
-                    ValidatorUtils.discoverValidators(new FlinkConfigManager(new Configuration()))
-                            .stream()
+                    ValidatorUtils.discoverValidators(configManager, pluginManager).stream()
                             .map(v -> v.getClass().getName())
                             .collect(Collectors.toSet()));
         } finally {

--- a/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
+++ b/flink-kubernetes-webhook/src/main/java/org/apache/flink/kubernetes/operator/admission/FlinkOperatorWebhook.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.admission;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.kubernetes.operator.admission.informer.InformerManager;
 import org.apache.flink.kubernetes.operator.admission.mutator.FlinkMutator;
 import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
@@ -28,6 +29,7 @@ import org.apache.flink.kubernetes.operator.ssl.ReloadableSslContext;
 import org.apache.flink.kubernetes.operator.utils.EnvUtils;
 import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
 import org.apache.flink.kubernetes.operator.utils.MutatorUtils;
+import org.apache.flink.kubernetes.operator.utils.OperatorPluginUtils;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
 
@@ -83,8 +85,10 @@ public class FlinkOperatorWebhook {
             informerManager.setNamespaces(operatorConfig.getWatchedNamespaces());
         }
 
-        this.validators = ValidatorUtils.discoverValidators(configManager);
-        this.mutators = MutatorUtils.discoverMutators(configManager);
+        PluginManager pluginManager =
+                OperatorPluginUtils.createPluginManager(configManager.getDefaultConfig());
+        this.validators = ValidatorUtils.discoverValidators(configManager, pluginManager);
+        this.mutators = MutatorUtils.discoverMutators(configManager, pluginManager);
         this.admissionHandler =
                 new AdmissionHandler(
                         new FlinkValidator(validators, informerManager),

--- a/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
+++ b/flink-kubernetes-webhook/src/test/java/org/apache/flink/kubernetes/operator/admission/AdmissionHandlerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.admission;
 
+import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.kubernetes.operator.admission.informer.InformerManager;
 import org.apache.flink.kubernetes.operator.admission.mutator.FlinkMutator;
 import org.apache.flink.kubernetes.operator.api.CrdConstants;
@@ -27,6 +28,7 @@ import org.apache.flink.kubernetes.operator.api.spec.FlinkSessionJobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.utils.MutatorUtils;
+import org.apache.flink.kubernetes.operator.utils.OperatorPluginUtils;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.Unpooled;
@@ -67,15 +69,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @EnableKubernetesMockClient(crud = true)
 public class AdmissionHandlerTest {
 
+    private static final FlinkConfigManager CONFIG_MANAGER = new FlinkConfigManager(ns -> {}, true);
+    private static final PluginManager PLUGIN_MANAGER =
+            OperatorPluginUtils.createPluginManager(CONFIG_MANAGER.getDefaultConfig());
+
     private KubernetesClient kubernetesClient;
     private AdmissionHandler admissionHandler =
             new AdmissionHandler(
                     new FlinkValidator(
-                            ValidatorUtils.discoverValidators(
-                                    new FlinkConfigManager(ns -> {}, true)),
+                            ValidatorUtils.discoverValidators(CONFIG_MANAGER, PLUGIN_MANAGER),
                             new InformerManager(null)),
                     new FlinkMutator(
-                            MutatorUtils.discoverMutators(new FlinkConfigManager(ns -> {}, true)),
+                            MutatorUtils.discoverMutators(CONFIG_MANAGER, PLUGIN_MANAGER),
                             new InformerManager(kubernetesClient)));
 
     @Test
@@ -149,12 +154,10 @@ public class AdmissionHandlerTest {
         admissionHandler =
                 new AdmissionHandler(
                         new FlinkValidator(
-                                ValidatorUtils.discoverValidators(
-                                        new FlinkConfigManager(ns -> {}, true)),
+                                ValidatorUtils.discoverValidators(CONFIG_MANAGER, PLUGIN_MANAGER),
                                 new InformerManager(null)),
                         new FlinkMutator(
-                                MutatorUtils.discoverMutators(
-                                        new FlinkConfigManager(ns -> {}, true)),
+                                MutatorUtils.discoverMutators(CONFIG_MANAGER, PLUGIN_MANAGER),
                                 informerManager));
 
         final EmbeddedChannel embeddedChannel = new EmbeddedChannel(admissionHandler);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The operator currently constructs a brand-new `PluginManager` four times during startup (one per consumer: metric reporters, validators, listeners, file systems), and the webhook constructs it twice more (validators, mutators). Every call rescans `/opt/flink/plugins`, builds a fresh isolated child `URLClassLoader` per plugin directory, and floods the startup logs with a duplicated `"Plugin loader with ID not found, creating it: <subdir>"` batch per call. This change consolidates discovery onto a single shared `PluginManager` per JVM, which removes the duplicate logs, drops redundant classloader allocations, and eliminates a latent classloader-identity hazard if a plugin class were ever loaded through two different SPIs.

## Brief change log

  - Added `OperatorPluginUtils` (in `flink-kubernetes-operator/utils/`) which owns the operator-wide plugin classloader policy. It exposes `enrichWithPluginParentFirstPatterns(Configuration)` and `createPluginManager(Configuration)`, and centralizes the `io.fabric8` / `com.fasterxml` parent-first patterns that previously lived in `ListenerUtils` only.
  - Added a 2-arg `(FlinkConfigManager, PluginManager)` overload to `ValidatorUtils.discoverValidators`, `ListenerUtils.discoverListeners`, `MutatorUtils.discoverMutators`, and a `(Configuration, PluginManager)` overload to `OperatorMetricUtils.initOperatorMetrics`. The existing single-arg overloads delegate to the new ones (creating a manager via `OperatorPluginUtils`) and are now annotated `@VisibleForTesting`, since after the refactor they have no production callers and exist only to keep test fixtures simple.
  - `FlinkOperator` constructor now creates one shared `PluginManager` via `OperatorPluginUtils.createPluginManager(baseConfig)` and threads it into all four consumers (`initOperatorMetrics`, `discoverValidators`, `discoverListeners`, `FileSystem.initialize`).
  - `FlinkOperatorWebhook` constructor mirrors the same pattern for `discoverValidators` and `discoverMutators`.
  - `ListenerUtils` no longer carries the `EXTRA_PARENT_FIRST_PATTERNS` constant or the `getListenerBaseConf` helper, the parent-first policy now applies process-wide via `OperatorPluginUtils`. Promoting it globally is intentional and safe: every plugin type (metric reporters, FS factories, validators, mutators, listeners) benefits from sharing the operator's fabric8 client and Jackson, avoiding duplicate informers and version skew.
  - Added a one-line INFO header before each `pluginManager.load(...)` call so the Flink-internal `"Plugin loader with ID found, reusing it: <subdir>"` batches are clearly attributed to a specific SPI: `"Loading FlinkResourceValidator implementations from plugin directory."` (`ValidatorUtils`), `"Loading FlinkResourceListener ..."` (`ListenerUtils`), `"Loading FlinkResourceMutator ..."` (`MutatorUtils`), and `"Initializing file system factories from plugin directory."` (`FlinkOperator`, before `FileSystem.initialize`). The metrics path already prints `"Initializing operator metrics using conf: ..."` and needs no extra header.

## Verifying this change

This change is already covered by existing tests, such as `ListenerUtilsTest`, `ValidatorUtilsTest`, `MutatorUtilsTest`, `OperatorMetricUtilsTest`, `FlinkOperatorTest`, `AdmissionHandlerTest`, and `FlinkStateSnapshotControllerTest` (the latter exercises the preserved single-arg overload). All pass locally. Runtime behavior was verified from the test logs: `FlinkOperatorTest` now emits a single `Initializing operator metrics ...` line followed directly by `FileSystem` initialization, with no repeated plugin scanning batches.

End-to-end verification on minikube against a real operator image with a populated `/opt/flink/plugins` confirms the same: the operator now logs exactly one `"Plugin loader with ID not found, creating it: <subdir>"` batch at startup (was 4 before this PR). The remaining `"Plugin loader with ID found, reusing it: <subdir>"` lines that still appear are emitted from inside Flink's `DefaultPluginManager.load(SomeSPI.class)` itself, once per registered loader per call, and are independent of how many `PluginManager` instances exist. They are out of scope for this PR (would require an upstream Flink log-level change), and operators that find them noisy can already silence them today via log4j:

```properties
logger.pluginmanager.name = org.apache.flink.core.plugin.DefaultPluginManager
logger.pluginmanager.level = WARN
```
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
