### PR TITLE
[FLINK-40374] Fix redeploy-from-savepoint for suspended jobs

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -379,9 +379,14 @@ public abstract class AbstractFlinkService implements FlinkService {
         try (var clusterClient = getClusterClient(conf)) {
             switch (suspendMode) {
                 case STATELESS:
+                    if (status.isJobCancellable()
+                            && !cancelJobOrError(clusterClient, status, true)) {
+                        // This is async we need to return and re-observe
+                        return CancelResult.pending();
+                    }
+                    break;
                 case CANCEL:
-                    if (!cancelJobOrError(
-                            clusterClient, status, suspendMode == SuspendMode.STATELESS)) {
+                    if (!cancelJobOrError(clusterClient, status, false)) {
                         // This is async we need to return and re-observe
                         return CancelResult.pending();
                     }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -379,8 +379,7 @@ public abstract class AbstractFlinkService implements FlinkService {
         try (var clusterClient = getClusterClient(conf)) {
             switch (suspendMode) {
                 case STATELESS:
-                    if (status.isJobCancellable()
-                            && !cancelJobOrError(clusterClient, status, true)) {
+                    if (!cancelJobOrError(clusterClient, status, true)) {
                         // This is async we need to return and re-observe
                         return CancelResult.pending();
                     }
@@ -421,7 +420,17 @@ public abstract class AbstractFlinkService implements FlinkService {
             RestClusterClient<String> clusterClient,
             CommonStatus<?> status,
             boolean ignoreMissing) {
-        var jobID = JobID.fromHexString(status.getJobStatus().getJobId());
+        var jobIdString = status.getJobStatus().getJobId();
+        if (jobIdString == null) {
+            if (ignoreMissing) {
+                LOG.info("Job already missing");
+                return true;
+            }
+            throw new UpgradeFailureException(
+                    "Cannot find job when trying to cancel",
+                    EventRecorder.Reason.CleanupFailed.name());
+        }
+        var jobID = JobID.fromHexString(jobIdString);
         if (ReconciliationUtils.isJobCancelling(status)) {
             LOG.info("Job already cancelling");
             return false;

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/sessionjob/SessionJobReconcilerTest.java
@@ -1091,4 +1091,40 @@ public class SessionJobReconcilerTest extends OperatorTestBase {
         assertFalse(deleteControl.isRemoveFinalizer());
         assertEquals(10_000, deleteControl.getScheduleDelay().get());
     }
+
+    @Test
+    public void testSavepointRedeployAfterSavepointSuspend() throws Exception {
+        // submit job
+        var readyCtx = TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient);
+        FlinkSessionJob sessionJob = TestUtils.buildSessionJob();
+        sessionJob.getSpec().getJob().setUpgradeMode(UpgradeMode.SAVEPOINT);
+
+        // reconcile and verify
+        reconciler.reconcile(sessionJob, readyCtx);
+        verifyAndSetRunningJobsToStatus(
+                sessionJob, JobState.RUNNING, RECONCILING, null, flinkService.listJobs());
+        Assertions.assertNotNull(sessionJob.getStatus().getJobStatus().getJobId());
+
+        // savepoint suspend
+        sessionJob.getSpec().getJob().setState(JobState.SUSPENDED);
+
+        // reconcile and verify
+        reconciler.reconcile(sessionJob, readyCtx);
+        verifyJobState(sessionJob, JobState.SUSPENDED, FINISHED);
+        assertNull(sessionJob.getStatus().getJobStatus().getJobId());
+
+        flinkService.clear();
+
+        // request redeploy from explicit savepoint
+        sessionJob.getSpec().getJob().setState(JobState.RUNNING);
+        sessionJob.getSpec().getJob().setInitialSavepointPath("s3://bucket/savepoint-explicit");
+        sessionJob.getSpec().getJob().setSavepointRedeployNonce(1L);
+
+        // reconcile and verify
+        reconciler.reconcile(sessionJob, readyCtx);
+        assertEquals(1, flinkService.listJobs().size());
+        assertEquals(
+                "s3://bucket/savepoint-explicit",
+                verifyAndReturnTheSubmittedJob(sessionJob, flinkService.listJobs()).f0);
+    }
 }

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -389,6 +389,34 @@ public class AbstractFlinkServiceTest {
     }
 
     /**
+     * A session job suspended with a savepoint has its jobId cleared and a terminal state.
+     * Redeploying from that state should recognise the null jobId as an already-missing job instead
+     * of trying to parse it.
+     */
+    @Test
+    public void cancelSessionJobWithStatelessModeAndNoJobId() throws Exception {
+        var testingClusterClient =
+                new TestingClusterClient<>(configuration, TestUtils.TEST_DEPLOYMENT_NAME);
+        testingClusterClient.setCancelFunction(
+                jobID -> {
+                    fail("cancel should not be called for a job with no recorded jobId");
+                    return null;
+                });
+        var flinkService = new TestingService(testingClusterClient);
+
+        var job = TestUtils.buildSessionJob();
+        var jobStatus = job.getStatus().getJobStatus();
+        jobStatus.setJobId(null);
+        jobStatus.setState(FINISHED);
+        ReconciliationUtils.updateStatusForDeployedSpec(job, new Configuration());
+
+        var result = flinkService.cancelSessionJob(job, SuspendMode.STATELESS, new Configuration());
+        assertFalse(result.isPending());
+        assertEquals(FINISHED, jobStatus.getState());
+        assertNull(jobStatus.getJobId());
+    }
+
+    /**
      * Reproduces the operator-upgrade scenario for Session Mode with CANCEL upgrade mode: when a
      * running session job's JobManager has already moved the job into a terminal state (e.g.
      * FAILED) and the operator (after a restart/upgrade) tries to cancel it, the cancellation


### PR DESCRIPTION
Redeploying a suspended FlinkSessionJob from an explicit savepoint (state SUSPENDED -> RUNNING via savepointRedeployNonce) always tried to cancel the job first, even though the suspend clears the jobId. FlinkDeployment guards this with isJobCancellable() but the session job path was missing the same guard.

## What is the purpose of the change

For a FlinkSessionJob, if a job is suspended with a savepoint, and the user then tries to explicitly redeploy it from a specific savepoint path (by setting spec.job.state=RUNNING, spec.job.initialSavepointPath, and bumping spec.job.savepointRedeployNonce), the reconciler would fail. 

## Brief change log

- Created a unit test to recreate the issue
- Copied the guard used for FlinkDeployment to FlinkSessionJob. 

## Verifying this change

This change added a unit test. It can also be verified manually by suspending a job on a session cluster and then resuming from a savepoint. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 

---

##### Was generative AI tooling used to co-author this PR?

- [ ] Yes (please specify the tool below)

