### PR TITLE
[hotfix] Strip B/G scale subresource in process-classes so partial builds keep CRDs valid

### DIFF
--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -322,7 +322,17 @@ under the License.
                     </execution>
                     <execution>
                         <id>flinkbgdeployments-remove-scale-subresource</id>
-                        <phase>package</phase>
+                        <!--
+                          Runs in process-classes, after crd-generator:generate and
+                          maven-resources:copy-resources (both bound to process-classes, but declared
+                          on plugins earlier in this POM so they execute first). Binding the strip
+                          here rather than to package keeps it aligned with the auto-copy of generated
+                          CRDs into the helm chart, so any build that regenerates the CRDs (e.g. mvn
+                          compile/test-compile, not just a full package) also strips the invalid B/G
+                          scale subresource. Otherwise a partial build can leave an un-stripped,
+                          invalid scale block in the committed CRD.
+                        -->
+                        <phase>process-classes</phase>
                         <goals>
                             <goal>run</goal>
                         </goals>


### PR DESCRIPTION
## What is the purpose of the change

The `flinkbluegreendeployments` CRD must not carry a `scale` subresource: it has no `statusReplicasPath` and is rejected by the API server (`helm install` fails with `spec.subresources.scale.statusReplicasPath: Required value`).

`RemoveScaleSubResource` strips that block, but it was bound to the **`package`** phase, while `crd-generator:generate` and the copy of generated CRDs into `helm/crds` (added when CRD auto-generation was wired up in #1140) run in **`process-classes`**. A build that stops before `package` -- e.g. `mvn compile` / `mvn test-compile` -- therefore regenerates and copies the *un-stripped* CRD into the committed chart without ever stripping it, leaving an invalid `scale` block that breaks `helm install`.

## Brief change log

- Bind the `flinkbgdeployments-remove-scale-subresource` execution to `process-classes` (after `crd-generator:generate` and `copy-resources`, which are ordered first by plugin declaration order) instead of `package`, so every build that regenerates the CRDs also strips the B/G scale subresource.

## Verifying this change

On a clean checkout, `mvn -pl flink-kubernetes-operator-api test-compile` now leaves `helm/.../flinkbluegreendeployments...yml` unchanged (the regenerated scale block is stripped in `process-classes`). Before this change, the same partial build re-introduced the invalid `scale` block.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no (build-only; keeps the committed CRD correct)
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no

🤖 Generated with [Claude Code](https://claude.com/claude-code)