### PR TITLE
[FLINK-40107] Group example modules under an examples aggregator pom

### DIFF
--- a/examples/autoscaling/pom.xml
+++ b/examples/autoscaling/pom.xml
@@ -22,19 +22,14 @@ under the License.
 
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-kubernetes-operator-parent</artifactId>
+        <artifactId>flink-kubernetes-operator-examples</artifactId>
         <version>1.16-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>autoscaling</artifactId>
 
     <name>Flink Autoscaler Test Job</name>
-
-    <!-- Given that this is an example skip maven deployment -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
 
     <dependencies>
 

--- a/examples/flink-beam-example/pom.xml
+++ b/examples/flink-beam-example/pom.xml
@@ -22,17 +22,15 @@ under the License.
 
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-kubernetes-operator-parent</artifactId>
+        <artifactId>flink-kubernetes-operator-examples</artifactId>
         <version>1.16-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>flink-beam-example</artifactId>
     <name>Flink Beam Example</name>
 
-    <!-- Given that this is an example skip maven deployment -->
     <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
         <beam.version>2.73.0</beam.version>
     </properties>
 

--- a/examples/flink-sql-runner-example/pom.xml
+++ b/examples/flink-sql-runner-example/pom.xml
@@ -22,18 +22,13 @@ under the License.
 
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-kubernetes-operator-parent</artifactId>
+        <artifactId>flink-kubernetes-operator-examples</artifactId>
         <version>1.16-SNAPSHOT</version>
-        <relativePath>../..</relativePath>
+        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>flink-sql-runner-example</artifactId>
     <name>Flink SQL Runner Example</name>
-
-    <!-- Given that this is an example skip maven deployment -->
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
 
     <dependencies>
         <!-- Apache Flink dependencies -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
@@ -6,9 +7,7 @@ regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
-
   http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,21 +22,24 @@ under the License.
 
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-kubernetes-operator-examples</artifactId>
+        <artifactId>flink-kubernetes-operator-parent</artifactId>
         <version>1.16-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 
-    <artifactId>kubernetes-client-examples</artifactId>
-    <name>Flink Kubernetes Client Code Example</name>
+    <artifactId>flink-kubernetes-operator-examples</artifactId>
+    <name>Flink Kubernetes Operator Examples</name>
+    <packaging>pom</packaging>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-kubernetes-operator</artifactId>
-            <version>1.16-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
-    </dependencies>
+    <!-- Given that these are examples skip maven deployment -->
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
 
+    <modules>
+        <module>autoscaling</module>
+        <module>flink-beam-example</module>
+        <module>flink-sql-runner-example</module>
+        <module>kubernetes-client-examples</module>
+    </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,7 @@ under the License.
         <module>flink-autoscaler</module>
         <module>flink-autoscaler-standalone</module>
         <module>flink-autoscaler-plugin-jdbc</module>
-        <module>examples/flink-sql-runner-example</module>
-        <module>examples/flink-beam-example</module>
-        <module>examples/kubernetes-client-examples</module>
-        <module>examples/autoscaling</module>
+        <module>examples</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## What is the purpose of the change

The parent `pom.xml` lists the four example modules individually next to the core modules. This groups them under a dedicated `examples` aggregator pom, so the parent references a single `examples` module and the aggregator owns the example list and their shared configuration. This mirrors Apache Flink's own `flink-examples` aggregator.

## Brief change log

- Add `examples/pom.xml`, a `pom`-packaged aggregator module:
  - Parent: `flink-kubernetes-operator-parent` (`relativePath ..`), artifactId `flink-kubernetes-operator-examples`.
  - `modules`: `autoscaling`, `flink-beam-example`, `flink-sql-runner-example`, `kubernetes-client-examples`.
  - `properties`: `maven.deploy.skip=true`, hoisted from the individual example poms so it is defined once and also skips deploy of the aggregator itself.
- Parent `pom.xml`: replace the four `examples/...` module entries with a single `<module>examples</module>` (core module list unchanged).
- Each example pom (`autoscaling`, `flink-beam-example`, `flink-sql-runner-example`, `kubernetes-client-examples`):
  - Change `<parent>` from `flink-kubernetes-operator-parent` (`relativePath ../..`) to `flink-kubernetes-operator-examples` (`relativePath ..`).
  - Remove the now-inherited `maven.deploy.skip` property.

Because the aggregator's parent is the root parent, the examples still inherit all managed dependencies, plugin configuration, and properties (e.g. `flink.version`) transitively, so no example dependency or build config changes.

## Verifying this change

- `mvn clean install -DskipTests` builds successfully with the examples now nested under the `examples` aggregator, and the reactor still builds all four examples.
- Confirm `maven.deploy.skip` is still in effect for every example (no example artifact is deployed).
- The XML format check (`sortpom`) passes for the new and modified poms.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
