### PR TITLE
[FLINK-40055] Serialize managed cluster config in the target Flink version's YAML dialect

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
@@ -234,17 +234,20 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
         return useStandardYamlConfig() ? "config.yaml" : "flink-conf.yaml";
     }
 
+    boolean useStandardYamlConfig() {
+        return useStandardYamlConfig(
+                kubernetesComponentConf.getFlinkConfiguration().get(FLINK_VERSION));
+    }
+
     /**
      * Determine based on the Flink Version if we should use the new standard config.yaml vs the old
      * flink-conf.yaml. While technically 1.19+ could use this we don't want to change the behaviour
      * for already released Flink versions, so only switch to new yaml from Flink 2.0 onwards.
      *
+     * @param flinkVersion Flink version of the target deployment
      * @return True for Flink version 2.0 and above
      */
-    boolean useStandardYamlConfig() {
-        return kubernetesComponentConf
-                .getFlinkConfiguration()
-                .get(FLINK_VERSION)
-                .isEqualOrNewer(FlinkVersion.v2_0);
+    public static boolean useStandardYamlConfig(FlinkVersion flinkVersion) {
+        return flinkVersion != null && flinkVersion.isEqualOrNewer(FlinkVersion.v2_0);
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/FlinkConfMountDecorator.java
@@ -157,7 +157,8 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
         // For Flink versions that use the standard config we have to set the standardYaml flag in
         // the Configuration object manually instead of simply cloning, otherwise it would simply
         // inherit it from the base config (which would always be false currently).
-        Configuration clusterSideConfig = new Configuration(useStandardYamlConfig());
+        Configuration clusterSideConfig =
+                new Configuration(useStandardYamlConfig(flinkConfig.get(FLINK_VERSION)));
         clusterSideConfig.addAll(flinkConfig);
         // Remove some configuration options that should not be taken to cluster side.
         clusterSideConfig.removeConfig(KubernetesConfigOptions.KUBE_CONFIG_FILE);
@@ -175,7 +176,7 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
     private void validateConfigKeysForV2(Configuration clusterSideConfig) {
 
         // Only validate Flink 2.0 yaml configs
-        if (!useStandardYamlConfig()) {
+        if (!useStandardYamlConfig(clusterSideConfig.get(FLINK_VERSION))) {
             return;
         }
 
@@ -231,12 +232,10 @@ public class FlinkConfMountDecorator extends AbstractKubernetesStepDecorator {
      * @return conf file name
      */
     public String getFlinkConfFilename() {
-        return useStandardYamlConfig() ? "config.yaml" : "flink-conf.yaml";
-    }
-
-    boolean useStandardYamlConfig() {
         return useStandardYamlConfig(
-                kubernetesComponentConf.getFlinkConfiguration().get(FLINK_VERSION));
+                        kubernetesComponentConf.getFlinkConfiguration().get(FLINK_VERSION))
+                ? "config.yaml"
+                : "flink-conf.yaml";
     }
 
     /**

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -31,6 +31,7 @@ import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.core.execution.RestoreMode;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
+import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
@@ -937,7 +938,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                                     ? RestoreMode.DEFAULT
                                     : null,
                             conf.get(FLINK_VERSION).isEqualOrNewer(FlinkVersion.v1_17)
-                                    ? conf.toMap()
+                                    ? configToMapWithVersionDialect(conf, flinkVersion)
                                     : null);
             LOG.info("Submitting job: {} to session cluster.", jobID);
             clusterClient
@@ -1043,17 +1044,33 @@ public abstract class AbstractFlinkService implements FlinkService {
 
     @VisibleForTesting
     protected static Configuration removeOperatorConfigs(Configuration config) {
-        Configuration newConfig = new Configuration();
-        config.toMap()
-                .forEach(
-                        (k, v) -> {
-                            if (!k.startsWith(K8S_OP_CONF_PREFIX)
-                                    && !k.startsWith(AutoScalerOptions.AUTOSCALER_CONF_PREFIX)) {
-                                newConfig.setString(k, v);
-                            }
-                        });
-
+        // Copy and remove keys directly: a toMap() round-trip would serialize values (e.g. the
+        // list-typed pipeline.jars) in the operator's own YAML dialect, which the target Flink
+        // version may not parse. Raw values let the write boundaries render per target version.
+        Configuration newConfig = new Configuration(config);
+        for (String key : config.keySet()) {
+            if (key.startsWith(K8S_OP_CONF_PREFIX)
+                    || key.startsWith(AutoScalerOptions.AUTOSCALER_CONF_PREFIX)) {
+                newConfig.removeKey(key);
+            }
+        }
         return newConfig;
+    }
+
+    /**
+     * Serialize the config in the YAML dialect of the given Flink version so the receiving cluster
+     * can parse the values regardless of the operator's own config format.
+     *
+     * @param conf Config to serialize
+     * @param flinkVersion Flink version of the receiving cluster
+     * @return Map of config entries in the target version's string format
+     */
+    @VisibleForTesting
+    protected static Map<String, String> configToMapWithVersionDialect(
+            Configuration conf, FlinkVersion flinkVersion) {
+        var copy = new Configuration(FlinkConfMountDecorator.useStandardYamlConfig(flinkVersion));
+        copy.addAll(conf);
+        return copy.toMap();
     }
 
     private void validateHaMetadataExists(Configuration conf) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -1042,11 +1042,12 @@ public abstract class AbstractFlinkService implements FlinkService {
                 timeout);
     }
 
+    /**
+     * Remove operator-only keys, preserving raw values so the write boundaries can serialize them
+     * in the target Flink version's YAML dialect.
+     */
     @VisibleForTesting
     protected static Configuration removeOperatorConfigs(Configuration config) {
-        // Copy and remove keys directly: a toMap() round-trip would serialize values (e.g. the
-        // list-typed pipeline.jars) in the operator's own YAML dialect, which the target Flink
-        // version may not parse. Raw values let the write boundaries render per target version.
         Configuration newConfig = new Configuration(config);
         for (String key : config.keySet()) {
             if (key.startsWith(K8S_OP_CONF_PREFIX)

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -25,8 +25,10 @@ import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
@@ -1086,6 +1088,34 @@ public class AbstractFlinkServiceTest {
         assertFalse(newConf.containsKey(opKey1));
         assertFalse(newConf.containsKey(opKey2));
         assertTrue(newConf.containsKey(regularKey));
+    }
+
+    @Test
+    public void removeOperatorConfigsKeepsTypedValuesTest() {
+        // Simulate an operator process running on standard config.yaml.
+        boolean previousDialect = GlobalConfiguration.isStandardYaml();
+        GlobalConfiguration.setStandardYaml(true);
+        try {
+            var jars = List.of("local:///opt/flink/job.jar");
+            var deployConfig = new Configuration(true);
+            deployConfig.set(PipelineOptions.JARS, jars);
+            deployConfig.setString("kubernetes.operator.myKey", "v");
+
+            var newConf = AbstractFlinkService.removeOperatorConfigs(deployConfig);
+
+            assertFalse(newConf.containsKey("kubernetes.operator.myKey"));
+            // Typed values must survive so write boundaries can render them per Flink version.
+            assertEquals(jars, newConf.get(PipelineOptions.JARS));
+            assertEquals(
+                    Map.of("pipeline.jars", "local:///opt/flink/job.jar"),
+                    AbstractFlinkService.configToMapWithVersionDialect(
+                            newConf, FlinkVersion.v1_20));
+            assertEquals(
+                    Map.of("pipeline.jars", "['local:///opt/flink/job.jar']"),
+                    AbstractFlinkService.configToMapWithVersionDialect(newConf, FlinkVersion.v2_0));
+        } finally {
+            GlobalConfiguration.setStandardYaml(previousDialect);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Fixes [FLINK-40055](https://issues.apache.org/jira/browse/FLINK-40055): the operator serializes managed-deployment config values in its **own** YAML dialect rather than the target deployment's. When the operator itself runs on standard `config.yaml`, list-typed options (e.g. `pipeline.jars`) are written into Flink 1.x deployments as YAML flow lists (`['local://…']`), which the legacy parser cannot read — the JobManager crashloops with `URISyntaxException`. Discovered via the CI failures on #1126, which this bug blocks (that PR makes `config.yaml` the operator's default format; today the bug is reachable via a conf-override dir or custom mount).

Root cause (full analysis on the Jira): the YAML dialect is process-global in flink-core (`Configuration()`'s no-arg constructor and `clone()` take `GlobalConfiguration.isStandardYaml()`), and `AbstractFlinkService#removeOperatorConfigs` bakes that dialect into every value via a `toMap()`/`setString` round-trip before `FlinkConfMountDecorator` — which already correctly picks the file name and format per target Flink version — gets to write the file.

The fix acts only at the serialization boundaries and leaves in-process parse semantics untouched (stamping the target dialect onto the long-lived resource configs was prototyped and rejected: the same flag governs how raw string values are *parsed*, so it changes read behavior for every consumer, and any downstream `clone()` silently resets it).

## Brief change log

- **`AbstractFlinkService#removeOperatorConfigs`** — copy via the copy constructor and `removeKey` directly instead of the `toMap()`/`setString` round-trip, so typed values survive untouched to the write boundaries that already render per target version.
- **`AbstractFlinkService#runJar`** — serialize the session-job REST config map in the receiving cluster's dialect (new `configToMapWithVersionDialect`, a throwaway dialect-stamped copy for the `JarRunRequestBody` only).
- **`FlinkConfMountDecorator#useStandardYamlConfig(FlinkVersion)`** — the Flink-2.0 dialect threshold becomes one shared public static (replacing the package-private instance method), so the rule lives in a single place.

## Verifying this change

This change added tests and can be verified as follows:

- **Unit test** (`AbstractFlinkServiceTest#removeOperatorConfigsKeepsTypedValuesTest`): pins the process-global standard-yaml flag (the condition CI never exercises otherwise), asserts operator keys are removed, typed `pipeline.jars` survives, and the same config serializes as the legacy scalar for `v1_20` and the standard flow list for `v2_0`.
- **All four operator-format × deployment-version combinations** in a kind cluster with a from-source operator image: the `v1_20` application deployment that crashloops without the fix (operator on `config.yaml`) reaches RUNNING with it; `v2_2` deployments work under both operator formats.
- **Config invariance**: the generated `flink-config-*` ConfigMap content is identical regardless of the operator's own format (only per-run identity values differ) — the operator's config format is invisible to managed deployments.
- **In-place operator config-format migration (chaos run)**: helm-flipped the operator chart legacy↔standard under RUNNING v1 and v2 jobs, killing JobManager pods after each flip to force a config re-read from the mounted ConfigMap: no job disruption, no JobManager pod churn, byte-identical generated configs, and every freshly started JobManager parsed its config.
- `mvn test` for the touched suites: `AbstractFlinkServiceTest` 40/40, `FlinkConfMountDecoratorTest` 5/5, `FlinkConfigManagerTest` 9/9.

## Does this pull request potentially affect one of the following parts:

- Dependencies (add or upgrade a dependency): **no**
- The public API (`CustomResourceDescriptors`): **no**
- Core observer or reconciler logic that is regularly executed: **yes** — `removeOperatorConfigs` runs on every cluster submission; behavior is unchanged for string values, and typed values now pass through unconverted (previously stringified in the operator's dialect).

## Documentation

- Does this introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable** (bug fix; no user-facing configuration change)

