### PR TITLE
Yd/fix observed generation suspended

### DIFF
--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkBlueGreenDeploymentStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkBlueGreenDeploymentStatus.java
@@ -44,12 +44,6 @@ public class FlinkBlueGreenDeploymentStatus {
     /** Last reconciled (serialized) deployment spec. */
     private String lastReconciledSpec;
 
-    /**
-     * Previous reconciled spec, saved before a transition overwrites lastReconciledSpec. Used to
-     * restore lastReconciledSpec on abort so it stays consistent with the active child.
-     */
-    private String previousReconciledSpec;
-
     /** Timestamp of last reconciliation. */
     private String lastReconciledTimestamp;
 

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkBlueGreenDeploymentStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkBlueGreenDeploymentStatus.java
@@ -44,6 +44,12 @@ public class FlinkBlueGreenDeploymentStatus {
     /** Last reconciled (serialized) deployment spec. */
     private String lastReconciledSpec;
 
+    /**
+     * Previous reconciled spec, saved before a transition overwrites lastReconciledSpec. Used to
+     * restore lastReconciledSpec on abort so it stays consistent with the active child.
+     */
+    private String previousReconciledSpec;
+
     /** Timestamp of last reconciliation. */
     private String lastReconciledTimestamp;
 

--- a/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkBlueGreenDeploymentStatus.java
+++ b/flink-kubernetes-operator-api/src/main/java/org/apache/flink/kubernetes/operator/api/status/FlinkBlueGreenDeploymentStatus.java
@@ -38,6 +38,9 @@ public class FlinkBlueGreenDeploymentStatus {
 
     private JobStatus jobStatus = new JobStatus();
 
+    /** Last observed generation of the FlinkBlueGreenDeployment. */
+    private Long observedGeneration;
+
     /** The state of the blue/green transition. */
     private FlinkBlueGreenDeploymentState blueGreenState;
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
@@ -89,9 +89,12 @@ public class FlinkStateSnapshotController
     @Override
     public DeleteControl cleanup(
             FlinkStateSnapshot flinkStateSnapshot, Context<FlinkStateSnapshot> josdkContext) {
-        flinkStateSnapshot.setStatus(
-                Objects.requireNonNullElseGet(
-                        flinkStateSnapshot.getStatus(), FlinkStateSnapshotStatus::new));
+        if (flinkStateSnapshot.getStatus() == null) {
+            LOG.info(
+                    "Snapshot {} has no status, was never reconciled. Removing finalizer.",
+                    flinkStateSnapshot.getMetadata().getName());
+            return DeleteControl.defaultDelete();
+        }
         var ctx = ctxFactory.getFlinkStateSnapshotContext(flinkStateSnapshot, josdkContext);
         try {
             metricManager.onRemove(flinkStateSnapshot);
@@ -116,8 +119,9 @@ public class FlinkStateSnapshotController
     @Override
     public ErrorStatusUpdateControl<FlinkStateSnapshot> updateErrorStatus(
             FlinkStateSnapshot resource, Context<FlinkStateSnapshot> context, Exception e) {
-        resource.setStatus(
-                Objects.requireNonNullElseGet(resource.getStatus(), FlinkStateSnapshotStatus::new));
+        if (resource.getStatus() == null) {
+            resource.setStatus(new FlinkStateSnapshotStatus());
+        }
         var ctx = ctxFactory.getFlinkStateSnapshotContext(resource, context);
         ReconciliationUtils.updateForReconciliationError(ctx, e);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
@@ -89,6 +89,9 @@ public class FlinkStateSnapshotController
     @Override
     public DeleteControl cleanup(
             FlinkStateSnapshot flinkStateSnapshot, Context<FlinkStateSnapshot> josdkContext) {
+        flinkStateSnapshot.setStatus(
+                Objects.requireNonNullElseGet(
+                        flinkStateSnapshot.getStatus(), FlinkStateSnapshotStatus::new));
         var ctx = ctxFactory.getFlinkStateSnapshotContext(flinkStateSnapshot, josdkContext);
         try {
             metricManager.onRemove(flinkStateSnapshot);
@@ -113,6 +116,8 @@ public class FlinkStateSnapshotController
     @Override
     public ErrorStatusUpdateControl<FlinkStateSnapshot> updateErrorStatus(
             FlinkStateSnapshot resource, Context<FlinkStateSnapshot> context, Exception e) {
+        resource.setStatus(
+                Objects.requireNonNullElseGet(resource.getStatus(), FlinkStateSnapshotStatus::new));
         var ctx = ctxFactory.getFlinkStateSnapshotContext(resource, context);
         ReconciliationUtils.updateForReconciliationError(ctx, e);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
@@ -119,9 +119,6 @@ public class FlinkStateSnapshotController
     @Override
     public ErrorStatusUpdateControl<FlinkStateSnapshot> updateErrorStatus(
             FlinkStateSnapshot resource, Context<FlinkStateSnapshot> context, Exception e) {
-        if (resource.getStatus() == null) {
-            resource.setStatus(new FlinkStateSnapshotStatus());
-        }
         var ctx = ctxFactory.getFlinkStateSnapshotContext(resource, context);
         ReconciliationUtils.updateForReconciliationError(ctx, e);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -695,6 +695,7 @@ public class BlueGreenDeploymentService {
         FlinkBlueGreenDeploymentState previousState =
                 getPreviousState(nextState, context.getDeployments());
         context.getDeploymentStatus().setBlueGreenState(previousState);
+        context.getDeploymentStatus().setSavepointTriggerId(null);
 
         var error =
                 String.format(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -162,18 +162,10 @@ public class BlueGreenDeploymentService {
                                 .rescheduleAfter(getReconciliationReschedInterval(context));
                     }
 
+                    setLastReconciledSpec(context);
                     try {
-                        var result =
-                                startTransition(
-                                        context,
-                                        currentBlueGreenDeploymentType,
-                                        currentFlinkDeployment);
-                        // Only stamp lastReconciledSpec after the transition
-                        // succeeds. If stamped before and the transition
-                        // fails/aborts, lastReconciledSpec drifts from the
-                        // active child's actual spec
-                        setLastReconciledSpec(context);
-                        return result;
+                        return startTransition(
+                                context, currentBlueGreenDeploymentType, currentFlinkDeployment);
                     } catch (Exception e) {
                         var error = "Could not start Transition. Details: " + e.getMessage();
                         context.getDeploymentStatus().setSavepointTriggerId(null);
@@ -188,12 +180,10 @@ public class BlueGreenDeploymentService {
                             "Savepoint redeploy triggered for '{}', using initialSavepointPath: {}",
                             context.getBgDeployment().getMetadata().getName(),
                             Objects.toString(jobSpec.getInitialSavepointPath(), "<none>"));
+                    setLastReconciledSpec(context);
                     try {
-                        var result =
-                                startSavepointRedeployTransition(
-                                        context, currentBlueGreenDeploymentType);
-                        setLastReconciledSpec(context);
-                        return result;
+                        return startSavepointRedeployTransition(
+                                context, currentBlueGreenDeploymentType);
                     } catch (Exception e) {
                         var error =
                                 "Could not start Savepoint Redeploy Transition. Details: "

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -162,10 +162,18 @@ public class BlueGreenDeploymentService {
                                 .rescheduleAfter(getReconciliationReschedInterval(context));
                     }
 
-                    setLastReconciledSpec(context);
                     try {
-                        return startTransition(
-                                context, currentBlueGreenDeploymentType, currentFlinkDeployment);
+                        var result =
+                                startTransition(
+                                        context,
+                                        currentBlueGreenDeploymentType,
+                                        currentFlinkDeployment);
+                        // Only stamp lastReconciledSpec after the transition
+                        // succeeds. If stamped before and the transition
+                        // fails/aborts, lastReconciledSpec drifts from the
+                        // active child's actual spec
+                        setLastReconciledSpec(context);
+                        return result;
                     } catch (Exception e) {
                         var error = "Could not start Transition. Details: " + e.getMessage();
                         context.getDeploymentStatus().setSavepointTriggerId(null);
@@ -180,10 +188,12 @@ public class BlueGreenDeploymentService {
                             "Savepoint redeploy triggered for '{}', using initialSavepointPath: {}",
                             context.getBgDeployment().getMetadata().getName(),
                             Objects.toString(jobSpec.getInitialSavepointPath(), "<none>"));
-                    setLastReconciledSpec(context);
                     try {
-                        return startSavepointRedeployTransition(
-                                context, currentBlueGreenDeploymentType);
+                        var result =
+                                startSavepointRedeployTransition(
+                                        context, currentBlueGreenDeploymentType);
+                        setLastReconciledSpec(context);
+                        return result;
                     } catch (Exception e) {
                         var error =
                                 "Could not start Savepoint Redeploy Transition. Details: "

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -695,7 +695,6 @@ public class BlueGreenDeploymentService {
         FlinkBlueGreenDeploymentState previousState =
                 getPreviousState(nextState, context.getDeployments());
         context.getDeploymentStatus().setBlueGreenState(previousState);
-        context.getDeploymentStatus().setSavepointTriggerId(null);
 
         var error =
                 String.format(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -685,6 +685,7 @@ public class BlueGreenDeploymentService {
         FlinkBlueGreenDeploymentState previousState =
                 getPreviousState(nextState, context.getDeployments());
         context.getDeploymentStatus().setBlueGreenState(previousState);
+        context.getDeploymentStatus().setSavepointTriggerId(null);
 
         var error =
                 String.format(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -44,7 +44,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.flink.kubernetes.operator.controller.bluegreen.BlueGreenKubernetesService.deleteFlinkDeployment;
 import static org.apache.flink.kubernetes.operator.controller.bluegreen.BlueGreenKubernetesService.deployCluster;
@@ -58,7 +60,7 @@ import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtil
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.isSavepointRequired;
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.millisToInstantStr;
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.prepareFlinkDeployment;
-import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.revertLastReconciledSpec;
+import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.revertToLastSpec;
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.setLastReconciledSpec;
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.triggerSavepoint;
 
@@ -67,6 +69,15 @@ public class BlueGreenDeploymentService {
 
     private static final Logger LOG = LoggerFactory.getLogger(BlueGreenDeploymentService.class);
     private static final long RETRY_DELAY_MS = 500;
+
+    /**
+     * In-memory cache of the pre-transition lastReconciledSpec, keyed by namespace. Saved before
+     * setLastReconciledSpec overwrites it during a transition, restored on abort so
+     * lastReconciledSpec stays consistent with the active child. Lost on operator restart, which
+     * falls back to pre-fix behavior (no revert) — acceptable since restart during the abort window
+     * is rare and not a regression.
+     */
+    private final Map<String, String> previousReconciledSpecs = new ConcurrentHashMap<>();
 
     // ==================== Deployment Initiation Methods ====================
 
@@ -164,6 +175,8 @@ public class BlueGreenDeploymentService {
                     }
 
                     try {
+                        // Save pre-transition lastReconciledSpec so we can restore on abort
+                        savePreTransitionSpec(context);
                         var result =
                                 startTransition(
                                         context,
@@ -186,6 +199,8 @@ public class BlueGreenDeploymentService {
                             context.getBgDeployment().getMetadata().getName(),
                             Objects.toString(jobSpec.getInitialSavepointPath(), "<none>"));
                     try {
+                        // Save pre-transition lastReconciledSpec so we can restore on abort
+                        savePreTransitionSpec(context);
                         var result =
                                 startSavepointRedeployTransition(
                                         context, currentBlueGreenDeploymentType);
@@ -694,15 +709,26 @@ public class BlueGreenDeploymentService {
         context.getDeploymentStatus().setBlueGreenState(previousState);
         context.getDeploymentStatus().setSavepointTriggerId(null);
 
-        // Revert lastReconciledSpec to the pre-transition spec so it stays
-        // consistent with the active child that is still running
-        revertLastReconciledSpec(context);
+        // Restore lastReconciledSpec and the B/G CR spec to the pre-transition state
+        // so they stay consistent with the active child that is still running.
+        String namespace = context.getBgDeployment().getMetadata().getNamespace();
+        String previousSpec = previousReconciledSpecs.remove(namespace);
+        if (previousSpec != null) {
+            context.getDeploymentStatus().setLastReconciledSpec(previousSpec);
+            revertToLastSpec(context);
+        }
 
         var error =
                 String.format(
                         "Aborting deployment '%s', rolling B/G deployment back to %s",
                         deploymentName, previousState);
         return markDeploymentFailing(context, error);
+    }
+
+    private void savePreTransitionSpec(BlueGreenContext context) {
+        String namespace = context.getBgDeployment().getMetadata().getNamespace();
+        previousReconciledSpecs.put(
+                namespace, context.getDeploymentStatus().getLastReconciledSpec());
     }
 
     @NotNull
@@ -745,6 +771,7 @@ public class BlueGreenDeploymentService {
         context.getDeploymentStatus().setDeploymentReadyTimestamp(millisToInstantStr(0));
         context.getDeploymentStatus().setAbortTimestamp(millisToInstantStr(0));
         context.getDeploymentStatus().setSavepointTriggerId(null);
+        previousReconciledSpecs.remove(context.getBgDeployment().getMetadata().getNamespace());
 
         updateBlueGreenIngress(context, nextState);
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -58,6 +58,7 @@ import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtil
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.isSavepointRequired;
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.millisToInstantStr;
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.prepareFlinkDeployment;
+import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.revertLastReconciledSpec;
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.setLastReconciledSpec;
 import static org.apache.flink.kubernetes.operator.utils.bluegreen.BlueGreenUtils.triggerSavepoint;
 
@@ -696,6 +697,10 @@ public class BlueGreenDeploymentService {
                 getPreviousState(nextState, context.getDeployments());
         context.getDeploymentStatus().setBlueGreenState(previousState);
         context.getDeploymentStatus().setSavepointTriggerId(null);
+
+        // Revert lastReconciledSpec to the pre-transition spec so it stays
+        // consistent with the active child that is still running
+        revertLastReconciledSpec(context);
 
         var error =
                 String.format(

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -169,10 +169,6 @@ public class BlueGreenDeploymentService {
                                         context,
                                         currentBlueGreenDeploymentType,
                                         currentFlinkDeployment);
-                        // Only stamp lastReconciledSpec after the transition
-                        // succeeds. If stamped before and the transition
-                        // fails/aborts, lastReconciledSpec drifts from the
-                        // active child's actual spec
                         setLastReconciledSpec(context);
                         return result;
                     } catch (Exception e) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/BlueGreenDeploymentService.java
@@ -879,6 +879,8 @@ public class BlueGreenDeploymentService {
         }
 
         deploymentStatus.setLastReconciledTimestamp(java.time.Instant.now().toString());
+        deploymentStatus.setObservedGeneration(
+                flinkBlueGreenDeployment.getMetadata().getGeneration());
         flinkBlueGreenDeployment.setStatus(deploymentStatus);
         return UpdateControl.patchStatus(flinkBlueGreenDeployment);
     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/handlers/InitializingBlueStateHandler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/bluegreen/handlers/InitializingBlueStateHandler.java
@@ -43,19 +43,24 @@ public class InitializingBlueStateHandler extends AbstractBlueGreenStateHandler 
     public UpdateControl<FlinkBlueGreenDeployment> handle(BlueGreenContext context) {
         FlinkBlueGreenDeploymentStatus deploymentStatus = context.getDeploymentStatus();
 
-        // Block initial deployment if job.state is SUSPENDED - user must start with RUNNING
+        // Block initial deployment if job.state is SUSPENDED - user must start with RUNNING.
+        // We still record the spec and update observedGeneration so external tools know the
+        // operator has processed this generation.
         var jobSpec = context.getBgDeployment().getSpec().getTemplate().getSpec().getJob();
         if (jobSpec != null && jobSpec.getState() == JobState.SUSPENDED) {
             LOG.info(
                     "Blocking initial deployment '{}' - job.state is SUSPENDED, waiting for RUNNING",
                     context.getBgDeployment().getMetadata().getName());
+            setLastReconciledSpec(context);
             return patchStatusUpdateControl(context, null, JobStatus.SUSPENDED, null);
         }
 
-        // Deploy only if this is the initial deployment (no previous spec exists)
-        // or if we're recovering from a failure and the spec has changed since the last attempt
+        // Deploy only if this is the initial deployment (no previous spec exists),
+        // recovering from a failure, or resuming from a suspended initial state
         if (deploymentStatus.getLastReconciledSpec() == null
                 || (deploymentStatus.getJobStatus().getState().equals(JobStatus.FAILING)
+                        && hasSpecChanged(context))
+                || (deploymentStatus.getJobStatus().getState().equals(JobStatus.SUSPENDED)
                         && hasSpecChanged(context))) {
 
             setLastReconciledSpec(context);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/AbstractFlinkResourceReconciler.java
@@ -109,8 +109,14 @@ public abstract class AbstractFlinkResourceReconciler<
         if (reconciliationStatus.isBeforeFirstDeployment()) {
             var spec = cr.getSpec();
 
-            // If the job is submitted in suspend state, no need to reconcile
+            // If the job is created in suspended state, acknowledge the spec without deploying.
+            // We must still update status (observedGeneration, lastReconciledSpec) so that
+            // external tools know the operator has processed this generation.
             if (spec.getJob() != null && spec.getJob().getState().equals(JobState.SUSPENDED)) {
+                LOG.info("Resource created in suspended state, acknowledging without deployment");
+                var deployConfig = ctx.getDeployConfig(spec);
+                ReconciliationUtils.updateStatusForDeployedSpec(cr, deployConfig, clock);
+                statusRecorder.patchAndCacheStatus(cr, ctx.getKubernetesClient());
                 return;
             }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/bluegreen/BlueGreenUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/bluegreen/BlueGreenUtils.java
@@ -89,6 +89,8 @@ public class BlueGreenUtils {
 
     public static void setLastReconciledSpec(BlueGreenContext context) {
         FlinkBlueGreenDeploymentStatus deploymentStatus = context.getDeploymentStatus();
+        // Save the current lastReconciledSpec so it can be restored on abort
+        deploymentStatus.setPreviousReconciledSpec(deploymentStatus.getLastReconciledSpec());
         deploymentStatus.setLastReconciledSpec(
                 SpecUtils.writeSpecAsJSON(context.getBgDeployment().getSpec(), "spec"));
         deploymentStatus.setLastReconciledTimestamp(Instant.now().toString());
@@ -102,6 +104,20 @@ public class BlueGreenUtils {
                                 "spec",
                                 FlinkBlueGreenDeploymentSpec.class));
         replaceFlinkBlueGreenDeployment(context);
+    }
+
+    /**
+     * Restores lastReconciledSpec from previousReconciledSpec and reverts the B/G CR's live spec to
+     * match. Called on abort so lastReconciledSpec stays consistent with the active child.
+     */
+    public static void revertLastReconciledSpec(BlueGreenContext context) {
+        FlinkBlueGreenDeploymentStatus deploymentStatus = context.getDeploymentStatus();
+        String previousSpec = deploymentStatus.getPreviousReconciledSpec();
+        if (previousSpec != null) {
+            deploymentStatus.setLastReconciledSpec(previousSpec);
+            deploymentStatus.setPreviousReconciledSpec(null);
+            revertToLastSpec(context);
+        }
     }
 
     /**

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/bluegreen/BlueGreenUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/bluegreen/BlueGreenUtils.java
@@ -89,8 +89,6 @@ public class BlueGreenUtils {
 
     public static void setLastReconciledSpec(BlueGreenContext context) {
         FlinkBlueGreenDeploymentStatus deploymentStatus = context.getDeploymentStatus();
-        // Save the current lastReconciledSpec so it can be restored on abort
-        deploymentStatus.setPreviousReconciledSpec(deploymentStatus.getLastReconciledSpec());
         deploymentStatus.setLastReconciledSpec(
                 SpecUtils.writeSpecAsJSON(context.getBgDeployment().getSpec(), "spec"));
         deploymentStatus.setLastReconciledTimestamp(Instant.now().toString());
@@ -104,20 +102,6 @@ public class BlueGreenUtils {
                                 "spec",
                                 FlinkBlueGreenDeploymentSpec.class));
         replaceFlinkBlueGreenDeployment(context);
-    }
-
-    /**
-     * Restores lastReconciledSpec from previousReconciledSpec and reverts the B/G CR's live spec to
-     * match. Called on abort so lastReconciledSpec stays consistent with the active child.
-     */
-    public static void revertLastReconciledSpec(BlueGreenContext context) {
-        FlinkBlueGreenDeploymentStatus deploymentStatus = context.getDeploymentStatus();
-        String previousSpec = deploymentStatus.getPreviousReconciledSpec();
-        if (previousSpec != null) {
-            deploymentStatus.setLastReconciledSpec(previousSpec);
-            deploymentStatus.setPreviousReconciledSpec(null);
-            revertToLastSpec(context);
-        }
     }
 
     /**

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -767,6 +767,13 @@ public class FlinkBlueGreenDeploymentControllerTest {
         rs = reconcile(rs.deployment);
         assertFailingWithError(rs, "Could not start Transition", error);
 
+        // lastReconciledSpec must NOT contain the failed spec change — otherwise
+        // subsequent deploys see no diff and fall into PATCH_CHILD (in-place
+        // upgrade) instead of a proper B/G transition
+        assertFalse(
+                rs.reconciledStatus.getLastReconciledSpec().contains(customValue),
+                "lastReconciledSpec should not be stamped when transition fails");
+
         // Recovery: Clear the fetch error and try again with new spec change
         flinkService.clearSavepointFetchError();
         customValue = UUID.randomUUID().toString() + "_recovery";

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -546,6 +546,9 @@ public class FlinkBlueGreenDeploymentControllerTest {
                 ReconciliationState.UPGRADING,
                 flinkDeployments.get(1).getStatus().getReconciliationStatus().getState());
         assertTrue(instantStrToMillis(rs.reconciledStatus.getAbortTimestamp()) > 0);
+        // savepointTriggerId must be cleared on abort so the next transition
+        // triggers a fresh savepoint instead of reusing a stale triggerId
+        assertNull(rs.reconciledStatus.getSavepointTriggerId());
 
         // Simulate another change in the spec to trigger a redeployment
         customValue = UUID.randomUUID().toString();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -767,13 +767,6 @@ public class FlinkBlueGreenDeploymentControllerTest {
         rs = reconcile(rs.deployment);
         assertFailingWithError(rs, "Could not start Transition", error);
 
-        // lastReconciledSpec must NOT contain the failed spec change — otherwise
-        // subsequent deploys see no diff and fall into PATCH_CHILD (in-place
-        // upgrade) instead of a proper B/G transition
-        assertFalse(
-                rs.reconciledStatus.getLastReconciledSpec().contains(customValue),
-                "lastReconciledSpec should not be stamped when transition fails");
-
         // Recovery: Clear the fetch error and try again with new spec change
         flinkService.clearSavepointFetchError();
         customValue = UUID.randomUUID().toString() + "_recovery";

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -770,6 +770,13 @@ public class FlinkBlueGreenDeploymentControllerTest {
         rs = reconcile(rs.deployment);
         assertFailingWithError(rs, "Could not start Transition", error);
 
+        // lastReconciledSpec must NOT contain the failed spec change — otherwise
+        // subsequent deploys see no diff and fall into PATCH_CHILD (in-place
+        // upgrade) instead of a proper B/G transition
+        assertFalse(
+                rs.reconciledStatus.getLastReconciledSpec().contains(customValue),
+                "lastReconciledSpec should not be stamped when transition fails");
+
         // Recovery: Clear the fetch error and try again with new spec change
         flinkService.clearSavepointFetchError();
         customValue = UUID.randomUUID().toString() + "_recovery";

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -546,9 +546,6 @@ public class FlinkBlueGreenDeploymentControllerTest {
                 ReconciliationState.UPGRADING,
                 flinkDeployments.get(1).getStatus().getReconciliationStatus().getState());
         assertTrue(instantStrToMillis(rs.reconciledStatus.getAbortTimestamp()) > 0);
-        // savepointTriggerId must be cleared on abort so the next transition
-        // triggers a fresh savepoint instead of reusing a stale triggerId
-        assertNull(rs.reconciledStatus.getSavepointTriggerId());
 
         // Simulate another change in the spec to trigger a redeployment
         customValue = UUID.randomUUID().toString();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -555,7 +555,6 @@ public class FlinkBlueGreenDeploymentControllerTest {
         assertFalse(
                 rs.reconciledStatus.getLastReconciledSpec().contains(customValue),
                 "lastReconciledSpec should be reverted on abort to match the active child");
-        assertNull(rs.reconciledStatus.getPreviousReconciledSpec());
 
         // Simulate another change in the spec to trigger a redeployment
         customValue = UUID.randomUUID().toString();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkBlueGreenDeploymentControllerTest.java
@@ -549,6 +549,13 @@ public class FlinkBlueGreenDeploymentControllerTest {
         // savepointTriggerId must be cleared on abort so the next transition
         // triggers a fresh savepoint instead of reusing a stale triggerId
         assertNull(rs.reconciledStatus.getSavepointTriggerId());
+        // lastReconciledSpec must NOT contain the failed spec change — on abort
+        // it should be reverted to the pre-transition spec so it stays consistent
+        // with the active child that is still running
+        assertFalse(
+                rs.reconciledStatus.getLastReconciledSpec().contains(customValue),
+                "lastReconciledSpec should be reverted on abort to match the active child");
+        assertNull(rs.reconciledStatus.getPreviousReconciledSpec());
 
         // Simulate another change in the spec to trigger a redeployment
         customValue = UUID.randomUUID().toString();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
@@ -718,19 +718,6 @@ public class FlinkStateSnapshotControllerTest {
         assertDeleteControl(controller.cleanup(checkpoint, context), true, null);
     }
 
-    @Test
-    public void testUpdateErrorStatusWithNullStatus() {
-        var deployment = createDeployment();
-        context = TestUtils.createSnapshotContext(client, deployment);
-        var snapshot = createSavepoint(deployment);
-        snapshot.setStatus(null);
-
-        controller.updateErrorStatus(snapshot, context, new Exception("test error"));
-
-        assertThat(snapshot.getStatus()).isNotNull();
-        assertThat(snapshot.getStatus().getError()).isNotNull();
-    }
-
     private FlinkStateSnapshot createSavepoint(FlinkDeployment deployment) {
         return createSavepoint(deployment, false, 7);
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
@@ -704,6 +704,33 @@ public class FlinkStateSnapshotControllerTest {
         assertSnapshotMetrics(listener, TestUtils.TEST_NAMESPACE, Map.of(), Map.of());
     }
 
+    @Test
+    public void testCleanupWithNullStatus() {
+        var deployment = createDeployment();
+        context = TestUtils.createSnapshotContext(client, deployment);
+
+        var savepoint = createSavepoint(deployment);
+        savepoint.setStatus(null);
+        assertDeleteControl(controller.cleanup(savepoint, context), true, null);
+
+        var checkpoint = createCheckpoint(deployment, CheckpointType.FULL, 0);
+        checkpoint.setStatus(null);
+        assertDeleteControl(controller.cleanup(checkpoint, context), true, null);
+    }
+
+    @Test
+    public void testUpdateErrorStatusWithNullStatus() {
+        var deployment = createDeployment();
+        context = TestUtils.createSnapshotContext(client, deployment);
+        var snapshot = createSavepoint(deployment);
+        snapshot.setStatus(null);
+
+        controller.updateErrorStatus(snapshot, context, new Exception("test error"));
+
+        assertThat(snapshot.getStatus()).isNotNull();
+        assertThat(snapshot.getStatus().getError()).isNotNull();
+    }
+
     private FlinkStateSnapshot createSavepoint(FlinkDeployment deployment) {
         return createSavepoint(deployment, false, 7);
     }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/ApplicationReconcilerTest.java
@@ -1343,6 +1343,46 @@ public class ApplicationReconcilerTest extends OperatorTestBase {
         assertEquals(2L, deployment.getStatus().getObservedGeneration());
     }
 
+    @Test
+    public void testSuspendedFirstDeploymentSetsObservedGeneration() throws Exception {
+        FlinkDeployment deployment = TestUtils.buildApplicationCluster();
+        deployment.getMetadata().setGeneration(1L);
+        deployment.getSpec().getJob().setState(JobState.SUSPENDED);
+
+        // Verify initial state: nothing has been reconciled yet
+        assertNull(deployment.getStatus().getObservedGeneration());
+        assertTrue(deployment.getStatus().getReconciliationStatus().isBeforeFirstDeployment());
+
+        // Reconcile the suspended deployment
+        reconciler.reconcile(deployment, context);
+
+        // observedGeneration must be set so external tools know we processed the spec
+        assertEquals(1L, deployment.getStatus().getObservedGeneration());
+
+        // lastReconciledSpec must be recorded so isBeforeFirstDeployment() returns false
+        assertFalse(deployment.getStatus().getReconciliationStatus().isBeforeFirstDeployment());
+        var lastReconciledSpec =
+                deployment.getStatus().getReconciliationStatus().deserializeLastReconciledSpec();
+        assertEquals(JobState.SUSPENDED, lastReconciledSpec.getJob().getState());
+
+        // State should be DEPLOYED and marked stable (suspended = stable by convention)
+        assertEquals(
+                ReconciliationState.DEPLOYED,
+                deployment.getStatus().getReconciliationStatus().getState());
+        assertTrue(deployment.getStatus().getReconciliationStatus().isLastReconciledSpecStable());
+
+        // No Flink cluster should have been created
+        assertEquals(0, flinkService.listJobs().size());
+
+        // Later: resuming the job should trigger a real deployment
+        deployment.getSpec().getJob().setState(JobState.RUNNING);
+        deployment.getMetadata().setGeneration(2L);
+        reconciler.reconcile(deployment, context);
+
+        assertEquals(1, flinkService.listJobs().size());
+        assertEquals(2L, deployment.getStatus().getObservedGeneration());
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     public void testRollbackUpgradeModeHandling(boolean jmStarted) throws Exception {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request adds a new feature to periodically create and maintain savepoints through the `FlinkDeployment` custom resource.)*


## Brief change log

*(for example:)*
  - *Periodic savepoint trigger is introduced to the custom resource*
  - *The operator checks on reconciliation whether the required time has passed*
  - *The JobManager's dispose savepoint API is used to clean up obsolete savepoints*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no)
  - Core observer or reconciler logic that is regularly executed: (yes / no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
