### PR TITLE
[hotfix] Reuse FlinkConfigManager#isSnapshotCrdInstalled in controllers

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -225,7 +225,8 @@ public class FlinkOperator {
                         observer,
                         statusRecorder,
                         eventRecorder,
-                        canaryResourceManager);
+                        canaryResourceManager,
+                        configManager);
         registeredControllers.add(operator.register(controller, this::overrideControllerConfigs));
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigManager.java
@@ -145,6 +145,10 @@ public class FlinkConfigManager {
         }
     }
 
+    public boolean isSnapshotCrdInstalled() {
+        return snapshotCrdInstalled;
+    }
+
     /**
      * Update the base configuration for the operator. Newly generated configs (observe, deploy,
      * etc.) will use this as the base.

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentController.java
@@ -19,7 +19,6 @@ package org.apache.flink.kubernetes.operator.controller;
 
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
-import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
 import org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
@@ -35,7 +34,6 @@ import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.EventSourceUtils;
 import org.apache.flink.kubernetes.operator.utils.ExceptionUtils;
-import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
@@ -92,7 +90,7 @@ public class FlinkDeploymentController
     }
 
     @Override
-    public DeleteControl cleanup(FlinkDeployment flinkApp, Context josdkContext) {
+    public DeleteControl cleanup(FlinkDeployment flinkApp, Context<FlinkDeployment> josdkContext) {
         if (canaryResourceManager.handleCanaryResourceDeletion(flinkApp)) {
             return DeleteControl.defaultDelete();
         }
@@ -124,8 +122,8 @@ public class FlinkDeploymentController
     }
 
     @Override
-    public UpdateControl<FlinkDeployment> reconcile(FlinkDeployment flinkApp, Context josdkContext)
-            throws Exception {
+    public UpdateControl<FlinkDeployment> reconcile(
+            FlinkDeployment flinkApp, Context<FlinkDeployment> josdkContext) throws Exception {
 
         if (canaryResourceManager.handleCanaryResourceReconciliation(
                 flinkApp, josdkContext.getClient())) {
@@ -192,7 +190,7 @@ public class FlinkDeploymentController
         if (flinkConfigManager.getOperatorConfiguration().isManageIngress()) {
             eventSources.add(EventSourceUtils.getIngressInformerEventSource(context));
         }
-        if (KubernetesClientUtils.isCrdInstalled(FlinkStateSnapshot.class)) {
+        if (flinkConfigManager.isSnapshotCrdInstalled()) {
             eventSources.add(
                     EventSourceUtils.getStateSnapshotForFlinkResourceInformerEventSource(context));
         } else {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -19,9 +19,9 @@ package org.apache.flink.kubernetes.operator.controller;
 
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
-import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
 import org.apache.flink.kubernetes.operator.api.lifecycle.ResourceLifecycleState;
 import org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobStatus;
+import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
 import org.apache.flink.kubernetes.operator.health.CanaryResourceManager;
 import org.apache.flink.kubernetes.operator.observer.Observer;
@@ -31,7 +31,6 @@ import org.apache.flink.kubernetes.operator.service.FlinkResourceContextFactory;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.kubernetes.operator.utils.EventSourceUtils;
 import org.apache.flink.kubernetes.operator.utils.ExceptionUtils;
-import org.apache.flink.kubernetes.operator.utils.KubernetesClientUtils;
 import org.apache.flink.kubernetes.operator.utils.StatusRecorder;
 import org.apache.flink.kubernetes.operator.utils.ValidatorUtils;
 import org.apache.flink.kubernetes.operator.validation.FlinkResourceValidator;
@@ -67,6 +66,7 @@ public class FlinkSessionJobController
     private final StatusRecorder<FlinkSessionJob, FlinkSessionJobStatus> statusRecorder;
     private final EventRecorder eventRecorder;
     private final CanaryResourceManager<FlinkSessionJob> canaryResourceManager;
+    private final FlinkConfigManager flinkConfigManager;
 
     public FlinkSessionJobController(
             Set<FlinkResourceValidator> validators,
@@ -75,7 +75,8 @@ public class FlinkSessionJobController
             Observer<FlinkSessionJob> observer,
             StatusRecorder<FlinkSessionJob, FlinkSessionJobStatus> statusRecorder,
             EventRecorder eventRecorder,
-            CanaryResourceManager<FlinkSessionJob> canaryResourceManager) {
+            CanaryResourceManager<FlinkSessionJob> canaryResourceManager,
+            FlinkConfigManager flinkConfigManager) {
         this.validators = validators;
         this.ctxFactory = ctxFactory;
         this.reconciler = reconciler;
@@ -83,6 +84,7 @@ public class FlinkSessionJobController
         this.statusRecorder = statusRecorder;
         this.eventRecorder = eventRecorder;
         this.canaryResourceManager = canaryResourceManager;
+        this.flinkConfigManager = flinkConfigManager;
     }
 
     @Override
@@ -179,7 +181,7 @@ public class FlinkSessionJobController
         List<EventSource<?, FlinkSessionJob>> eventSources = new ArrayList<>();
         eventSources.add(EventSourceUtils.getFlinkDeploymentInformerEventSource(context));
 
-        if (KubernetesClientUtils.isCrdInstalled(FlinkStateSnapshot.class)) {
+        if (flinkConfigManager.isSnapshotCrdInstalled()) {
             eventSources.add(
                     EventSourceUtils.getStateSnapshotForFlinkResourceInformerEventSource(context));
         } else {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/TestingFlinkSessionJobController.java
@@ -97,7 +97,8 @@ public class TestingFlinkSessionJobController
                         new FlinkSessionJobObserver(eventRecorder),
                         statusRecorder,
                         eventRecorder,
-                        canaryResourceManager);
+                        canaryResourceManager,
+                        configManager);
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

`FlinkConfigManager` already discovers whether the `FlinkStateSnapshot` CRD is installed at operator startup (via the boolean it accepts from `FlinkOperator`) and stores the result in a final field. Despite that, both `FlinkDeploymentController` and `FlinkSessionJobController` were calling `KubernetesClientUtils.isCrdInstalled(FlinkStateSnapshot.class)` again from their `prepareEventSources` methods. That helper does not just hit the API server, it also constructs a brand-new `KubernetesClient` (`new KubernetesClientBuilder().build()`) with its own TLS handshake and auth chain, then issues a `list().getItems()` call. The result is three independent API roundtrips and three transient clients to answer the same question whose answer is already cached on `FlinkConfigManager`.

This PR exposes that flag through a getter and switches both controllers to use it.

## Brief change log

  - Added `FlinkConfigManager#isSnapshotCrdInstalled()` (plain Java getter, no Lombok) returning the existing `snapshotCrdInstalled` field.
  - Replaced `KubernetesClientUtils.isCrdInstalled(FlinkStateSnapshot.class)` with `flinkConfigManager.isSnapshotCrdInstalled()` in `FlinkDeploymentController#prepareEventSources` and `FlinkSessionJobController#prepareEventSources`.
  - Removed the now-unused imports `KubernetesClientUtils` and `FlinkStateSnapshot` from both controllers.
  - Added a `FlinkConfigManager` field + constructor parameter on `FlinkSessionJobController` (it did not have one before). Updated `FlinkOperator#registerSessionJobController` and `TestingFlinkSessionJobController` to pass it in.
  - While in `FlinkDeploymentController`, specialized two method signatures from raw `Context` to `Context<FlinkDeployment>` (`cleanup` and `reconcile`), resolving raw-type warnings the IDE was flagging in the file we were already editing.

## Verifying this change

This change is already covered by existing tests, such as `FlinkDeploymentControllerTest`, `FlinkSessionJobControllerTest`, `FlinkStateSnapshotControllerTest`, `FlinkConfigManagerTest`, and `FlinkOperatorTest`.

Behavioral equivalence: `prepareEventSources` is invoked once at JOSDK controller registration. The `snapshotCrdInstalled` flag is computed once at `FlinkOperator` construction (right before `FlinkConfigManager` is built). Both points happen during operator startup with no possibility of the CRD state changing between them, so the answer used by both controllers is identical to today's behavior. The only difference is that we no longer build two transient `KubernetesClient` instances and issue two extra `list()` calls.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
