### PR TITLE
[FLINK-38049] Fix stateless job incorrectly using last-state restore when HA is enabled

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractJobReconciler.java
@@ -607,13 +607,15 @@ public abstract class AbstractJobReconciler<
                 ctx.getResource().getStatus().getJobStatus().getSavepointInfo().getLastSavepoint();
         var lastSavepointKnown = upgradeStatePath != null || savepointLegacy != null;
 
-        if (requireHaMetadata) {
+        boolean statelessResubmit =
+                ctx.getResource().getSpec().getJob().getUpgradeMode() == UpgradeMode.STATELESS;
+        boolean useHaMetadata = requireHaMetadata && !statelessResubmit;
+        if (useHaMetadata) {
             specToRecover.getJob().setUpgradeMode(UpgradeMode.LAST_STATE);
-        } else if (ctx.getResource().getSpec().getJob().getUpgradeMode() != UpgradeMode.STATELESS
-                && lastSavepointKnown) {
+        } else if (!statelessResubmit && lastSavepointKnown) {
             specToRecover.getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
         }
-        restoreJob(ctx, specToRecover, ctx.getObserveConfig(), requireHaMetadata);
+        restoreJob(ctx, specToRecover, ctx.getObserveConfig(), useHaMetadata);
     }
 
     private void redeployWithSavepoint(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -1262,6 +1262,35 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
     }
 
     @Test
+    public void testRestartUnhealthyStatelessJobWithHaEnabled() throws Exception {
+        // FLINK-38049: stateless jobs with HA enabled should not fall back to last-state on restart
+        FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        // buildApplicationCluster() defaults to STATELESS upgrade mode with HA enabled
+        Assertions.assertEquals(UpgradeMode.STATELESS, getJobSpec(deployment).getUpgradeMode());
+
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(OPERATOR_CLUSTER_HEALTH_CHECK_ENABLED.key(), "true");
+        reconciler.reconcile(deployment, context);
+        verifyAndSetRunningJobsToStatus(deployment, flinkService.listJobs());
+
+        var clusterHealthInfo = new ClusterHealthInfo();
+        clusterHealthInfo.setTimeStamp(System.currentTimeMillis());
+        clusterHealthInfo.setNumRestarts(2);
+        clusterHealthInfo.setHealthResult(ClusterHealthResult.error("unhealthy"));
+        ClusterHealthEvaluator.setLastValidClusterHealthInfo(
+                deployment.getStatus().getClusterInfo(), clusterHealthInfo);
+
+        reconciler.reconcile(deployment, context);
+
+        // Job must be resubmitted in stateless mode: no savepoint path
+        var jobs = flinkService.listJobs();
+        Assertions.assertEquals(1, jobs.size());
+        Assertions.assertNull(jobs.get(0).f0);
+    }
+
+    @Test
     public void testReconcileIfUpgradeModeNotAvailable() throws Exception {
         FlinkDeployment deployment = TestUtils.buildApplicationCluster();
         getJobSpec(deployment).setUpgradeMode(UpgradeMode.SAVEPOINT);


### PR DESCRIPTION
## What is the purpose of the change

When HA is enabled and a stateless job is resubmitted (e.g. due to an unhealthy cluster), `resubmitJob` unconditionally overrode the upgrade mode to `LAST_STATE` and passed `requireHaMetadata=true` to `restoreJob`, ignoring the user-configured `STATELESS` upgrade mode. This caused the job to attempt a last-state restore from HA metadata instead of starting fresh.

## Brief change log

- `AbstractJobReconciler#resubmitJob`: skip the `LAST_STATE` mode override and the `requireHaMetadata` flag when the spec's upgrade mode is `STATELESS`
- Add `ApplicationReconcilerTest#testRestartUnhealthyStatelessJobWithHaEnabled` to reproduce the scenario: a stateless job with HA enabled is resubmitted after an unhealthy event with no HA metadata available — previously this would throw `UpgradeFailureException`, now it succeeds

## Verifying this change

New unit test `testRestartUnhealthyStatelessJobWithHaEnabled` in `ApplicationReconcilerTest` covers the fix. Existing `ApplicationReconcilerTest` and `ApplicationReconcilerUpgradeModeTest` suites (109 tests total) continue to pass.

## Does this pull request potentially affect one of the following areas

- Job lifecycle/upgrade: **yes** — affects resubmit path for stateless jobs when HA is active

_This is a fix for [FLINK-38049](https://issues.apache.org/jira/browse/FLINK-38049)._