### PR TITLE
[FLINK-39356] Fix NPE during FlinkStateSnapshot cleanup when status i…

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
@@ -89,6 +89,12 @@ public class FlinkStateSnapshotController
     @Override
     public DeleteControl cleanup(
             FlinkStateSnapshot flinkStateSnapshot, Context<FlinkStateSnapshot> josdkContext) {
+        if (flinkStateSnapshot.getStatus() == null) {
+            LOG.info(
+                    "Snapshot {} has no status, was never reconciled. Removing finalizer.",
+                    flinkStateSnapshot.getMetadata().getName());
+            return DeleteControl.defaultDelete();
+        }
         var ctx = ctxFactory.getFlinkStateSnapshotContext(flinkStateSnapshot, josdkContext);
         try {
             metricManager.onRemove(flinkStateSnapshot);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotController.java
@@ -90,9 +90,6 @@ public class FlinkStateSnapshotController
     public DeleteControl cleanup(
             FlinkStateSnapshot flinkStateSnapshot, Context<FlinkStateSnapshot> josdkContext) {
         if (flinkStateSnapshot.getStatus() == null) {
-            LOG.info(
-                    "Snapshot {} has no status, was never reconciled. Removing finalizer.",
-                    flinkStateSnapshot.getMetadata().getName());
             return DeleteControl.defaultDelete();
         }
         var ctx = ctxFactory.getFlinkStateSnapshotContext(flinkStateSnapshot, josdkContext);

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/controller/FlinkStateSnapshotControllerTest.java
@@ -729,6 +729,20 @@ public class FlinkStateSnapshotControllerTest {
         assertSnapshotMetrics(listener, TestUtils.TEST_NAMESPACE, Map.of(), Map.of());
     }
 
+    @Test
+    public void testCleanupWithNullStatus() {
+        var deployment = createDeployment();
+        context = TestUtils.createSnapshotContext(client, deployment);
+
+        var savepoint = createSavepoint(deployment);
+        savepoint.setStatus(null);
+        assertDeleteControl(controller.cleanup(savepoint, context), true, null);
+
+        var checkpoint = createCheckpoint(deployment, CheckpointType.FULL, 0);
+        checkpoint.setStatus(null);
+        assertDeleteControl(controller.cleanup(checkpoint, context), true, null);
+    }
+
     private FlinkStateSnapshot createSavepoint(FlinkDeployment deployment) {
         return createSavepoint(deployment, false, 7);
     }


### PR DESCRIPTION
Problem:

A FlinkStateSnapshot deleted before the controller ever reconciled it has no status, since the status is only initialized in reconcile(). The cleanup path builds a FlinkStateSnapshotContext, which dereferences the status via getStatus().toBuilder(), so cleanup() threw a NullPointerException before entering its try block. The finalizer was never removed, leaving the resource stuck in terminating state and blocking namespace deletion, with the failed cleanup retried indefinitely.

Fix:

Return DeleteControl.defaultDelete() from cleanup() when the status is null. Such a snapshot was never triggered against Flink, so there is nothing to dispose of and the finalizer can be removed immediately.

Verification:

Added FlinkStateSnapshotControllerTest#testCleanupWithNullStatus, covering both a savepoint and a checkpoint whose status is null.

Verified manually on a local minikube cluster: a FlinkStateSnapshot deleted before the operator reconciles it now has its finalizer removed and the resource disappears, instead of hanging in terminating state.

