### PR TITLE
[hotfix] Fix typos in operator documentation, comments and scripts

### DIFF
--- a/docs/content.zh/docs/custom-resource/autoscaler.md
+++ b/docs/content.zh/docs/custom-resource/autoscaler.md
@@ -26,7 +26,7 @@ under the License.
 
 # Autoscaler
 
-The operator provides a job autoscaler functionality that collects various metrics from running Flink jobs and automatically scales individual job vertexes (chained operator groups) to eliminate backpressure and satisfy the utilization target set by the user.
+The operator provides a job autoscaler functionality that collects various metrics from running Flink jobs and automatically scales individual job vertices (chained operator groups) to eliminate backpressure and satisfy the utilization target set by the user.
 By adjusting parallelism on a job vertex level (in contrast to job parallelism) we can efficiently autoscale complex and heterogeneous streaming applications.
 
 Key benefits to the user:
@@ -46,7 +46,7 @@ Collected metrics:
  - Busy and backpressured time at each job vertex
 
 {{< hint info >}}
-Please note that we are not using any container memory / CPU utilization metrics directly here. High utilization will be reflected in the processing rate and busy time metrics of the individual job vertexes.
+Please note that we are not using any container memory / CPU utilization metrics directly here. High utilization will be reflected in the processing rate and busy time metrics of the individual job vertices.
 {{< /hint >}}
 
 The algorithm starts from the sources and recursively computes the required processing capacity (target data rate) for each operator in the pipeline. At the source vertices, target data rate is equal to incoming data rate (from the Kafka topic).
@@ -152,7 +152,7 @@ During this time period no metrics will be collected and no scaling actions will
 ### Target utilization and flexible boundaries
 
 In order to provide stable job performance and some buffer for load fluctuations, the autoscaler allows users to set a target utilization level for the job (`job.autoscaler.target.utilization`).
-A target of `0.6` means we are targeting 60% utilization/load for the job vertexes.
+A target of `0.6` means we are targeting 60% utilization/load for the job vertices.
 
 In general, it's not recommended to set target utilization close to 100% as performance usually degrades as we reach capacity limits in most real world systems.
 

--- a/docs/content/docs/concepts/controller-flow.md
+++ b/docs/content/docs/concepts/controller-flow.md
@@ -125,7 +125,7 @@ If an UPGRADE type change is detected in the spec we execute the job upgrade flo
 
 #### UpgradeMode and suspend/cancel behaviour
 
-The operator must always respect the upgrade mode setting when it comes to stateful upgrades to avoid data loss. There is however some flexibility in the mechanism to account for unhealthy jobs and to provide extra safeguards during version upgrades. The **getAvailableUpgradeMode** method is an important corner stone in the upgrade logic, and it is used to decide what actualy upgrade mode should be used given the request from the user and current cluster state.
+The operator must always respect the upgrade mode setting when it comes to stateful upgrades to avoid data loss. There is however some flexibility in the mechanism to account for unhealthy jobs and to provide extra safeguards during version upgrades. The **getAvailableUpgradeMode** method is an important corner stone in the upgrade logic, and it is used to decide what actual upgrade mode should be used given the request from the user and current cluster state.
 
 In normal healthy cases, the available upgrade mode will be the same as what the user has in the spec. However, there are some cases where we have to change between savepoint and last-state upgrade mode. Savepoint upgrade mode can only be used if the job is healthy and running, for failing, restarting or otherwise unhealthy deployments, we are allowed to use last-state upgrade mode as long as HA metadata is available (and not explicitly configured otherwise). This allows us to have a robust upgrade flow even if a job failed, while keeping state consistency.
 

--- a/docs/content/docs/custom-resource/autoscaler.md
+++ b/docs/content/docs/custom-resource/autoscaler.md
@@ -26,7 +26,7 @@ under the License.
 
 # Autoscaler
 
-The operator provides a job autoscaler functionality that collects various metrics from running Flink jobs and automatically scales individual job vertexes (chained operator groups) to eliminate backpressure and satisfy the utilization target set by the user.
+The operator provides a job autoscaler functionality that collects various metrics from running Flink jobs and automatically scales individual job vertices (chained operator groups) to eliminate backpressure and satisfy the utilization target set by the user.
 By adjusting parallelism on a job vertex level (in contrast to job parallelism) we can efficiently autoscale complex and heterogeneous streaming applications.
 
 Key benefits to the user:
