### PR TITLE
[FLINK-38795] Support Flink 2.0+ HA in standalone mode

### DIFF
--- a/flink-kubernetes-standalone/pom.xml
+++ b/flink-kubernetes-standalone/pom.xml
@@ -54,6 +54,13 @@ under the License.
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <version>${hamcrest.version}</version>

--- a/flink-kubernetes-standalone/pom.xml
+++ b/flink-kubernetes-standalone/pom.xml
@@ -48,6 +48,13 @@ under the License.
 
         <!-- Test -->
         <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-container</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
+++ b/flink-kubernetes-standalone/src/main/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecorator.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.kubeclient.decorators;
 
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.decorators.AbstractKubernetesStepDecorator;
 import org.apache.flink.kubernetes.operator.kubeclient.parameters.StandaloneKubernetesJobManagerParameters;
@@ -38,6 +39,9 @@ public class CmdStandaloneJobManagerDecorator extends AbstractKubernetesStepDeco
     public static final String APPLICATION_MODE_ARG = "standalone-job";
     public static final String POD_IP_ARG =
             String.format("$(%s)", Constants.ENV_FLINK_POD_IP_ADDRESS);
+    public static final String DYNAMIC_PROPERTY_FLAG = "-D";
+    public static final String JOBMANAGER_RPC_ADDRESS_ARG =
+            String.format("%s=%s", JobManagerOptions.ADDRESS.key(), POD_IP_ARG);
 
     private final StandaloneKubernetesJobManagerParameters kubernetesJobManagerParameters;
 
@@ -64,7 +68,7 @@ public class CmdStandaloneJobManagerDecorator extends AbstractKubernetesStepDeco
                         .addToArgs(JOBMANAGER_ENTRYPOINT_ARG);
 
         if (kubernetesJobManagerParameters.isHAEnabled()) {
-            containerBuilder.addToArgs(POD_IP_ARG);
+            containerBuilder.addToArgs(DYNAMIC_PROPERTY_FLAG, JOBMANAGER_RPC_ADDRESS_ARG);
         }
 
         return containerBuilder.build();
@@ -99,8 +103,8 @@ public class CmdStandaloneJobManagerDecorator extends AbstractKubernetesStepDeco
         }
 
         if (kubernetesJobManagerParameters.isHAEnabled()) {
-            args.add("--host");
-            args.add(POD_IP_ARG);
+            args.add(DYNAMIC_PROPERTY_FLAG);
+            args.add(JOBMANAGER_RPC_ADDRESS_ARG);
         }
 
         List<String> jobSpecArgs = kubernetesJobManagerParameters.getJobSpecArgs();

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
@@ -32,9 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @link CmdStandaloneJobManagerDecorator unit tests
@@ -67,11 +65,11 @@ public class CmdStandaloneJobManagerDecoratorTest {
                 StandaloneKubernetesConfigOptionsInternal.ClusterMode.SESSION);
 
         FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
-        assertThat(
-                decoratedPod.getMainContainer().getCommand(), containsInAnyOrder(MOCK_ENTRYPATH));
-        assertThat(
-                decoratedPod.getMainContainer().getArgs(),
-                containsInAnyOrder(CmdStandaloneJobManagerDecorator.JOBMANAGER_ENTRYPOINT_ARG));
+        assertThat(decoratedPod.getMainContainer().getCommand())
+                .containsExactlyInAnyOrder(MOCK_ENTRYPATH);
+        assertThat(decoratedPod.getMainContainer().getArgs())
+                .containsExactlyInAnyOrder(
+                        CmdStandaloneJobManagerDecorator.JOBMANAGER_ENTRYPOINT_ARG);
     }
 
     @Test
@@ -85,17 +83,16 @@ public class CmdStandaloneJobManagerDecoratorTest {
         configuration.set(SavepointConfigOptions.SAVEPOINT_PATH, "/tmp/savepoint/path");
 
         FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
-        assertThat(
-                decoratedPod.getMainContainer().getCommand(), containsInAnyOrder(MOCK_ENTRYPATH));
-        assertThat(
-                decoratedPod.getMainContainer().getArgs(),
-                containsInAnyOrder(
+        assertThat(decoratedPod.getMainContainer().getCommand())
+                .containsExactlyInAnyOrder(MOCK_ENTRYPATH);
+        assertThat(decoratedPod.getMainContainer().getArgs())
+                .containsExactlyInAnyOrder(
                         CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG,
                         "--allowNonRestoredState",
                         "--fromSavepoint",
                         "/tmp/savepoint/path",
                         "--job-classname",
-                        testMainClass));
+                        testMainClass);
     }
 
     @Test
@@ -105,11 +102,10 @@ public class CmdStandaloneJobManagerDecoratorTest {
                 StandaloneKubernetesConfigOptionsInternal.ClusterMode.APPLICATION);
 
         FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
-        assertThat(
-                decoratedPod.getMainContainer().getCommand(), containsInAnyOrder(MOCK_ENTRYPATH));
-        assertThat(
-                decoratedPod.getMainContainer().getArgs(),
-                containsInAnyOrder(CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG));
+        assertThat(decoratedPod.getMainContainer().getCommand())
+                .containsExactlyInAnyOrder(MOCK_ENTRYPATH);
+        assertThat(decoratedPod.getMainContainer().getArgs())
+                .containsExactlyInAnyOrder(CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG);
     }
 
     @Test
@@ -124,13 +120,12 @@ public class CmdStandaloneJobManagerDecoratorTest {
 
         FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
 
-        assertThat(
-                decoratedPod.getMainContainer().getCommand(), containsInAnyOrder(MOCK_ENTRYPATH));
-        assertThat(
-                decoratedPod.getMainContainer().getArgs(),
-                containsInAnyOrder(
+        assertThat(decoratedPod.getMainContainer().getCommand())
+                .containsExactlyInAnyOrder(MOCK_ENTRYPATH);
+        assertThat(decoratedPod.getMainContainer().getArgs())
+                .containsExactlyInAnyOrder(
                         CmdStandaloneJobManagerDecorator.JOBMANAGER_ENTRYPOINT_ARG,
-                        CmdStandaloneJobManagerDecorator.POD_IP_ARG));
+                        CmdStandaloneJobManagerDecorator.POD_IP_ARG);
     }
 
     @Test
@@ -144,13 +139,12 @@ public class CmdStandaloneJobManagerDecoratorTest {
 
         FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
 
-        assertThat(
-                decoratedPod.getMainContainer().getArgs(),
-                contains(
+        assertThat(decoratedPod.getMainContainer().getArgs())
+                .containsExactly(
                         CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG,
                         "--host",
                         CmdStandaloneJobManagerDecorator.POD_IP_ARG,
                         "--test",
-                        "123"));
+                        "123");
     }
 }

--- a/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
+++ b/flink-kubernetes-standalone/src/test/java/org/apache/flink/kubernetes/operator/kubeclient/decorators/CmdStandaloneJobManagerDecoratorTest.java
@@ -20,16 +20,24 @@ package org.apache.flink.kubernetes.operator.kubeclient.decorators;
 import org.apache.flink.client.deployment.ClusterSpecification;
 import org.apache.flink.client.deployment.application.ApplicationConfiguration;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.HighAvailabilityOptions;
+import org.apache.flink.configuration.JobManagerOptions;
+import org.apache.flink.container.entrypoint.StandaloneApplicationClusterConfigurationParserFactory;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.operator.kubeclient.parameters.StandaloneKubernetesJobManagerParameters;
 import org.apache.flink.kubernetes.operator.standalone.StandaloneKubernetesConfigOptionsInternal;
+import org.apache.flink.runtime.entrypoint.ClusterConfiguration;
+import org.apache.flink.runtime.entrypoint.EntrypointClusterConfigurationParserFactory;
+import org.apache.flink.runtime.entrypoint.parser.CommandLineParser;
+import org.apache.flink.runtime.entrypoint.parser.ParserResultFactory;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -73,7 +81,7 @@ public class CmdStandaloneJobManagerDecoratorTest {
     }
 
     @Test
