### PR TITLE
[FLINK-40104] Logging framework JARs are placed under /log instead of the operator lib directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,7 @@ ENV WEBHOOK_JAR=flink-kubernetes-webhook-$OPERATOR_VERSION-shaded.jar
 ENV KUBERNETES_STANDALONE_JAR=flink-kubernetes-standalone-$OPERATOR_VERSION.jar
 
 ENV OPERATOR_LIB=$FLINK_HOME/operator-lib
-ENV OPERATOR_LOG=$FLINK_HOME/log
-RUN mkdir -p $OPERATOR_LIB $OPERATOR_LOG/log4j $OPERATOR_LOG/logback
+RUN mkdir -p $OPERATOR_LIB/log4j $OPERATOR_LIB/logback
 
 WORKDIR /flink-kubernetes-operator
 RUN groupadd --system --gid=9999 flink && \
@@ -57,8 +56,8 @@ COPY --chown=flink:flink --from=build /app/flink-kubernetes-operator/target/$OPE
 COPY --chown=flink:flink --from=build /app/flink-kubernetes-webhook/target/$WEBHOOK_JAR .
 COPY --chown=flink:flink --from=build /app/flink-kubernetes-standalone/target/$KUBERNETES_STANDALONE_JAR .
 COPY --chown=flink:flink --from=build /app/flink-kubernetes-operator/target/plugins $FLINK_HOME/plugins
-COPY --chown=flink:flink --from=build /app/flink-kubernetes-operator/target/log4j/ $FLINK_HOME/log/log4j/
-COPY --chown=flink:flink --from=build /app/flink-kubernetes-operator/target/logback/ $FLINK_HOME/log/logback/
+COPY --chown=flink:flink --from=build /app/flink-kubernetes-operator/target/log4j/ $OPERATOR_LIB/log4j/
+COPY --chown=flink:flink --from=build /app/flink-kubernetes-operator/target/logback/ $OPERATOR_LIB/logback/
 COPY --chown=flink:flink --from=build /app/tools/license/licenses-output/NOTICE .
 COPY --chown=flink:flink --from=build /app/tools/license/licenses-output/licenses ./licenses
 COPY --chown=flink:flink --from=build /app/LICENSE ./LICENSE

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -45,12 +45,11 @@ maybe_enable_jemalloc
 
 # Select the logging framework JARs to put on the classpath.
 # Supported values: "log4j2" (default), "logback".
-OPERATOR_LOG=${FLINK_HOME:-/opt/flink}/log
 LOGGING_FRAMEWORK="${LOGGING_FRAMEWORK:-log4j2}"
 if [ "$LOGGING_FRAMEWORK" = "logback" ]; then
-    LOG_CLASSPATH="$OPERATOR_LOG/logback/*"
+    LOG_CLASSPATH="$OPERATOR_LIB/logback/*"
 else
-    LOG_CLASSPATH="$OPERATOR_LOG/log4j/*"
+    LOG_CLASSPATH="$OPERATOR_LIB/log4j/*"
 fi
 
 if [ "$1" = "help" ]; then


### PR DESCRIPTION
## What is the purpose of the change

The Logback support added in FLINK-39501 (PR #1096) stores the logging-framework JARs under `$FLINK_HOME/log` via a dedicated `OPERATOR_LOG` env var, and the container entrypoint redundantly redefines `OPERATOR_LOG` (which is already inherited from the Dockerfile `ENV`).

`$FLINK_HOME/log` is the conventional Flink log-output directory, so placing classpath JARs there is a category error. It is also latently fragile: mounting a volume at `/opt/flink/log` for log persistence would shadow the `log4j`/`logback` subdirectories, drop the selected logging JARs from the classpath, and break operator startup.

This change moves the logging-framework JARs under the operator library directory (`$OPERATOR_LIB`) and removes the redundant env var, keeping `$FLINK_HOME/log` reserved for log output.

## Brief change log

- `Dockerfile`: remove the `OPERATOR_LOG` env var, create `$OPERATOR_LIB/log4j` and `$OPERATOR_LIB/logback`, and copy the framework JARs there instead of `$FLINK_HOME/log/...`.
- `docker-entrypoint.sh`: drop the redundant `OPERATOR_LOG` redefine and build `LOG_CLASSPATH` from `$OPERATOR_LIB/<framework>/*`.

`OPERATOR_LIB` remains at `$FLINK_HOME/operator-lib`, kept separate from Flink's own `$FLINK_HOME/lib`.

## Verifying this change

This change is image-layout only and does not alter runtime behavior with the default configuration.

- Java's `-cp "$OPERATOR_LIB/*"` wildcard is non-recursive, so the `log4j`/`logback` subdirectories are not swept onto the classpath. Only the framework selected by `LOGGING_FRAMEWORK` is added explicitly, so there is no SLF4J multiple-binding conflict.
- Manual verification: `docker build -t flink-kubernetes-operator .`, then confirm `/opt/flink/operator-lib/log4j` and `/opt/flink/operator-lib/logback` contain the expected JARs, the operator and webhook start (`docker run --rm flink-kubernetes-operator help`), and switching `LOGGING_FRAMEWORK=logback` puts the Logback JARs on the classpath.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
