### PR TITLE
[FLINK-40243] Bump postgresql jdbc driver from 42.5.6 to 42.7.13

### DIFF
--- a/flink-autoscaler-plugin-jdbc/pom.xml
+++ b/flink-autoscaler-plugin-jdbc/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
     <properties>
         <testcontainers.version>2.0.5</testcontainers.version>
-        <postgres.version>42.5.6</postgres.version>
+        <postgres.version>42.7.13</postgres.version>
         <mysql.version>8.4.0</mysql.version>
     </properties>
 


### PR DESCRIPTION
## What is the purpose of the change
Bump the postgresql JDBC driver to address a known CVE. The dependency is declared `<scope>test</scope>` in `flink-autoscaler-plugin-jdbc` and is not bundled in any release artifact.

## Brief change log

**PostgreSQL JDBC driver** (`flink-autoscaler-plugin-jdbc/pom.xml`):
- CVE-2026-42198 — SCRAM-SHA-256 iteration-count DoS (CVSS 7.5 HIGH)
- **Current**: Maven Repository: org.postgresql » postgresql » 42.5.6
- **Latest**: Maven Repository: org.postgresql » postgresql » 42.7.13

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): **yes**
- The public API, i.e., is any changes to the `CustomResourceDescriptors`: **no**
- Core observer or reconciler logic that is regularly executed: **no**

## Documentation
- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? not applicable