### PR TITLE
[FLINK-39826][autoscaler] Strengthen autoscaler configuration validation

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/validation/AutoscalerValidator.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/validation/AutoscalerValidator.java
@@ -25,11 +25,6 @@ import org.apache.flink.configuration.Configuration;
 
 import java.util.Optional;
 
-import static org.apache.flink.autoscaler.config.AutoScalerOptions.OBSERVED_SCALABILITY_COEFFICIENT_MIN;
-import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_MAX;
-import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_MIN;
-import static org.apache.flink.autoscaler.config.AutoScalerOptions.UTILIZATION_TARGET;
-
 /** Validator for Autoscaler. */
 public class AutoscalerValidator {
 
@@ -41,17 +36,46 @@ public class AutoscalerValidator {
      */
     public Optional<String> validateAutoscalerOptions(Configuration flinkConf) {
 
-        if (!flinkConf.getBoolean(AutoScalerOptions.AUTOSCALER_ENABLED)) {
+        if (!flinkConf.get(AutoScalerOptions.AUTOSCALER_ENABLED)) {
             return Optional.empty();
         }
         return firstPresent(
                 validateNumber(flinkConf, AutoScalerOptions.MAX_SCALE_DOWN_FACTOR, 0.0d),
                 validateNumber(flinkConf, AutoScalerOptions.MAX_SCALE_UP_FACTOR, 0.0d),
-                validateNumber(flinkConf, UTILIZATION_TARGET, 0.0d, 1.0d),
+                validateNumber(flinkConf, AutoScalerOptions.UTILIZATION_TARGET, 0.0d, 1.0d),
                 validateNumber(flinkConf, AutoScalerOptions.TARGET_UTILIZATION_BOUNDARY, 0.0d),
-                validateNumber(flinkConf, UTILIZATION_MAX, flinkConf.get(UTILIZATION_TARGET), 1.0d),
-                validateNumber(flinkConf, UTILIZATION_MIN, 0.0d, flinkConf.get(UTILIZATION_TARGET)),
-                validateNumber(flinkConf, OBSERVED_SCALABILITY_COEFFICIENT_MIN, 0.01d, 1d),
+                validateNumber(
+                        flinkConf,
+                        AutoScalerOptions.UTILIZATION_MAX,
+                        flinkConf.get(AutoScalerOptions.UTILIZATION_TARGET),
+                        1.0d),
+                validateNumber(
+                        flinkConf,
+                        AutoScalerOptions.UTILIZATION_MIN,
+                        0.0d,
+                        flinkConf.get(AutoScalerOptions.UTILIZATION_TARGET)),
+                validateNumber(flinkConf, AutoScalerOptions.GC_PRESSURE_THRESHOLD, 0.0d, 1.0d),
+                validateNumber(flinkConf, AutoScalerOptions.HEAP_USAGE_THRESHOLD, 0.0d, 1.0d),
+                // The following options only take effect when their feature is enabled, so they are
+                // only validated in that case.
+                validateNumberIfEnabled(
+                        flinkConf,
+                        AutoScalerOptions.OBSERVED_SCALABILITY_ENABLED,
+                        AutoScalerOptions.OBSERVED_SCALABILITY_COEFFICIENT_MIN,
+                        0.01d,
+                        1d),
+                validateNumberIfEnabled(
+                        flinkConf,
+                        AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED,
+                        AutoScalerOptions.SCALING_EFFECTIVENESS_THRESHOLD,
+                        0.0d,
+                        1.0d),
+                validateNumberIfEnabled(
+                        flinkConf,
+                        AutoScalerOptions.MEMORY_TUNING_ENABLED,
+                        AutoScalerOptions.MEMORY_TUNING_OVERHEAD,
+                        0.0d,
+                        1.0d),
                 CalendarUtils.validateExcludedPeriods(flinkConf));
     }
 
@@ -89,6 +113,23 @@ public class AutoscalerValidator {
                     String.format(
                             "Invalid value in the autoscaler config %s", autoScalerConfig.key()));
         }
+    }
+
+    /**
+     * Validates a numeric option only when the feature it belongs to is enabled. When the feature
+     * is disabled the option has no effect, so an out-of-range value is harmless and is not
+     * reported.
+     */
+    private static <T extends Number> Optional<String> validateNumberIfEnabled(
+            Configuration flinkConfiguration,
+            ConfigOption<Boolean> enabledConfig,
+            ConfigOption<T> autoScalerConfig,
+            Double min,
+            Double max) {
+        if (!flinkConfiguration.get(enabledConfig)) {
+            return Optional.empty();
+        }
+        return validateNumber(flinkConfiguration, autoScalerConfig, min, max);
     }
 
     private static <T extends Number> Optional<String> validateNumber(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/validation/AutoscalerValidatorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/validation/AutoscalerValidatorTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.autoscaler.validation;
+
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nullable;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link AutoscalerValidator}. */
+class AutoscalerValidatorTest {
+
+    private final AutoscalerValidator validator = new AutoscalerValidator();
+
+    private static Configuration enabledConf() {
+        var conf = new Configuration();
+        conf.set(AutoScalerOptions.AUTOSCALER_ENABLED, true);
+        return conf;
+    }
+
+    @Test
+    void testDisabledAutoscalerSkipsValidation() {
+        // Out-of-range value is ignored when the autoscaler is disabled.
+        var conf = new Configuration();
+        conf.set(AutoScalerOptions.AUTOSCALER_ENABLED, false);
+        conf.set(AutoScalerOptions.SCALING_EFFECTIVENESS_THRESHOLD, 2.0d);
+
+        assertThat(validator.validateAutoscalerOptions(conf)).isEmpty();
+    }
+
+    @Test
+    void testDefaultsAreValid() {
+        assertThat(validator.validateAutoscalerOptions(enabledConf())).isEmpty();
+    }
+
+    /**
+     * Numeric options together with the lower/upper bound enforced and, where applicable, the
+     * feature flag that must be enabled for the option to be validated.
+     */
+    static Stream<Arguments> boundedOptions() {
+        return Stream.of(
+                // Always validated when the autoscaler is enabled.
+                Arguments.of(AutoScalerOptions.GC_PRESSURE_THRESHOLD, null, 0.0d, 1.0d),
+                Arguments.of(AutoScalerOptions.HEAP_USAGE_THRESHOLD, null, 0.0d, 1.0d),
+                // Only validated when their feature is enabled.
+                Arguments.of(
+                        AutoScalerOptions.SCALING_EFFECTIVENESS_THRESHOLD,
+                        AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED,
+                        0.0d,
+                        1.0d),
+                Arguments.of(
+                        AutoScalerOptions.MEMORY_TUNING_OVERHEAD,
+                        AutoScalerOptions.MEMORY_TUNING_ENABLED,
+                        0.0d,
+                        1.0d),
+                Arguments.of(
+                        AutoScalerOptions.OBSERVED_SCALABILITY_COEFFICIENT_MIN,
+                        AutoScalerOptions.OBSERVED_SCALABILITY_ENABLED,
+                        0.01d,
+                        1.0d));
+    }
+
+    private static Configuration confWithFeatureEnabled(
+            @Nullable ConfigOption<Boolean> enableFlag) {
+        var conf = enabledConf();
+        if (enableFlag != null) {
+            conf.set(enableFlag, true);
+        }
+        return conf;
+    }
+
+    @ParameterizedTest
+    @MethodSource("boundedOptions")
+    void testValueAboveMaxIsRejected(
+            ConfigOption<Double> option,
+            @Nullable ConfigOption<Boolean> enableFlag,
+            double min,
+            double max) {
+        var conf = confWithFeatureEnabled(enableFlag);
+        conf.set(option, max + 0.0001d);
+
+        assertThat(validator.validateAutoscalerOptions(conf))
+                .hasValueSatisfying(error -> assertThat(error).contains(option.key()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("boundedOptions")
+    void testValueBelowMinIsRejected(
+            ConfigOption<Double> option,
+            @Nullable ConfigOption<Boolean> enableFlag,
+            double min,
+            double max) {
+        var conf = confWithFeatureEnabled(enableFlag);
+        conf.set(option, min - 0.0001d);
+
+        assertThat(validator.validateAutoscalerOptions(conf))
+                .hasValueSatisfying(error -> assertThat(error).contains(option.key()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("boundedOptions")
+    void testBoundaryValuesAreAccepted(
+            ConfigOption<Double> option,
+            @Nullable ConfigOption<Boolean> enableFlag,
+            double min,
+            double max) {
+        var lower = confWithFeatureEnabled(enableFlag);
+        lower.set(option, min);
+        assertThat(validator.validateAutoscalerOptions(lower)).isEmpty();
+
+        var upper = confWithFeatureEnabled(enableFlag);
+        upper.set(option, max);
+        assertThat(validator.validateAutoscalerOptions(upper)).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("boundedOptions")
+    void testOutOfRangeIgnoredWhenFeatureDisabled(
+            ConfigOption<Double> option,
+            @Nullable ConfigOption<Boolean> enableFlag,
+            double min,
+            double max) {
+        if (enableFlag == null) {
+            // Not a feature-gated option, nothing to assert here.
+            return;
+        }
+        var conf = enabledConf();
+        // Feature flag left disabled on purpose.
+        conf.set(option, max + 1.0d);
+
+        assertThat(validator.validateAutoscalerOptions(conf)).isEmpty();
+    }
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -18,6 +18,7 @@
 package org.apache.flink.kubernetes.operator.validation;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.validation.AutoscalerValidator;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
@@ -675,6 +676,31 @@ public class DefaultValidator implements FlinkResourceValidator {
             return Optional.empty();
         }
         Configuration flinkConfiguration = Configuration.fromMap(effectiveConfig);
-        return autoscalerValidator.validateAutoscalerOptions(flinkConfiguration);
+        return firstPresent(
+                autoscalerValidator.validateAutoscalerOptions(flinkConfiguration),
+                validateMetricsWindow(flinkConfiguration));
+    }
+
+    private Optional<String> validateMetricsWindow(Configuration conf) {
+        if (!conf.get(AutoScalerOptions.AUTOSCALER_ENABLED)) {
+            return Optional.empty();
+        }
+        // The autoscaler collects one metric sample per reconcile loop and requires at least two
+        // samples within the metric window to evaluate scaling. If the window is smaller than the
+        // reconcile interval, the window is trimmed down to a single sample on every loop and
+        // autoscaling is never applied.
+        var metricsWindow = conf.get(AutoScalerOptions.METRICS_WINDOW);
+        var reconcileInterval =
+                conf.get(KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL);
+        if (metricsWindow.compareTo(reconcileInterval) < 0) {
+            return Optional.of(
+                    String.format(
+                            "The autoscaler metric window (%s=%s) must not be smaller than the operator reconcile interval (%s=%s), otherwise fewer than two metric samples are retained and autoscaling is never applied.",
+                            AutoScalerOptions.METRICS_WINDOW.key(),
+                            metricsWindow,
+                            KubernetesOperatorConfigOptions.OPERATOR_RECONCILE_INTERVAL.key(),
+                            reconcileInterval));
+        }
+        return Optional.empty();
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -485,15 +485,11 @@ public class DefaultValidatorTest {
                 });
 
         testError(
-                dep -> {
-                    dep.getSpec().getJobManager().getResource().setEphemeralStorage("abc");
-                },
+                dep -> dep.getSpec().getJobManager().getResource().setEphemeralStorage("abc"),
                 "JobManager resource ephemeral storage parse error: Character a is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark.");
 
         testError(
-                dep -> {
-                    dep.getSpec().getTaskManager().getResource().setEphemeralStorage("abc");
-                },
+                dep -> dep.getSpec().getTaskManager().getResource().setEphemeralStorage("abc"),
                 "TaskManager resource ephemeral storage parse error: Character a is neither a decimal digit number, decimal point, nor \"e\" notation exponential mark.");
     }
 
@@ -852,9 +848,7 @@ public class DefaultValidatorTest {
                                             CheckpointingOptions.CHECKPOINTS_DIRECTORY.key(),
                                                     "test-checkpoint-dir"));
                 },
-                flinkDeployment -> {
-                    flinkDeployment.getSpec().setFlinkConfiguration(Map.of());
-                },
+                flinkDeployment -> flinkDeployment.getSpec().setFlinkConfiguration(Map.of()),
                 null);
     }
 
@@ -961,15 +955,32 @@ public class DefaultValidatorTest {
     public void testAutoScalerDeploymentWithInvalidScalingCoefficientMin() {
         var result =
                 testAutoScalerConfiguration(
-                        flinkConf ->
-                                flinkConf.put(
-                                        AutoScalerOptions.OBSERVED_SCALABILITY_COEFFICIENT_MIN
-                                                .key(),
-                                        "1.2"));
+                        flinkConf -> {
+                            // The coefficient is only validated when observed scalability is on.
+                            flinkConf.put(
+                                    AutoScalerOptions.OBSERVED_SCALABILITY_ENABLED.key(), "true");
+                            flinkConf.put(
+                                    AutoScalerOptions.OBSERVED_SCALABILITY_COEFFICIENT_MIN.key(),
+                                    "1.2");
+                        });
         assertErrorContains(
                 result,
                 getFormattedErrorMessage(
                         AutoScalerOptions.OBSERVED_SCALABILITY_COEFFICIENT_MIN, 0.01d, 1d));
+    }
+
+    @Test
+    public void testInvalidScalingCoefficientMinIgnoredWhenObservedScalabilityDisabled() {
+        var result =
+                testAutoScalerConfiguration(
+                        flinkConf -> {
+                            flinkConf.put(
+                                    AutoScalerOptions.OBSERVED_SCALABILITY_ENABLED.key(), "false");
+                            flinkConf.put(
+                                    AutoScalerOptions.OBSERVED_SCALABILITY_COEFFICIENT_MIN.key(),
+                                    "1.2");
+                        });
+        assertErrorNotContains(result);
     }
 
     @Test
@@ -1005,6 +1016,37 @@ public class DefaultValidatorTest {
     @Test
     public void testValidateSessionJob() {
         testSessionJobAutoScalerConfiguration(flinkConf -> {}).ifPresent(Assertions::fail);
+    }
+
+    @Test
+    public void testMetricsWindowSmallerThanReconcileIntervalIsRejected() {
+        // The default reconcile interval is 60s. A smaller metric window means fewer than two
+        // samples are retained per loop and autoscaling never runs, so it must be rejected.
+        var result =
+                testAutoScalerConfiguration(
+                        flinkConf -> flinkConf.put(AutoScalerOptions.METRICS_WINDOW.key(), "30 s"));
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertTrue(result.get().contains(AutoScalerOptions.METRICS_WINDOW.key()));
+    }
+
+    @Test
+    public void testMetricsWindowLargerThanReconcileIntervalIsAccepted() {
+        var result =
+                testAutoScalerConfiguration(
+                        flinkConf ->
+                                flinkConf.put(AutoScalerOptions.METRICS_WINDOW.key(), "5 min"));
+        assertErrorNotContains(result);
+    }
+
+    @Test
+    public void testSmallMetricsWindowIgnoredWhenAutoscalerDisabled() {
+        var result =
+                testAutoScalerConfiguration(
+                        flinkConf -> {
+                            flinkConf.put(AutoScalerOptions.AUTOSCALER_ENABLED.key(), "false");
+                            flinkConf.put(AutoScalerOptions.METRICS_WINDOW.key(), "1 s");
+                        });
+        assertErrorNotContains(result);
     }
 
     @Test
@@ -1128,9 +1170,7 @@ public class DefaultValidatorTest {
 
         deploymentResult =
                 testAutoScalerConfiguration(
-                        flinkConf -> {
-                            flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "0.8");
-                        });
+                        flinkConf -> flinkConf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "0.8"));
         assertErrorContains(
                 deploymentResult,
                 getFormattedErrorMessage(
@@ -1140,9 +1180,8 @@ public class DefaultValidatorTest {
 
         deploymentResult =
                 testAutoScalerConfiguration(
-                        flinkConf -> {
-                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "1.5");
-                        });
+                        flinkConf ->
+                                flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "1.5"));
 
         assertErrorContains(
                 deploymentResult,
@@ -1170,9 +1209,7 @@ public class DefaultValidatorTest {
 
         sessionResult =
                 testSessionJobAutoScalerConfiguration(
-                        flinkConf -> {
-                            flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "0.6");
-                        });
+                        flinkConf -> flinkConf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "0.6"));
         assertErrorContains(
                 sessionResult,
                 getFormattedErrorMessage(
@@ -1182,9 +1219,8 @@ public class DefaultValidatorTest {
 
         sessionResult =
                 testSessionJobAutoScalerConfiguration(
-                        flinkConf -> {
-                            flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "1.5");
-                        });
+                        flinkConf ->
+                                flinkConf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "1.5"));
 
         assertErrorContains(
                 sessionResult,
@@ -1224,7 +1260,7 @@ public class DefaultValidatorTest {
         conf.put(AutoScalerOptions.AUTOSCALER_ENABLED.key(), "true");
         conf.put(AutoScalerOptions.MAX_SCALE_UP_FACTOR.key(), "100000.0");
         conf.put(AutoScalerOptions.MAX_SCALE_DOWN_FACTOR.key(), "0.6");
-        conf.put(AutoScalerOptions.SCALING_EFFECTIVENESS_DETECTION_ENABLED.key(), "0.1");
+        conf.put(AutoScalerOptions.SCALING_EFFECTIVENESS_THRESHOLD.key(), "0.1");
         conf.put(AutoScalerOptions.UTILIZATION_TARGET.key(), "0.7");
         conf.put(AutoScalerOptions.UTILIZATION_MAX.key(), "1.0");
         conf.put(AutoScalerOptions.UTILIZATION_MIN.key(), "0.3");
@@ -1238,17 +1274,6 @@ public class DefaultValidatorTest {
                 configValue.key(),
                 min != null ? min.toString() : "-Infinity",
                 max != null ? max.toString() : "+Infinity");
-    }
-
-    private static String getFormattedNumberOrderErrorMessage(
-            ConfigOption<Double> configValueLeft, ConfigOption<Double> configValueRight) {
-        return String.format(
-                "The AutoScalerOption %s or %s is invalid, %s must be less than or equal to the value of "
-                        + "%s",
-                configValueLeft.key(),
-                configValueRight.key(),
-                configValueLeft.key(),
-                configValueRight.key());
     }
 
     private static String getFormattedErrorMessage(ConfigOption<Double> configValue, Double min) {


### PR DESCRIPTION
## What is the purpose of the change

Strengthen autoscaler configuration validation so invalid values are rejected at resource submission time instead of silently degrading or disabling autoscaling. Two related gaps are addressed:

  - Several ratio-style autoscaler options had no range validation, so out-of-range values were accepted and only surfaced as confusing runtime behavior.
  - The metric window could be configured smaller than the operator reconcile interval, which silently prevents autoscaling because fewer than two metric samples are ever retained.

## Brief change log

  - Add [0, 1] range validation for `memory.gc-pressure.threshold` and `memory.heap-usage.threshold` (always evaluated when the autoscaler is enabled).
  - Validate `scaling.effectiveness.threshold`, `memory.tuning.overhead`, and `observed-scalability.coefficient-min` only when their respective feature is enabled, via a new `validateNumberIfEnabled` helper. `observed-scalability.coefficient-min` was previously validated unconditionally.
  - Reference all options through the qualified `AutoScalerOptions.` form to match the convention used across the module, and replace the deprecated `getBoolean` call with `get`.
  - Add `AutoscalerValidatorTest` covering bounds, boundary values, feature gating, and the disabled-autoscaler short-circuit.
  - In `DefaultValidator`, reject configurations where `job.autoscaler.metrics.window` is smaller than `kubernetes.operator.reconcile.interval` when the autoscaler is enabled, since the metric window is then trimmed to a single sample per loop and the autoscaler never gathers the two samples it needs to evaluate scaling.
  - Add `DefaultValidatorTest` cases for the rejection, the accepted case, and the disabled-autoscaler short-circuit.

## Verifying this change

This change added tests and can be verified as follows:

  - `AutoscalerValidatorTest` (new) covers the numeric bounds and the feature-gating behavior of `AutoscalerValidator`.
  - `DefaultValidatorTest` adds cases for the metric-window vs reconcile-interval check and for the now feature-gated `observed-scalability.coefficient-min`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes (resource validation runs as part of reconciliation, though this change only adds lightweight config checks)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

## Notes for reviewers

  - Behavior change: `observed-scalability.coefficient-min` was validated unconditionally before and is now validated only when `observed-scalability.enabled` is true. A test covers the disabled case to make this explicit.
  - Scope: the metric-window check lives in the operator's `DefaultValidator` because it needs both the autoscaler `metrics.window` and the operator `reconcile.interval`. The standalone autoscaler uses a different loop-interval option and is not covered by this check.
