### PR TITLE
[FLINK-38466] Bump derby from 10.15.2.0 to 10.17.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@ under the License.
 		     of entries in the form '[-]{2}add-[opens|exports]=<module>/<package>=ALL-UNNAMED'.-->
         <surefire.module.config/>
 
-        <derby.version>10.15.2.0</derby.version>
+        <derby.version>10.17.1.0</derby.version>
         <awaitility.version>4.2.2</awaitility.version>
 
         <!-- valid options can be checked at https://central.sonatype.com/search?q=kubernetes-httpclient- currently: okhttp, jdk, jetty, vertx -->


### PR DESCRIPTION
## What is the purpose of the change
Bump derby version to 10.17.1.0

## Brief change log
The current version 10.15.2.0 has a direct vulnerability - CVE-2022-46337. To remediate this, upgrade to latest 10.17.1.0

**Current** - Maven Repository: org.apache.derby » derby » 10.15.2.0

**Latest** - Maven Repository: org.apache.derby » derby » 10.17.1.0

FYI: The derby release notes mentioned that "support for java versions earlier than 21 were removed." Derby's scope is mainly for Integration tests. Local testing showed successful build.

Note: Derby is declared `<scope>test</scope>` and is not bundled in any release artifact, so no NOTICE update is required per Apache legal guidelines.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): **yes**
- The public API, i.e., is any changes to the `CustomResourceDescriptors`: **no**
- Core observer or reconciler logic that is regularly executed: **no**

## Documentation
- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? not applicable