### PR TITLE
[FLINK-40246] Migrate logging stack to SLF4J 2.x and bump Logback to 1.5.34

### DIFF
--- a/docs/content.zh/docs/operations/logging.md
+++ b/docs/content.zh/docs/operations/logging.md
@@ -115,11 +115,7 @@ Logback XML overrides replace the entire default configuration. Unlike Log4j2 `.
 
 ## Logging Library Version Overrides
 
-The operator ships with Logback 1.2.x and SLF4J 1.7.x. These versions are bundled in the Docker image and the SLF4J 1.7.x API is shaded into the operator JAR.
-
-{{< hint warning >}}
-Upgrading to Logback 1.4+/1.5+ or SLF4J 2.x is not supported. SLF4J 2.x uses a `ServiceLoader`-based binding mechanism that is incompatible with the SLF4J 1.7.x API shaded inside the operator. Replacing the JARs at runtime will result in `ClassNotFoundException: org.slf4j.impl.StaticLoggerBinder`.
-{{< /hint >}}
+The operator ships with Logback 1.5.x and SLF4J 2.0.x. These versions are bundled in the Docker image and the SLF4J 2.0.x API is shaded into the operator JAR.
 
 ## FlinkDeployment Logging Configuration
 

--- a/docs/content/docs/operations/logging.md
+++ b/docs/content/docs/operations/logging.md
@@ -115,11 +115,7 @@ Logback XML overrides replace the entire default configuration. Unlike Log4j2 `.
 
 ## Logging Library Version Overrides
 
-The operator ships with Logback 1.2.x and SLF4J 1.7.x. These versions are bundled in the Docker image and the SLF4J 1.7.x API is shaded into the operator JAR.
-
-{{< hint warning >}}
-Upgrading to Logback 1.4+/1.5+ or SLF4J 2.x is not supported. SLF4J 2.x uses a `ServiceLoader`-based binding mechanism that is incompatible with the SLF4J 1.7.x API shaded inside the operator. Replacing the JARs at runtime will result in `ClassNotFoundException: org.slf4j.impl.StaticLoggerBinder`.
-{{< /hint >}}
+The operator ships with Logback 1.5.x and SLF4J 2.0.x. These versions are bundled in the Docker image and the SLF4J 2.0.x API is shaded into the operator JAR.
 
 ## FlinkDeployment Logging Configuration
 

--- a/e2e-tests/test_logback_logging.sh
+++ b/e2e-tests/test_logback_logging.sh
@@ -42,10 +42,18 @@ operator_namespace=$(get_operator_pod_namespace)
 operator_pod=$(get_operator_pod_name)
 echo "Current operator pod is ${operator_pod} in namespace ${operator_namespace}"
 
-# Check that there are no SLF4J multiple-bindings warnings
-echo "Checking for SLF4J multiple bindings warnings..."
-if kubectl logs "${operator_pod}" -c flink-kubernetes-operator -n "${operator_namespace}" | grep -q "SLF4J: Class path contains multiple SLF4J bindings"; then
-  echo "ERROR: Found SLF4J multiple bindings warning"
+# Check that there are no SLF4J provider problems. SLF4J 2.x reports "providers"
+# where 1.7.x reported "bindings", so both wordings are matched. The no-provider
+# case is checked too: SLF4J does not fail on a missing backend, it installs a NOP
+# logger and silently discards every log line.
+echo "Checking for SLF4J provider warnings..."
+operator_logs=$(kubectl logs "${operator_pod}" -c flink-kubernetes-operator -n "${operator_namespace}")
+if echo "${operator_logs}" | grep -qE "Class path contains multiple SLF4J (providers|bindings)"; then
+  echo "ERROR: Found SLF4J multiple providers warning"
+  passed=false
+fi
+if echo "${operator_logs}" | grep -qE "No SLF4J providers were found|Failed to load class \"org.slf4j.impl.StaticLoggerBinder\""; then
+  echo "ERROR: SLF4J found no provider and fell back to the NOP logger"
   passed=false
 fi
 

--- a/examples/autoscaling/pom.xml
+++ b/examples/autoscaling/pom.xml
@@ -64,7 +64,7 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/examples/flink-beam-example/pom.xml
+++ b/examples/flink-beam-example/pom.xml
@@ -95,7 +95,7 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/examples/flink-sql-runner-example/pom.xml
+++ b/examples/flink-sql-runner-example/pom.xml
@@ -66,7 +66,7 @@ under the License.
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/flink-autoscaler-plugin-jdbc/pom.xml
+++ b/flink-autoscaler-plugin-jdbc/pom.xml
@@ -96,12 +96,25 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <!-- The only SLF4J binding on the test classpath, since flink-test-utils-junit
+             brings the SLF4J 1.7 binding which SLF4J 2.x ignores. -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-test-utils-junit</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
             <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
                 <exclusion>
                     <artifactId>slf4j-api</artifactId>
                     <groupId>org.slf4j</groupId>

