### PR TITLE
[FLINK-36744][docs] Document operator's FlinkVersion compatibility policy

### DIFF
--- a/docs/content.zh/docs/operations/compatibility.md
+++ b/docs/content.zh/docs/operations/compatibility.md
@@ -1,5 +1,5 @@
 ---
-title: "Compatibility Guarantees"
+title: "兼容性保证"
 weight: 4
 type: docs
 aliases:
@@ -24,40 +24,52 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Compatibility Guarantees
+# 兼容性保证
 
-It is very important for users to clearly understand the compatibility guarantees the operator provides when upgrading to new versions.
+用户清楚地了解 Operator 在升级到新版本时提供的兼容性保证非常重要。
 
-## Custom Resource backward compatibility
+## 自定义资源向后兼容性
 
-The main user facing api of the operator are the Flink [custom resources]({{< ref "docs/custom-resource/overview" >}}).
+Operator 面向用户的主要 API 是 Flink [自定义资源]({{< ref "docs/custom-resource/overview" >}})。
 
-Starting from `v1beta1` (operator version 1.0.0) we aim to provide backward compatibility for the already deployed Flink custom resources (`FlinkDeployment`, `FlinkSessionJob`).
+从 `v1beta1`（Operator 版本 1.0.0）开始，我们致力于为已部署的 Flink 自定义资源（`FlinkDeployment`、`FlinkSessionJob`）提供向后兼容性。
 
-This means that if you have Flink resources deployed (and Flink applications running), you can still safely upgrade to newer versions of the operator and CRD without any problems.
-This should ensure a smooth operational experience where you can always benefit from the latest fixes and improvements without risking current deployments.
+这意味着，如果您已部署了 Flink 资源（且 Flink 应用程序正在运行），您仍然可以安全地升级到更新版本的 Operator 和 CRD，而不会出现任何问题。
+这将确保顺畅的操作体验，让您始终能够受益于最新的修复和改进，而不会危及当前的部署。
 
 {{< hint warning >}}
-We do not guarantee that you will always be able to deploy new resources using old API versions.
-For example when in the future we upgrade from `v1beta1 -> v1`, while it is guaranteed that your current jobs won't fail, you might need to upgrade to `v1` before you can submit new resources.
+我们不保证您始终能够使用旧 API 版本部署新资源。
+例如，当我们将来从 `v1beta1 -> v1` 升级时，虽然可以保证您当前的作业不会失败，但您可能需要先升级到 `v1` 才能提交新资源。
 {{< /hint >}}
 
-## Contents of the resource status
+## 资源状态的内容
 
-Currently, the `FlinkDeployment` and `FlinkSessionJob` resources contain a very detailed status information that contains everything necessary for the operator to manage the resources.
-Most of this information should be considered ***internal*** to operator logic and is subject to change/disappear in the future.
+目前，`FlinkDeployment` 和 `FlinkSessionJob` 资源包含非常详细的状态信息，其中包含 Operator 管理资源所需的一切内容。
+这些信息大部分应被视为 Operator 逻辑的***内部***信息，将来可能会更改或消失。
 
-In general, we are aiming to slim down the status to only contain information that is relevant to users/client for the next major CRD version (`v1`).
+总体而言，我们的目标是在下一个主要 CRD 版本（`v1`）中将状态精简为仅包含与用户/客户端相关的信息。
 
-## Java API compatibility
+## Java API 兼容性
 
-While it is very important for us to provide [backward compatibility for the custom resources](#custom-resource-backward-compatibility), at this time we cannot provide the same guarantee for Java API.
+尽管为自定义资源提供[向后兼容性](#自定义资源向后兼容性)对我们非常重要，但目前我们无法为 Java API 提供同样的保证。
 
-The operator related java interfaces, such as Validators should be considered experimental/evolving and can possibly break between releases.
+与 Operator 相关的 Java 接口（例如验证器）应被视为实验性/演进中的接口，可能在不同版本之间发生破坏性变更。
 
-## Helm chart compatibility
+## Helm Chart 兼容性
 
-The Helm chart included in the operator repo provides a convenient way to deploy and manage the operator in complex environments.
-We are constantly working on improving the configuration parameters and features to cover all the different scenarios.
+Operator 仓库中包含的 Helm Chart 提供了一种在复杂环境中部署和管理 Operator 的便捷方式。
+我们不断致力于改进配置参数和功能，以覆盖所有不同的场景。
 
-At this time we do not provide backward compatibility for the Helm chart configuration / components. Please verify your custom settings before upgrading to a new version.
+目前，我们不为 Helm Chart 配置/组件提供向后兼容性。在升级到新版本之前，请验证您的自定义设置。
+
+## Flink 版本兼容性
+
+从 Flink Kubernetes Operator 1.7 开始，Operator 仅支持基于 Operator 发布日期的最近 4 个 Flink 次要版本。
+超出此范围的版本将在 API 中被标记为 `@Deprecated`，并在使用时产生验证警告。
+
+如需了解当前支持和已弃用的 Flink 版本的完整列表，请参阅
+[FlinkVersion.java](https://github.com/apache/flink-kubernetes-operator/blob/main/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkVersion.java)。
+
+{{< hint warning >}}
+强烈建议升级到受支持的 Flink 版本，以确保与 Operator 的持续兼容性。
+{{< /hint >}}

--- a/docs/content/docs/operations/compatibility.md
+++ b/docs/content/docs/operations/compatibility.md
@@ -61,3 +61,17 @@ The Helm chart included in the operator repo provides a convenient way to deploy
 We are constantly working on improving the configuration parameters and features to cover all the different scenarios.
 
 At this time we do not provide backward compatibility for the Helm chart configuration / components. Please verify your custom settings before upgrading to a new version.
+
+## Flink Version Compatibility
+
+Starting with Flink Kubernetes Operator 1.7, the operator supports only the last 4 Flink minor
+versions based on the operator release date. Versions outside this range are marked as
+`@Deprecated` in the API and will produce a validation warning when used.
+
+For the exact list of currently supported and deprecated Flink versions, refer to
+[FlinkVersion.java](https://github.com/apache/flink-kubernetes-operator/blob/main/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkVersion.java).
+
+{{< hint warning >}}
+It is strongly recommended to upgrade to a supported Flink version to ensure continued
+compatibility with the operator.
+{{< /hint >}}


### PR DESCRIPTION
## What is the purpose of the change (FLINK-36744)

This pull request documents the FlinkVersion compatibility policy introduced 
in Flink Kubernetes Operator 1.7, which was previously only discoverable in 
source code (FlinkVersion.java) and not mentioned in the official documentation.

Adds a new "Flink Version Compatibility" section to the Compatibility Guarantees 
documentation page explaining the last-4-minor-versions policy and linking to 
FlinkVersion.java for the current supported version list.

Also updates the Chinese translation (content.zh) with full translated content 
and the new section.

## Brief change log

  - Added "Flink Version Compatibility" section to `docs/content/docs/operations/compatibility.md`
  - Added "Flink 版本兼容性" section to `docs/content.zh/docs/operations/compatibility.md`
  - Translated existing English content to Chinese in `content.zh/docs/operations/compatibility.md`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable