### PR TITLE
[FLINK-39819] Avoid redundant JSON String round-trips in SpecUtils.clone and DiffResult.toString

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/utils/SpecUtils.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/utils/SpecUtils.java
@@ -130,16 +130,11 @@ public class SpecUtils {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> T clone(T object) {
         if (object == null) {
             return null;
         }
-        try {
-            return (T)
-                    objectMapper.readValue(
-                            objectMapper.writeValueAsString(object), object.getClass());
-        } catch (JsonProcessingException e) {
-            throw new IllegalStateException(e);
-        }
+        return (T) objectMapper.convertValue(object, object.getClass());
     }
 }

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/SpecUtilsTest.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/utils/SpecUtilsTest.java
@@ -27,10 +27,28 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /** Test for {@link SpecUtils}. */
 class SpecUtilsTest {
+
+    @Test
+    void testCloneProducesDeepCopy() {
+        FlinkDeploymentSpec original = BaseTestUtils.buildApplicationCluster().getSpec();
+
+        FlinkDeploymentSpec cloned = SpecUtils.clone(original);
+
+        assertNotSame(original, cloned);
+        assertEquals(original, cloned);
+        assertNotSame(original.getJob(), cloned.getJob());
+
+        cloned.getJob().setParallelism(original.getJob().getParallelism() + 1);
+
+        assertNotEquals(original.getJob().getParallelism(), cloned.getJob().getParallelism());
+        assertNull(SpecUtils.clone(null));
+    }
 
     @Test
     void testSpecSerializationWithVersion() throws JsonProcessingException {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/diff/DiffResult.java
@@ -70,12 +70,8 @@ public class DiffResult<T> {
         diffList.forEach(
                 diff -> {
                     try {
-                        JsonNode diffBefore =
-                                objectMapper.readTree(
-                                        objectMapper.writeValueAsString(diff.getLeft()));
-                        JsonNode diffAfter =
-                                objectMapper.readTree(
-                                        objectMapper.writeValueAsString(diff.getRight()));
+                        JsonNode diffBefore = objectMapper.valueToTree(diff.getLeft());
+                        JsonNode diffAfter = objectMapper.valueToTree(diff.getRight());
                         JsonNode jsonDiff = JsonDiff.asJson(diffBefore, diffAfter);
                         jsonDiff.forEach(
                                 row -> {


### PR DESCRIPTION
## What is the purpose of the change

Both `SpecUtils.clone` and `DiffResult.toString` route data through a redundant intermediate JSON String: they serialize an object to text and then immediately parse that text back into an object or a tree. The String is never used for anything else. This PR removes that hop by converting directly between the object and its in-memory form. The meaningful win is `clone`, which runs on every reconcile cycle for every managed resource.

## Brief change log

  - `SpecUtils.clone` now uses `objectMapper.convertValue(object, object.getClass())` instead of `readValue(writeValueAsString(object), ...)`, converting object to tree to object without the String round-trip. Removes the checked-exception handling that the String path required.
  - `DiffResult.toString` now uses `objectMapper.valueToTree(...)` instead of `readTree(writeValueAsString(...))` to build the before/after JSON trees for the `SpecChanged` event message.

## Verifying this change

This change is already covered by existing tests, such as the reconciler suites that exercise `ReconciliationUtils.clone` on the hot path (controller and `AbstractFlinkResourceReconciler` tests) and the diff suites that exercise `DiffResult.toString` (`ReflectiveDiffBuilder` tests). The change is behavior preserving for the CRD and Fabric8 model types involved, which are JSON-native and already round-tripped through JSON by Kubernetes.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes (`SpecUtils.clone` is invoked per reconcile cycle via `ReconciliationUtils.clone`)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable