### PR TITLE
[FLINK-39838] Bump Flink version to 1.20.4

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -95,7 +95,7 @@ jobs:
           if [[ ${{ inputs.flink-version }} == v2* ]]; then
             EXAMPLES_JAR="https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming/2.0.0/flink-examples-streaming-2.0.0.jar"
           elif [[ "${{ inputs.test }}" == "test_batch_job.sh" ]]; then
-            EXAMPLES_JAR="https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming/1.20.1/flink-examples-streaming-1.20.1.jar"
+            EXAMPLES_JAR="https://repo1.maven.org/maven2/org/apache/flink/flink-examples-streaming/1.20.4/flink-examples-streaming-1.20.4.jar"
           fi
           ESCAPED_EXAMPLES_JAR=$(printf '%s\n' "$EXAMPLES_JAR" | sed -e 's/[\/&]/\\&/g')
           

--- a/examples/autoscaling/Dockerfile
+++ b/examples/autoscaling/Dockerfile
@@ -16,5 +16,5 @@
 # limitations under the License.
 ################################################################################
 
-FROM flink:1.20.1-java17
+FROM flink:1.20.4-java17
 COPY ./target/autoscaling*.jar /opt/flink/usrlib/autoscaling.jar

--- a/flink-autoscaler-standalone/pom.xml
+++ b/flink-autoscaler-standalone/pom.xml
@@ -84,7 +84,7 @@ under the License.
                     <artifactId>commons-text</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>org.lz4</groupId>
+                    <groupId>at.yawk.lz4</groupId>
                     <artifactId>lz4-java</artifactId>
                 </exclusion>
             </exclusions>

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
@@ -164,13 +164,13 @@ class RestApiMetricsCollectorTest {
                                     new StandaloneClientHAServices(
                                             miniCluster.getRestAddress().get().toString()));
             var collector = new RestApiMetricsCollector<>();
-            Map<FlinkMetric, Metric> flinkMetricMetricMap = new HashMap<>();
-            // Metrics might not be available yet so retry the query until it returns results or the
-            // timeout reached.
+            // Metrics might not be available yet, and the JobManager exposes the slot metrics
+            // before the TaskManager has registered its slots (reporting 0). Retry the assertion
+            // until the slots are registered, or the timeout is reached.
             await().atMost(Duration.ofSeconds(60))
-                    .until(
+                    .untilAsserted(
                             () -> {
-                                final Map<FlinkMetric, Metric> results =
+                                final Map<FlinkMetric, Metric> flinkMetricMetricMap =
                                         collector.queryJmMetrics(
                                                 client,
                                                 Map.of(
@@ -178,18 +178,15 @@ class RestApiMetricsCollectorTest {
                                                         FlinkMetric.NUM_TASK_SLOTS_TOTAL,
                                                         "taskSlotsAvailable",
                                                         FlinkMetric.NUM_TASK_SLOTS_AVAILABLE));
-                                flinkMetricMetricMap.putAll(results);
-                                return !results.isEmpty();
+                                assertThat(flinkMetricMetricMap)
+                                        .hasSize(2)
+                                        .hasEntrySatisfying(
+                                                FlinkMetric.NUM_TASK_SLOTS_TOTAL,
+                                                metricValue -> assertMetricValueIs(metricValue, 3))
+                                        .hasEntrySatisfying(
+                                                FlinkMetric.NUM_TASK_SLOTS_AVAILABLE,
+                                                metricValue -> assertMetricValueIs(metricValue, 3));
                             });
-
-            assertThat(flinkMetricMetricMap)
-                    .hasSize(2)
-                    .hasEntrySatisfying(
-                            FlinkMetric.NUM_TASK_SLOTS_TOTAL,
-                            metricValue -> assertMetricValueIs(metricValue, 3))
-                    .hasEntrySatisfying(
-                            FlinkMetric.NUM_TASK_SLOTS_AVAILABLE,
-                            metricValue -> assertMetricValueIs(metricValue, 3));
         }
     }
 

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -393,7 +393,7 @@ under the License.
                         </artifactItem>
                         <!--
                         flink-metrics-otel is only published from Flink 2.0.0 onwards on Maven Central.
-                        While this repo still pins flink.version=1.20.1 the artifact cannot be resolved
+                        While this repo still pins flink.version=1.20.4 the artifact cannot be resolved
                         and breaks the build. Restore this block once flink.version is bumped to >= 2.0.0
                         (introduced by FLINK-39541).
                         <artifactItem>

--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- at.yawk.lz4:lz4-java:jar:1.10.3
 - com.fasterxml.jackson.core:jackson-annotations:jar:2.21.3
 - com.fasterxml.jackson.core:jackson-core:jar:2.21.3
 - com.fasterxml.jackson.core:jackson-databind:jar:2.21.3
@@ -70,7 +71,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.8.21
 - org.jetbrains.kotlin:kotlin-stdlib:jar:1.8.21
 - org.jetbrains:annotations:jar:13.0
-- org.lz4:lz4-java:jar:1.8.0
 - org.objenesis:objenesis:jar:2.1
 - org.quartz-scheduler:quartz:jar:2.4.0
 - org.slf4j:slf4j-api:jar:1.7.36

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@ under the License.
         <lombok.version>1.18.30</lombok.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-io.version>2.17.0</commons-io.version>
-        <flink.version>1.20.1</flink.version>
+        <flink.version>1.20.4</flink.version>
         <guava.version>33.4.0-jre</guava.version>
 
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
## What is the purpose of the change

Bump the Flink version the operator builds against from `1.20.1` (Jan 2025) to `1.20.4` (Apr 2026) — the latest patch in the 1.20 line — to pick up the bug and security fixes accumulated across the 1.20.2, 1.20.3 and 1.20.4 releases. As a patch bump within the same minor it is source/binary compatible.

`flink.version` is the version the operator *builds* against; runtime support for the wider Flink range (2.0/2.1/2.2) is covered separately by the CI version matrix, so this does not change which Flink versions the operator can deploy.

## Brief change log

  - Bump `flink.version` `1.20.1` -> `1.20.4` in the root `pom.xml`
  - Align the autoscaling example image base from `flink:1.20.1-java17` to `flink:1.20.4-java17`
  - Align the e2e batch-job examples jar from `1.20.1` to `1.20.4`
  - Update the `flink-metrics-otel` comment that referenced the pinned `flink.version`

## Verifying this change

This change is already covered by existing tests / CI. Locally verified that `mvn clean install javadoc:javadoc -Pgenerate-docs` builds all modules successfully against Flink 1.20.4.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes** (Flink `1.20.1` -> `1.20.4`, patch upgrade)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
