### PR TITLE
[FLINK-40341] Bump jackson-bom to 2.21.5

### DIFF
--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -7,11 +7,11 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - at.yawk.lz4:lz4-java:jar:1.10.3
-- com.fasterxml.jackson.core:jackson-annotations:jar:2.21.3
-- com.fasterxml.jackson.core:jackson-core:jar:2.21.3
-- com.fasterxml.jackson.core:jackson-databind:jar:2.21.3
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.21.3
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.21.3
+- com.fasterxml.jackson.core:jackson-annotations:jar:2.21
+- com.fasterxml.jackson.core:jackson-core:jar:2.21.5
+- com.fasterxml.jackson.core:jackson-databind:jar:2.21.5
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.21.5
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.21.5
 - com.google.code.findbugs:jsr305:jar:1.3.9
 - com.google.errorprone:error_prone_annotations:jar:2.36.0
 - com.google.guava:failureaccess:jar:1.0.2

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@ under the License.
                 <artifactId>jackson-bom</artifactId>
                 <type>pom</type>
                 <scope>import</scope>
-                <version>2.21.3</version>
+                <version>2.21.5</version>
             </dependency>
             <dependency>
                 <groupId>org.junit</groupId>


### PR DESCRIPTION
## What is the purpose of the change

`jackson-bom` is pinned at 2.21.3, which is affected by 11 advisories — 10 against `jackson-databind`, one against `jackson-core`. Three are HIGH: GHSA-j3rv-43j4-c7qm and GHSA-rmj7-2vxq-3g9f (`PolymorphicTypeValidator` bypasses) and GHSA-r7wm-3cxj-wff9 (`maxNumberLength` bypass in the async parser). 2.21.5 is the lowest version clearing all of them.

Two notes:

`jackson-annotations` resolves to 2.21, not 2.21.5 — `jackson-bom` pins it through a separate property that stays at the minor. 

This covers only the directly managed jackson. The relocated copies bundled via Flink (`flink-shaded-jackson` 2.14.2, and `flink-kubernetes`'s 2.15.3 under `org/apache/flink/kubernetes/shaded/`) are unaffected and come from separate release trains.

## Brief change log

  - `jackson-bom` 2.21.3 -> 2.21.5 in `pom.xml`
  - Refreshed the five jackson entries in `flink-kubernetes-operator/src/main/resources/META-INF/NOTICE`

## Verifying this change

Covered by existing tests; the full suite passes unchanged (2216 in `flink-kubernetes-operator`, 105 in `flink-kubernetes-webhook`, plus the remaining modules). OSV reports 0 advisories for all five artifacts at the resolved versions.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes** - `jackson-bom`
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
