### PR TITLE
[FLINK-31849] Adds basic CRD validations

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkDeploymentSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkDeploymentSpec.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Experimental;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.fabric8.crd.generator.annotation.SchemaFrom;
+import io.fabric8.generator.annotation.Required;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import lombok.AllArgsConstructor;
@@ -52,7 +53,7 @@ public class FlinkDeploymentSpec extends AbstractFlinkSpec {
     private String serviceAccount;
 
     /** Flink image version. */
-    private FlinkVersion flinkVersion;
+    @Required private FlinkVersion flinkVersion;
 
     /** Ingress specs. */
     private IngressSpec ingress;

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkStateSnapshotSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/FlinkStateSnapshotSpec.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.api.spec;
 import org.apache.flink.annotation.Experimental;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.fabric8.generator.annotation.Min;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -46,6 +47,7 @@ public class FlinkStateSnapshotSpec {
      * Maximum number of retries before the snapshot is considered as failed. Set to -1 for
      * unlimited or 0 for no retries.
      */
+    @Min(-1)
     private int backoffLimit = -1;
 
     public boolean isSavepoint() {

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/IngressSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/IngressSpec.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.api.spec;
 import org.apache.flink.annotation.Experimental;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.fabric8.generator.annotation.Required;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressTLS;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,7 +40,7 @@ import java.util.Map;
 public class IngressSpec {
 
     /** Ingress template for the JobManager service. */
-    private String template;
+    @Required private String template;
 
     /** Ingress className for the Flink deployment. */
     private String className;

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobManagerSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/JobManagerSpec.java
@@ -21,6 +21,7 @@ import org.apache.flink.annotation.Experimental;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.fabric8.crd.generator.annotation.SchemaFrom;
+import io.fabric8.generator.annotation.Min;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -51,6 +52,7 @@ public class JobManagerSpec {
     private ResourceRequirements resources;
 
     /** Number of JobManager replicas. Must be 1 for non-HA deployments. */
+    @Min(1)
     private int replicas = 1;
 
     /** JobManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. */

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/TaskManagerSpec.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/spec/TaskManagerSpec.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.operator.api.diff.SpecDiff;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.fabric8.crd.generator.annotation.SchemaFrom;
+import io.fabric8.generator.annotation.Min;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -57,6 +58,7 @@ public class TaskManagerSpec implements Diffable<TaskManagerSpec> {
     /** Number of TaskManager replicas. If defined, takes precedence over parallelism */
     @SpecDiff(value = DiffType.SCALE, mode = KubernetesDeploymentMode.STANDALONE)
     @SpecReplicas
+    @Min(1)
     private Integer replicas;
 
     /** TaskManager pod template. It will be merged with FlinkDeploymentSpec.podTemplate. */

--- a/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/FlinkConfigurationYamlSupportTest.java
+++ b/flink-kubernetes-operator-api/src/test/java/org/apache/flink/kubernetes/operator/api/FlinkConfigurationYamlSupportTest.java
@@ -17,12 +17,17 @@
 
 package org.apache.flink.kubernetes.operator.api;
 
+import org.apache.flink.kubernetes.operator.api.spec.IngressSpec;
+import org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.fabric8.kubeapitest.junit.EnableKubeAPIServer;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +35,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @EnableKubeAPIServer
 class FlinkConfigurationYamlSupportTest {
@@ -39,6 +45,8 @@ class FlinkConfigurationYamlSupportTest {
             "src/test/resources/pre-flink-configuration-yaml-crd.yml";
     public static final String NEW_CRD_PATH =
             "../helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml";
+    public static final String SNAPSHOT_CRD_PATH =
+            "../helm/flink-kubernetes-operator/crds/flinkstatesnapshots.flink.apache.org-v1.yml";
 
     static KubernetesClient client;
 
@@ -66,6 +74,65 @@ class FlinkConfigurationYamlSupportTest {
                         .get();
         assertThat(deployment.getSpec().getFlinkConfiguration()).hasSize(3);
         assertThat(deployment.getSpec().getFlinkConfiguration().asFlatMap()).hasSize(5);
+    }
+
+    /**
+     * Verifies that the validation constraints declared via CRD-generator annotations are enforced
+     * by the API server at admission time, rather than only by {@code
+     * DefaultValidator} during reconciliation. Covers {@code @Min(1)} on the JobManager/TaskManager
+     * replicas, {@code @Required} on {@code flinkVersion} and the ingress template, and
+     * {@code @Min(-1)} on the snapshot {@code backoffLimit}.
+     */
+    @Test
+    void crdRejectsInvalidSpecValues() {
+        applyCRD(NEW_CRD_PATH);
+
+        // A fully specified deployment satisfies all the schema constraints.
+        client.resource(validDeployment("valid-dep")).create();
+
+        // @Min(1) on JobManagerSpec.replicas
+        var jmReplicas = validDeployment("invalid-jm-replicas");
+        jmReplicas.getSpec().getJobManager().setReplicas(0);
+        assertRejected(jmReplicas);
+
+        // @Min(1) on TaskManagerSpec.replicas
+        var tmReplicas = validDeployment("invalid-tm-replicas");
+        tmReplicas.getSpec().getTaskManager().setReplicas(0);
+        assertRejected(tmReplicas);
+
+        // @Required on FlinkDeploymentSpec.flinkVersion
+        var noVersion = validDeployment("invalid-no-version");
+        noVersion.getSpec().setFlinkVersion(null);
+        assertRejected(noVersion);
+
+        // @Required on IngressSpec.template (an ingress without a template)
+        var noTemplate = validDeployment("invalid-ingress");
+        noTemplate.getSpec().setIngress(new IngressSpec());
+        assertRejected(noTemplate);
+
+        // @Min(-1) on FlinkStateSnapshotSpec.backoffLimit (-1 is the unlimited-retries sentinel)
+        applyCRD(SNAPSHOT_CRD_PATH);
+        client.resource(validSnapshot("valid-snapshot")).create();
+        var badBackoff = validSnapshot("invalid-backoff");
+        badBackoff.getSpec().setBackoffLimit(-2);
+        assertRejected(badBackoff);
+    }
+
+    private FlinkDeployment validDeployment(String name) {
+        var deployment = BaseTestUtils.buildApplicationCluster();
+        deployment.getMetadata().setName(name);
+        deployment.getMetadata().setNamespace("default");
+        return deployment;
+    }
+
+    private FlinkStateSnapshot validSnapshot(String name) {
+        return BaseTestUtils.buildFlinkStateSnapshotSavepoint(
+                name, "default", "test-path", true, null);
+    }
+
+    private void assertRejected(HasMetadata resource) {
+        assertThatThrownBy(() -> client.resource(resource).create())
+                .isInstanceOf(KubernetesClientException.class);
     }
 
     private GenericKubernetesResource applyResource(String path) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/validation/DefaultValidator.java
@@ -154,7 +154,9 @@ public class DefaultValidator implements FlinkResourceValidator {
         var spec = deployment.getSpec();
         var version = spec.getFlinkVersion();
         if (version == null) {
-            return Optional.of("Flink Version must be defined.");
+            // Presence is enforced by the CRD schema (@Required on
+            // FlinkDeploymentSpec.flinkVersion); nothing further to validate here.
+            return Optional.empty();
         }
 
         if (!FlinkVersion.isSupported(version)) {
@@ -182,11 +184,10 @@ public class DefaultValidator implements FlinkResourceValidator {
     }
 
     private Optional<String> validateIngress(IngressSpec ingress, String name, String namespace) {
-        if (ingress == null) {
+        if (ingress == null || ingress.getTemplate() == null) {
+            // Template presence (when an ingress is configured) is enforced by the CRD schema
+            // (@Required on IngressSpec.template).
             return Optional.empty();
-        }
-        if (ingress.getTemplate() == null) {
-            return Optional.of("Ingress template must be defined");
         }
         try {
             IngressUtils.getIngressUrl(ingress.getTemplate(), name, namespace);
@@ -294,9 +295,10 @@ public class DefaultValidator implements FlinkResourceValidator {
 
         var tmReplicasDefined = tm != null && tm.getReplicas() != null;
 
-        if (tmReplicasDefined && tm.getReplicas() < 1) {
-            return Optional.of("TaskManager replicas must be larger than 0");
-        } else if (!tmReplicasDefined && job.getParallelism() < 1) {
+        // TaskManager replicas >= 1 is enforced by the CRD schema (@Min(1) on
+        // TaskManagerSpec.replicas). Only the parallelism fallback (used when replicas are not
+        // set) needs checking here, since parallelism defaults to 0 and is otherwise unconstrained.
+        if (!tmReplicasDefined && job.getParallelism() < 1) {
             return Optional.of("Job parallelism must be larger than 0");
         }
 
@@ -414,9 +416,8 @@ public class DefaultValidator implements FlinkResourceValidator {
     }
 
     private Optional<String> validateJmReplicas(int replicas, Map<String, String> confMap) {
-        if (replicas < 1) {
-            return Optional.of("JobManager replicas should not be configured less than one.");
-        } else if (replicas > 1
+        // replicas >= 1 is enforced by the CRD schema (@Min(1) on JobManagerSpec.replicas).
+        if (replicas > 1
                 && !HighAvailabilityMode.isHighAvailabilityModeActivated(
                         Configuration.fromMap(confMap))) {
             return Optional.of(
@@ -442,8 +443,7 @@ public class DefaultValidator implements FlinkResourceValidator {
         return firstPresent(
                 tmMemoryConfigValidation,
                 validateResources("TaskManager", tmSpec.getResource()),
-                validateResourceRequirements("TaskManager", tmSpec.getResources()),
-                validateTmReplicas(tmSpec));
+                validateResourceRequirements("TaskManager", tmSpec.getResources()));
     }
 
     private Optional<String> validateTmMemoryConfig(Configuration conf) {
@@ -453,13 +453,6 @@ public class DefaultValidator implements FlinkResourceValidator {
             return Optional.of(
                     "TaskManager resource memory must be defined using `spec.taskManager.resource.memory`"
                             + " or `spec.taskManager.resources.requests.memory`");
-        }
-        return Optional.empty();
-    }
-
-    private Optional<String> validateTmReplicas(TaskManagerSpec tmSpec) {
-        if (tmSpec.getReplicas() != null && tmSpec.getReplicas() < 1) {
-            return Optional.of("TaskManager replicas should not be configured less than one.");
         }
         return Optional.empty();
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/validation/DefaultValidatorTest.java
@@ -39,7 +39,6 @@ import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.spec.KubernetesDeploymentMode;
 import org.apache.flink.kubernetes.operator.api.spec.SavepointSpec;
-import org.apache.flink.kubernetes.operator.api.spec.TaskManagerSpec;
 import org.apache.flink.kubernetes.operator.api.spec.UpgradeMode;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentReconciliationStatus;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
@@ -100,13 +99,8 @@ public class DefaultValidatorTest {
                 dep -> dep.getSpec().getJob().setParallelism(0),
                 "Job parallelism must be larger than 0");
 
-        testError(
-                dep -> {
-                    var tmSpec = new TaskManagerSpec();
-                    tmSpec.setReplicas(0);
-                    dep.getSpec().setTaskManager(tmSpec);
-                },
-                "TaskManager replicas must be larger than 0");
+        // TaskManager replicas < 1 is rejected by the CRD schema (@Min(1)) at admission, not by
+        // DefaultValidator; see FlinkConfigurationYamlSupportTest#crdRejectsInvalidSpecValues.
 
         testSuccess(
                 dep -> {
@@ -239,9 +233,9 @@ public class DefaultValidatorTest {
                                                 Constants.CONFIG_FILE_LOG4J_NAME,
                                                 "rootLogger.level = INFO")));
 
-        testError(
-                dep -> dep.getSpec().setIngress(new IngressSpec()),
-                "Ingress template must be defined");
+        // An ingress without a template is rejected by the CRD schema (@Required) at admission,
+        // not by DefaultValidator; see
+        // FlinkConfigurationYamlSupportTest#crdRejectsInvalidSpecValues.
 
         testError(
                 dep ->
@@ -279,9 +273,8 @@ public class DefaultValidatorTest {
                                                 "true")),
                 "HA must be enabled for rollback support.");
 
-        testError(
-                dep -> dep.getSpec().getJobManager().setReplicas(0),
-                "JobManager replicas should not be configured less than one.");
+        // JobManager replicas < 1 is rejected by the CRD schema (@Min(1)) at admission, not by
+        // DefaultValidator; see FlinkConfigurationYamlSupportTest#crdRejectsInvalidSpecValues.
 
         // Test resource validation
         testSuccessDeprecatedResource(
@@ -577,7 +570,8 @@ public class DefaultValidatorTest {
                 },
                 "Cannot switch from standalone kubernetes to native kubernetes cluster");
 
-        testError(dep -> dep.getSpec().setFlinkVersion(null), "Flink Version must be defined.");
+        // A null flinkVersion is rejected by the CRD schema (@Required) at admission, not by
+        // DefaultValidator; see FlinkConfigurationYamlSupportTest#crdRejectsInvalidSpecValues.
 
         testError(
                 dep -> dep.getSpec().setFlinkVersion(FlinkVersion.v1_14),

--- a/helm/flink-kubernetes-operator/crds/flinkbluegreendeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkbluegreendeployments.flink.apache.org-v1.yml
@@ -53,6 +53,8 @@ spec:
                           type: "string"
                       type: "object"
                     type: "array"
+                required:
+                - "template"
                 type: "object"
               template:
                 properties:
@@ -176,6 +178,8 @@ spec:
                                   type: "string"
                               type: "object"
                             type: "array"
+                        required:
+                        - "template"
                         type: "object"
                       job:
                         properties:
@@ -3724,6 +3728,7 @@ spec:
                                 type: "object"
                             type: "object"
                           replicas:
+                            minimum: 1.0
                             type: "integer"
                           resource:
                             properties:
@@ -10793,6 +10798,7 @@ spec:
                                 type: "object"
                             type: "object"
                           replicas:
+                            minimum: 1.0
                             type: "integer"
                           resource:
                             properties:
@@ -10830,6 +10836,8 @@ spec:
                                 type: "object"
                             type: "object"
                         type: "object"
+                    required:
+                    - "flinkVersion"
                     type: "object"
                 type: "object"
             type: "object"

--- a/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkdeployments.flink.apache.org-v1.yml
@@ -75,6 +75,8 @@ spec:
                           type: "string"
                       type: "object"
                     type: "array"
+                required:
+                - "template"
                 type: "object"
               job:
                 properties:
@@ -3623,6 +3625,7 @@ spec:
                         type: "object"
                     type: "object"
                   replicas:
+                    minimum: 1.0
                     type: "integer"
                   resource:
                     properties:
@@ -10692,6 +10695,7 @@ spec:
                         type: "object"
                     type: "object"
                   replicas:
+                    minimum: 1.0
                     type: "integer"
                   resource:
                     properties:
@@ -10729,6 +10733,8 @@ spec:
                         type: "object"
                     type: "object"
                 type: "object"
+            required:
+            - "flinkVersion"
             type: "object"
           status:
             properties:

--- a/helm/flink-kubernetes-operator/crds/flinkstatesnapshots.flink.apache.org-v1.yml
+++ b/helm/flink-kubernetes-operator/crds/flinkstatesnapshots.flink.apache.org-v1.yml
@@ -33,6 +33,7 @@ spec:
           spec:
             properties:
               backoffLimit:
+                minimum: -1.0
                 type: "integer"
               checkpoint:
                 type: "object"


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request moves simple, single-field spec validation from the operator's imperative DefaultValidator into declarative CRD-generator annotations, so these constraints are enforced by the Kubernetes API server at admission time rather than only during reconciliation. This gives users immediate, schema-level feedback on  `kubectl apply` and simplifies the validation logic in the operator.


## Brief change log

 - Annotated four spec fields with CRD-generator validation annotations: @Min(1) on JobManagerSpec.replicas and TaskManagerSpec.replicas, and @Required on FlinkDeploymentSpec.flinkVersion and IngressSpec.template
  -   Regenerated the flinkdeployments and flinkbluegreendeployments CRDs, which now carry minimum: 1 on the replicas fields and flinkVersion/template in their required lists
  - Removed the now-redundant imperative checks from DefaultValidator (including the validateTmReplicas method), keeping only the validation that genuinely cannot be expressed declaratively (e.g. the conditional parallelism fallback, the JM replicas > 1 requires HA cross-field rule, and the ingress URL parsing)

## Verifying this change
 - Added F`linkConfigurationYamlSupportTest#crdRejectsInvalidSpecValues`, which applies the regenerated CRD to an in-process API server (kubeapitest) and verifies that resources violating each new constraintare rejected at admission, while a fully specified deployment is accepted
  - Updated DefaultValidatorTest to drop the now-removed imperative checks; the remaining 41 validator tests pass, confirming no regression in the validation that stays in the operator

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: yes. 
  - Core observer or reconciler logic that is regularly executed: no (validation logic only; no observer/reconciler changes)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
