### PR TITLE
[FLINK-40372][metrics] Unregister JOSDK resource metrics after cleanup

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetrics.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetrics.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.kubernetes.operator.metrics;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.kubernetes.operator.api.FlinkBlueGreenDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkSessionJob;
@@ -39,8 +40,7 @@ import io.javaoperatorsdk.operator.processing.event.Event;
 import io.javaoperatorsdk.operator.processing.event.ResourceID;
 import io.javaoperatorsdk.operator.processing.event.source.controller.ResourceEvent;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -60,13 +60,8 @@ public class OperatorJosdkMetrics implements Metrics {
     private final FlinkConfigManager configManager;
     private final Clock clock;
 
-    private final Map<ResourceID, KubernetesResourceNamespaceMetricGroup> resourceNsMetricGroups =
-            new ConcurrentHashMap<>();
-    private final Map<ResourceID, KubernetesResourceMetricGroup> resourceMetricGroups =
-            new ConcurrentHashMap<>();
-
+    private final Map<ResourceKey, ResourceMetrics> resourceMetrics = new ConcurrentHashMap<>();
     private final Map<List<String>, Histogram> histograms = new ConcurrentHashMap<>();
-    private final Map<List<String>, Counter> counters = new ConcurrentHashMap<>();
 
     public OperatorJosdkMetrics(
             KubernetesOperatorMetricGroup operatorMetricGroup, FlinkConfigManager configManager) {
@@ -92,41 +87,58 @@ public class OperatorJosdkMetrics implements Metrics {
     public void eventReceived(Event event, Map<String, Object> metadata) {
         if (event instanceof ResourceEvent) {
             var action = ((ResourceEvent) event).getAction();
-            counter(getResourceMg(event.getRelatedCustomResourceID(), metadata), RESOURCE, EVENT)
-                    .inc();
-            counter(
-                            getResourceMg(event.getRelatedCustomResourceID(), metadata),
-                            RESOURCE,
-                            EVENT,
-                            action.name())
-                    .inc();
+            resourceMetrics.compute(
+                    getResourceKey(event.getRelatedCustomResourceID(), metadata),
+                    (key, metrics) -> {
+                        if (metrics == null) {
+                            metrics = newResourceMetrics(key);
+                        }
+                        metrics.counter(RESOURCE, EVENT).inc();
+                        metrics.counter(RESOURCE, EVENT, action.name()).inc();
+                        return metrics;
+                    });
         }
     }
 
     @Override
     public void cleanupDone(ResourceID resourceID, Map<String, Object> metadata) {
-        counter(getResourceMg(resourceID, metadata), RECONCILIATION, "cleanup").inc();
+        resourceMetrics.computeIfPresent(
+                getResourceKey(resourceID, metadata),
+                (key, metrics) -> {
+                    metrics.close();
+                    return null;
+                });
     }
 
     @Override
     public void reconciliationSubmitted(
             HasMetadata resource, RetryInfo retryInfoNullable, Map<String, Object> metadata) {
-        var resourceID = ResourceID.fromResource(resource);
-        counter(getResourceMg(resourceID, metadata), RECONCILIATION).inc();
-
-        if (retryInfoNullable != null) {
-            counter(getResourceMg(resourceID, metadata), RECONCILIATION, "retries").inc();
-        }
+        resourceMetrics.compute(
+                getResourceKey(ResourceID.fromResource(resource), metadata),
+                (key, metrics) -> {
+                    if (metrics == null) {
+                        metrics = newResourceMetrics(key);
+                    }
+                    metrics.counter(RECONCILIATION).inc();
+                    if (retryInfoNullable != null) {
+                        metrics.counter(RECONCILIATION, "retries").inc();
+                    }
+                    return metrics;
+                });
     }
 
     @Override
     public void reconciliationFinished(
             HasMetadata resource, RetryInfo retryInfoNullable, Map<String, Object> metadata) {
-        counter(
-                        getResourceMg(ResourceID.fromResource(resource), metadata),
-                        RECONCILIATION,
-                        "finished")
-                .inc();
+        // Update-only: a completion callback may race a concurrent delete and arrive after
+        // cleanupDone(). If the key was already removed, computeIfPresent skips the lambda so
+        // metrics are never re-registered for a cleaned-up resource.
+        resourceMetrics.computeIfPresent(
+                getResourceKey(ResourceID.fromResource(resource), metadata),
+                (key, metrics) -> {
+                    metrics.counter(RECONCILIATION, "finished").inc();
+                    return metrics;
+                });
     }
 
     @Override
@@ -135,11 +147,13 @@ public class OperatorJosdkMetrics implements Metrics {
             RetryInfo retryInfoNullable,
             Exception exception,
             Map<String, Object> metadata) {
-        counter(
-                        getResourceMg(ResourceID.fromResource(resource), metadata),
-                        RECONCILIATION,
-                        "failed")
-                .inc();
+        // Update-only, see reconciliationFinished().
+        resourceMetrics.computeIfPresent(
+                getResourceKey(ResourceID.fromResource(resource), metadata),
+                (key, metrics) -> {
+                    metrics.counter(RECONCILIATION, "failed").inc();
+                    return metrics;
+                });
     }
 
     private Histogram histogram(ControllerExecution<?> execution, String name) {
@@ -147,8 +161,13 @@ public class OperatorJosdkMetrics implements Metrics {
         return histograms.computeIfAbsent(
                 groups,
                 k -> {
-                    var group =
-                            getResourceNsMg(execution.resourceID(), execution.metadata())
+                    var key = getResourceKey(execution.resourceID(), execution.metadata());
+                    MetricGroup group =
+                            operatorMetricGroup
+                                    .createResourceNamespaceGroup(
+                                            configManager.getDefaultConfig(),
+                                            key.resourceClass(),
+                                            key.resourceID().getNamespace().orElse("default"))
                                     .addGroup(OPERATOR_SDK_GROUP);
                     for (String mg : groups) {
                         group = group.addGroup(mg);
@@ -169,39 +188,27 @@ public class OperatorJosdkMetrics implements Metrics {
         return TimeUnit.NANOSECONDS.toSeconds(clock.relativeTimeNanos() - startTime);
     }
 
-    private Counter counter(MetricGroup parent, String... names) {
-        var key = new ArrayList<String>(parent.getScopeComponents().length + names.length);
-        Arrays.stream(parent.getScopeComponents()).forEach(key::add);
-        Arrays.stream(names).forEach(key::add);
-
-        return counters.computeIfAbsent(
-                key,
-                s -> {
-                    MetricGroup group = parent.addGroup(OPERATOR_SDK_GROUP);
-                    for (String name : names) {
-                        group = group.addGroup(name);
-                    }
-                    var finalGroup = group;
-                    return OperatorMetricUtils.synchronizedCounter(finalGroup.counter("Count"));
-                });
-    }
-
-    private KubernetesResourceNamespaceMetricGroup getResourceNsMg(
-            ResourceID resourceID, Map<String, Object> metadata) {
+    private ResourceKey getResourceKey(ResourceID resourceID, Map<String, Object> metadata) {
         Class<? extends CustomResource<?, ?>> resourceClass =
                 getResourceClass(metadata)
                         .orElseThrow(
                                 () ->
                                         new RuntimeException(
                                                 "Unknown resource kind for " + resourceID));
+        return new ResourceKey(resourceClass, resourceID);
+    }
 
-        return resourceNsMetricGroups.computeIfAbsent(
-                resourceID,
-                rid ->
-                        operatorMetricGroup.createResourceNamespaceGroup(
+    private ResourceMetrics newResourceMetrics(ResourceKey key) {
+        var resourceID = key.resourceID();
+        var resourceGroup =
+                operatorMetricGroup
+                        .createResourceNamespaceGroup(
                                 configManager.getDefaultConfig(),
-                                resourceClass,
-                                rid.getNamespace().orElse("default")));
+                                key.resourceClass(),
+                                resourceID.getNamespace().orElse("default"))
+                        .createResourceGroup(
+                                configManager.getDefaultConfig(), resourceID.getName());
+        return new ResourceMetrics(resourceGroup);
     }
 
     private Optional<Class<? extends CustomResource<?, ?>>> getResourceClass(
@@ -229,13 +236,42 @@ public class OperatorJosdkMetrics implements Metrics {
         return Optional.of(resourceClass);
     }
 
-    private KubernetesResourceMetricGroup getResourceMg(
-            ResourceID resourceID, Map<String, Object> metadata) {
-        return resourceMetricGroups.computeIfAbsent(
-                resourceID,
-                rid ->
-                        getResourceNsMg(rid, metadata)
-                                .createResourceGroup(
-                                        configManager.getDefaultConfig(), rid.getName()));
+    @VisibleForTesting
+    int getResourceMetricsCacheSize() {
+        return resourceMetrics.size();
+    }
+
+    /** Cache key that fully identifies a reconciled resource by its kind and {@link ResourceID}. */
+    private record ResourceKey(
+            Class<? extends CustomResource<?, ?>> resourceClass, ResourceID resourceID) {}
+
+    /** Holds the metric group and counters owned by a single reconciled resource. */
+    private static final class ResourceMetrics {
+        private final KubernetesResourceMetricGroup group;
+        // Only accessed from within resourceMetrics.compute*/computeIfPresent lambdas, which are
+        // serialized per ResourceKey by the backing ConcurrentHashMap, so a plain HashMap is safe.
+        private final Map<List<String>, Counter> counters = new HashMap<>();
+
+        private ResourceMetrics(KubernetesResourceMetricGroup group) {
+            this.group = group;
+        }
+
+        private Counter counter(String... names) {
+            return counters.computeIfAbsent(
+                    List.of(names),
+                    k -> {
+                        MetricGroup metricGroup = group.addGroup(OPERATOR_SDK_GROUP);
+                        for (String name : names) {
+                            metricGroup = metricGroup.addGroup(name);
+                        }
+                        return OperatorMetricUtils.synchronizedCounter(
+                                metricGroup.counter("Count"));
+                    });
+        }
+
+        private void close() {
+            group.close();
+            counters.clear();
+        }
     }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetricsTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/OperatorJosdkMetricsTest.java
@@ -19,6 +19,7 @@ package org.apache.flink.kubernetes.operator.metrics;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
 import org.apache.flink.kubernetes.operator.config.FlinkConfigManager;
 import org.apache.flink.kubernetes.operator.controller.FlinkDeploymentController;
 import org.apache.flink.kubernetes.operator.exception.ReconciliationException;
@@ -36,6 +37,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -120,17 +125,15 @@ public class OperatorJosdkMetricsTest {
 
     @Test
     public void testMetrics() {
-        operatorMetrics.reconciliationFailed(resource, null, null, metadata);
-        assertEquals(1, listener.size());
-        assertEquals(1, getCount("Reconciliation.failed"));
-        operatorMetrics.reconciliationFailed(resource, null, null, metadata);
-        operatorMetrics.reconciliationFailed(resource, null, null, metadata);
-        assertEquals(1, listener.size());
-        assertEquals(3, getCount("Reconciliation.failed"));
-
         operatorMetrics.reconciliationSubmitted(resource, null, metadata);
-        assertEquals(2, listener.size());
+        assertEquals(1, listener.size());
         assertEquals(1, getCount("Reconciliation"));
+
+        operatorMetrics.reconciliationFailed(resource, null, null, metadata);
+        operatorMetrics.reconciliationFailed(resource, null, null, metadata);
+        operatorMetrics.reconciliationFailed(resource, null, null, metadata);
+        assertEquals(2, listener.size());
+        assertEquals(3, getCount("Reconciliation.failed"));
 
         operatorMetrics.reconciliationSubmitted(
                 resource,
@@ -156,17 +159,13 @@ public class OperatorJosdkMetricsTest {
         assertEquals(1, getCount("Resource.Event"));
         assertEquals(1, getCount("Resource.Event.ADDED"));
 
-        operatorMetrics.cleanupDone(resourceId, metadata);
-        assertEquals(6, listener.size());
-        assertEquals(1, getCount("Reconciliation.cleanup"));
-
         operatorMetrics.reconciliationFinished(resource, null, metadata);
-        assertEquals(7, listener.size());
+        assertEquals(6, listener.size());
         assertEquals(1, getCount("Reconciliation.finished"));
 
         operatorMetrics.reconciliationSubmitted(
                 testResource(new ResourceID("other", "otherns")), null, metadata);
-        assertEquals(8, listener.size());
+        assertEquals(7, listener.size());
         assertEquals(
                 1,
                 listener.getCounter(
@@ -179,6 +178,156 @@ public class OperatorJosdkMetricsTest {
                                         "Count"))
                         .get()
                         .getCount());
+    }
+
+    @Test
+    public void testCleanupMetrics() {
+        operatorMetrics.reconciliationSubmitted(resource, null, metadata);
+        operatorMetrics.reconciliationFailed(resource, null, null, metadata);
+        assertEquals(2, listener.size());
+        assertEquals(1, operatorMetrics.getResourceMetricsCacheSize());
+
+        operatorMetrics.cleanupDone(resourceId, metadata);
+        assertEquals(0, listener.size());
+        assertEquals(0, operatorMetrics.getResourceMetricsCacheSize());
+
+        operatorMetrics.reconciliationFinished(resource, null, metadata);
+        operatorMetrics.reconciliationFailed(resource, null, null, metadata);
+        assertEquals(0, listener.size());
+        assertEquals(0, operatorMetrics.getResourceMetricsCacheSize());
+
+        // cleanupDone is idempotent.
+        operatorMetrics.cleanupDone(resourceId, metadata);
+        assertEquals(0, listener.size());
+        assertEquals(0, operatorMetrics.getResourceMetricsCacheSize());
+
+        operatorMetrics.reconciliationSubmitted(resource, null, metadata);
+        assertEquals(1, listener.size());
+        assertEquals(1, getCount("Reconciliation"));
+        assertEquals(1, operatorMetrics.getResourceMetricsCacheSize());
+    }
+
+    @Test
+    public void testDifferentKindsWithSameResourceIdAreIndependent() {
+        Map<String, Object> snapshotMetadata =
+                Map.of(
+                        Constants.RESOURCE_GVK_KEY,
+                        GroupVersionKind.gvkFor(FlinkStateSnapshot.class));
+        var snapshot = new FlinkStateSnapshot();
+        snapshot.getMetadata().setName(resourceId.getName());
+        snapshot.getMetadata().setNamespace(resourceId.getNamespace().orElseThrow());
+
+        operatorMetrics.reconciliationSubmitted(resource, null, metadata);
+        operatorMetrics.reconciliationSubmitted(snapshot, null, snapshotMetadata);
+        assertEquals(2, listener.size());
+        assertEquals(2, operatorMetrics.getResourceMetricsCacheSize());
+
+        // Cleaning up the deployment must not touch the snapshot with the same name/namespace.
+        operatorMetrics.cleanupDone(resourceId, metadata);
+        assertEquals(1, listener.size());
+        assertEquals(1, operatorMetrics.getResourceMetricsCacheSize());
+
+        operatorMetrics.cleanupDone(resourceId, snapshotMetadata);
+        assertEquals(0, listener.size());
+        assertEquals(0, operatorMetrics.getResourceMetricsCacheSize());
+    }
+
+    @Test
+    public void testCleanupWithDynamicScopeFormat() {
+        var shortScopeConfig = new Configuration();
+        shortScopeConfig.set(
+                KubernetesOperatorMetricOptions.SCOPE_NAMING_KUBERNETES_OPERATOR_RESOURCE,
+                "<resourcename>");
+        var customListener = new TestingMetricListener(shortScopeConfig);
+        var configManager = new FlinkConfigManager(shortScopeConfig);
+        var customMetrics =
+                new OperatorJosdkMetrics(customListener.getMetricGroup(), configManager);
+        var otherResourceId = new ResourceID("other", "testns");
+        var otherResource = testResource(otherResourceId);
+
+        customMetrics.reconciliationSubmitted(resource, null, metadata);
+        configManager.updateDefaultConfig(new Configuration());
+        customMetrics.reconciliationSubmitted(otherResource, null, metadata);
+        assertEquals(2, customListener.size());
+        assertEquals(2, customMetrics.getResourceMetricsCacheSize());
+
+        customMetrics.cleanupDone(otherResourceId, metadata);
+        assertEquals(1, customListener.size());
+        assertEquals(1, customMetrics.getResourceMetricsCacheSize());
+        assertEquals(
+                1,
+                customListener
+                        .getCounter(
+                                customListener.getResourceMetricId(
+                                        FlinkDeployment.class,
+                                        "testns",
+                                        "testname",
+                                        "JOSDK",
+                                        "Reconciliation",
+                                        "Count"))
+                        .orElseThrow()
+                        .getCount());
+
+        customMetrics.cleanupDone(resourceId, metadata);
+        assertEquals(0, customListener.size());
+        assertEquals(0, customMetrics.getResourceMetricsCacheSize());
+    }
+
+    @Test
+    public void testConcurrentCleanupAndFinished() throws Exception {
+        runConcurrentCleanupRace(
+                currentResource ->
+                        operatorMetrics.reconciliationFinished(currentResource, null, metadata));
+    }
+
+    @Test
+    public void testConcurrentCleanupAndFailed() throws Exception {
+        runConcurrentCleanupRace(
+                currentResource ->
+                        operatorMetrics.reconciliationFailed(
+                                currentResource, null, null, metadata));
+    }
+
+    private void runConcurrentCleanupRace(Consumer<HasMetadata> completion) throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            for (int i = 0; i < 500; i++) {
+                var currentResourceId = new ResourceID("testname-" + i, "testns");
+                var currentResource = testResource(currentResourceId);
+                operatorMetrics.reconciliationSubmitted(currentResource, null, metadata);
+
+                var start = new CountDownLatch(1);
+                var cleanup =
+                        executor.submit(
+                                () -> {
+                                    awaitQuietly(start);
+                                    operatorMetrics.cleanupDone(currentResourceId, metadata);
+                                });
+                var completionTask =
+                        executor.submit(
+                                () -> {
+                                    awaitQuietly(start);
+                                    completion.accept(currentResource);
+                                });
+                start.countDown();
+                cleanup.get();
+                completionTask.get();
+
+                assertEquals(0, listener.size());
+                assertEquals(0, operatorMetrics.getResourceMetricsCacheSize());
+            }
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 
     private Histogram getHistogram(String... names) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/TestingMetricListener.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/metrics/TestingMetricListener.java
@@ -30,9 +30,9 @@ import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import io.fabric8.kubernetes.client.CustomResource;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -43,7 +43,7 @@ public class TestingMetricListener {
     private static final String NAME = "test-op-name";
     private static final String HOST = "test-op-host";
     private final KubernetesOperatorMetricGroup metricGroup;
-    private final Map<String, Metric> metrics = new HashMap();
+    private final Map<String, Metric> metrics = new ConcurrentHashMap<>();
     private final ScheduledExecutorService executor;
     private Configuration configuration;
     private ViewUpdater viewUpdater;
@@ -66,6 +66,10 @@ public class TestingMetricListener {
                                         viewUpdater.notifyOfAddedView((View) metric);
                                     }
                                 })
+                        .setUnregisterConsumer(
+                                (metric, name, group) ->
+                                        this.metrics.remove(
+                                                group.getMetricIdentifier(name), metric))
                         .build();
         this.metricGroup =
                 KubernetesOperatorMetricGroup.create(


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes [FLINK-40372](https://issues.apache.org/jira/browse/FLINK-40372).

`OperatorJosdkMetrics` caches resource-level metric groups and counters by `ResourceID`, but `cleanupDone` previously only incremented a cleanup counter. Metrics for deleted resources therefore remained registered and strongly referenced for the lifetime of the operator. Workloads that continuously create uniquely named resources, such as periodic `FlinkStateSnapshot` resources, could grow resource metric cardinality without bound.

This change removes the resource-specific metric caches and closes the resource metric group after JOSDK reports cleanup, unregistering the deleted resource's counters from the Flink metric registry.

## Brief change log

- Remove resource and resource-namespace metric group cache entries when cleanup completes.
- Remove cached counters belonging to the deleted resource scope.
- Close the resource metric group to unregister its counters.
- Extend the metric test listener and add coverage for cleanup, repeated cleanup, and same-name resource recreation.

## Verifying this change

This change added tests and can be verified as follows:

- `OperatorJosdkMetricsTest`: 3 tests passed, covering cleanup, repeated cleanup, and metric re-registration for a recreated resource.
- Broader metrics test set: 41 tests passed across 8 metrics test classes.
- Spotless and Checkstyle checks passed.
- `git diff --check` passed.

A full `mvn clean verify` has not been run locally.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
- Core observer or reconciler logic that is regularly executed: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex (GPT-5) Reviewed by Human
