### PR TITLE
[FLINK-40375] Fix kube-apiserver and mock-server tests silently skipped in CI

### DIFF
--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -27,7 +27,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.zaxxer:HikariCP:jar:5.1.0
 - commons-cli:commons-cli:jar:1.5.0
 - commons-collections:commons-collections:jar:3.2.2
-- commons-io:commons-io:jar:2.17.0
+- commons-io:commons-io:jar:2.22.0
 - io.fabric8:kubernetes-client-api:jar:7.8.0
 - io.fabric8:kubernetes-client:jar:7.8.0
 - io.fabric8:kubernetes-httpclient-okhttp:jar:7.8.0

--- a/flink-kubernetes-standalone/pom.xml
+++ b/flink-kubernetes-standalone/pom.xml
@@ -81,6 +81,22 @@ under the License.
             <scope>test</scope>
         </dependency>
 
+        <!-- Not inherited: kubernetes-server-mock declares it optional, and this module
+             otherwise only has the client shaded into flink-kubernetes. -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Managed kubernetes-client excludes all httpclient impls; the mock server needs one. -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-httpclient-${fabric8.httpclient.impl}</artifactId>
+            <version>${fabric8.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ under the License.
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
         <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
@@ -79,7 +79,9 @@ under the License.
 
         <lombok.version>1.18.30</lombok.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
-        <commons-io.version>2.17.0</commons-io.version>
+        <!-- Must be >= what commons-compress (via io.fabric8:kube-api-test) needs, else
+             kube-apiserver binary extraction fails with an IllegalAccessError. -->
+        <commons-io.version>2.22.0</commons-io.version>
         <flink.version>1.20.4</flink.version>
         <guava.version>33.4.0-jre</guava.version>
 


### PR DESCRIPTION
## What is the purpose of the change

Five test classes report `Tests run: 0` while the build passes, so 10 test methods
contribute no coverage. This fixes the underlying failures and makes such failures
fail the build instead of passing silently.

The cause is not a binary *download* failure — the download succeeds and extraction
then fails. Two independent problems compound:

**1. Binary extraction crashes.** `flink-kubernetes-operator-api` declares
`commons-io:2.17.0` directly, which by Maven's nearest-definition rule overrides the
`2.20.0` that `commons-compress:1.28.0` (pulled in by `io.fabric8:kube-api-test`) is
built against:

```
java.lang.IllegalAccessError: class org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream
tried to access protected method 'java.io.InputStream org.apache.commons.io.build.AbstractStreamBuilder.getInputStream()'
	at org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream.<init>(GzipCompressorInputStream.java:265)
	at io.fabric8.kubeapitest.binary.BinaryDownloader.extractFiles(BinaryDownloader.java:94)
	at io.fabric8.kubeapitest.junit.KubeAPIServerExtension.beforeAll(KubeAPIServerExtension.java:48)
```

This only reproduces on a cold `~/.kubeapitest` cache, which is why it appears on CI
runners but not on developer machines with a warm cache.

**2. The failure is swallowed.** Both failures occur in `beforeAll`, and
maven-surefire-plugin 3.0.0-M4 discards those — fixed in 3.0.0-M5
([SUREFIRE-1741](https://issues.apache.org/jira/browse/SUREFIRE-1741), of which
[SUREFIRE-1688](https://issues.apache.org/jira/browse/SUREFIRE-1688) is a duplicate).
The surefire XML report contains no error record at all.

Bumping surefire then turned the build red on two further classes with the same
suppressed-`beforeAll` pattern but a different cause: `kubernetes-server-mock`
declares `kubernetes-client` as `<optional>true</optional>` so it is not inherited
transitively, and `flink-kubernetes-standalone` only has the fabric8 client shaded
into `flink-kubernetes`. Its mock-server tests failed with
`NoClassDefFoundError: io/fabric8/kubernetes/api/model/HasMetadata`. Supplying the
unshaded client then surfaced a second layer, since `kubernetes-client` is managed
with every httpclient implementation excluded. Both were pre-existing — confirmed
reporting `Tests run: 0` on surefire 3.0.0-M4.

## Brief change log

- Bump `maven-surefire-plugin` from 3.0.0-M4 to 3.5.6 so `beforeAll` failures fail the build
- Bump `commons-io` from 2.17.0 to 2.22.0 (latest stable in the major), with a comment recording the constraint
- Add unshaded `io.fabric8:kubernetes-client` and an httpclient implementation at test scope to `flink-kubernetes-standalone`
- Update the operator `NOTICE` for the bundled `commons-io` version

`maven-failsafe-plugin` needs no change — it is already on 3.0.0-M5, which contains the fix.

## Verifying this change

Verified locally with a cold `~/.kubeapitest` cache and all quality checks enabled.

Before (at the previous base commit), the build was **green while running 2718 tests**,
with these classes silently at `Tests run: 0`:

| Test class | Before | After |
|---|---|---|
| `FlinkConfigurationYamlSupportTest` | 0 | 1 |
| `EventUtilsApiServerTest` | 0 | 2 |
| `FlinkOperatorTest` | 0 | 2 |
| `KubernetesStandaloneClusterDescriptorTest` | 0 | 3 |
| `Fabric8FlinkStandaloneKubeClientTest` | 0 | 2 |

`mvn clean install` now passes and runs 10 more tests than before. Reverting only the
`commons-io` bump correctly produces `BUILD FAILURE` (exit 1) rather than
`Tests run: 0` + `BUILD SUCCESS`, confirming the failure is no longer silent.

Note: `ScalingExecutorTest` also reports `Tests run: 0` because its `@Nested` class is
credited with the full count. That is a reporting artifact present identically on both
surefire versions, not a skipped test, and is unaffected by this change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes** — `commons-io` 2.17.0 -> 2.22.0 (bundled, `NOTICE` updated); two test-scope dependencies added to `flink-kubernetes-standalone`; `maven-surefire-plugin` 3.0.0-M4 -> 3.5.6
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - Core observer or reconciler logic that is regularly executed: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