--- a/flink-autoscaler-standalone/pom.xml
+++ b/flink-autoscaler-standalone/pom.xml
@@ -116,7 +116,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
         </dependency>
 

--- a/flink-autoscaler-standalone/src/main/resources/META-INF/NOTICE
+++ b/flink-autoscaler-standalone/src/main/resources/META-INF/NOTICE
@@ -20,7 +20,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.logging.log4j:log4j-1.2-api:jar:2.25.4
 - org.apache.logging.log4j:log4j-api:jar:2.25.4
 - org.apache.logging.log4j:log4j-core:jar:2.25.4
-- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.25.4
+- org.apache.logging.log4j:log4j-slf4j2-impl:jar:2.25.4
 - org.javassist:javassist:jar:3.24.0-GA
 - org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.9.10
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.8.21
@@ -29,7 +29,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.jetbrains:annotations:jar:13.0
 - org.objenesis:objenesis:jar:2.1
 - org.quartz-scheduler:quartz:jar:2.4.0
-- org.slf4j:slf4j-api:jar:1.7.36
+- org.slf4j:slf4j-api:jar:2.0.18
 - org.snakeyaml:snakeyaml-engine:jar:2.6
 - tools.profiler:async-profiler:jar:2.9
 

--- a/flink-autoscaler/pom.xml
+++ b/flink-autoscaler/pom.xml
@@ -83,12 +83,25 @@ under the License.
             <artifactId>guava</artifactId>
         </dependency>
 
+        <!-- The only SLF4J binding on the test classpath, since flink-test-utils-junit
+             brings the SLF4J 1.7 binding which SLF4J 2.x ignores. -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-test-utils-junit</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
             <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.junit.vintage</groupId>
                     <artifactId>junit-vintage-engine</artifactId>

--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -103,7 +103,7 @@ under the License.
         <!-- Logging -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
         </dependency>
 

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -123,8 +123,9 @@ under the License.
         </dependency>
 
         <!-- Logging: SLF4J API and Log4j2 implementation are shaded into the operator JAR.
-             Only the SLF4J bindings (log4j-slf4j-impl / logback-classic) are excluded
-             and shipped as separate JARs so the entrypoint can pick one. -->
+             Only the SLF4J bindings (log4j-slf4j2-impl / logback-classic + logback-core)
+             are excluded and shipped as separate JARs so the entrypoint can pick one.
+             SLF4J 2.x is required: JOSDK and the fabric8 client are compiled against it. -->
 
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -134,7 +135,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -318,7 +319,7 @@ under the License.
                         <!-- Log4j2 SLF4J binding (default logging framework) -->
                         <artifactItem>
                             <groupId>org.apache.logging.log4j</groupId>
-                            <artifactId>log4j-slf4j-impl</artifactId>
+                            <artifactId>log4j-slf4j2-impl</artifactId>
                             <version>${log4j.version}</version>
                             <outputDirectory>${project.build.directory}/log4j</outputDirectory>
                         </artifactItem>

--- a/flink-kubernetes-operator/pom.xml
+++ b/flink-kubernetes-operator/pom.xml
@@ -125,7 +125,11 @@ under the License.
         <!-- Logging: SLF4J API and Log4j2 implementation are shaded into the operator JAR.
              Only the SLF4J bindings (log4j-slf4j2-impl / logback-classic + logback-core)
              are excluded and shipped as separate JARs so the entrypoint can pick one.
-             SLF4J 2.x is required: JOSDK and the fabric8 client are compiled against it. -->
+             SLF4J 2.x is required: JOSDK and the fabric8 client are compiled against it.
+
+             The binding artifacts are declared provided purely so their versions are
+             resolved and recorded here; the maven-dependency-plugin below stages them
+             into the image from its own artifactItems, independently of this graph. -->
 
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -213,6 +217,13 @@ under the License.
             <artifactId>flink-test-utils</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <!-- SLF4J 1.7 binding; the module already provides log4j-slf4j2-impl. -->
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-slf4j-impl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -63,7 +63,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.logging.log4j:log4j-1.2-api:jar:2.25.4
 - org.apache.logging.log4j:log4j-api:jar:2.25.4
 - org.apache.logging.log4j:log4j-core:jar:2.25.4
-- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.25.4
 - org.checkerframework:checker-qual:jar:3.43.0
 - org.javassist:javassist:jar:3.24.0-GA
 - org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.8.21
@@ -73,7 +72,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.jetbrains:annotations:jar:13.0
 - org.objenesis:objenesis:jar:2.1
 - org.quartz-scheduler:quartz:jar:2.4.0
