### PR TITLE
[FLINK-39970] Retry incomplete JobManager deployment deletion

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -1243,9 +1243,10 @@ public abstract class AbstractFlinkService implements FlinkService {
                         Objects::isNull, timeout.toMillis(), TimeUnit.MILLISECONDS);
                 LOG.info("Completed {}", operation);
             } catch (KubernetesClientException kce) {
-                // We completely ignore not found errors and simply log others
+                // Not found means deletion completed. Other errors must abort this reconcile so a
+                // replacement cluster is not submitted while the old deployment still exists.
                 if (kce.getCode() != HttpURLConnection.HTTP_NOT_FOUND) {
-                    LOG.warn("Error while " + operation, kce);
+                    throw kce;
                 }
             }
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/NativeFlinkService.java
@@ -56,6 +56,7 @@ import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.EditReplacePatchable;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;
@@ -323,23 +324,29 @@ public class NativeFlinkService extends AbstractFlinkService {
         // here is to initiate JM shutdown before the TMs
         var jmShutdownTimeout =
                 ObjectUtils.min(JM_SHUTDOWN_MAX_WAIT, remainingTimeout.dividedBy(2));
-        var remaining =
-                deleteBlocking(
-                        "Scaling JobManager Deployment to zero",
-                        () -> {
-                            try {
-                                jmDeployment.patch(
-                                        PatchContext.of(PatchType.JSON_MERGE), SCALE_TO_ZERO);
-                            } catch (Exception ignore) {
-                                // Ignore all errors here as this is an optional step
-                                return null;
-                            }
-                            return kubernetesClient
-                                    .pods()
-                                    .inNamespace(namespace)
-                                    .withLabels(KubernetesUtils.getJobManagerSelectors(clusterId));
-                        },
-                        jmShutdownTimeout);
-        return remainingTimeout.minus(jmShutdownTimeout).plus(remaining);
+        try {
+            var remaining =
+                    deleteBlocking(
+                            "Scaling JobManager Deployment to zero",
+                            () -> {
+                                try {
+                                    jmDeployment.patch(
+                                            PatchContext.of(PatchType.JSON_MERGE), SCALE_TO_ZERO);
+                                } catch (Exception ignore) {
+                                    // Ignore all errors here as this is an optional step
+                                    return null;
+                                }
+                                return kubernetesClient
+                                        .pods()
+                                        .inNamespace(namespace)
+                                        .withLabels(
+                                                KubernetesUtils.getJobManagerSelectors(clusterId));
+                            },
+                            jmShutdownTimeout);
+            return remainingTimeout.minus(jmShutdownTimeout).plus(remaining);
+        } catch (KubernetesClientException kce) {
+            LOG.warn("JobManager shutdown did not complete, proceeding with deletion", kce);
+            return remainingTimeout.minus(jmShutdownTimeout);
+        }
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -1319,19 +1319,18 @@ public class AbstractFlinkServiceTest {
         assertTrue(remainingMillis > 0);
         assertTrue(remainingMillis < 10000 - deleteDelay / 2);
 
-        // Test actual timeout
-        remainingMillis =
-                flinkService
-                        .deleteDeploymentBlocking(
+        // A timeout must abort reconciliation so a replacement is not created before deletion.
+        assertThrows(
+                KubernetesClientException.class,
+                () ->
+                        flinkService.deleteDeploymentBlocking(
                                 "Test",
                                 client.apps()
                                         .deployments()
                                         .inNamespace(namespace)
                                         .withName(deploymentName),
                                 DeletionPropagation.BACKGROUND,
-                                Duration.ofMillis(10))
-                        .toMillis();
-        assertEquals(0, remainingMillis);
+                                Duration.ofMillis(10)));
     }
 
     @ParameterizedTest
@@ -1362,18 +1361,32 @@ public class AbstractFlinkServiceTest {
                         })
                 .always();
 
-        var remaining =
-                AbstractFlinkService.deleteBlocking(
-                        "Test",
-                        () ->
-                                client.apps()
-                                        .deployments()
-                                        .inNamespace(namespace)
-                                        .withName(deploymentName),
-                        Duration.ofMillis(1000));
+        if (errorCode == HttpURLConnection.HTTP_NOT_FOUND) {
+            var remaining =
+                    AbstractFlinkService.deleteBlocking(
+                            "Test",
+                            () ->
+                                    client.apps()
+                                            .deployments()
+                                            .inNamespace(namespace)
+                                            .withName(deploymentName),
+                            Duration.ofMillis(1000));
+            assertTrue(remaining.toMillis() < 1000);
+        } else {
+            assertThrows(
+                    KubernetesClientException.class,
+                    () ->
+                            AbstractFlinkService.deleteBlocking(
+                                    "Test",
+                                    () ->
+                                            client.apps()
+                                                    .deployments()
+                                                    .inNamespace(namespace)
+                                                    .withName(deploymentName),
+                                    Duration.ofMillis(1000)));
+        }
 
         assertEquals(1, mockServer.getRequestCount() - reqCount);
-        assertTrue(remaining.toMillis() < 1000);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Kubernetes deployment deletion waits can fail or time out before the old JobManager deployment is fully removed. The operator currently logs these failures and continues reconciliation, which can submit a replacement cluster while the old deployment is still terminating and result in `AlreadyExists` errors.

## Brief change log

- Propagate non-404 errors while waiting for Kubernetes resources to be deleted.
- Retry reconciliation instead of creating a replacement cluster before deletion completes.
- Preserve the best-effort JobManager shutdown behavior before mandatory deployment deletion.
- Update deletion error and timeout tests.

## Verifying this change

This change added and updated tests and was verified with:

```bash
JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home \
  mvn -pl flink-kubernetes-operator -am \
  -DskipITs \
  -Dtest=AbstractFlinkServiceTest \
  -Dsurefire.failIfNoSpecifiedTests=false test
```

Tests run: 40, failures: 0, errors: 0, skipped: 0.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
- Core observer or reconciler logic that is regularly executed: yes

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
