### PR TITLE
[hotfix] Clean up FlinkBlueGreenDeploymentController

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentController.java
@@ -18,7 +18,6 @@
 package org.apache.flink.kubernetes.operator.controller;
 
 import org.apache.flink.kubernetes.operator.api.FlinkBlueGreenDeployment;
-import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.status.FlinkBlueGreenDeploymentState;
 import org.apache.flink.kubernetes.operator.api.status.FlinkBlueGreenDeploymentStatus;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
@@ -30,15 +29,12 @@ import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.utils.EventSourceUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 
-import io.javaoperatorsdk.operator.api.config.informer.InformerEventSourceConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.processing.event.source.EventSource;
-import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
-import io.javaoperatorsdk.operator.processing.event.source.informer.Mappers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,26 +46,35 @@ import static org.apache.flink.kubernetes.operator.api.status.FlinkBlueGreenDepl
 /**
  * Controller that runs the main reconcile loop for Flink Blue/Green deployments.
  *
- * <p>State Machine Flow
+ * <h2>State Machine Flow</h2>
  *
- * <p>Deployment States
+ * <p>Deployment states:
  *
- * <p>1. INITIALIZING_BLUE - First-time deployment setup 2. ACTIVE_BLUE - Blue environment serving
- * traffic, monitoring for updates 3. TRANSITIONING_TO_GREEN - Deploying Green environment while
- * Blue serves traffic 4. ACTIVE_GREEN - Green environment serving traffic, monitoring for updates
- * 5. TRANSITIONING_TO_BLUE - Deploying Blue environment while Green serves traffic
+ * <ol>
+ *   <li>{@code INITIALIZING_BLUE}: First-time deployment setup.
+ *   <li>{@code ACTIVE_BLUE}: Blue environment serving traffic, monitoring for updates.
+ *   <li>{@code TRANSITIONING_TO_GREEN}: Deploying Green environment while Blue serves traffic.
+ *   <li>{@code ACTIVE_GREEN}: Green environment serving traffic, monitoring for updates.
+ *   <li>{@code TRANSITIONING_TO_BLUE}: Deploying Blue environment while Green serves traffic.
+ * </ol>
  *
- * <p>Orchestration Process
+ * <h2>Orchestration Process</h2>
  *
- * <p>FlinkBlueGreenDeploymentController.reconcile() 1. Create BlueGreenContext with current
- * deployment state 2. Query StateHandlerRegistry for appropriate handler 3. Delegate to specific
- * StateHandler.handle(context) 4. StateHandler invokes BlueGreenDeploymentService operations 5.
- * Return UpdateControl with next reconciliation schedule
+ * <p>{@link #reconcile(FlinkBlueGreenDeployment, Context)} performs:
+ *
+ * <ol>
+ *   <li>Create a {@link BlueGreenContext} with the current deployment state.
+ *   <li>Query {@link BlueGreenStateHandlerRegistry} for the appropriate handler.
+ *   <li>Delegate to {@link BlueGreenStateHandler#handle(BlueGreenContext)}.
+ *   <li>The handler invokes {@link BlueGreenDeploymentService} operations.
+ *   <li>Return an {@link UpdateControl} with the next reconciliation schedule.
+ * </ol>
  */
 @ControllerConfiguration
 public class FlinkBlueGreenDeploymentController implements Reconciler<FlinkBlueGreenDeployment> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FlinkDeploymentController.class);
+    private static final Logger LOG =
+            LoggerFactory.getLogger(FlinkBlueGreenDeploymentController.class);
 
     private final FlinkResourceContextFactory ctxFactory;
     private final BlueGreenStateHandlerRegistry handlerRegistry;
@@ -92,18 +97,7 @@ public class FlinkBlueGreenDeploymentController implements Reconciler<FlinkBlueG
     public List<EventSource<?, FlinkBlueGreenDeployment>> prepareEventSources(
             EventSourceContext<FlinkBlueGreenDeployment> context) {
         List<EventSource<?, FlinkBlueGreenDeployment>> eventSources = new ArrayList<>();
-
-        InformerEventSourceConfiguration<FlinkDeployment> config =
-                InformerEventSourceConfiguration.from(
-                                FlinkDeployment.class, FlinkBlueGreenDeployment.class)
-                        .withSecondaryToPrimaryMapper(
-                                Mappers.fromOwnerReferences(context.getPrimaryResourceClass()))
-                        .withNamespacesInheritedFromController()
-                        .withFollowControllerNamespacesChanges(true)
-                        .build();
-
-        eventSources.add(new InformerEventSource<>(config, context));
-
+        eventSources.add(EventSourceUtils.getBlueGreenFlinkDeploymentInformerEventSource(context));
         if (flinkConfigManager.getOperatorConfiguration().isManageIngress()) {
             eventSources.add(EventSourceUtils.getBlueGreenIngressInformerEventSource(context));
         }
@@ -119,12 +113,8 @@ public class FlinkBlueGreenDeploymentController implements Reconciler<FlinkBlueG
 
         if (deploymentStatus == null) {
             var context =
-                    new BlueGreenContext(
-                            bgDeployment,
-                            new FlinkBlueGreenDeploymentStatus(),
-                            josdkContext,
-                            null,
-                            ctxFactory);
+                    ctxFactory.getBlueGreenContext(
+                            bgDeployment, new FlinkBlueGreenDeploymentStatus(), josdkContext, null);
             UpdateControl<FlinkBlueGreenDeployment> updateControl =
                     BlueGreenDeploymentService.patchStatusUpdateControl(
                                     context, INITIALIZING_BLUE, null, null)
@@ -134,15 +124,14 @@ public class FlinkBlueGreenDeploymentController implements Reconciler<FlinkBlueG
         } else {
             FlinkBlueGreenDeploymentState currentState = deploymentStatus.getBlueGreenState();
             var context =
-                    new BlueGreenContext(
+                    ctxFactory.getBlueGreenContext(
                             bgDeployment,
                             deploymentStatus,
                             josdkContext,
                             currentState == INITIALIZING_BLUE
                                     ? null
                                     : FlinkBlueGreenDeployments.fromSecondaryResources(
-                                            josdkContext),
-                            ctxFactory);
+                                            josdkContext));
 
             LOG.debug(
                     "Processing state: {} for deployment: {}",
@@ -154,9 +143,5 @@ public class FlinkBlueGreenDeploymentController implements Reconciler<FlinkBlueG
             statusRecorder.patchAndCacheStatus(bgDeployment, josdkContext.getClient());
             return updateControl;
         }
-    }
-
-    public static void logAndThrow(String message) {
-        throw new RuntimeException(message);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeployments.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeployments.java
@@ -51,7 +51,7 @@ public class FlinkBlueGreenDeployments {
                 context.getSecondaryResources(FlinkDeployment.class);
 
         if (secondaryResources.isEmpty() || secondaryResources.size() > 2) {
-            FlinkBlueGreenDeploymentController.logAndThrow(
+            throw new RuntimeException(
                     "Unexpected number of dependent deployments: " + secondaryResources.size());
         }
 
@@ -63,13 +63,13 @@ public class FlinkBlueGreenDeployments {
 
             if (flinkBlueGreenDeploymentType == BlueGreenDeploymentType.BLUE) {
                 if (flinkBlueGreenDeployments.getFlinkDeploymentBlue() != null) {
-                    FlinkBlueGreenDeploymentController.logAndThrow(
+                    throw new RuntimeException(
                             "Detected multiple Dependent Deployments of type BLUE");
                 }
                 flinkBlueGreenDeployments.setFlinkDeploymentBlue(dependentDeployment);
             } else {
                 if (flinkBlueGreenDeployments.getFlinkDeploymentGreen() != null) {
-                    FlinkBlueGreenDeploymentController.logAndThrow(
+                    throw new RuntimeException(
                             "Detected multiple Dependent Deployments of type GREEN");
                 }
                 flinkBlueGreenDeployments.setFlinkDeploymentGreen(dependentDeployment);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
@@ -20,15 +20,19 @@ package org.apache.flink.kubernetes.operator.service;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
+import org.apache.flink.kubernetes.operator.api.FlinkBlueGreenDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
 import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
+import org.apache.flink.kubernetes.operator.api.status.FlinkBlueGreenDeploymentStatus;
 import org.apache.flink.kubernetes.operator.artifact.ArtifactManager;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
+import org.apache.flink.kubernetes.operator.controller.FlinkBlueGreenDeployments;
 import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentContext;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.controller.FlinkSessionJobContext;
 import org.apache.flink.kubernetes.operator.controller.FlinkStateSnapshotContext;
+import org.apache.flink.kubernetes.operator.controller.bluegreen.BlueGreenContext;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesOperatorMetricGroup;
 import org.apache.flink.kubernetes.operator.metrics.KubernetesResourceMetricGroup;
 import org.apache.flink.kubernetes.operator.metrics.OperatorMetricUtils;
@@ -98,39 +102,40 @@ public class FlinkResourceContextFactory {
                 configManager);
     }
 
+    public BlueGreenContext getBlueGreenContext(
+            FlinkBlueGreenDeployment bgDeployment,
+            FlinkBlueGreenDeploymentStatus deploymentStatus,
+            Context<FlinkBlueGreenDeployment> josdkContext,
+            FlinkBlueGreenDeployments deployments) {
+        return new BlueGreenContext(
+                bgDeployment, deploymentStatus, josdkContext, deployments, this);
+    }
+
+    @SuppressWarnings("unchecked")
     public <CR extends AbstractFlinkResource<?, ?>> FlinkResourceContext<CR> getResourceContext(
-            CR resource, Context josdkContext) {
+            CR resource, Context<CR> josdkContext) {
         var resMg =
                 resourceMetricGroups.computeIfAbsent(
                         Tuple2.of(resource.getClass(), ResourceID.fromResource(resource)),
                         r ->
                                 OperatorMetricUtils.createResourceMetricGroup(
                                         operatorMetricGroup, configManager, resource));
-        String jobId = null;
-        if (resource.getStatus() != null) {
-            if (resource.getStatus().getJobStatus() != null) {
-                jobId = resource.getStatus().getJobStatus().getJobId();
-            }
-        }
-        if (resource instanceof FlinkDeployment) {
-            var flinkDep = (FlinkDeployment) resource;
-            var resourceId = ResourceID.fromResource(flinkDep);
-            var flinkDepJobId = jobId;
+        if (resource instanceof FlinkDeployment flinkDeployment) {
+            var resourceId = ResourceID.fromResource(flinkDeployment);
             return (FlinkResourceContext<CR>)
                     new FlinkDeploymentContext(
-                            flinkDep,
+                            flinkDeployment,
                             josdkContext,
                             resMg,
                             configManager,
                             this::getFlinkService,
                             lastRecordedExceptionCache.computeIfAbsent(
                                     resourceId, id -> new ExceptionCacheEntry()));
-        } else if (resource instanceof FlinkSessionJob) {
+        } else if (resource instanceof FlinkSessionJob flinkSessionJob) {
             var resourceId = ResourceID.fromResource(resource);
-            var flinkSessionJobId = jobId;
             return (FlinkResourceContext<CR>)
                     new FlinkSessionJobContext(
-                            (FlinkSessionJob) resource,
+                            flinkSessionJob,
                             josdkContext,
                             resMg,
                             configManager,
@@ -146,24 +151,19 @@ public class FlinkResourceContextFactory {
     @VisibleForTesting
     protected FlinkService getFlinkService(FlinkResourceContext<?> ctx) {
         var deploymentMode = ctx.getDeploymentMode();
-        switch (deploymentMode) {
-            case NATIVE:
-                return new NativeFlinkService(
-                        ctx.getKubernetesClient(),
-                        artifactManager,
-                        clientExecutorService,
-                        ctx.getOperatorConfig(),
-                        eventRecorder);
-            case STANDALONE:
-                return new StandaloneFlinkService(
-                        ctx.getKubernetesClient(),
-                        artifactManager,
-                        clientExecutorService,
-                        ctx.getOperatorConfig());
-            default:
-                throw new UnsupportedOperationException(
-                        String.format("Unsupported deployment mode: %s", deploymentMode));
-        }
+        return switch (deploymentMode) {
+            case NATIVE -> new NativeFlinkService(
+                    ctx.getKubernetesClient(),
+                    artifactManager,
+                    clientExecutorService,
+                    ctx.getOperatorConfig(),
+                    eventRecorder);
+            case STANDALONE -> new StandaloneFlinkService(
+                    ctx.getKubernetesClient(),
+                    artifactManager,
+                    clientExecutorService,
+                    ctx.getOperatorConfig());
+        };
     }
 
     public <CR extends AbstractFlinkResource<?, ?>> void cleanup(CR flinkApp) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkResourceContextFactory.java
@@ -113,7 +113,7 @@ public class FlinkResourceContextFactory {
 
     @SuppressWarnings("unchecked")
     public <CR extends AbstractFlinkResource<?, ?>> FlinkResourceContext<CR> getResourceContext(
-            CR resource, Context<CR> josdkContext) {
+            CR resource, Context<?> josdkContext) {
         var resMg =
                 resourceMetricGroups.computeIfAbsent(
                         Tuple2.of(resource.getClass(), ResourceID.fromResource(resource)),

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventSourceUtils.java
@@ -39,6 +39,7 @@ import io.javaoperatorsdk.operator.processing.event.source.EventSource;
 import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
 import io.javaoperatorsdk.operator.processing.event.source.SecondaryToPrimaryMapper;
 import io.javaoperatorsdk.operator.processing.event.source.informer.InformerEventSource;
+import io.javaoperatorsdk.operator.processing.event.source.informer.Mappers;
 
 import java.util.Collections;
 import java.util.List;
@@ -127,6 +128,20 @@ public class EventSourceUtils {
                         .withFollowControllerNamespacesChanges(true)
                         .build();
 
+        return new InformerEventSource<>(configuration, context);
+    }
+
+    public static InformerEventSource<FlinkDeployment, FlinkBlueGreenDeployment>
+            getBlueGreenFlinkDeploymentInformerEventSource(
+                    EventSourceContext<FlinkBlueGreenDeployment> context) {
+        var configuration =
+                InformerEventSourceConfiguration.from(
+                                FlinkDeployment.class, FlinkBlueGreenDeployment.class)
+                        .withSecondaryToPrimaryMapper(
+                                Mappers.fromOwnerReferences(context.getPrimaryResourceClass()))
+                        .withNamespacesInheritedFromController()
+                        .withFollowControllerNamespacesChanges(true)
+                        .build();
         return new InformerEventSource<>(configuration, context);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

`FlinkBlueGreenDeploymentController` had accumulated a handful of small but real issues:
- The logger was instantiated against `FlinkDeploymentController.class` (wrong category for every log line emitted by the blue/green path).
- The JavaDoc state machine and orchestration sections were collapsed into single paragraphs that did not render as lists.
- The `InformerEventSource` for `FlinkDeployment` was built inline in `prepareEventSources` instead of being centralized in `EventSourceUtils` like every other controller
- The `BlueGreenContext` was constructed inline in `reconcile` instead of going through `FlinkResourceContextFactory` like every other context type.
- A `logAndThrow(String)` helper existed that did not log and just wrapped `throw new RuntimeException(message)` without adding anything.

This PR fixes all of the above and also cleans up a few warnings in `FlinkResourceContextFactory`.

## Brief change log

  - Fixed the SLF4J logger category in `FlinkBlueGreenDeploymentController` (`FlinkDeploymentController.class` → `FlinkBlueGreenDeploymentController.class`).
  - Rewrote the controller-level JavaDoc to use proper `<h2>` headings and `<ol>` lists for the state machine and orchestration sections, with `{@link}` references to the relevant types.
  - Added `EventSourceUtils.getBlueGreenFlinkDeploymentInformerEventSource(...)` (parallels the existing `getBlueGreenIngressInformerEventSource`) and switched `prepareEventSources` to use it. The inline `InformerEventSourceConfiguration` / `InformerEventSource` / `Mappers` code in the controller is gone.
  - Added `FlinkResourceContextFactory.getBlueGreenContext(...)` (parallels `getFlinkStateSnapshotContext`) and switched both branches of `reconcile` to use it instead of constructing `BlueGreenContext` inline.
  - Removed `FlinkBlueGreenDeploymentController.logAndThrow(String)`. Replaced its three call sites in `FlinkBlueGreenDeployments.fromSecondaryResources` with direct `throw new RuntimeException(...)` statements.
  - In `FlinkResourceContextFactory`: collapsed the `instanceof FlinkDeployment` / `instanceof FlinkSessionJob` checks into pattern-matching `instanceof`, converted the deployment-mode `switch` into a switch expression, removed the dead `jobId` / `flinkDepJobId` / `flinkSessionJobId` locals, tightened the `getResourceContext` generic to `Context<CR>`, and added `@SuppressWarnings("unchecked")` for the down-cast.
  - Pruned the now-unused imports from the controller (`FlinkDeployment`, `InformerEventSourceConfiguration`, `InformerEventSource`, `Mappers`).

## Verifying this change

This change is already covered by existing tests, such as `FlinkBlueGreenDeploymentControllerTest`, `BlueGreenUtilsTest`, `BlueGreenIngressIT`, `FlinkDeploymentControllerTest`, `FlinkSessionJobControllerTest`, `FlinkStateSnapshotControllerTest`, `ApplicationReconcilerTest`, and `SessionJobReconcilerTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes (control flow in `FlinkBlueGreenDeploymentController#reconcile` and `#prepareEventSources` was restructured. Behavior is unchanged, the call sites just go through `EventSourceUtils` and `FlinkResourceContextFactory.getBlueGreenContext` instead of inline construction.)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable