### PR TITLE
[FLINK-39743] [flink-autoscaler] Fix incorrect expected processing rate computation

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -247,7 +247,8 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
         }
 
         // Cap target capacity according to the capped scale factor
-        double cappedTargetCapacity = averageTrueProcessingRate * (newParallelism / currentParallelism);
+        double cappedTargetCapacity =
+                (averageTrueProcessingRate / currentParallelism) * newParallelism;
         LOG.debug("Capped target processing capacity for {} is {}", vertex, cappedTargetCapacity);
 
         // We record our expectations for this scaling operation

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -246,15 +246,15 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
             return ParallelismChange.noChange(currentParallelism);
         }
 
-        // Cap target capacity according to the capped scale factor
-        double cappedTargetCapacity =
+        // Cap expected target processing rate according to the capped scale factor
+        double expectedProcessingRate =
                 (averageTrueProcessingRate / currentParallelism) * newParallelism;
-        LOG.debug("Capped target processing capacity for {} is {}", vertex, cappedTargetCapacity);
+        LOG.debug("Expected target processing rate for {} is {}", vertex, expectedProcessingRate);
 
         // We record our expectations for this scaling operation
         evaluatedMetrics.put(
                 ScalingMetric.EXPECTED_PROCESSING_RATE,
-                EvaluatedScalingMetric.of(cappedTargetCapacity));
+                EvaluatedScalingMetric.of(expectedProcessingRate));
 
         return detectBlockScaling(
                 context,

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java
@@ -226,10 +226,6 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
             scaleFactor = maxScaleFactor;
         }
 
-        // Cap target capacity according to the capped scale factor
-        double cappedTargetCapacity = averageTrueProcessingRate * scaleFactor;
-        LOG.debug("Capped target processing capacity for {} is {}", vertex, cappedTargetCapacity);
-
         int newParallelism =
                 scale(
                         vertex,
@@ -249,6 +245,10 @@ public class JobVertexScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
             delayedScaleDown.clearVertex(vertex);
             return ParallelismChange.noChange(currentParallelism);
         }
+
+        // Cap target capacity according to the capped scale factor
+        double cappedTargetCapacity = averageTrueProcessingRate * (newParallelism / currentParallelism);
+        LOG.debug("Capped target processing capacity for {} is {}", vertex, cappedTargetCapacity);
 
         // We record our expectations for this scaling operation
         evaluatedMetrics.put(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -827,6 +827,62 @@ public class JobVertexScalerTest {
         assertTrue(evaluated.containsKey(ScalingMetric.EXPECTED_PROCESSING_RATE));
     }
 
+    @Test
+    public void testExpectedProcessingRateComputation() {
+        var jobVertexID = new JobVertexID();
+        conf.set(UTILIZATION_TARGET, 1.0);
+        conf.set(AutoScalerOptions.SCALE_DOWN_INTERVAL, Duration.ZERO);
+        var delayedScaleDown = new DelayedScaleDown();
+        var history = new TreeMap<Instant, ScalingSummary>();
+
+        // Max scale-up factor caps raw target parallelism 200 to 15
+        conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.5);
+        var evaluated = evaluated(10, 200, 10);
+        assertEquals(
+                ParallelismChange.build(15, 10, true),
+                vertexScaler.computeScaleTargetParallelism(
+                        context,
+                        jobVertexID,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
+        assertEquals(15.0, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
+
+        // Key-group alignment rounds raw target parallelism 3.33 up to 4
+        conf.set(AutoScalerOptions.MAX_SCALE_UP_FACTOR, (double) Integer.MAX_VALUE);
+        conf.set(UTILIZATION_TARGET, 0.6);
+        evaluated = evaluated(2, 100, 100);
+        assertEquals(
+                ParallelismChange.build(4, 2, true),
+                vertexScaler.computeScaleTargetParallelism(
+                        context,
+                        jobVertexID,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
+        assertEquals(200.0, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
+
+        // Source-partition count caps raw target parallelism 200 to 150
+        conf.set(UTILIZATION_TARGET, 1.0);
+        evaluated = evaluated(10, 200, 100);
+        evaluated.put(ScalingMetric.NUM_SOURCE_PARTITIONS. EvaluatedScalingMetric.of(15));
+        assertEquals(
+                ParallelismChange.build(15, 10, true),
+                vertexScaler.computeScaleTargetParallelism(
+                        context,
+                        jobVertexID,
+                        NOT_ADJUST_INPUTS,
+                        evaluated,
+                        history,
+                        restartTime,
+                        delayedScaleDown));
+        assertEquals(150.0, evaluated.get(ScalingMetric.EXPECTED_PROCESSING_RATE).getCurrent());
+    }
+
     @ParameterizedTest
     @MethodSource("adjustmentInputsProvider")
     public void testSendingIneffectiveScalingEvents(Collection<ShipStrategy> inputShipStrategies) {

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -869,7 +869,7 @@ public class JobVertexScalerTest {
         // Source-partition count caps raw target parallelism 200 to 150
         conf.set(UTILIZATION_TARGET, 1.0);
         evaluated = evaluated(10, 200, 100);
-        evaluated.put(ScalingMetric.NUM_SOURCE_PARTITIONS. EvaluatedScalingMetric.of(15));
+        evaluated.put(ScalingMetric.NUM_SOURCE_PARTITIONS, EvaluatedScalingMetric.of(15));
         assertEquals(
                 ParallelismChange.build(15, 10, true),
                 vertexScaler.computeScaleTargetParallelism(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingExecutorTest.java
@@ -724,7 +724,7 @@ public class ScalingExecutorTest {
                                         1,
                                         2,
                                         100.0,
-                                        157.0,
+                                        200.0,
                                         110.0)));
         assertTrue(
                 event.getMessage()


### PR DESCRIPTION
## What is the purpose of the change

The Flink Autoscaler computes the expected processing rate (EXPECTED_PROCESSING_RATE) using cappedTargetCapacity, which is derived from the initial scaling factor proposed by the algorithm after bounding it within MAX_SCALE_DOWN_FACTOR and MAX_SCALE_UP_FACTOR.

https://github.com/apache/flink-kubernetes-operator/blame/main/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobVertexScaler.java#L255

However, the recommended parallelism can later be modified inside the scale method due to additional constraints such as max parallelism, vertex-level min/max limits, and input partition counts. As a result, the final applied caling factor may differ from the factor originally used to compute cappedTargetCapacity. This mismatch can cause effective scaling actions to be incorrectly classified as ineffective.

This pull request is to compute the expected processing rate after the scale method finalizes and adjusts newParallelism based on constraints such as max parallelism, vertex-level min/max limits, input partition counts, etc.

## Brief change log

  - Compute the expected processing rate after the scale method finalizes and adjusts newParallelism based on constraints such as max parallelism, vertex-level min/max limits, input partition counts, etc.

## Verifying this change
This change added tests and can be verified as follows:

  - Added unit tests for expected processing rate computation.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
