### PR TITLE
[FLINK-39890] Fix NaN in observed scaling coefficient when baseline rate is zero

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/AutoScalerUtils.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/utils/AutoScalerUtils.java
@@ -135,11 +135,12 @@ public class AutoScalerUtils {
             squaredSum += parallelism * parallelism;
         }
 
-        if (squaredSum == 0.0) {
+        double denominator = squaredSum * baselineProcessingRate;
+        if (denominator == 0.0) {
             return 1.0; // Fallback to linear scaling if denominator is zero
         }
 
-        double alpha = sum / (squaredSum * baselineProcessingRate);
+        double alpha = sum / denominator;
 
         return Math.max(lowerBound, Math.min(upperBound, alpha));
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -1307,6 +1307,24 @@ public class JobVertexScalerTest {
         assertEquals(1, linearReturnWithTwoScalingHistoryRecordScalingCoefficient);
     }
 
+    @Test
+    public void testCalculateScalingCoefficientWithZeroProcessingRateFallsBackToLinear() {
+        var currentTime = Instant.now();
+
+        var zeroProcessingRateHistory = new TreeMap<Instant, ScalingSummary>();
+        zeroProcessingRateHistory.put(
+                currentTime.minusSeconds(20), new ScalingSummary(2, 4, evaluated(2, 0, 0)));
+        zeroProcessingRateHistory.put(
+                currentTime.minusSeconds(10), new ScalingSummary(4, 8, evaluated(4, 0, 0)));
+        zeroProcessingRateHistory.put(currentTime, new ScalingSummary(8, 16, evaluated(8, 0, 0)));
+
+        double scalingCoefficient =
+                JobVertexScaler.calculateObservedScalingCoefficient(
+                        zeroProcessingRateHistory, conf);
+
+        assertEquals(1.0, scalingCoefficient);
+    }
+
     @ParameterizedTest
     @MethodSource("adjustmentInputsProvider")
     public void testParallelismScalingWithObservedScalingCoefficient(


### PR DESCRIPTION
## What is the purpose of the change

When `job.autoscaler.observed-scalability.enabled` is `true`, the autoscaler throws a `NumberFormatException` while computing the observed scaling coefficient for any vertex with a zero true-processing-rate (idle / very low traffic). The exception aborts the entire scaling pass, so no parallelism overrides / resource requirements are applied and the job stays stuck at its deployed parallelism.

The root cause is in `AutoScalerUtils.optimizeLinearScalingCoefficient`: the denominator is `squaredSum * baselineProcessingRate`, but only `squaredSum` is guarded against zero. An idle vertex reports a finite true processing rate of `0.0` (passing the caller's `isNaN` guard), giving `baselineProcessingRate == 0.0` and `sum == 0.0`. The result is `alpha = 0.0 / 0.0 = NaN`, which `Math.max`/`Math.min` do not sanitize, so it reaches `BigDecimal.valueOf(NaN)` and fails.

This change guards the full denominator so a zero baseline (or zero `squaredSum`) falls back to linear scaling.

## Brief change log

  - Guard the complete denominator `squaredSum * baselineProcessingRate` in `AutoScalerUtils.optimizeLinearScalingCoefficient`, returning the linear-scaling fallback (`1.0`) when it is zero

## Verifying this change

This change added tests and can be verified as follows:

  - Added `testCalculateScalingCoefficientWithZeroProcessingRateFallsBackToLinear` to `JobVertexScalerTest`, which builds a scaling history of vertices with a zero true-processing-rate and asserts `calculateObservedScalingCoefficient` returns the linear-scaling coefficient `1.0` instead of producing `NaN`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes (the observed scaling coefficient is computed on every scaling pass)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
