### PR TITLE
[FLINK-39853][test] Upgrade Testcontainers to 2.0.5 and remove JUnit 4 dependency

### DIFF
--- a/flink-autoscaler-plugin-jdbc/pom.xml
+++ b/flink-autoscaler-plugin-jdbc/pom.xml
@@ -32,7 +32,7 @@ under the License.
     <packaging>jar</packaging>
 
     <properties>
-        <testcontainers.version>1.18.2</testcontainers.version>
+        <testcontainers.version>2.0.5</testcontainers.version>
         <postgres.version>42.5.6</postgres.version>
         <mysql.version>8.4.0</mysql.version>
     </properties>
@@ -117,20 +117,6 @@ under the License.
             </exclusions>
         </dependency>
 
-        <!--
-            Testcontainers 1.x container types implement org.junit.rules.TestRule, so JUnit 4
-            must stay on the test compile classpath even though all tests use JUnit 5. The unused
-            junit-vintage-engine is excluded above; only the junit:junit core jar is pulled in here.
-            TODO: remove this once Testcontainers is upgraded to a version without the JUnit 4
-            TestRule coupling (tracked in a follow-up JIRA).
-        -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
@@ -155,7 +141,7 @@ under the License.
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -169,7 +155,7 @@ under the License.
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>mysql</artifactId>
+            <artifactId>testcontainers-mysql</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQLExtension.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/mysql/MySQLExtension.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 
 import java.util.List;
 
@@ -37,11 +37,11 @@ class MySQLExtension implements BeforeAllCallback, AfterAllCallback, AfterEachCa
     private static final List<String> TABLES =
             List.of("t_flink_autoscaler_state_store", "t_flink_autoscaler_event_handler");
 
-    private final MySQLContainer<?> container;
+    private final MySQLContainer container;
 
     public MySQLExtension(String mysqlVersion) {
         this.container =
-                new MySQLContainer<>(String.format("mysql:%s", mysqlVersion))
+                new MySQLContainer(String.format("mysql:%s", mysqlVersion))
                         .withCommand("--character-set-server=utf8")
                         .withDatabaseName(DATABASE_NAME)
                         .withUsername(USER_NAME)

--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/postgres/PostgreSQLExtension.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/testutils/databases/postgres/PostgreSQLExtension.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.util.List;
 
@@ -37,11 +37,11 @@ class PostgreSQLExtension implements BeforeAllCallback, AfterAllCallback, AfterE
     private static final List<String> TABLES =
             List.of("t_flink_autoscaler_state_store", "t_flink_autoscaler_event_handler");
 
-    private final PostgreSQLContainer<?> container;
+    private final PostgreSQLContainer container;
 
     public PostgreSQLExtension(String postgresqlVersion) {
         this.container =
-                new PostgreSQLContainer<>(String.format("postgres:%s", postgresqlVersion))
+                new PostgreSQLContainer(String.format("postgres:%s", postgresqlVersion))
                         .withDatabaseName(DATABASE_NAME)
                         .withUsername(USER_NAME)
                         .withPassword(PASSWORD)


### PR DESCRIPTION
## What is the purpose of the change

Testcontainers 2.x dropped its JUnit 4 coupling, so JUnit 4 is no longer required on the test classpath. This upgrades Testcontainers `1.18.2` → `2.0.5` in `flink-autoscaler-plugin-jdbc` and removes the JUnit 4 dependency.

## Brief change log

- Bump `testcontainers.version` `1.18.2` → `2.0.5` (via `testcontainers-bom`).
- Drop the explicit `junit:junit` test dependency (no longer needed); keep the `junit-vintage-engine` / `junit:junit` exclusions as a guard.
- Handle 2.0 breaking changes: renamed artifacts (`org.testcontainers:mysql`/`postgresql` → `testcontainers-mysql`/`testcontainers-postgresql`) and relocated, no-longer-generic container classes (`org.testcontainers.{mysql,postgresql}.*`).
- Removes the transitive dependency vulnerability in lz4.

## Verifying this change

Covered by the existing JDBC container ITCases; all pass against Testcontainers 2.0.5 (MySQL 5.6/5.7/8.0, PostgreSQL 15, Derby). The dependency tree shows no `junit:junit` or `junit-vintage-engine`.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): **yes** (Testcontainers `1.18.2` → `2.0.5`; removes JUnit 4)
- The public API, i.e., `CustomResourceDescriptors`: no
- Core observer or reconciler logic that is regularly executed: no

## Documentation

- Does this pull request introduce a new feature? no
