### PR TITLE
[hotfix][api] Remove unused Diffable markers from spec/status types

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/AbstractFlinkSpec.java
@@ -20,7 +20,6 @@ package org.apache.flink.kubernetes.operator.api.spec;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.diff.DiffType;
-import org.apache.flink.kubernetes.operator.api.diff.Diffable;
 import org.apache.flink.kubernetes.operator.api.diff.SpecDiff;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -39,7 +38,7 @@ import java.util.Map;
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder
-public abstract class AbstractFlinkSpec implements Diffable<AbstractFlinkSpec> {
+public abstract class AbstractFlinkSpec {
 
     /** Job specification for application deployments/session job. Null for session clusters. */
     private JobSpec job;

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkStateSnapshotSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkStateSnapshotSpec.java
@@ -18,7 +18,6 @@
 package org.apache.flink.kubernetes.operator.api.spec;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.kubernetes.operator.api.diff.Diffable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
@@ -33,7 +32,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 @SuperBuilder
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class FlinkStateSnapshotSpec implements Diffable<FlinkStateSnapshotSpec> {
+public class FlinkStateSnapshotSpec {
     /** Source to take a snapshot of. Not required if it's a savepoint and alreadyExists is true. */
     private JobReference jobReference;
 

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkStateSnapshotStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkStateSnapshotStatus.java
@@ -18,7 +18,6 @@
 package org.apache.flink.kubernetes.operator.api.status;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.kubernetes.operator.api.diff.Diffable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.fabric8.crd.generator.annotation.PrinterColumn;
@@ -34,7 +33,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @SuperBuilder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class FlinkStateSnapshotStatus implements Diffable<FlinkStateSnapshotStatus> {
+public class FlinkStateSnapshotStatus {
 
     /** Current state of the snapshot. */
     @PrinterColumn(name = "Snapshot State")


### PR DESCRIPTION
## What is the purpose of the change

`Diffable` is a marker interface that `ReflectiveDiffBuilder` consults only to decide whether to recurse into a **nested** field (`Diffable.class.isAssignableFrom(field.getType())`). The root object of a diff is always processed unconditionally, so a root type's `Diffable`-ness is never checked.

This change removes those unused markers so `Diffable` only appears where the engine actually uses it.

## Brief change log

  - Removed `implements Diffable<...>` and the now-unused `Diffable` import from `AbstractFlinkSpec`.
  - Removed the same from `FlinkStateSnapshotSpec` and `FlinkStateSnapshotStatus`.
  - Kept `Diffable` on `JobSpec` and `TaskManagerSpec`, the nested fields the diff engine genuinely recurses into.

## Verifying this change

This change is already covered by existing tests, all of them passing already with this new change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no (`Diffable` is an internal marker interface, not serialized; no CRD/schema impact)
  - Core observer or reconciler logic that is regularly executed: no (diff behavior is unchanged)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable