### PR TITLE
[FLINK-39727] Bump fabric8 and operator-sdk to retire transitive CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,10 @@ under the License.
         <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
         <git-commit-id-maven-plugin.version>5.0.0</git-commit-id-maven-plugin.version>
 
-        <operator.sdk.version>5.2.2</operator.sdk.version>
+        <operator.sdk.version>5.3.4</operator.sdk.version>
         <operator.sdk.webhook-framework.version>3.0.0</operator.sdk.webhook-framework.version>
 
-        <fabric8.version>7.3.1</fabric8.version>
+        <fabric8.version>7.7.0</fabric8.version>
 
         <lombok.version>1.18.30</lombok.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>


### PR DESCRIPTION
## What is the purpose of the change

Retire Netty/Okio CVEs flowing through `kubernetes-client` and `operator-framework` by bumping the two direct dependencies to the latest stable within their major lines. No `<dependencyManagement>` overrides on transitives.

JIRA: [FLINK-39727](https://issues.apache.org/jira/browse/FLINK-39727)

## Brief change log

- `pom.xml`: `fabric8.version` 7.3.1 → 7.7.0 (latest 7.x stable, 2026-05-12)
- `pom.xml`: `operator.sdk.version` 5.2.2 → 5.3.4 (latest 5.x stable, 2026-05-19)

Residual Netty CVEs flowing through `flink-runtime` remain blocked on a future Flink minor bump (Netty ≥ 4.1.133).

## Verifying this change

Covered by existing tests. Verify locally with `mvn verify`; reviewers should confirm CRD codegen output is unchanged and exercise the admission webhook over TLS in the integration suite.

## Does this pull request potentially affect one of the following parts:

- Dependencies: **yes** (version bumps only)
- Public API / CRDs: no (verify CRD codegen)
- Core observer/reconciler logic: no

## Documentation

- New feature: no