### PR TITLE
[FLINK-40162] Handle UpgradeFailureException in FlinkSessionJobController

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobController.java
@@ -24,6 +24,7 @@ import org.apache.flink.kubernetes.operator.api.status.FlinkSessionJobStatus;
 import org.apache.flink.kubernetes.operator.api.validation.FlinkResourceValidator;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
+import org.apache.flink.kubernetes.operator.exception.UpgradeFailureException;
 import org.apache.flink.kubernetes.operator.health.CanaryResourceManager;
 import org.apache.flink.kubernetes.operator.observer.Observer;
 import org.apache.flink.kubernetes.operator.reconciler.Reconciler;
@@ -107,18 +108,20 @@ public class FlinkSessionJobController
             return UpdateControl.noUpdate();
         }
 
-        observer.observe(ctx);
-        if (!validateSessionJob(ctx)) {
-            statusRecorder.patchAndCacheStatus(flinkSessionJob, ctx.getKubernetesClient());
-            return ReconciliationUtils.toUpdateControl(
-                    ctx.getOperatorConfig(), flinkSessionJob, previousJob, false);
-        }
-
         try {
+            observer.observe(ctx);
+            if (!validateSessionJob(ctx)) {
+                statusRecorder.patchAndCacheStatus(flinkSessionJob, ctx.getKubernetesClient());
+                return ReconciliationUtils.toUpdateControl(
+                        ctx.getOperatorConfig(), flinkSessionJob, previousJob, false);
+            }
             statusRecorder.patchAndCacheStatus(flinkSessionJob, ctx.getKubernetesClient());
             reconciler.reconcile(ctx);
+        } catch (UpgradeFailureException ufe) {
+            ReconciliationUtils.updateForReconciliationError(ctx, ufe);
+            triggerErrorEvent(ctx, ufe, ufe.getReason());
         } catch (Exception e) {
-            triggerErrorEvent(ctx, e);
+            triggerErrorEvent(ctx, e, EventRecorder.Reason.Error.name());
             throw new ReconciliationException(e);
         }
         statusRecorder.patchAndCacheStatus(flinkSessionJob, ctx.getKubernetesClient());
@@ -158,11 +161,11 @@ public class FlinkSessionJobController
         return deleteControl;
     }
 
-    private void triggerErrorEvent(FlinkResourceContext<?> ctx, Exception e) {
+    private void triggerErrorEvent(FlinkResourceContext<?> ctx, Exception e, String reason) {
         eventRecorder.triggerEvent(
                 ctx.getResource(),
                 EventRecorder.Type.Warning,
-                EventRecorder.Reason.Error.name(),
+                reason,
                 ExceptionUtils.getExceptionMessage(e),
                 EventRecorder.Component.Job,
                 ctx.getKubernetesClient());

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkSessionJobControllerTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.kubernetes.operator.observer.JobStatusObserver;
 import org.apache.flink.kubernetes.operator.service.CheckpointHistoryWrapper;
 import org.apache.flink.kubernetes.operator.utils.EventRecorder;
 import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.state.memory.NonPersistentMetadataCheckpointStorageLocation;
 import org.apache.flink.util.SerializedThrowable;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -54,6 +55,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.api.common.JobStatus.CANCELLING;
+import static org.apache.flink.api.common.JobStatus.FINISHED;
 import static org.apache.flink.api.common.JobStatus.RECONCILING;
 import static org.apache.flink.api.common.JobStatus.RUNNING;
 import static org.apache.flink.kubernetes.operator.TestUtils.MAX_RECONCILE_TIMES;
@@ -830,5 +832,67 @@ class FlinkSessionJobControllerTest {
         assertEquals(
                 sessionJob.getStatus().getReconciliationStatus().getLastReconciledSpec(),
                 sessionJob.getStatus().getReconciliationStatus().getLastStableSpec());
+    }
+
+    @Test
+    public void testJobFinishedWithNonExternallyAddressableCheckpoint() throws Exception {
+        // Submit the session job
+        testController.reconcile(sessionJob, context);
+        assertEquals(RECONCILING, sessionJob.getStatus().getJobStatus().getState());
+
+        // Observe RUNNING state
+        testController.reconcile(sessionJob, context);
+        assertEquals(RUNNING, sessionJob.getStatus().getJobStatus().getState());
+
+        // Simulate the job finishing quickly
+        var jobs = flinkService.listJobs();
+        assertEquals(1, jobs.size());
+        var job = jobs.get(0);
+        jobs.set(
+                0,
+                Tuple3.of(
+                        job.f0,
+                        new JobStatusMessage(
+                                job.f1.getJobId(),
+                                job.f1.getJobName(),
+                                FINISHED,
+                                job.f1.getStartTime()),
+                        job.f2));
+
+        // Simulate checkpointing enabled but no state.checkpoints.dir configured
+        flinkService.setCheckpointInfo(
+                Tuple2.of(
+                        Optional.of(
+                                new CheckpointHistoryWrapper.CompletedCheckpointInfo(
+                                        1L,
+                                        NonPersistentMetadataCheckpointStorageLocation
+                                                .EXTERNAL_POINTER,
+                                        System.currentTimeMillis())),
+                        Optional.empty()));
+
+        // Reconcile - should handle the UpgradeFailureException gracefully
+        testController.events().clear();
+        testController.reconcile(sessionJob, context);
+
+        // Job status should reflect FINISHED, not be stuck at RECONCILING
+        assertEquals(FINISHED, sessionJob.getStatus().getJobStatus().getState());
+
+        // Reconciliation status should reflect the error
+        assertEquals(
+                ReconciliationState.DEPLOYED,
+                sessionJob.getStatus().getReconciliationStatus().getState());
+
+        // Error should be recorded about the non-externally-addressable checkpoint
+        assertNotNull(sessionJob.getStatus().getError());
+        assertTrue(sessionJob.getStatus().getError().contains("not externally addressable"));
+
+        // Verify warning event was emitted with the specific reason
+        var errorEvent =
+                testController.events().stream()
+                        .filter(e -> e.getType().equals(EventRecorder.Type.Warning.toString()))
+                        .findFirst();
+        assertTrue(errorEvent.isPresent());
+        assertEquals("CheckpointNotFound", errorEvent.get().getReason());
+        assertTrue(errorEvent.get().getMessage().contains("not externally addressable"));
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

The state of the FlinkSessionJob (`status.jobStatus.state` and `status.state`) is stuck and not updated in case of an UpgradeFailureException (for instance, if the job ends quickly and the checkpointing interval is set, but state.checkpoints.dir is not configured).

## Brief change log

 - Moves  observer.observe() inside try-catch and add explicit catch for UpgradeFailureException, similar to FlinkDeploymentController.
 - `triggerErrorEvent` now accepts a reason similar to FlinkDeploymentController

## Verifying this change
This change added tests and can be verified as follows:

 - testJobFinishedWithNonExternallyAddressableCheckpoint: Submits a session job, simulates it finishing with a checkpoint whose external pointer is   non-externally-addressable (checkpointing enabled but no state.checkpoints.dir), and verifies the job status correctly reflects FINISHED with the error recorded.
- Manual testing using minikube using the exact JIRA reproducer in the ticket (SleepJob with 5s delay, execution.checkpointing.interval: 2000, no state.checkpoints.dir):
  - FKO 1.15.0: job stuck at RUNNING/STABLE despite Flink REST API showing FINISHED
  - Patched FKO: job correctly transitions to FINISHED/STABLE with error recorded

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no (I think)
 
## Documentation

  - Does this pull request introduce a new feature? no