-    public void testApplicationCommandAndArgsAdded() {
+    public void testApplicationCommandAndArgsAdded() throws Exception {
         final String testMainClass = "org.main.class";
         configuration.set(
                 StandaloneKubernetesConfigOptionsInternal.CLUSTER_MODE,
@@ -93,6 +101,10 @@ public class CmdStandaloneJobManagerDecoratorTest {
                         "/tmp/savepoint/path",
                         "--job-classname",
                         testMainClass);
+
+        parseEntrypointConfig(
+                new StandaloneApplicationClusterConfigurationParserFactory(),
+                decoratedPod.getMainContainer().getArgs());
     }
 
     @Test
@@ -123,9 +135,10 @@ public class CmdStandaloneJobManagerDecoratorTest {
         assertThat(decoratedPod.getMainContainer().getCommand())
                 .containsExactlyInAnyOrder(MOCK_ENTRYPATH);
         assertThat(decoratedPod.getMainContainer().getArgs())
-                .containsExactlyInAnyOrder(
+                .containsExactly(
                         CmdStandaloneJobManagerDecorator.JOBMANAGER_ENTRYPOINT_ARG,
-                        CmdStandaloneJobManagerDecorator.POD_IP_ARG);
+                        CmdStandaloneJobManagerDecorator.DYNAMIC_PROPERTY_FLAG,
+                        CmdStandaloneJobManagerDecorator.JOBMANAGER_RPC_ADDRESS_ARG);
     }
 
     @Test
@@ -142,9 +155,80 @@ public class CmdStandaloneJobManagerDecoratorTest {
         assertThat(decoratedPod.getMainContainer().getArgs())
                 .containsExactly(
                         CmdStandaloneJobManagerDecorator.APPLICATION_MODE_ARG,
-                        "--host",
-                        CmdStandaloneJobManagerDecorator.POD_IP_ARG,
+                        CmdStandaloneJobManagerDecorator.DYNAMIC_PROPERTY_FLAG,
+                        CmdStandaloneJobManagerDecorator.JOBMANAGER_RPC_ADDRESS_ARG,
                         "--test",
                         "123");
+    }
+
+    @Test
+    public void testApplicationHAArgsUnderstoodByFlinkRuntime() throws Exception {
+        configuration.set(
+                StandaloneKubernetesConfigOptionsInternal.CLUSTER_MODE,
+                StandaloneKubernetesConfigOptionsInternal.ClusterMode.APPLICATION);
+        configuration.set(HighAvailabilityOptions.HA_MODE, "KUBERNETES");
+
+        FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
+
+        Configuration parsed =
+                parseEntrypointConfig(
+                        new StandaloneApplicationClusterConfigurationParserFactory(),
+                        decoratedPod.getMainContainer().getArgs());
+
+        assertThat(parsed.get(JobManagerOptions.ADDRESS))
+                .isEqualTo(CmdStandaloneJobManagerDecorator.POD_IP_ARG);
+    }
+
+    @Test
+    public void testSessionHAArgsUnderstoodByFlinkRuntime() throws Exception {
+        configuration.set(
+                StandaloneKubernetesConfigOptionsInternal.CLUSTER_MODE,
+                StandaloneKubernetesConfigOptionsInternal.ClusterMode.SESSION);
+        configuration.set(
+                HighAvailabilityOptions.HA_MODE,
+                "org.apache.flink.kubernetes.highavailability.KubernetesHaServicesFactory");
+
+        FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
+
+        Configuration parsed =
+                parseEntrypointConfig(
+                        new EntrypointClusterConfigurationParserFactory(),
+                        decoratedPod.getMainContainer().getArgs());
+
+        assertThat(parsed.get(JobManagerOptions.ADDRESS))
+                .isEqualTo(CmdStandaloneJobManagerDecorator.POD_IP_ARG);
+    }
+
+    @Test
+    public void testApplicationWithoutHADoesNotSetRpcAddress() throws Exception {
+        configuration.set(
+                StandaloneKubernetesConfigOptionsInternal.CLUSTER_MODE,
+                StandaloneKubernetesConfigOptionsInternal.ClusterMode.APPLICATION);
+
+        FlinkPod decoratedPod = decorator.decorateFlinkPod(new FlinkPod.Builder().build());
+
+        Configuration parsed =
+                parseEntrypointConfig(
+                        new StandaloneApplicationClusterConfigurationParserFactory(),
+                        decoratedPod.getMainContainer().getArgs());
+
+        assertThat(parsed.get(JobManagerOptions.ADDRESS)).isNull();
+    }
+
+    private static Configuration parseEntrypointConfig(
+            ParserResultFactory<? extends ClusterConfiguration> factory, List<String> containerArgs)
+            throws Exception {
+        // Dropping the leading entrypoint token (standalone-job / jobmanager); not seen by the JVM.
+        List<String> entrypointArgs = containerArgs.subList(1, containerArgs.size());
+
+        // Adding configDir as it's required by the parser factory
+        List<String> argsWithConfigDir = new ArrayList<>();
+        argsWithConfigDir.add("--configDir");
+        argsWithConfigDir.add("unused");
+        argsWithConfigDir.addAll(entrypointArgs);
+
+        ClusterConfiguration parsed =
+                new CommandLineParser<>(factory).parse(argsWithConfigDir.toArray(new String[0]));
+        return ConfigurationUtils.createConfiguration(parsed.getDynamicProperties());
     }
 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When HA is was enabled in standalone deployment mode, the JobManager decorator passed the pod IP to the entrypoint using the `--host` CLI argument (application mode) and a bare positional argument (session mode). That `--host` argument was removed from the standalone entrypoints in Flink 2.0, breaking standalone HA deployments.

## Brief change log

Replace `--host` with the recommended dynamic config `-D jobmanager.rpc.address=$(POD_IP)` in both application and session modes.

This is a valid config in both Flink 1.x and 2.x, so no version detection is required.

## Verifying this change

- Existing unit tests, expanded with use of the real argument parser
- Existing e2e tests exercise this code path

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable