### PR TITLE
[FLINK-40092] Finalize BlueGreen transition after deleting previous deployment 

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -608,7 +608,7 @@ public class BlueGreenDeploymentService {
         long deletionTimestamp = deploymentReadyTimestamp + deploymentDeletionDelayMs;
 
         if (deletionTimestamp < System.currentTimeMillis()) {
-            return deleteDeployment(currentDeployment, context);
+            return deleteDeployment(currentDeployment, context, nextState);
         } else {
             return waitBeforeDeleting(currentDeployment, deletionTimestamp);
         }
@@ -627,17 +627,20 @@ public class BlueGreenDeploymentService {
     }
 
     private UpdateControl<FlinkBlueGreenDeployment> deleteDeployment(
-            FlinkDeployment currentDeployment, BlueGreenContext context) {
+            FlinkDeployment currentDeployment,
+            BlueGreenContext context,
+            FlinkBlueGreenDeploymentState nextState) {
 
         boolean deleted = deleteFlinkDeployment(currentDeployment, context);
 
         if (!deleted) {
             LOG.info("FlinkDeployment '{}' not deleted, will retry", currentDeployment);
+            return UpdateControl.<FlinkBlueGreenDeployment>noUpdate()
+                    .rescheduleAfter(RETRY_DELAY_MS);
         } else {
             LOG.info("FlinkDeployment '{}' deleted!", currentDeployment);
+            return finalizeBlueGreenDeployment(context, nextState);
         }
-
-        return UpdateControl.<FlinkBlueGreenDeployment>noUpdate().rescheduleAfter(RETRY_DELAY_MS);
     }
 
     // ==================== Abort and Retry Methods ====================

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -57,11 +57,13 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import static org.apache.flink.kubernetes.operator.api.spec.FlinkBlueGreenDeploymentConfigOptions.ABORT_GRACE_PERIOD;
@@ -71,6 +73,7 @@ import static org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils.SAMPL
 import static org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils.TEST_DEPLOYMENT_NAME;
 import static org.apache.flink.kubernetes.operator.api.utils.BaseTestUtils.TEST_NAMESPACE;
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.instantStrToMillis;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -584,16 +587,21 @@ public class FlinkBlueGreenDeploymentControllerTest {
                 rs.reconciledStatus.getBlueGreenState());
         assertEquals(2, getFlinkDeployments().size());
 
-        // Green becomes ready -> marks the ready timestamp and schedules deletion of Blue
-        simulateSuccessfulJobStart(getFlinkDeployments().get(1));
-        rs = reconcile(rs.deployment);
+        // Green becomes ready -> marks the ready timestamp and schedules deletion of Blue.
+        simulateSuccessfulJobStart(getFlinkDeploymentByName(GREEN_CLUSTER_ID));
 
-        // Let the (zero) deletion delay elapse
-        Thread.sleep(10);
+        // Reconcile until the (zero) deletion delay elapses: Blue is deleted at cutover and the
+        // transition finalizes forward to ACTIVE_GREEN.
+        var latestRs = new AtomicReference<>(rs);
+        await().atMost(Duration.ofSeconds(10))
+                .until(
+                        () -> {
+                            latestRs.set(reconcile(latestRs.get().deployment));
+                            return latestRs.get().reconciledStatus.getBlueGreenState()
+                                    == FlinkBlueGreenDeploymentState.ACTIVE_GREEN;
+                        });
+        rs = latestRs.get();
 
-        // This reconcile deletes Blue at cutover. The transition must finalize forward to
-        // ACTIVE_GREEN within the same reconcile
-        rs = reconcile(rs.deployment);
         assertEquals(1, getFlinkDeployments().size(), "Blue should be deleted at cutover");
         assertEquals(
                 FlinkBlueGreenDeploymentState.ACTIVE_GREEN,
@@ -604,16 +612,14 @@ public class FlinkBlueGreenDeploymentControllerTest {
                 instantStrToMillis(rs.reconciledStatus.getAbortTimestamp()),
                 "Abort timer must be cleared once finalized");
 
-        // Post-cutover restart: Green briefly goes not-ready as it rescales into the capacity Blue
-        // just freed.
-        simulateJobFailure(getFlinkDeployments().get(0));
+        // Post-cutover restart: Green briefly goes not-ready
+        simulateJobFailure(getFlinkDeploymentByName(GREEN_CLUSTER_ID));
         rs = reconcile(rs.deployment);
 
-        var green = getFlinkDeployments().get(0);
         assertEquals(1, getFlinkDeployments().size(), "Green must still exist");
         assertNotEquals(
                 JobState.SUSPENDED,
-                green.getSpec().getJob().getState(),
+                getFlinkDeploymentByName(GREEN_CLUSTER_ID).getSpec().getJob().getState(),
                 "Green must not be suspended by a post-cutover not-ready blip");
         assertEquals(
                 FlinkBlueGreenDeploymentState.ACTIVE_GREEN,
@@ -1535,6 +1541,13 @@ public class FlinkBlueGreenDeploymentControllerTest {
                 .inNamespace(TEST_NAMESPACE)
                 .list()
                 .getItems();
+    }
+
+    private FlinkDeployment getFlinkDeploymentByName(String name) {
+        return getFlinkDeployments().stream()
+                .filter(d -> name.equals(d.getMetadata().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("FlinkDeployment '" + name + "' not found"));
     }
 
     private static FlinkBlueGreenDeployment buildSessionCluster(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -558,6 +558,69 @@ public class FlinkBlueGreenDeploymentControllerTest {
         testTransitionToGreen(rs, customValue, null);
     }
 
+    @ParameterizedTest
+    @MethodSource("org.apache.flink.kubernetes.operator.TestUtils#flinkVersions")
+    public void verifyGreenNotAbortedWhenNotReadyAfterBlueDeleted(FlinkVersion flinkVersion)
+            throws Exception {
+        var blueGreenDeployment =
+                buildSessionCluster(
+                        TEST_DEPLOYMENT_NAME,
+                        TEST_NAMESPACE,
+                        flinkVersion,
+                        null,
+                        UpgradeMode.STATELESS);
+        // Tiny abort grace so the abort deadline is already expired by the time Blue is deleted.
+        var configuration = blueGreenDeployment.getSpec().getConfiguration();
+        configuration.put(ABORT_GRACE_PERIOD.key(), "1");
+        configuration.put(DEPLOYMENT_DELETION_DELAY.key(), "0");
+
+        var rs = executeBasicDeployment(flinkVersion, blueGreenDeployment, false, null);
+
+        // Trigger the transition to Green
+        simulateChangeInSpec(rs.deployment, UUID.randomUUID().toString(), 0, null);
+        rs = reconcile(rs.deployment);
+        assertEquals(
+                FlinkBlueGreenDeploymentState.TRANSITIONING_TO_GREEN,
+                rs.reconciledStatus.getBlueGreenState());
+        assertEquals(2, getFlinkDeployments().size());
+
+        // Green becomes ready -> marks the ready timestamp and schedules deletion of Blue
+        simulateSuccessfulJobStart(getFlinkDeployments().get(1));
+        rs = reconcile(rs.deployment);
+
+        // Let the (zero) deletion delay elapse
+        Thread.sleep(10);
+
+        // This reconcile deletes Blue at cutover. The transition must finalize forward to
+        // ACTIVE_GREEN within the same reconcile
+        rs = reconcile(rs.deployment);
+        assertEquals(1, getFlinkDeployments().size(), "Blue should be deleted at cutover");
+        assertEquals(
+                FlinkBlueGreenDeploymentState.ACTIVE_GREEN,
+                rs.reconciledStatus.getBlueGreenState(),
+                "Transition must commit forward to ACTIVE_GREEN when Blue is deleted");
+        assertEquals(
+                0,
+                instantStrToMillis(rs.reconciledStatus.getAbortTimestamp()),
+                "Abort timer must be cleared once finalized");
+
+        // Post-cutover restart: Green briefly goes not-ready as it rescales into the capacity Blue
+        // just freed.
+        simulateJobFailure(getFlinkDeployments().get(0));
+        rs = reconcile(rs.deployment);
+
+        var green = getFlinkDeployments().get(0);
+        assertEquals(1, getFlinkDeployments().size(), "Green must still exist");
+        assertNotEquals(
+                JobState.SUSPENDED,
+                green.getSpec().getJob().getState(),
+                "Green must not be suspended by a post-cutover not-ready blip");
+        assertEquals(
+                FlinkBlueGreenDeploymentState.ACTIVE_GREEN,
+                rs.reconciledStatus.getBlueGreenState(),
+                "Must remain ACTIVE_GREEN; must not roll back after cutover");
+    }
+
     private static String getFlinkConfigurationValue(
             FlinkDeploymentSpec flinkDeploymentSpec, String propertyName) {
         return flinkDeploymentSpec.getFlinkConfiguration().get(propertyName).asText();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -577,7 +577,16 @@ public class FlinkBlueGreenDeploymentControllerTest {
         configuration.put(ABORT_GRACE_PERIOD.key(), "1");
         configuration.put(DEPLOYMENT_DELETION_DELAY.key(), "0");
 
+        blueGreenDeployment
+                .getSpec()
+                .setIngress(
+                        IngressSpec.builder()
+                                .template("{{name}}.{{namespace}}.example.com")
+                                .className("nginx")
+                                .build());
+
         var rs = executeBasicDeployment(flinkVersion, blueGreenDeployment, false, null);
+        assertIngressPointsToService(BLUE_CLUSTER_ID + REST_SVC_NAME_SUFFIX);
 
         // Trigger the transition to Green
         simulateChangeInSpec(rs.deployment, UUID.randomUUID().toString(), 0, null);
@@ -611,6 +620,7 @@ public class FlinkBlueGreenDeploymentControllerTest {
                 0,
                 instantStrToMillis(rs.reconciledStatus.getAbortTimestamp()),
                 "Abort timer must be cleared once finalized");
+        assertIngressPointsToService(GREEN_CLUSTER_ID + REST_SVC_NAME_SUFFIX);
 
         // Post-cutover restart: Green briefly goes not-ready
         simulateJobFailure(getFlinkDeploymentByName(GREEN_CLUSTER_ID));


### PR DESCRIPTION
## What is the purpose of the change

This pull request removes an unnecessary extra reconciliation loop during `FlinkBlueGreenDeployment` cutover, and in doing so closes a window that could cause a spurious abort with no rollback target.

Previously, after the operator successfully deleted the previous (Blue) `FlinkDeployment`, it returned `noUpdate().rescheduleAfter(RETRY_DELAY_MS)` **without finalizing**, leaving the BlueGreen resource in `TRANSITIONING_TO_GREEN`. Finalization to the terminal `ACTIVE_GREEN` state only happened on a *later* reconciliation.

That extra loop is not just wasteful, it re-runs `monitorTransition` on Green while the transition is still considered in-flight, so if Green is observed **not ready** in that window it is routed to `shouldWeAbort` and Green is suspended. With Blue already deleted, there is no rollback target left so the terminal state is no pipelines running i.e. downtime!

As a result, once the previous deployment has been successfully deleted, the transition can and should be committed forward immediately. This change reuses the existing `finalizeBlueGreenDeployment` logic in the same reconciliation that deletes Blue, so the abort path is no longer reachable after cutover. 

## Brief change log

- Pass the target `FlinkBlueGreenDeploymentState` into `deleteDeployment`.
- Finalize the BlueGreen transition immediately after successful deletion of the previous `FlinkDeployment`.
- Preserve the existing retry behavior when deletion fails or is not acknowledged.
- Add a regression test verifying that the transition commits to `ACTIVE_GREEN` in the same reconciliation that deletes Blue.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
- Core observer or reconciler logic that is regularly executed: yes

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable