### PR TITLE
[FLINK-39752] Thread EventRecorder through FlinkResourceContext instead of holding it on the factory

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -207,7 +207,6 @@ public class FlinkOperator {
 
     @VisibleForTesting
     void registerSessionJobController() {
-        var eventRecorder = EventRecorder.create(client, listeners);
         var metricManager =
                 MetricManager.createFlinkSessionJobMetricManager(baseConfig, metricGroup);
         var statusRecorder = StatusRecorder.create(client, metricManager, listeners);
@@ -240,7 +239,6 @@ public class FlinkOperator {
                 MetricManager.createFlinkStateSnapshotMetricManager(baseConfig, metricGroup);
         var statusRecorder =
                 StatusRecorder.createForFlinkStateSnapshot(client, metricManager, listeners);
-        var eventRecorder = EventRecorder.create(client, listeners);
         var reconciler = new StateSnapshotReconciler(ctxFactory, eventRecorder);
         var observer = new StateSnapshotObserver(ctxFactory, eventRecorder);
         var controller =


### PR DESCRIPTION
## What is the purpose of the change

`FlinkResourceContextFactory` holds a single operator-scoped `EventRecorder`, which it uses when creating the `FlinkService`. The deployment controller reuses that same shared instance, but `registerSessionJobController` and `registerSnapshotController` each create their own `EventRecorder` via `EventRecorder.create(...)`. As a result, for those two controllers the recorder used by the reconciler and observer is a different instance from the one the `FlinkService` emits through.

This is harmless today because `EventRecorder` is a stateless dispatcher over the shared listeners and client, but it is a latent inconsistency that would become a real bug the moment any per-instance state is added to `EventRecorder`.

This PR removes the per-controller recorder creation so that the session-job and snapshot controllers reuse the single shared `EventRecorder` the factory already holds. Every controller and the `FlinkService` it drives now route through one operator-scoped recorder.

## Brief change log

  - Removed the local `EventRecorder.create(...)` in `FlinkOperator.registerSessionJobController` and `FlinkOperator.registerSnapshotController` so both reuse the shared `eventRecorder` field that is also passed to `FlinkResourceContextFactory`.

## Verifying this change

This change is already covered by existing tests, such as `FlinkDeploymentControllerTest`, `FlinkSessionJobControllerTest`, and `FlinkStateSnapshotControllerTest`. The behavior is unchanged because the shared and per-controller recorders are functionally identical, the change only collapses them to a single instance.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable