### PR TITLE
[FLINK-39713] Bump log4j, jackson, and Beam to retire CVEs

### DIFF
--- a/examples/flink-beam-example/pom.xml
+++ b/examples/flink-beam-example/pom.xml
@@ -33,7 +33,7 @@ under the License.
     <!-- Given that this is an example skip maven deployment -->
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <beam.version>2.62.0</beam.version>
+        <beam.version>2.73.0</beam.version>
     </properties>
 
     <repositories>

--- a/flink-autoscaler-standalone/src/main/resources/META-INF/NOTICE
+++ b/flink-autoscaler-standalone/src/main/resources/META-INF/NOTICE
@@ -17,10 +17,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-io:commons-io:jar:2.15.1
 - org.apache.commons:commons-lang3:jar:3.18.0
 - org.apache.commons:commons-math3:jar:3.6.1
-- org.apache.logging.log4j:log4j-1.2-api:jar:2.23.1
-- org.apache.logging.log4j:log4j-api:jar:2.23.1
-- org.apache.logging.log4j:log4j-core:jar:2.23.1
-- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.23.1
+- org.apache.logging.log4j:log4j-1.2-api:jar:2.25.4
+- org.apache.logging.log4j:log4j-api:jar:2.25.4
+- org.apache.logging.log4j:log4j-core:jar:2.25.4
+- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.25.4
 - org.javassist:javassist:jar:3.24.0-GA
 - org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.9.10
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.8.21

--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:jar:2.15.0
-- com.fasterxml.jackson.core:jackson-core:jar:2.15.0
-- com.fasterxml.jackson.core:jackson-databind:jar:2.15.0
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.15.0
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.15.0
+- com.fasterxml.jackson.core:jackson-annotations:jar:2.21.3
+- com.fasterxml.jackson.core:jackson-core:jar:2.21.3
+- com.fasterxml.jackson.core:jackson-databind:jar:2.21.3
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.21.3
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.21.3
 - com.google.code.findbugs:jsr305:jar:1.3.9
 - com.google.errorprone:error_prone_annotations:jar:2.36.0
 - com.google.guava:failureaccess:jar:1.0.2
@@ -59,10 +59,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:jar:3.18.0
 - org.apache.commons:commons-math3:jar:3.6.1
 - org.apache.commons:commons-text:jar:1.10.0
-- org.apache.logging.log4j:log4j-1.2-api:jar:2.23.1
-- org.apache.logging.log4j:log4j-api:jar:2.23.1
-- org.apache.logging.log4j:log4j-core:jar:2.23.1
-- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.23.1
+- org.apache.logging.log4j:log4j-1.2-api:jar:2.25.4
+- org.apache.logging.log4j:log4j-api:jar:2.25.4
+- org.apache.logging.log4j:log4j-core:jar:2.25.4
+- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.25.4
 - org.checkerframework:checker-qual:jar:3.43.0
 - org.javassist:javassist:jar:3.24.0-GA
 - org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.8.21
@@ -76,7 +76,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.slf4j:slf4j-api:jar:1.7.36
 - org.snakeyaml:snakeyaml-engine:jar:2.6
 - org.xerial.snappy:snappy-java:jar:1.1.10.4
-- org.yaml:snakeyaml:jar:2.0
+- org.yaml:snakeyaml:jar:2.5
 - tools.profiler:async-profiler:jar:2.9
 - io.github.java-diff-utils:java-diff-utils:4.15
 - io.fabric8:kubernetes-httpclient-jdk:7.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@ under the License.
         <guava.version>33.4.0-jre</guava.version>
 
         <slf4j.version>1.7.36</slf4j.version>
-        <log4j.version>2.23.1</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <logback.version>1.2.13</logback.version>
 
         <spotless.version>2.40.0</spotless.version>
@@ -126,7 +126,7 @@ under the License.
                 <artifactId>jackson-bom</artifactId>
                 <type>pom</type>
                 <scope>import</scope>
-                <version>2.15.0</version>
+                <version>2.21.3</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>


### PR DESCRIPTION
## What is the purpose of the change

Retire CVEs flagged by Trivy by bumping three direct dependencies. No `<dependencyManagement>` overrides on transitives.

JIRA: [FLINK-39713](https://issues.apache.org/jira/browse/FLINK-39713)

## Brief change log

- `pom.xml`: `log4j.version` 2.23.1 → 2.25.4
- `pom.xml`: `jackson-bom` 2.15.0 → 2.21.3
- `examples/flink-beam-example/pom.xml`: `beam.version` 2.62.0 → 2.73.0 — retires the 37 Trivy findings in the Beam-transitive chain (kaml, okio, wire-runtime, kafka-clients, opentelemetry-api, spring-*, parallel Netty); example-only scope, `beam-runners-flink-1.19` still publishes at 2.73.0 so no runner-artifact change. Per-CVE detail on [FLINK-39713](https://issues.apache.org/jira/browse/FLINK-39713).

Residual Netty / lz4-java / commons-lang3 CVEs come through `flink-runtime` and need a future Flink minor with Netty ≥ 4.1.133.

## Verifying this change

- **Unit tests:** Full reactor `mvn -B -ntp test` — 2,568 / 0 failures / 0 errors / 0 skipped.
- **Static + dependency-tree audit of the Jackson surface:** see the comment thread below.
- **Upgrade roundtrip on a local minikube cluster:**
  1. Built operator at `main` (`ac1b1357`, jackson-bom 2.15.0), helm-installed.
  2. Applied `examples/basic.yaml` (`basic-example`, 1 JM + 1 TM). Waited until `RUNNING/STABLE`. Status fields — including the `reconciliationStatus.lastReconciledSpec` / `lastStableSpec` JSON strings from `StatusRecorder` — were written by Jackson 2.15.0.
  3. Built the bumped image from `cve/log4j-jackson-bump` (jackson-bom 2.21.3), helm-upgraded.
  4. Waited 60 s under the bumped operator, then triggered a fresh reconcile with `kubectl annotate`.

  End state: `lifecycleState=STABLE / jobStatus.state=RUNNING / observedGeneration=1 / reconciliationStatus.state=DEPLOYED`. JM + TM pods at **0 restarts** across the upgrade. Bumped operator logs showed repeated `Resource fully reconciled, nothing to do…`. Jackson-error sweep across 1000 lines (`jackson | deserializ* | JsonProcessing* | JsonMapping* | MismatchedInput | UnrecognizedProperty | InvalidFormat | JsonParseException`) returned **0 matches**. Bumped Jackson reads cleanly what 2.15.0 wrote.

## Does this pull request potentially affect one of the following parts:

- Dependencies: **yes** (version bumps only)
- Public API / CRDs: no
- Core observer/reconciler logic: no

## Documentation

- New feature: no