### PR TITLE
[FLINK-39958] Autoscaler Flink REST client timeout is silently overridden by the operator client timeout

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContext.java
@@ -72,9 +72,11 @@ public abstract class FlinkResourceContext<CR extends AbstractFlinkResource<?, ?
         if (deployConf != null) {
             conf.addAll(deployConf);
         }
-        conf.set(
-                AutoScalerOptions.FLINK_CLIENT_TIMEOUT,
-                getOperatorConfig().getFlinkClientTimeout());
+        if (!conf.contains(AutoScalerOptions.FLINK_CLIENT_TIMEOUT)) {
+            conf.set(
+                    AutoScalerOptions.FLINK_CLIENT_TIMEOUT,
+                    getOperatorConfig().getFlinkClientTimeout());
+        }
 
         CommonStatus<?> status = getResource().getStatus();
         String jobId = status.getJobStatus().getJobId();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContextTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkResourceContextTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.controller;
 
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.TestingFlinkService;
@@ -148,6 +149,45 @@ public class FlinkResourceContextTest {
         assertTrue(sessionJobCtx.getObserveConfig() == conf);
         assertTrue(sessionJobCtx.getObserveConfig() == conf);
         assertEquals(2, counter.get());
+    }
+
+    @Test
+    void testAutoscalerFlinkClientTimeoutDefaultsToOperatorTimeout() {
+        var conf = new Configuration();
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_FLINK_CLIENT_TIMEOUT,
+                Duration.ofSeconds(60));
+        configManager = new FlinkConfigManager(conf);
+
+        // No explicit autoscaler client timeout -> falls back to the operator timeout.
+        var ctx = getContext(TestUtils.buildApplicationCluster());
+        assertEquals(
+                Duration.ofSeconds(60),
+                ctx.getJobAutoScalerContext()
+                        .getConfiguration()
+                        .get(AutoScalerOptions.FLINK_CLIENT_TIMEOUT));
+    }
+
+    @Test
+    void testExplicitAutoscalerFlinkClientTimeoutIsRespected() {
+        var conf = new Configuration();
+        conf.set(
+                KubernetesOperatorConfigOptions.OPERATOR_FLINK_CLIENT_TIMEOUT,
+                Duration.ofSeconds(60));
+        configManager = new FlinkConfigManager(conf);
+
+        var dep = TestUtils.buildApplicationCluster();
+        dep.getSpec()
+                .getFlinkConfiguration()
+                .put(AutoScalerOptions.FLINK_CLIENT_TIMEOUT.key(), "30 s");
+
+        // An explicit autoscaler timeout must not be silently overridden by the operator timeout.
+        var ctx = getContext(dep);
+        assertEquals(
+                Duration.ofSeconds(30),
+                ctx.getJobAutoScalerContext()
+                        .getConfiguration()
+                        .get(AutoScalerOptions.FLINK_CLIENT_TIMEOUT));
     }
 
     FlinkResourceContext getContext(AbstractFlinkResource<?, ?> cr) {


### PR DESCRIPTION
## What is the purpose of the change

The autoscaler option `AutoScalerOptions.FLINK_CLIENT_TIMEOUT` (`job.autoscaler.flink.rest-client.timeout`, fallback `kubernetes.operator.flink.rest-client.timeout`, default `10s`) had no effect inside the Kubernetes operator: when the operator builds the autoscaler context in `FlinkResourceContext.createJobAutoScalerContext`, it ingests the resource's effective deploy config (which already contains any user-set `job.autoscaler.flink.rest-client.timeout`) and then **unconditionally** overwrote `AutoScalerOptions.FLINK_CLIENT_TIMEOUT` with the operator-level `OPERATOR_FLINK_CLIENT_TIMEOUT` (`kubernetes.operator.flink.client.timeout`). As a result a user's explicit autoscaler timeout was always clobbered, so the documented option was a no-op in operator mode (it works in the standalone autoscaler, which has no operator config to override it).

This PR makes the operator timeout a default rather than an unconditional override, so an explicitly configured autoscaler timeout is honored.

## Brief change log

  - `FlinkResourceContext.createJobAutoScalerContext`: apply the operator client timeout to `AutoScalerOptions.FLINK_CLIENT_TIMEOUT` only when the user has not explicitly set it, guarded with `conf.contains(AutoScalerOptions.FLINK_CLIENT_TIMEOUT)`, matching the existing `setDefaultConf` pattern. The operator timeout remains the default (so the autoscaler stays consistent with the rest of the operator's Flink REST interactions), while an explicit `job.autoscaler.flink.rest-client.timeout` is respected.

## Verifying this change

This change can be verified with the new and existing unit tests + some existing examples.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes (autoscaler context creation in the reconcile loop)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

