### PR TITLE
[FLINK-37448] Report actual TaskManager count in status.taskManager.replicas

### DIFF
--- a/docs/content.zh/docs/custom-resource/reference.md
+++ b/docs/content.zh/docs/custom-resource/reference.md
@@ -375,4 +375,4 @@ This page serves as a full reference for FlinkDeployment custom resource definit
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
 | labelSelector | java.lang.String | TaskManager label selector. |
-| replicas | int | Number of TaskManager replicas if defined in the spec. |
+| replicas | int | Actual number of TaskManagers registered with the running Flink cluster. This is 0 until the running cluster has been observed (which only happens once the JobManager is ready) and may transiently report a partial count while TaskManagers are still registering. |

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -569,4 +569,4 @@ This serves as a full reference for FlinkDeployment and FlinkSessionJob custom r
 | Parameter | Type | Docs |
 | ----------| ---- | ---- |
 | labelSelector | java.lang.String | TaskManager label selector. |
-| replicas | int | Number of TaskManager replicas if defined in the spec. |
+| replicas | int | Actual number of TaskManagers registered with the running Flink cluster. This is 0 until the running cluster has been observed (which only happens once the JobManager is ready) and may transiently report a partial count while TaskManagers are still registering. |

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/TaskManagerInfo.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/TaskManagerInfo.java
@@ -38,6 +38,10 @@ public class TaskManagerInfo {
     /** TaskManager label selector. */
     @LabelSelector private String labelSelector;
 
-    /** Number of TaskManager replicas if defined in the spec. */
+    /**
+     * Actual number of TaskManagers registered with the running Flink cluster. This is 0 until the
+     * running cluster has been observed (which only happens once the JobManager is ready) and may
+     * transiently report a partial count while TaskManagers are still registering.
+     */
     @StatusReplicas private int replicas = 0;
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -81,26 +81,20 @@ public abstract class AbstractFlinkDeploymentObserver
     private void observeClusterInfo(FlinkResourceContext<FlinkDeployment> ctx) {
         var flinkApp = ctx.getResource();
         try {
-            var observeConfig = ctx.getObserveConfig();
-            // Fetch the actual number of registered TaskManagers once and reuse it both for the
-            // cluster resource totals and the reported replica count, so a single /taskmanagers
-            // call backs a consistent snapshot.
-            var replicas = ctx.getFlinkService().getTaskManagerReplicas(observeConfig);
-            Map<String, String> clusterInfo =
+            var clusterInfo =
                     ctx.getFlinkService()
                             .getClusterInfo(
-                                    observeConfig,
-                                    flinkApp.getStatus().getJobStatus().getJobId(),
-                                    replicas);
-            flinkApp.getStatus().getClusterInfo().putAll(clusterInfo);
+                                    ctx.getObserveConfig(),
+                                    flinkApp.getStatus().getJobStatus().getJobId());
+            flinkApp.getStatus().getClusterInfo().putAll(clusterInfo.getInfo());
             logger.debug("ClusterInfo: {}", flinkApp.getStatus().getClusterInfo());
 
-            // Report the actual number of TaskManagers registered with the running cluster rather
-            // than a value derived from the spec, so the status reflects dynamically changing
-            // deployments (e.g. standalone reactive mode).
             var labelSelector =
                     FlinkUtils.getTaskManagerLabelSelector(flinkApp.getMetadata().getName());
-            flinkApp.getStatus().setTaskManager(new TaskManagerInfo(labelSelector, replicas));
+            flinkApp.getStatus()
+                    .setTaskManager(
+                            new TaskManagerInfo(
+                                    labelSelector, clusterInfo.getTaskManagerReplicas()));
         } catch (Exception e) {
             logger.warn("Exception while fetching cluster info", e);
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/AbstractFlinkDeploymentObserver.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.operator.api.spec.JobSpec;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.status.FlinkDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
+import org.apache.flink.kubernetes.operator.api.status.TaskManagerInfo;
 import org.apache.flink.kubernetes.operator.controller.FlinkResourceContext;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
 import org.apache.flink.kubernetes.operator.exception.MissingJobManagerException;
@@ -80,13 +81,26 @@ public abstract class AbstractFlinkDeploymentObserver
     private void observeClusterInfo(FlinkResourceContext<FlinkDeployment> ctx) {
         var flinkApp = ctx.getResource();
         try {
+            var observeConfig = ctx.getObserveConfig();
+            // Fetch the actual number of registered TaskManagers once and reuse it both for the
+            // cluster resource totals and the reported replica count, so a single /taskmanagers
+            // call backs a consistent snapshot.
+            var replicas = ctx.getFlinkService().getTaskManagerReplicas(observeConfig);
             Map<String, String> clusterInfo =
                     ctx.getFlinkService()
                             .getClusterInfo(
-                                    ctx.getObserveConfig(),
-                                    flinkApp.getStatus().getJobStatus().getJobId());
+                                    observeConfig,
+                                    flinkApp.getStatus().getJobStatus().getJobId(),
+                                    replicas);
             flinkApp.getStatus().getClusterInfo().putAll(clusterInfo);
             logger.debug("ClusterInfo: {}", flinkApp.getStatus().getClusterInfo());
+
+            // Report the actual number of TaskManagers registered with the running cluster rather
+            // than a value derived from the spec, so the status reflects dynamically changing
+            // deployments (e.g. standalone reactive mode).
+            var labelSelector =
+                    FlinkUtils.getTaskManagerLabelSelector(flinkApp.getMetadata().getName());
+            flinkApp.getStatus().setTaskManager(new TaskManagerInfo(labelSelector, replicas));
         } catch (Exception e) {
             logger.warn("Exception while fetching cluster info", e);
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
@@ -36,12 +36,7 @@ public class SessionObserver extends AbstractFlinkDeploymentObserver {
         // Check if session cluster can serve rest calls following our practice in JobObserver
         try {
             logger.debug("Observing session cluster");
-            var observeConfig = ctx.getObserveConfig();
-            // The TaskManager count also exercises the /taskmanagers REST endpoint, keeping the
-            // health-check coverage getClusterInfo previously provided when it fetched the count
-            // itself.
-            var taskManagerReplicas = ctx.getFlinkService().getTaskManagerReplicas(observeConfig);
-            ctx.getFlinkService().getClusterInfo(observeConfig, null, taskManagerReplicas);
+            ctx.getFlinkService().getClusterInfo(ctx.getObserveConfig(), null);
             var rs = ctx.getResource().getStatus().getReconciliationStatus();
             if (rs.getState() == ReconciliationState.DEPLOYED) {
                 rs.markReconciledSpecAsStable();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserver.java
@@ -36,7 +36,12 @@ public class SessionObserver extends AbstractFlinkDeploymentObserver {
         // Check if session cluster can serve rest calls following our practice in JobObserver
         try {
             logger.debug("Observing session cluster");
-            ctx.getFlinkService().getClusterInfo(ctx.getObserveConfig(), null);
+            var observeConfig = ctx.getObserveConfig();
+            // The TaskManager count also exercises the /taskmanagers REST endpoint, keeping the
+            // health-check coverage getClusterInfo previously provided when it fetched the count
+            // itself.
+            var taskManagerReplicas = ctx.getFlinkService().getTaskManagerReplicas(observeConfig);
+            ctx.getFlinkService().getClusterInfo(observeConfig, null, taskManagerReplicas);
             var rs = ctx.getResource().getStatus().getReconciliationStatus();
             if (rs.getState() == ReconciliationState.DEPLOYED) {
                 rs.markReconciledSpecAsStable();

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -172,9 +172,7 @@ public class ReconciliationUtils {
                     ((FlinkDeploymentStatus) status)
                             .setTaskManager(
                                     getTaskManagerInfo(
-                                            target.getMetadata().getName(),
-                                            conf,
-                                            stateAfterReconcile));
+                                            target.getMetadata().getName(), stateAfterReconcile));
                 }
                 reconciliationStatus.serializeAndSetLastReconciledSpec(clonedSpec, target);
                 if (spec.getJob().getState() == JobState.SUSPENDED) {
@@ -239,11 +237,13 @@ public class ReconciliationUtils {
         }
     }
 
-    private static TaskManagerInfo getTaskManagerInfo(
-            String name, Configuration conf, JobState jobState) {
-        var labelSelector = "component=taskmanager,app=" + name;
+    private static TaskManagerInfo getTaskManagerInfo(String name, JobState jobState) {
         if (jobState == JobState.RUNNING) {
-            return new TaskManagerInfo(labelSelector, FlinkUtils.getNumTaskManagers(conf));
+            // The actual replica count is populated during observation from the running cluster
+            // (see AbstractFlinkDeploymentObserver#observeClusterInfo). Here we only set the label
+            // selector; the replica count stays 0 until the running cluster is observed (which only
+            // happens once the JobManager deployment is ready).
+            return new TaskManagerInfo(FlinkUtils.getTaskManagerLabelSelector(name), 0);
         } else {
             return new TaskManagerInfo("", 0);
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/ReconciliationUtils.java
@@ -50,6 +50,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -169,10 +171,12 @@ public class ReconciliationUtils {
 
                 if (target instanceof FlinkDeployment) {
                     // For application deployments we update the taskmanager info
-                    ((FlinkDeploymentStatus) status)
-                            .setTaskManager(
-                                    getTaskManagerInfo(
-                                            target.getMetadata().getName(), stateAfterReconcile));
+                    var deploymentStatus = (FlinkDeploymentStatus) status;
+                    deploymentStatus.setTaskManager(
+                            getTaskManagerInfo(
+                                    target.getMetadata().getName(),
+                                    stateAfterReconcile,
+                                    deploymentStatus.getTaskManager()));
                 }
                 reconciliationStatus.serializeAndSetLastReconciledSpec(clonedSpec, target);
                 if (spec.getJob().getState() == JobState.SUSPENDED) {
@@ -237,13 +241,13 @@ public class ReconciliationUtils {
         }
     }
 
-    private static TaskManagerInfo getTaskManagerInfo(String name, JobState jobState) {
+    private static TaskManagerInfo getTaskManagerInfo(
+            String name, JobState jobState, @Nullable TaskManagerInfo current) {
         if (jobState == JobState.RUNNING) {
-            // The actual replica count is populated during observation from the running cluster
-            // (see AbstractFlinkDeploymentObserver#observeClusterInfo). Here we only set the label
-            // selector; the replica count stays 0 until the running cluster is observed (which only
-            // happens once the JobManager deployment is ready).
-            return new TaskManagerInfo(FlinkUtils.getTaskManagerLabelSelector(name), 0);
+            // Preserve the last observed replica count across reconciles so the scale subresource
+            // does not transiently report 0 after upgrades; observation will refresh it.
+            int replicas = current != null ? current.getReplicas() : 0;
+            return new TaskManagerInfo(FlinkUtils.getTaskManagerLabelSelector(name), replicas);
         } else {
             return new TaskManagerInfo("", 0);
         }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -787,22 +787,22 @@ public abstract class AbstractFlinkService implements FlinkService {
     }
 
     @Override
-    public Map<String, String> getClusterInfo(
-            Configuration conf, @Nullable String jobId, int taskManagerReplicas) throws Exception {
-        Map<String, String> clusterInfo = new HashMap<>();
+    public ClusterInfo getClusterInfo(Configuration conf, @Nullable String jobId) throws Exception {
+        int taskManagerReplicas = getTaskManagersInfo(conf).getTaskManagerInfos().size();
+        Map<String, String> info = new HashMap<>();
 
-        populateFlinkVersion(conf, clusterInfo);
+        populateFlinkVersion(conf, info);
 
-        clusterInfo.put(
+        info.put(
                 FIELD_NAME_TOTAL_CPU,
                 String.valueOf(FlinkUtils.calculateClusterCpuUsage(conf, taskManagerReplicas)));
-        clusterInfo.put(
+        info.put(
                 FIELD_NAME_TOTAL_MEMORY,
                 String.valueOf(FlinkUtils.calculateClusterMemoryUsage(conf, taskManagerReplicas)));
 
-        populateStateSize(conf, jobId, clusterInfo);
+        populateStateSize(conf, jobId, info);
 
-        return clusterInfo;
+        return new ClusterInfo(info, taskManagerReplicas);
     }
 
     private void populateFlinkVersion(Configuration conf, Map<String, String> clusterInfo)
@@ -1113,11 +1113,6 @@ public abstract class AbstractFlinkService implements FlinkService {
                             EmptyRequestBody.getInstance())
                     .get(operatorConfig.getFlinkClientTimeout().toSeconds(), TimeUnit.SECONDS);
         }
-    }
-
-    @Override
-    public int getTaskManagerReplicas(Configuration conf) throws Exception {
-        return getTaskManagersInfo(conf).getTaskManagerInfos().size();
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -787,13 +787,12 @@ public abstract class AbstractFlinkService implements FlinkService {
     }
 
     @Override
-    public Map<String, String> getClusterInfo(Configuration conf, @Nullable String jobId)
-            throws Exception {
+    public Map<String, String> getClusterInfo(
+            Configuration conf, @Nullable String jobId, int taskManagerReplicas) throws Exception {
         Map<String, String> clusterInfo = new HashMap<>();
 
         populateFlinkVersion(conf, clusterInfo);
 
-        var taskManagerReplicas = getTaskManagersInfo(conf).getTaskManagerInfos().size();
         clusterInfo.put(
                 FIELD_NAME_TOTAL_CPU,
                 String.valueOf(FlinkUtils.calculateClusterCpuUsage(conf, taskManagerReplicas)));
@@ -1114,6 +1113,11 @@ public abstract class AbstractFlinkService implements FlinkService {
                             EmptyRequestBody.getInstance())
                     .get(operatorConfig.getFlinkClientTimeout().toSeconds(), TimeUnit.SECONDS);
         }
+    }
+
+    @Override
+    public int getTaskManagerReplicas(Configuration conf) throws Exception {
+        return getTaskManagersInfo(conf).getTaskManagerInfos().size();
     }
 
     @Override

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/ClusterInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/ClusterInfo.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.service;
+
+import lombok.Value;
+
+import java.util.Map;
+
+/** Snapshot of the observed Flink cluster returned by {@link FlinkService#getClusterInfo}. */
+@Value
+public class ClusterInfo {
+    /** Info map merged into {@code status.clusterInfo} (flink version, totals, state size, ...). */
+    Map<String, String> info;
+
+    /** Number of TaskManagers currently registered with the running cluster. */
+    int taskManagerReplicas;
+}

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -117,17 +117,14 @@ public interface FlinkService {
 
     void disposeSavepoint(String savepointPath, Configuration conf) throws Exception;
 
-    Map<String, String> getClusterInfo(
-            Configuration conf, @Nullable String jobId, int taskManagerReplicas) throws Exception;
-
     /**
-     * Returns the actual number of TaskManagers currently registered with the running Flink
-     * cluster, as reported by the Flink REST API. Unlike the value derived from the spec
-     * (parallelism / slots), this reflects the real cluster state, which is important for
-     * deployments where the TaskManager count fluctuates dynamically (e.g. standalone reactive
-     * mode).
+     * Returns a snapshot of the running Flink cluster: the info map merged into {@code
+     * status.clusterInfo} plus the actual number of TaskManagers currently registered. The replica
+     * count reflects the real cluster state (important for deployments where the TaskManager count
+     * fluctuates dynamically, e.g. standalone reactive mode) rather than a value derived from the
+     * spec.
      */
-    int getTaskManagerReplicas(Configuration conf) throws Exception;
+    ClusterInfo getClusterInfo(Configuration conf, @Nullable String jobId) throws Exception;
 
     PodList getJmPodList(FlinkDeployment deployment, Configuration conf);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/FlinkService.java
@@ -117,7 +117,17 @@ public interface FlinkService {
 
     void disposeSavepoint(String savepointPath, Configuration conf) throws Exception;
 
-    Map<String, String> getClusterInfo(Configuration conf, @Nullable String jobId) throws Exception;
+    Map<String, String> getClusterInfo(
+            Configuration conf, @Nullable String jobId, int taskManagerReplicas) throws Exception;
+
+    /**
+     * Returns the actual number of TaskManagers currently registered with the running Flink
+     * cluster, as reported by the Flink REST API. Unlike the value derived from the spec
+     * (parallelism / slots), this reflects the real cluster state, which is important for
+     * deployments where the TaskManager count fluctuates dynamically (e.g. standalone reactive
+     * mode).
+     */
+    int getTaskManagerReplicas(Configuration conf) throws Exception;
 
     PodList getJmPodList(FlinkDeployment deployment, Configuration conf);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkUtils.java
@@ -351,6 +351,11 @@ public class FlinkUtils {
                 || haMode.equalsIgnoreCase("kubernetes");
     }
 
+    /** Builds the label selector matching the TaskManager pods of the given cluster. */
+    public static String getTaskManagerLabelSelector(String clusterId) {
+        return "component=taskmanager,app=" + clusterId;
+    }
+
     public static int getNumTaskManagers(Configuration conf) {
         int parallelism = conf.get(CoreOptions.DEFAULT_PARALLELISM);
         return getNumTaskManagers(conf, parallelism);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -51,6 +51,7 @@ import org.apache.flink.kubernetes.operator.service.AbstractFlinkService;
 import org.apache.flink.kubernetes.operator.service.CheckpointHistoryWrapper;
 import org.apache.flink.kubernetes.operator.service.SuspendMode;
 import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfigOptionsInternal;
+import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.runtime.client.DuplicateJobSubmissionException;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
@@ -155,6 +156,13 @@ public class TestingFlinkService extends AbstractFlinkService {
 
     @Getter private int desiredReplicas = 0;
     @Getter private int cancelJobCallCount = 0;
+
+    // Simulates the actual number of TaskManagers registered with the cluster. When null, a
+    // converged cluster is assumed and the count is derived from the spec.
+    @Setter private Integer taskManagerReplicas = null;
+
+    // When set, getTaskManagerReplicas throws to simulate a REST failure during observation.
+    @Setter private boolean taskManagerReplicasError = false;
 
     @Getter private Configuration submittedConf;
 
@@ -717,12 +725,24 @@ public class TestingFlinkService extends AbstractFlinkService {
     }
 
     @Override
-    public Map<String, String> getClusterInfo(Configuration conf, String jobId)
-            throws TimeoutException {
+    public Map<String, String> getClusterInfo(
+            Configuration conf, String jobId, int taskManagerReplicas) throws TimeoutException {
         if (!isPortReady) {
             throw new TimeoutException("JM port is unavailable");
         }
         return CLUSTER_INFO;
+    }
+
+    @Override
+    public int getTaskManagerReplicas(Configuration conf) {
+        if (taskManagerReplicasError) {
+            throw new RuntimeException("Failed to fetch TaskManager count");
+        }
+        if (taskManagerReplicas != null) {
+            return taskManagerReplicas;
+        }
+        // Assume a converged cluster where the registered TaskManagers match the spec.
+        return FlinkUtils.getNumTaskManagers(conf);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/TestingFlinkService.java
@@ -49,6 +49,7 @@ import org.apache.flink.kubernetes.operator.observer.CheckpointStatsResult;
 import org.apache.flink.kubernetes.operator.observer.SavepointFetchResult;
 import org.apache.flink.kubernetes.operator.service.AbstractFlinkService;
 import org.apache.flink.kubernetes.operator.service.CheckpointHistoryWrapper;
+import org.apache.flink.kubernetes.operator.service.ClusterInfo;
 import org.apache.flink.kubernetes.operator.service.SuspendMode;
 import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfigOptionsInternal;
 import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
@@ -161,7 +162,7 @@ public class TestingFlinkService extends AbstractFlinkService {
     // converged cluster is assumed and the count is derived from the spec.
     @Setter private Integer taskManagerReplicas = null;
 
-    // When set, getTaskManagerReplicas throws to simulate a REST failure during observation.
+    // When set, getClusterInfo throws to simulate a REST failure while fetching the TM count.
     @Setter private boolean taskManagerReplicasError = false;
 
     @Getter private Configuration submittedConf;
@@ -725,24 +726,18 @@ public class TestingFlinkService extends AbstractFlinkService {
     }
 
     @Override
-    public Map<String, String> getClusterInfo(
-            Configuration conf, String jobId, int taskManagerReplicas) throws TimeoutException {
+    public ClusterInfo getClusterInfo(Configuration conf, String jobId) throws TimeoutException {
         if (!isPortReady) {
             throw new TimeoutException("JM port is unavailable");
         }
-        return CLUSTER_INFO;
-    }
-
-    @Override
-    public int getTaskManagerReplicas(Configuration conf) {
         if (taskManagerReplicasError) {
             throw new RuntimeException("Failed to fetch TaskManager count");
         }
-        if (taskManagerReplicas != null) {
-            return taskManagerReplicas;
-        }
-        // Assume a converged cluster where the registered TaskManagers match the spec.
-        return FlinkUtils.getNumTaskManagers(conf);
+        int replicas =
+                taskManagerReplicas != null
+                        ? taskManagerReplicas
+                        : FlinkUtils.getNumTaskManagers(conf);
+        return new ClusterInfo(CLUSTER_INFO, replicas);
     }
 
     @Override

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -323,8 +323,6 @@ public class FlinkDeploymentControllerTest {
         var jobs = flinkService.listJobs();
         assertEquals(1, jobs.size());
         assertEquals("s0", jobs.get(0).f0);
-        // The actual replica count is populated during observation from the running cluster; right
-        // after reconciliation (cluster not yet observed) it stays 0.
         assertEquals(
                 new TaskManagerInfo(
                         FlinkUtils.getTaskManagerLabelSelector(appCluster.getMetadata().getName()),

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkDeploymentControllerTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
 import org.apache.flink.kubernetes.operator.reconciler.deployment.AbstractFlinkResourceReconciler;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
+import org.apache.flink.kubernetes.operator.utils.FlinkUtils;
 import org.apache.flink.kubernetes.operator.utils.IngressUtils;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.util.SerializedThrowable;
@@ -211,13 +212,18 @@ public class FlinkDeploymentControllerTest {
         }
 
         appCluster.getSpec().getJob().setState(JobState.RUNNING);
+        // Simulate a cluster whose actual registered TaskManager count differs from the
+        // spec-derived count (parallelism 1), so the assertion below verifies the value observed
+        // from the running cluster rather than a spec-derived one.
+        flinkService.setTaskManagerReplicas(3);
         verifyReconcileNormalLifecycle(appCluster);
         var jobs = flinkService.listJobs();
         assertEquals(1, jobs.size());
         assertEquals("s0", jobs.get(0).f0);
         assertEquals(
                 new TaskManagerInfo(
-                        "component=taskmanager,app=" + appCluster.getMetadata().getName(), 1),
+                        FlinkUtils.getTaskManagerLabelSelector(appCluster.getMetadata().getName()),
+                        3),
                 appCluster.getStatus().getTaskManager());
     }
 
@@ -317,9 +323,12 @@ public class FlinkDeploymentControllerTest {
         var jobs = flinkService.listJobs();
         assertEquals(1, jobs.size());
         assertEquals("s0", jobs.get(0).f0);
+        // The actual replica count is populated during observation from the running cluster; right
+        // after reconciliation (cluster not yet observed) it stays 0.
         assertEquals(
                 new TaskManagerInfo(
-                        "component=taskmanager,app=" + appCluster.getMetadata().getName(), 1),
+                        FlinkUtils.getTaskManagerLabelSelector(appCluster.getMetadata().getName()),
+                        0),
                 appCluster.getStatus().getTaskManager());
         assertEquals("s0", appCluster.getStatus().getJobStatus().getUpgradeSavepointPath());
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/ApplicationObserverTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.kubernetes.operator.api.status.JobStatus;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
 import org.apache.flink.kubernetes.operator.api.status.SavepointFormatType;
 import org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType;
+import org.apache.flink.kubernetes.operator.api.status.TaskManagerInfo;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.exception.DeploymentFailedException;
@@ -87,6 +88,65 @@ public class ApplicationObserverTest extends OperatorTestBase {
                 .getFlinkConfiguration()
                 .put(PipelineOptionsInternal.PIPELINE_FIXED_JOB_ID.key(), jobId);
         deployment.getStatus().getJobStatus().setJobId(jobId);
+    }
+
+    @Test
+    public void observeReportsActualTaskManagerReplicas() throws Exception {
+        Configuration conf =
+                configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
+
+        observer.observe(deployment, TestUtils.createEmptyContext());
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
+
+        // The actual number of TaskManagers registered with the cluster (e.g. fluctuating in
+        // reactive mode), independent of the spec-derived count.
+        flinkService.setTaskManagerReplicas(5);
+
+        // Drive the deployment to a ready state so cluster info gets observed.
+        observer.observe(deployment, readyContext);
+        observer.observe(deployment, readyContext);
+        assertEquals(
+                JobManagerDeploymentStatus.READY,
+                deployment.getStatus().getJobManagerDeploymentStatus());
+
+        var labelSelector =
+                FlinkUtils.getTaskManagerLabelSelector(deployment.getMetadata().getName());
+
+        // The status reflects the actual count from the cluster, not ceil(parallelism / slots).
+        assertEquals(
+                new TaskManagerInfo(labelSelector, 5), deployment.getStatus().getTaskManager());
+
+        // The reported count tracks the actual cluster state across observations.
+        flinkService.setTaskManagerReplicas(3);
+        observer.observe(deployment, readyContext);
+        assertEquals(
+                new TaskManagerInfo(labelSelector, 3), deployment.getStatus().getTaskManager());
+    }
+
+    @Test
+    public void observePreservesTaskManagerOnFetchFailure() throws Exception {
+        Configuration conf =
+                configManager.getDeployConfig(deployment.getMetadata(), deployment.getSpec());
+
+        observer.observe(deployment, TestUtils.createEmptyContext());
+        flinkService.submitApplicationCluster(deployment.getSpec().getJob(), conf, false);
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
+
+        flinkService.setTaskManagerReplicas(4);
+        observer.observe(deployment, readyContext);
+        observer.observe(deployment, readyContext);
+
+        var labelSelector =
+                FlinkUtils.getTaskManagerLabelSelector(deployment.getMetadata().getName());
+        assertEquals(
+                new TaskManagerInfo(labelSelector, 4), deployment.getStatus().getTaskManager());
+
+        // A failure while fetching the cluster info must not overwrite the last known good value.
+        flinkService.setTaskManagerReplicasError(true);
+        observer.observe(deployment, readyContext);
+        assertEquals(
+                new TaskManagerInfo(labelSelector, 4), deployment.getStatus().getTaskManager());
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/deployment/SessionObserverTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.kubernetes.operator.TestUtils;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.status.JobManagerDeploymentStatus;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
+import org.apache.flink.kubernetes.operator.api.status.TaskManagerInfo;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.observer.TestObserverAdapter;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
@@ -99,6 +100,34 @@ public class SessionObserverTest extends OperatorTestBase {
         assertEquals(
                 JobManagerDeploymentStatus.READY,
                 deployment.getStatus().getJobManagerDeploymentStatus());
+    }
+
+    @Test
+    public void observeReportsActualTaskManagerReplicas() {
+        FlinkDeployment deployment = TestUtils.buildSessionCluster();
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
+
+        // The actual number of TaskManagers registered with the session cluster, independent of
+        // any spec-derived count.
+        flinkService.setTaskManagerReplicas(5);
+
+        // Drive the session cluster to a ready state so cluster info gets observed.
+        observer.observe(deployment, readyContext);
+        observer.observe(deployment, readyContext);
+        assertEquals(
+                JobManagerDeploymentStatus.READY,
+                deployment.getStatus().getJobManagerDeploymentStatus());
+
+        var labelSelector =
+                FlinkUtils.getTaskManagerLabelSelector(deployment.getMetadata().getName());
+        assertEquals(
+                new TaskManagerInfo(labelSelector, 5), deployment.getStatus().getTaskManager());
+
+        // The reported count tracks the actual cluster state across observations.
+        flinkService.setTaskManagerReplicas(2);
+        observer.observe(deployment, readyContext);
+        assertEquals(
+                new TaskManagerInfo(labelSelector, 2), deployment.getStatus().getTaskManager());
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -1195,14 +1195,19 @@ public class AbstractFlinkServiceTest {
                         AbstractFlinkService.FIELD_NAME_TOTAL_MEMORY,
                         "" + MemorySize.ofMebiBytes(1000).getBytes() * 2);
 
-        assertEquals(expectedEntries, flinkService.getClusterInfo(conf, null));
+        // The REST API reports a single registered TaskManager (tmsInfo above), which
+        // getTaskManagerReplicas surfaces and the caller passes into getClusterInfo for the
+        // resource totals.
+        assertEquals(1, flinkService.getTaskManagerReplicas(conf));
+
+        assertEquals(expectedEntries, flinkService.getClusterInfo(conf, null, 1));
 
         assertEquals(
                 ImmutableMap.<String, String>builder()
                         .putAll(expectedEntries)
                         .put(AbstractFlinkService.FIELD_NAME_STATE_SIZE, "42424242")
                         .build(),
-                flinkService.getClusterInfo(conf, JobID.generate().toHexString()));
+                flinkService.getClusterInfo(conf, JobID.generate().toHexString(), 1));
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -1195,19 +1195,16 @@ public class AbstractFlinkServiceTest {
                         AbstractFlinkService.FIELD_NAME_TOTAL_MEMORY,
                         "" + MemorySize.ofMebiBytes(1000).getBytes() * 2);
 
-        // The REST API reports a single registered TaskManager (tmsInfo above), which
-        // getTaskManagerReplicas surfaces and the caller passes into getClusterInfo for the
-        // resource totals.
-        assertEquals(1, flinkService.getTaskManagerReplicas(conf));
-
-        assertEquals(expectedEntries, flinkService.getClusterInfo(conf, null, 1));
+        var clusterInfo = flinkService.getClusterInfo(conf, null);
+        assertEquals(1, clusterInfo.getTaskManagerReplicas());
+        assertEquals(expectedEntries, clusterInfo.getInfo());
 
         assertEquals(
                 ImmutableMap.<String, String>builder()
                         .putAll(expectedEntries)
                         .put(AbstractFlinkService.FIELD_NAME_STATE_SIZE, "42424242")
                         .build(),
-                flinkService.getClusterInfo(conf, JobID.generate().toHexString(), 1));
+                flinkService.getClusterInfo(conf, JobID.generate().toHexString()).getInfo());
     }
 
     @Test

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/ReconciliationUtilsTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.spec.JobState;
 import org.apache.flink.kubernetes.operator.api.status.ReconciliationState;
+import org.apache.flink.kubernetes.operator.api.status.TaskManagerInfo;
 import org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
 import org.apache.flink.kubernetes.operator.reconciler.ReconciliationUtils;
@@ -62,6 +63,20 @@ public class ReconciliationUtilsTest {
         assertFalse(updateControl.isPatchResource());
         assertFalse(updateControl.isPatchStatus());
         assertNotEquals(0, updateControl.getScheduleDelay().get());
+    }
+
+    @Test
+    public void taskManagerReplicasPreservedAcrossReconciles() {
+        FlinkDeployment app = BaseTestUtils.buildApplicationCluster();
+        app.getSpec().getJob().setState(JobState.RUNNING);
+        app.getStatus().getReconciliationStatus().setState(ReconciliationState.DEPLOYED);
+
+        var labelSelector = FlinkUtils.getTaskManagerLabelSelector(app.getMetadata().getName());
+        app.getStatus().setTaskManager(new TaskManagerInfo(labelSelector, 7));
+
+        ReconciliationUtils.updateStatusForDeployedSpec(app, new Configuration());
+
+        assertEquals(new TaskManagerInfo(labelSelector, 7), app.getStatus().getTaskManager());
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

`status.taskManager.replicas` previously held a value computed from the spec at reconcile time (`ceil(parallelism / slots)`). This is inaccurate for deployments where the number of TaskManagers fluctuates dynamically rather than being fixed by configuration - most notably standalone clusters running in reactive mode.

This change makes the field report the **actual** number of TaskManagers registered with the running Flink cluster, sourced from the Flink REST API (`/taskmanagers`), for both application and session deployments.

## Brief change log

  - Added `FlinkService#getTaskManagerReplicas(Configuration)`, implemented in `AbstractFlinkService` via the existing `/taskmanagers` REST call; `getClusterInfo` now routes through it (single source of truth).
  - `AbstractFlinkDeploymentObserver#observeClusterInfo` now sets `status.taskManager` (label selector + actual replica count) whenever the JobManager is ready, covering both application and session clusters.
  - `ReconciliationUtils#getTaskManagerInfo` no longer derives the count from the spec; at reconcile time it only sets the label selector (replicas stay `0` until the cluster is observed) and still clears the info when not running.
  - Extracted the duplicated TaskManager label selector into FlinkUtils#getTaskManagerLabelSelector`.
  - Updated the `TaskManagerInfo.replicas` JavaDoc and the generated CRD eference docs to reflect the new semantics.

Note: this changes the semantics of `status.taskManager.replicas` from a spec-derived value to the observed cluster state.

## Verifying this change

This change added tests and can be verified as follows:

  - `ApplicationObserverTest#observeReportsActualTaskManagerReplicas` verifies the
    status reflects the cluster's actual TaskManager count (independent of the
    spec-derived value) and tracks changes across observations.
  - `TestingFlinkService` gained an overridable `taskManagerReplicas` stub
    (defaults to a converged cluster, i.e. the spec-derived count).
  - Existing controller/observer/service/metrics tests updated/confirmed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no (the field already exists; only its reported value changes)
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no (behavior change to an existing status field)
  - If yes, how is the feature documented? JavaDocs / docs (CRD reference updated)