### PR TITLE
[FLINK-39808] Tighten FlinkVersion.isSupported() to reject @Deprecated versions and restore the deprecate-and-raise-floor pattern

### DIFF
--- a/docs/content.zh/docs/custom-resource/reference.md
+++ b/docs/content.zh/docs/custom-resource/reference.md
@@ -80,10 +80,10 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | ----- | ---- |
 | v1_13 | No longer supported since 1.7 operator release. |
 | v1_14 | No longer supported since 1.7 operator release. |
-| v1_15 |  |
-| v1_16 |  |
-| v1_17 |  |
-| v1_18 |  |
+| v1_15 | Deprecated since 1.10 operator release. |
+| v1_16 | Deprecated since 1.11 operator release. |
+| v1_17 | Deprecated since 1.13 operator release. |
+| v1_18 | Deprecated since 1.13 operator release. |
 | v1_19 |  |
 | v1_20 |  |
 

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -158,8 +158,8 @@ This serves as a full reference for FlinkDeployment and FlinkSessionJob custom r
 | v1_14 | No longer supported since 1.7 operator release. |
 | v1_15 | Deprecated since 1.10 operator release. |
 | v1_16 | Deprecated since 1.11 operator release. |
-| v1_17 |  |
-| v1_18 |  |
+| v1_17 | Deprecated since 1.13 operator release. |
+| v1_18 | Deprecated since 1.13 operator release. |
 | v1_19 |  |
 | v1_20 |  |
 | v2_0 |  |

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkVersion.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkVersion.java
@@ -20,6 +20,9 @@ package org.apache.flink.kubernetes.operator.api.spec;
 
 import org.apache.flink.annotation.Experimental;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 /** Enumeration for supported Flink versions. */
 @Experimental
 public enum FlinkVersion {
@@ -35,8 +38,10 @@ public enum FlinkVersion {
     /** Deprecated since 1.11 operator release. */
     @Deprecated
     v1_16(1, 16),
+    /** Deprecated since 1.13 operator release. */
     @Deprecated
     v1_17(1, 17),
+    /** Deprecated since 1.13 operator release. */
     @Deprecated
     v1_18(1, 18),
     v1_19(1, 19),
@@ -46,6 +51,8 @@ public enum FlinkVersion {
     v2_2(2, 2),
     v2_3(2, 3),
     v2_4(2, 4);
+
+    private static final Set<FlinkVersion> DEPRECATED = computeDeprecated();
 
     /** The major integer from the Flink semver. For example for Flink 1.18.1 this would be 1. */
     private final int majorVersion;
@@ -66,6 +73,24 @@ public enum FlinkVersion {
             return this.minorVersion >= otherVersion.minorVersion;
         }
         return false;
+    }
+
+    private static Set<FlinkVersion> computeDeprecated() {
+        Set<FlinkVersion> deprecated = EnumSet.noneOf(FlinkVersion.class);
+        for (FlinkVersion v : values()) {
+            try {
+                if (FlinkVersion.class.getField(v.name()).isAnnotationPresent(Deprecated.class)) {
+                    deprecated.add(v);
+                }
+            } catch (NoSuchFieldException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        return deprecated;
+    }
+
+    public boolean isDeprecated() {
+        return DEPRECATED.contains(this);
     }
 
     public static boolean isSupported(FlinkVersion version) {

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/spec/FlinkVersionTest.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/spec/FlinkVersionTest.java
@@ -35,7 +35,45 @@ class FlinkVersionTest {
 
     @Test
     void isSupported() {
+        assertFalse(FlinkVersion.isSupported(null));
+        assertFalse(FlinkVersion.isSupported(FlinkVersion.v1_13));
+        assertFalse(FlinkVersion.isSupported(FlinkVersion.v1_14));
+        assertTrue(FlinkVersion.isSupported(FlinkVersion.v1_15));
+        assertTrue(FlinkVersion.isSupported(FlinkVersion.v1_18));
+        assertTrue(FlinkVersion.isSupported(FlinkVersion.v1_19));
         assertTrue(FlinkVersion.isSupported(FlinkVersion.v1_20));
+        assertTrue(FlinkVersion.isSupported(FlinkVersion.v2_0));
+        assertTrue(FlinkVersion.isSupported(FlinkVersion.v2_4));
+    }
+
+    @Test
+    void isDeprecated() {
+        assertTrue(FlinkVersion.v1_13.isDeprecated());
+        assertTrue(FlinkVersion.v1_14.isDeprecated());
+        assertTrue(FlinkVersion.v1_15.isDeprecated());
+        assertTrue(FlinkVersion.v1_16.isDeprecated());
+        assertTrue(FlinkVersion.v1_17.isDeprecated());
+        assertTrue(FlinkVersion.v1_18.isDeprecated());
+        assertFalse(FlinkVersion.v1_19.isDeprecated());
+        assertFalse(FlinkVersion.v1_20.isDeprecated());
+        assertFalse(FlinkVersion.v2_0.isDeprecated());
+        assertFalse(FlinkVersion.v2_4.isDeprecated());
+    }
+
+    @Test
+    void isDeprecatedMatchesDeprecatedAnnotation() throws Exception {
+        for (FlinkVersion v : FlinkVersion.values()) {
+            boolean annotated =
+                    FlinkVersion.class.getField(v.name()).isAnnotationPresent(Deprecated.class);
+            assertEquals(
+                    annotated,
+                    v.isDeprecated(),
+                    v
+                            + ": @Deprecated says "
+                            + annotated
+                            + " but isDeprecated() says "
+                            + v.isDeprecated());
+        }
     }
 
     @Test

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/BaseTestUtils.java
@@ -70,7 +70,7 @@ public class BaseTestUtils {
     public static final String SAMPLE_SESSION_JOB_JAR = "https://example.com/sample.jar";
 
     public static FlinkDeployment buildSessionCluster() {
-        return buildSessionCluster(FlinkVersion.v1_17);
+        return buildSessionCluster(FlinkVersion.v1_20);
     }
 
     public static FlinkDeployment buildSessionCluster(FlinkVersion version) {
@@ -94,15 +94,15 @@ public class BaseTestUtils {
     }
 
     public static FlinkDeployment buildApplicationCluster(JobState state) {
-        return buildApplicationCluster(FlinkVersion.v1_17, state);
+        return buildApplicationCluster(FlinkVersion.v1_20, state);
     }
 
     public static FlinkDeployment buildApplicationCluster() {
-        return buildApplicationCluster(FlinkVersion.v1_17, JobState.RUNNING);
+        return buildApplicationCluster(FlinkVersion.v1_20, JobState.RUNNING);
     }
 
     public static FlinkDeployment buildApplicationCluster(String name, String namespace) {
-        return buildApplicationCluster(name, namespace, FlinkVersion.v1_17, JobState.RUNNING);
+        return buildApplicationCluster(name, namespace, FlinkVersion.v1_20, JobState.RUNNING);
     }
 
     public static FlinkDeployment buildApplicationCluster(FlinkVersion version) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/ValidatorUtils.java
@@ -34,7 +34,7 @@ import java.util.Set;
 /** Validator utilities. */
 public final class ValidatorUtils {
 
-    private static final Logger LOG = LoggerFactory.getLogger(FlinkUtils.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ValidatorUtils.class);
 
     public static Set<FlinkResourceValidator> discoverValidators(FlinkConfigManager configManager) {
         var conf = configManager.getDefaultConfig();
@@ -71,6 +71,11 @@ public final class ValidatorUtils {
                     "Flink version " + version + " is not supported by this operator version",
                     ctx.getJosdkContext().getClient());
             return false;
+        }
+        if (version.isDeprecated()) {
+            LOG.warn(
+                    "Flink version {} is deprecated and may be removed in a future operator release. Plan to upgrade to a non-deprecated version.",
+                    version);
         }
         return true;
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestUtils.java
@@ -215,7 +215,7 @@ public class TestUtils extends BaseTestUtils {
 
     public static <T extends HasMetadata> Context<T> createContextWithReadyFlinkDeployment(
             Map<String, String> flinkDepConfig, KubernetesClient client) {
-        return createContextWithReadyFlinkDeployment(flinkDepConfig, client, FlinkVersion.v1_18);
+        return createContextWithReadyFlinkDeployment(flinkDepConfig, client, FlinkVersion.v1_20);
     }
 
     public static <T extends HasMetadata> Context<T> createContextWithReadyFlinkDeployment(
@@ -413,7 +413,7 @@ public class TestUtils extends BaseTestUtils {
 
     public static Stream<Arguments> flinkVersionsAndUpgradeModes() {
         List<Arguments> args = new ArrayList<>();
-        for (FlinkVersion version : Set.of(FlinkVersion.v1_16, FlinkVersion.v1_20)) {
+        for (FlinkVersion version : Set.of(FlinkVersion.v1_19, FlinkVersion.v1_20)) {
             for (UpgradeMode upgradeMode : UpgradeMode.values()) {
                 args.add(arguments(version, upgradeMode));
             }
@@ -422,7 +422,7 @@ public class TestUtils extends BaseTestUtils {
     }
 
     public static Stream<Arguments> flinkVersions() {
-        return Stream.of(arguments(FlinkVersion.v1_16), arguments(FlinkVersion.v1_20));
+        return Stream.of(arguments(FlinkVersion.v1_19), arguments(FlinkVersion.v1_20));
     }
 
     public static FlinkDeployment createCanaryDeployment() {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -465,6 +465,8 @@ public class DefaultValidatorTest {
                         + " is not supported by this operator version");
 
         testSuccess(dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_15));
+        testSuccess(dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_18));
+        testSuccess(dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_19));
 
         testError(
                 dep -> dep.getSpec().setServiceAccount(null),
@@ -752,7 +754,7 @@ public class DefaultValidatorTest {
             // Stopped with LAST_STATE mode with different Flink Version
             suspendSpec.getJob().setUpgradeMode(fromUpgrade);
             suspendSpec.getJob().setState(fromState);
-            suspendSpec.setFlinkVersion(FlinkVersion.v1_18);
+            suspendSpec.setFlinkVersion(FlinkVersion.v1_19);
 
             dep.getStatus()
                     .getReconciliationStatus()


### PR DESCRIPTION
## What is the purpose of the change

`FlinkVersion` carries `@Deprecated` annotations on `v1_15` through `v1_18` (added by FLINK-37236 and FLINK-38147), but the annotation had no runtime expression. Users running deprecated versions got no apply-time signal: javadoc and reference docs flagged the status, but `kubectl apply` succeeded silently, no event fired, no log line was emitted, and the CRD enum listed `v1_17` next to `v1_20` with no distinction. The annotation existed only as a Java-IDE marker the operator silently ignored.

This PR closes that gap without introducing a behavioral cliff. `isSupported()` is unchanged, so deprecated versions continue to validate and reconcile as today. The operator now emits a `WARN` log once per reconcile when a resource's `flinkVersion` is deprecated, including a "plan to upgrade" hint. The `@Deprecated` annotation becomes the single source of truth for the deprecation state via a new `isDeprecated()` query backed by reflection at class init, so future deprecations only need to add `@Deprecated` to the enum constant and the warning path picks it up automatically.

This is the shape agreed with @gyfora on the JIRA after [his feedback on the original scope](https://issues.apache.org/jira/browse/FLINK-39808?focusedCommentId=18085129). Policy documentation ("@Deprecated means bug fixes no longer guaranteed, operator emits a runtime warning, version still accepted until removed from the enum entirely") will land separately as part of FLINK-39571.

## Brief change log

- `FlinkVersion` gains a private static `EnumSet<FlinkVersion> DEPRECATED` populated once at class init by reflecting over each enum constant's `@Deprecated` annotation, and a public instance method `boolean isDeprecated()` backed by it. Single source of truth, no second site to bump on future deprecations.
- `FlinkVersion.isSupported(FlinkVersion)` is unchanged in behavior: `version != null && version.isEqualOrNewer(v1_15)`. No upgrade cliff, no rejection of deprecated versions.
- `ValidatorUtils.validateSupportedVersion` emits a `LOG.warn(...)` once per reconcile when `version.isDeprecated()` is true. No event, no rejection. Existing `UnsupportedFlinkVersion` event path for genuinely unsupported versions is untouched.
- `FlinkVersionTest` extended with two new tests: an `isDeprecated()` behavior table (asserts `true` for `v1_13..v1_18`, `false` for `v1_19..v2_4`), and a structural-invariant test `isDeprecatedMatchesDeprecatedAnnotation` that iterates `values()` and cross-checks `v.isDeprecated() == v.field.isAnnotationPresent(Deprecated.class)`. Future contributors who mark a version `@Deprecated` without thinking about the warning path will get a failing test, not a silent miss.
- Javadoc comments added for `v1_17` and `v1_18` ("Deprecated since 1.13 operator release") to match the pattern used for `v1_15` and `v1_16`.
- Test fixture hygiene (independent of the policy change): `BaseTestUtils` builder defaults and `TestUtils.createContextWithReadyFlinkDeployment` default moved from `v1_17` / `v1_18` to `v1_20`, parameterized version sets in `TestUtils` shifted from `{v1_16, v1_20}` to `{v1_19, v1_20}`. Keeps test setup on actively-supported versions.
- Docs: English `overview.md` lists only non-deprecated versions as recommended values for `flinkVersion`. English `reference.md` Notes column filled in for `v1_17` and `v1_18`. Chinese `overview.md` and `reference.md` mirrored and brought to parity with the English versions (the Chinese reference table was already drifted on `v1_15` and `v1_16`, this PR closes that drift too).
- Drive-by: `ValidatorUtils.java` logger fix (`LoggerFactory.getLogger(FlinkUtils.class)` was wrong, should have been `ValidatorUtils.class`). Trivially in scope of the same file touched by the warning addition. Happy to split into a separate `[hotfix]` if reviewers prefer.

## Verifying this change

This change is covered by existing tests plus the new `FlinkVersionTest` cases.

- `mvn test -pl flink-kubernetes-operator-api` passes including the new `isDeprecated` table and `isDeprecatedMatchesDeprecatedAnnotation` invariant.
- `mvn test -pl flink-kubernetes-operator` passes. The four classes that exercise the validator / `UnsupportedFlinkVersion` event path (`DefaultValidatorTest`, `FlinkDeploymentControllerTest`, `FlinkSessionJobControllerTest`, `FlinkStateSnapshotControllerTest`) all pass unchanged in semantic, since `isSupported()` was not tightened.
- `mvn spotless:check -pl flink-kubernetes-operator-api,flink-kubernetes-operator` is clean.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no.
- The public API, i.e., is any changes to the `CustomResourceDescriptors`: no. The `FlinkVersion` enum constants and their `@Deprecated` annotations are unchanged.
- Core observer or reconciler logic that is regularly executed: yes, but additively. `ValidatorUtils.validateSupportedVersion` now emits a `WARN` log when the resource's `flinkVersion` is deprecated. Validation outcome and reconcile flow are unchanged: deprecated versions continue to be accepted. No `UnsupportedFlinkVersion` events fire for previously-accepted versions, so there is no behavioral cliff for users running v1_15..v1_18.

## Documentation

- Does this pull request introduce a new feature? No.
- Is documentation updated? Yes, the FlinkVersion reference table notes and the supported-versions list in overview are refreshed in both English and Chinese. The broader support-policy write-up ("what @Deprecated on a FlinkVersion means for the operator's behavior") will land separately as part of FLINK-39571.