@@ -46,7 +46,7 @@ Collected metrics:
  - Busy and backpressured time at each job vertex
 
 {{< hint info >}}
-Please note that we are not using any container memory / CPU utilization metrics directly here. High utilization will be reflected in the processing rate and busy time metrics of the individual job vertexes.
+Please note that we are not using any container memory / CPU utilization metrics directly here. High utilization will be reflected in the processing rate and busy time metrics of the individual job vertices.
 {{< /hint >}}
 
 The algorithm starts from the sources and recursively computes the required processing capacity (target data rate) for each operator in the pipeline. At the source vertices, target data rate is equal to incoming data rate (from the Kafka topic).
@@ -152,7 +152,7 @@ During this time period no metrics will be collected and no scaling actions will
 ### Target utilization and flexible boundaries
 
 In order to provide stable job performance and some buffer for load fluctuations, the autoscaler allows users to set a target utilization level for the job (`job.autoscaler.target.utilization`).
-A target of `0.6` means we are targeting 60% utilization/load for the job vertexes.
+A target of `0.6` means we are targeting 60% utilization/load for the job vertices.
 
 In general, it's not recommended to set target utilization close to 100% as performance usually degrades as we reach capacity limits in most real world systems.
 

--- a/docs/content/docs/custom-resource/reference.md
+++ b/docs/content/docs/custom-resource/reference.md
@@ -22,7 +22,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Custom Resource Defintion Reference
+# Custom Resource Definition Reference
 
 This serves as a full reference for FlinkDeployment and FlinkSessionJob custom resource definitions, including all possible configuration parameters.
 

--- a/docs/content/docs/custom-resource/snapshots.md
+++ b/docs/content/docs/custom-resource/snapshots.md
@@ -192,7 +192,7 @@ To disable automatic savepoint cleanup by the operator you can set `kubernetes.o
 #### Checkpoints
 
 FlinkStateSnapshots of checkpoint type will always be cleaned up. It's not possible to set max age for them.
-The maxmimum amount of checkpoint resources retained will be deteremined by the Flink configuration `state.checkpoints.num-retained`.
+The maximum amount of checkpoint resources retained will be determined by the Flink configuration `state.checkpoints.num-retained`.
 
 {{< hint warning >}}
 Checkpoint cleanup is only supported if FlinkStateSnapshot resources are enabled.

--- a/docs/layouts/partials/docs/inject/menu-after.html
+++ b/docs/layouts/partials/docs/inject/menu-after.html
@@ -54,7 +54,7 @@ under the License.
   </ul>
 </li>
 
-<!-- merge languages into a single dictonary -->
+<!-- merge languages into a single dictionary -->
 {{ $translations := dict }}
 {{ range .Site.Home.AllTranslations }}
   {{ $translations = merge $translations (dict .Language.Lang .) }}

--- a/docs/layouts/partials/docs/simple-title.html
+++ b/docs/layouts/partials/docs/simple-title.html
@@ -17,7 +17,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 <!-- 
-  Partial to generate page name without sytling
+  Partial to generate page name without styling
   from Title or File name. Accepts Page as context.
 -->
 {{ $title := "" }}

--- a/docs/layouts/shortcodes/beta.html
+++ b/docs/layouts/shortcodes/beta.html
@@ -19,7 +19,7 @@ under the License.
     Adds a warning that the current feature is in BETA.
 */}}
 <blockquote class="book-hint warning">
-    This feature is currency marked as <b>BETA</b> and in an evolving state.
-    As such, there are <b>no guaruntees</b> made about feature stability
+    This feature is currently marked as <b>BETA</b> and in an evolving state.
+    As such, there are <b>no guarantees</b> made about feature stability
     and breaking changes may occur in future Flink versions.
 </blockquote>

--- a/docs/layouts/shortcodes/center.html
+++ b/docs/layouts/shortcodes/center.html
@@ -18,7 +18,7 @@ under the License.
 */}}{{/*
     Shortcode for centering text
 
-    Parmeters: markdown text
+    Parameters: markdown text
 */}}
 <div style="text-align: center;">
     {{ .Inner | markdownify }}

--- a/docs/layouts/shortcodes/gh_link.html
+++ b/docs/layouts/shortcodes/gh_link.html
@@ -19,7 +19,7 @@ under the License.
     Shortcode for linking to a file in github. This shortcode
     will automatically discover the repo and correct branch.
 
-    Parmeters: 
+    Parameters: 
         - file: The absolute path to the image file (required)
         - name: The rendered link name (required)
 */}}

--- a/docs/layouts/shortcodes/github_repo.html
+++ b/docs/layouts/shortcodes/github_repo.html
@@ -18,5 +18,5 @@ under the License.
 */}}{{/*
     Shortcode that interpolates the the full github repo
 
-    Parmeters: None
+    Parameters: None
 */}}{{- $.Site.Params.GithubRepo -}}

--- a/docs/layouts/shortcodes/img.html
+++ b/docs/layouts/shortcodes/img.html
@@ -21,7 +21,7 @@ under the License.
   because we can configure the HTML image tag
   properties.
 
-  Parmeters: 
+  Parameters: 
       - src: The absolute path to the image file (required)
       - alt: Image alt text (optional)
       - width: Image width (optional)

--- a/docs/layouts/shortcodes/javadoc.html
+++ b/docs/layouts/shortcodes/javadoc.html
@@ -18,7 +18,7 @@ under the License.
 */}}{{/*
     Shortcode for linking to Flinks JavaDoc
 
-    Parmeters: 
+    Parameters: 
         - name: The rendered link name (required)
 */}}
 <a href="{{ .Site.Params.JavaDoc }}">

--- a/docs/layouts/shortcodes/label.html
+++ b/docs/layouts/shortcodes/label.html
@@ -21,7 +21,7 @@ under the License.
   because we can configure the HTML image tag
   properties.
 
-  Parmeters: 
+  Parameters: 
       - src: The absolute path to the image file (required)
       - alt: Image alt text (optional)
       - width: Image width (optional)

--- a/docs/layouts/shortcodes/scala_version.html
+++ b/docs/layouts/shortcodes/scala_version.html
@@ -18,5 +18,5 @@ under the License.
 */}}{{/*
     Shortcode for interpolating the scala version set in conf.toml
 
-    Parmeters: None
+    Parameters: None
 */}}{{- $.Site.Params.ScalaVersion -}}

--- a/docs/layouts/shortcodes/stable.html
+++ b/docs/layouts/shortcodes/stable.html
@@ -19,5 +19,5 @@ under the License.
   Shortcode that only renders its contents if the site
   is marked as stable.
 
-  Parmeters: Markdown text
+  Parameters: Markdown text
 */}}{{ if $.Site.Params.IsStable }}{{ .Inner | markdownify }}{{ end }}

--- a/docs/layouts/shortcodes/stable_branch.html
+++ b/docs/layouts/shortcodes/stable_branch.html
@@ -18,5 +18,5 @@ under the License.
 */}}{{/*
     Shortcode that interpolates the stable version title
 
-    Parmeters: None
+    Parameters: None
 */}}{{ if $.Site.Params.IsStable }}{{- $.Site.Params.Branch -}}{{else}}release-{{- index (index $.Site.Params.PreviousDocs 0) 0 -}}{{ end }}

--- a/docs/layouts/shortcodes/top.html
+++ b/docs/layouts/shortcodes/top.html
@@ -18,7 +18,7 @@ under the License.
 */}}{{/*
   Shortcode that adds a "Back to Top" link.
 
-  Parmeters: None
+  Parameters: None
 */}}
 <p><a href="#top" class="top pull-right"><i class="fas fa-triangle"></i> Back to top</a></p>
 

--- a/docs/layouts/shortcodes/unstable.html
+++ b/docs/layouts/shortcodes/unstable.html
@@ -19,5 +19,5 @@ under the License.
   Shortcode that only renders its contents if the site
   is not marked as stable.
 
-  Parmeters: Markdown text
+  Parameters: Markdown text
 */}}{{ if (not $.Site.Params.IsStable) }}{{ .Inner | markdownify }}{{ end }}

--- a/docs/layouts/shortcodes/version.html
+++ b/docs/layouts/shortcodes/version.html
@@ -18,5 +18,5 @@ under the License.
 */}}{{/*
     Shortcode that interpolates the the full maven version (x.y.z)
 
-    Parmeters: None
+    Parameters: None
 */}}{{- $.Site.Params.Version -}}

--- a/docs/static/js/flink.js
+++ b/docs/static/js/flink.js
@@ -21,7 +21,7 @@
  * Function to synchronize all tabs on a page to a given user selection. 
  * 
  * The selection of a tab group should only change if it contains an 
- * input with the given tabId. Otherwise, its current seletion should
+ * input with the given tabId. Otherwise, its current selection should
  * remain unchanged.
  * 
  * See layouts/shortcodes/tabs.html

--- a/docs/template/crd-ref.template
+++ b/docs/template/crd-ref.template
@@ -22,7 +22,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Custom Resource Defintion Reference
+# Custom Resource Definition Reference
 
 This serves as a full reference for FlinkDeployment and FlinkSessionJob custom resource definitions, including all possible configuration parameters.
 

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -314,7 +314,7 @@ function enable_minikube_ingress {
 function start_minikube_if_not_running {
     if ! minikube status; then
         echo "Starting minikube ..."
-        # Please update tbe docs when changing kubernetes version
+        # Please update the docs when changing kubernetes version
         minikube start \
         --kubernetes-version=v1.28.0 \
         --extra-config=kubelet.image-gc-high-threshold=99 \

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/RestApiMetricsCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/RestApiMetricsCollector.java
@@ -172,7 +172,7 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
             if (!tmMetrics.isEmpty()) {
                 return tmMetrics;
             } else {
-                // If metrics are missing that means we cant find even the required ones
+                // If metrics are missing that means we can't find even the required ones
                 // Let's error out and retry in the next loop.
                 jobsWithGcMetrics.remove(ctx.getJobKey());
                 throw new RuntimeException("Missing required TM metrics");

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/state/AutoScalerStateStore.java
@@ -85,7 +85,7 @@ public interface AutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
     @Nonnull
     DelayedScaleDown getDelayedScaleDown(Context jobContext) throws Exception;
 
-    /** Removes all data from this context. Flush stil needs to be called. */
+    /** Removes all data from this context. Flush still needs to be called. */
     void clearAll(Context jobContext) throws Exception;
 
     /**

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -769,7 +769,7 @@ public class JobVertexScalerTest {
                         restartTime,
                         delayedScaleDown));
 
-        // Allow scale up if current parallelism doesnt match last (user rescaled manually)
+        // Allow scale up if current parallelism doesn't match last (user rescaled manually)
         evaluated = evaluated(10, 180, 90);
         assertEquals(
                 ParallelismChange.build(20, 10, true),
@@ -967,7 +967,7 @@ public class JobVertexScalerTest {
         // reset tpr
         evaluated.put(ScalingMetric.TRUE_PROCESSING_RATE, tpr);
 
-        // Repeat ineffective scale with postive interval, no event is triggered
+        // Repeat ineffective scale with positive interval, no event is triggered
         conf.set(AutoScalerOptions.SCALING_EVENT_INTERVAL, Duration.ofSeconds(1800));
         assertEquals(
                 ParallelismChange.noChange(20),

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkConfigBuilder.java
@@ -528,7 +528,7 @@ public class FlinkConfigBuilder {
 
         // Running an application job through standalone mode doesn't requires file uri scheme and
         // doesn't accept
-        // local scheme which is used for native so convert here to improve compatibilty at the
+        // local scheme which is used for native so convert here to improve compatibility at the
         // operator layer
         if (uri.getScheme().equals("local")) {
             uri =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkStateSnapshotUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkStateSnapshotUtils.java
@@ -322,7 +322,7 @@ public class FlinkStateSnapshotUtils {
      *
      * @param snapshot snapshot resource
      * @param location result location
-     * @param setTriggerTimestamp if ture, set the trigger timestamp to current time
+     * @param setTriggerTimestamp if true, set the trigger timestamp to current time
      */
     public static void snapshotSuccessful(
             FlinkStateSnapshot snapshot, String location, boolean setTriggerTimestamp) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerEventHandlerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesAutoScalerEventHandlerTest.java
@@ -314,7 +314,7 @@ public class KubernetesAutoScalerEventHandlerTest {
         assertEquals(null, event.getMetadata().getLabels().get(PARALLELISM_MAP_KEY));
         assertEquals(1, event.getCount());
 
-        // Get recommendation event even parallelism map doesn't change and within supression
+        // Get recommendation event even parallelism map doesn't change and within suppression
         // interval
         eventHandler.handleScalingEvent(ctx, scalingSummaries1, disabledMessage, interval);
         assertEquals(1, flinkResourceEventCollector.events.size());
@@ -334,7 +334,7 @@ public class KubernetesAutoScalerEventHandlerTest {
         assertEquals("1286380436", event.getMetadata().getLabels().get(PARALLELISM_MAP_KEY));
         assertEquals(2, event.getCount());
 
-        // Get recommendation event even parallelism map doesn't change and within supression
+        // Get recommendation event even parallelism map doesn't change and within suppression
         // interval
         eventHandler.handleScalingEvent(ctx, scalingSummaries1, enabledMessage, interval);
         assertEquals(1, flinkResourceEventCollector.events.size());
@@ -388,7 +388,7 @@ public class KubernetesAutoScalerEventHandlerTest {
         assertNull(event.getMetadata().getLabels().get(PARALLELISM_MAP_KEY));
         assertEquals(1, event.getCount());
 
-        // Get recommendation event even parallelism map doesn't change and within supression
+        // Get recommendation event even parallelism map doesn't change and within suppression
         // interval
         eventHandler.handleScalingEvent(ctx, scalingSummaries1, disabledMessage, interval);
         assertEquals(1, flinkResourceEventCollector.events.size());
@@ -408,7 +408,7 @@ public class KubernetesAutoScalerEventHandlerTest {
         assertEquals("1286380436", event.getMetadata().getLabels().get(PARALLELISM_MAP_KEY));
         assertEquals(2, event.getCount());
 
-        // Get recommendation event even parallelism map doesn't change and within supression
+        // Get recommendation event even parallelism map doesn't change and within suppression
         // interval
         eventHandler.handleScalingEvent(ctx, scalingSummaries1, enabledMessage, interval);
         assertEquals(1, flinkResourceEventCollector.events.size());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
@@ -428,7 +428,8 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
 
         // Make sure the upgrade was executed as long as we have the savepoint information
         if (fromMode == UpgradeMode.LAST_STATE && toMode != UpgradeMode.STATELESS) {
-            // We can't make progress as no HA meta available after LAST_STATE, upgrade. It means the
+            // We can't make progress as no HA meta available after LAST_STATE, upgrade. It means
+            // the
             // job started and terminated, but we didn't see...
             assertEquals(
                     JobManagerDeploymentStatus.DEPLOYING,

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerUpgradeModeTest.java
@@ -428,7 +428,7 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
 
         // Make sure the upgrade was executed as long as we have the savepoint information
         if (fromMode == UpgradeMode.LAST_STATE && toMode != UpgradeMode.STATELESS) {
-            // We cant make progress as no HA meta available after LAST_STATE, upgrade. It means the
+            // We can't make progress as no HA meta available after LAST_STATE, upgrade. It means the
             // job started and terminated, but we didn't see...
             assertEquals(
                     JobManagerDeploymentStatus.DEPLOYING,
@@ -447,7 +447,7 @@ public class ApplicationReconcilerUpgradeModeTest extends OperatorTestBase {
                     toMode == UpgradeMode.STATELESS ? UpgradeMode.STATELESS : UpgradeMode.SAVEPOINT,
                     lastReconciledSpec.getJob().getUpgradeMode());
 
-            // Complete upgrade and recover succesfully with the latest savepoint
+            // Complete upgrade and recover successfully with the latest savepoint
             reconciler.reconcile(deployment, context);
             lastReconciledSpec =
                     deployment

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/SecureFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/SecureFlinkServiceTest.java
@@ -146,7 +146,7 @@ public class SecureFlinkServiceTest {
         Map<String, String> originalEnv = System.getenv();
         Configuration deployConfig = createOperatorConfig();
         Map<String, String> systemEnv = new HashMap<>(originalEnv);
-        // Set the env var to define the certficates
+        // Set the env var to define the certificates
         systemEnv.put(EnvUtils.ENV_OPERATOR_TRUSTSTORE_PATH, getAbsolutePath("/keystore.jks"));
         systemEnv.put(EnvUtils.ENV_OPERATOR_KEYSTORE_PASSWORD, "password1234");
         TestUtils.setEnv(systemEnv);
@@ -167,7 +167,7 @@ public class SecureFlinkServiceTest {
         Configuration deployConfig = createOperatorConfig();
         deployConfig.set(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
         Map<String, String> systemEnv = new HashMap<>(originalEnv);
-        // Set the env var to define the certficates
+        // Set the env var to define the certificates
         systemEnv.put(EnvUtils.ENV_OPERATOR_TRUSTSTORE_PATH, getAbsolutePath("/truststore.jks"));
         systemEnv.put(EnvUtils.ENV_OPERATOR_KEYSTORE_PASSWORD, "password1234");
         TestUtils.setEnv(systemEnv);
@@ -195,7 +195,7 @@ public class SecureFlinkServiceTest {
         Configuration deployConfig = createOperatorConfig();
         deployConfig.set(SecurityOptions.SSL_REST_AUTHENTICATION_ENABLED, true);
         Map<String, String> systemEnv = new HashMap<>(originalEnv);
-        // Set the env var to define the certficates
+        // Set the env var to define the certificates
         systemEnv.put(EnvUtils.ENV_OPERATOR_TRUSTSTORE_PATH, getAbsolutePath("/truststore.jks"));
         systemEnv.put(EnvUtils.ENV_OPERATOR_KEYSTORE_PATH, getAbsolutePath("/keystore.jks"));
         systemEnv.put(EnvUtils.ENV_OPERATOR_KEYSTORE_PASSWORD, "password1234");
@@ -216,7 +216,7 @@ public class SecureFlinkServiceTest {
         Map<String, String> originalEnv = System.getenv();
         Configuration deployConfig = createOperatorConfig();
         Map<String, String> systemEnv = new HashMap<>(originalEnv);
-        // Set the env var to define the certficates
+        // Set the env var to define the certificates
         systemEnv.put(EnvUtils.ENV_OPERATOR_TRUSTSTORE_PATH, getAbsolutePath("/truststore.jks"));
         systemEnv.put(EnvUtils.ENV_OPERATOR_KEYSTORE_PASSWORD, "password1234");
         TestUtils.setEnv(systemEnv);
@@ -236,7 +236,7 @@ public class SecureFlinkServiceTest {
         Map<String, String> originalEnv = System.getenv();
         Configuration deployConfig = createOperatorConfig();
         Map<String, String> systemEnv = new HashMap<>(originalEnv);
-        // Set the env var to define the certficates
+        // Set the env var to define the certificates
         systemEnv.put(EnvUtils.ENV_OPERATOR_TRUSTSTORE_PATH, getAbsolutePath("/truststore.jks"));
         systemEnv.put(EnvUtils.ENV_OPERATOR_KEYSTORE_PASSWORD, "password1234");
         TestUtils.setEnv(systemEnv);
@@ -259,7 +259,7 @@ public class SecureFlinkServiceTest {
         Map<String, String> originalEnv = System.getenv();
         Configuration deployConfig = createOperatorConfig();
         Map<String, String> systemEnv = new HashMap<>(originalEnv);
-        // Set the env var to define the certficates
+        // Set the env var to define the certificates
         systemEnv.put(EnvUtils.ENV_OPERATOR_TRUSTSTORE_PATH, getAbsolutePath("/truststore.jks"));
         systemEnv.put(EnvUtils.ENV_OPERATOR_KEYSTORE_PASSWORD, "password1234");
         TestUtils.setEnv(systemEnv);

--- a/tools/olm/generate-olm-bundle.sh
+++ b/tools/olm/generate-olm-bundle.sh
@@ -59,10 +59,10 @@ build_push_catalog(){
 
 # Simplest way to build local index(catalog) image without any upgrade path
 # opm index add --bundles "${BUNDLE_IMG}" --tag "${CATALOG_IMG}" -c docker
-# But we also want to test upgrade from the previus version
-# Therefor, building local catalog image using latest file-based-catalog format
+# But we also want to test upgrade from the previous version
+# Therefore, building local catalog image using latest file-based-catalog format
 # https://olm.operatorframework.io/docs/reference/file-based-catalogs/#opm-generate-dockerfile
-# We assume someone runing an older olm bundle.
+# We assume someone running an older olm bundle.
 # This enables testing upgrade from the previous version using startingCSV in Subscription
 generate_fbc_config() {
 rm -rf "${CATDIR}"

--- a/tools/releasing/create_release_branch.sh
+++ b/tools/releasing/create_release_branch.sh
@@ -40,7 +40,7 @@ CURR_DIR=`pwd`
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="${BASE_DIR}/../../"
 
-# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should always exist in project root
 if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
     echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
     exit 1

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -52,7 +52,7 @@ CURR_DIR=`pwd`
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="$( cd "$( dirname "${BASE_DIR}/../../../" )" >/dev/null && pwd )"
 
-# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should always exist in project root
 if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
     echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
     exit 1

--- a/tools/releasing/deploy_staging_jars.sh
+++ b/tools/releasing/deploy_staging_jars.sh
@@ -31,7 +31,7 @@ CURR_DIR=`pwd`
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="${BASE_DIR}/../../"
 
-# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should always exist in project root
 if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
     echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
     exit 1

--- a/tools/releasing/update_branch_version.sh
+++ b/tools/releasing/update_branch_version.sh
@@ -46,7 +46,7 @@ CURR_DIR=`pwd`
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 PROJECT_ROOT="${BASE_DIR}/../../"
 
-# Sanity check to ensure that resolved paths are valid; a LICENSE file should aways exist in project root
+# Sanity check to ensure that resolved paths are valid; a LICENSE file should always exist in project root
 if [ ! -f ${PROJECT_ROOT}/LICENSE ]; then
     echo "Project root path ${PROJECT_ROOT} is not valid; script may be in the wrong directory."
     exit 1


### PR DESCRIPTION
## What is the purpose of the change

Fixes spelling typos across the operator's documentation, code comments/JavaDoc,
and release scripts. No functional changes; no JIRA required per the contribution
guidelines for typo fixes.

## Brief change log

**Documentation (markdown, doclet template, theme)**
- `concepts/controller-flow.md`: `actualy` → `actual`
- `custom-resource/snapshots.md`: `maxmimum` → `maximum`, `deteremined` → `determined`
- `custom-resource/reference.md` **and** `docs/template/crd-ref.template`: `Defintion` → `Definition` (the template is the doclet source that generates `reference.md`, so both are fixed)
- `custom-resource/autoscaler.md` (EN + ZH): `vertexes` → `vertices`
- `shortcodes/beta.html`: `currency` → `currently`, `guaruntees` → `guarantees` (rendered BETA-feature hint)
- `shortcodes/*.html`: `Parmeters` → `Parameters` (comments)
- `partials/.../simple-title.html`: `sytling` → `styling`; `inject/menu-after.html`: `dictonary` → `dictionary`
- `static/js/flink.js`: `seletion` → `selection`

**Code comments & JavaDoc**
- `ture`→`true`, `stil`→`still`, `compatibilty`→`compatibility`, `cant`→`can't`, `doesnt`→`doesn't`, `postive`→`positive`, `supression`→`suppression`, `succesfully`→`successfully`, `certficates`→`certificates` (across `FlinkStateSnapshotUtils`, `AutoScalerStateStore`, `FlinkConfigBuilder`, `RestApiMetricsCollector` and several tests)

**Scripts**
- `tools/releasing/*.sh`: `aways` → `always`
- `tools/olm/generate-olm-bundle.sh`: `previus`/`Therefor`/`runing` → `previous`/`Therefore`/`running`
- `e2e-tests/utils.sh`: `tbe` → `the`

## AI assistance disclosure

- [x] Claude Code