-- org.slf4j:slf4j-api:jar:1.7.36
+- org.slf4j:slf4j-api:jar:2.0.18
 - org.snakeyaml:snakeyaml-engine:jar:2.6
 - org.xerial.snappy:snappy-java:jar:1.1.10.4
 - org.yaml:snakeyaml:jar:2.5

--- a/flink-kubernetes-standalone/pom.xml
+++ b/flink-kubernetes-standalone/pom.xml
@@ -83,7 +83,7 @@ under the License.
 
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
             <version>${log4j.version}</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,15 @@ under the License.
 
     <dependencyManagement>
         <dependencies>
+            <!-- Pinned so that modules which pick up slf4j-api transitively from Flink
+                 (1.7.36) still get the 2.x API that the log4j-slf4j2-impl and logback
+                 bindings require. A mismatch is silent: SLF4J falls back to a NOP
+                 logger and discards all output. -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@ under the License.
         <flink.version>1.20.4</flink.version>
         <guava.version>33.4.0-jre</guava.version>
 
-        <slf4j.version>1.7.36</slf4j.version>
+        <slf4j.version>2.0.18</slf4j.version>
         <log4j.version>2.25.4</log4j.version>
-        <logback.version>1.2.13</logback.version>
+        <logback.version>1.5.34</logback.version>
 
         <spotless.version>2.40.0</spotless.version>
         <it.skip>true</it.skip>


### PR DESCRIPTION
## What is the purpose of the change

`logback-core` 1.2.13 is the terminal release of an EOL line, so the CVEs filed against it will never be fixed there. This upgrades it to 1.5.34.

Logback and SLF4J have to move together: 1.2.13 binds only to SLF4J 1.7.x (`StaticLoggerBinder`), 1.5.x only to SLF4J 2.x (`ServiceLoader`). Bumping either alone leaves SLF4J unbound, and it falls back to a no-op logger instead of failing loudly. The Log4j2 binding becomes `log4j-slf4j2-impl` for the same reason.

`slf4j-api` 2.0.18 matches what JOSDK 5.5.0 and fabric8 7.8.0 already declare. Flink is unaffected: its jars only call the SLF4J API, which stays binary compatible for callers across 1.7 and 2.x.

### CVEs addressed

All six are against `ch.qos.logback:logback-core`.

| CVE | GHSA | Severity | Vulnerable range | First fixed |
| --- | --- | --- | --- | --- |
| CVE-2024-12798 | GHSA-pr98-23f8-jwxv | Medium | `< 1.3.15` (and `1.4.0`–`1.5.13`) | 1.3.15 / 1.5.13 |
| CVE-2024-12801 | GHSA-6v67-2wr5-gvf4 | Low | `< 1.3.15` (and `1.4.0`–`1.5.13`) | 1.3.15 / 1.5.13 |
| CVE-2025-11226 | GHSA-25qh-j22f-pwp8 | Medium | `< 1.3.16` (and `1.4.0`–`1.5.19`) | 1.3.16 / 1.5.19 |
| CVE-2026-1225 | GHSA-qqpg-mvqg-649v | Low | `< 1.5.25` | 1.5.25 |
| CVE-2026-9828 | GHSA-p47f-322f-whfh | Low | `<= 1.5.32` | 1.5.33 |
| CVE-2026-10532 | GHSA-jhq6-gfmj-v8fx | Low | `< 1.5.34` | 1.5.34 |

The JIRA proposes 1.5.25 as the target. CVE-2026-10532 raises the floor to 1.5.34.

## Brief change log

  - `slf4j-api` 1.7.36 -> 2.0.18, `logback-classic` / `logback-core` 1.2.13 -> 1.5.34
  - `log4j-slf4j-impl` -> `log4j-slf4j2-impl` across all modules, including the `maven-dependency-plugin` artifact item that stages the binding into the Docker image
  - `NOTICE` files: refreshed `slf4j-api` versions, and dropped `log4j-slf4j-impl` from the operator's since it became `provided` in FLINK-39501 and is no longer bundled
  - Removed the "Logging Library Version Overrides" hint from `docs/content{,.zh}/docs/operations/logging.md`: swapping the shipped logging jars is not a supported user operation

## Verifying this change

Covered by existing tests; the full suite passes locally (2216 in `flink-kubernetes-operator`, 105 in `flink-kubernetes-webhook`, plus the remaining modules).

The real gate is `e2e-tests/test_logback_logging.sh`, which asserts no duplicate-binding warning across Flink 1.20/2.0/2.1/2.2 in both native and standalone mode. It runs in the `e2e_logging` CI job. Draft until that has passed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes** - `slf4j-api`, `logback-classic`, `logback-core`, and `log4j-slf4j-impl` is replaced by `log4j-slf4j2-impl`
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable - existing logging documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

