### PR TITLE
[hotfix][ci] Replace disallowed azure/setup-helm action with a direct Helm download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,13 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4
-        with:
-          version: v3.17.3
+        run: |
+          HELM_VERSION=v3.17.3
+          curl -fsSLo /tmp/helm.tar.gz "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          echo "$(curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz.sha256sum" | cut -d' ' -f1)  /tmp/helm.tar.gz" | sha256sum -c -
+          mkdir -p /tmp/helm
+          tar -xzf /tmp/helm.tar.gz -C /tmp/helm
+          sudo mv /tmp/helm/linux-amd64/helm /usr/local/bin/helm
 
       - name: Install Helm unittest plugin
         run: helm plugin install https://github.com/helm-unittest/helm-unittest.git --version 0.8.1


### PR DESCRIPTION
## What is the purpose of the change

The `Helm Lint Test` CI job used the `azure/setup-helm` action, which is no longer on the ASF INFRA GitHub Actions allowlist. GitHub rejects disallowed actions at workflow startup, so the whole "Flink Kubernetes Operator CI" workflow fails with `startup_failure` and no jobs run. This blocks CI on every PR.

This change installs Helm with a plain `curl` step instead, so no third-party action is needed.

## Brief change log

- Replace the `azure/setup-helm@<sha>` step in `ci.yml` with a bash step that downloads Helm from the official `get.helm.sh` host, verifies its SHA-256 checksum, and installs it to `/usr/local/bin`.
- Keep the same pinned version (`v3.17.3`) and follow the existing `chart-testing` step style (download and extract under `/tmp`).

## Verifying this change

This change is CI-only. It is verified by the workflow starting successfully and the `Helm Lint Test` job running Helm unittest and chart-testing lint as before.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
