### PR TITLE
[FLINK-40380] Document the runtime configuration and stop jobs from overriding operator config through it

### DIFF
--- a/docs/content.zh/docs/internals/startup.md
+++ b/docs/content.zh/docs/internals/startup.md
@@ -170,15 +170,22 @@ The process installs a shutdown hook honoring `kubernetes.operator.termination.t
 
 ### Configuration
 
-The configuration manager loads the operator's settings at startup and derives every Flink-facing configuration from them. Three configurations matter throughout the operator:
+The configuration manager loads the operator's settings at startup and derives every Flink-facing configuration from them. Four configurations matter throughout the operator:
 
 | Config  | Derived From                                                                                                                                                                                                                                                    | Used For                                                                                                     |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
 | Default | The `flink-operator-config` ConfigMap, refined by per-namespace overrides (`kubernetes.operator.default-configuration.namespace.<namespace>.<key>`) and per-Flink-version overrides (`kubernetes.operator.default-configuration.flink-version.<version>.<key>`) | The operator's own behavior, and the base of everything below                                                |
 | Deploy  | The namespace and Flink version defaults, always merged with the current spec's `flinkConfiguration`, plus operator-managed additions such as the resource generation annotation                                                                                | Submitting and upgrading the Flink cluster                                                                   |
-| Observe | The same recipe applied to the last reconciled spec and its `flinkConfiguration`, with a session job's own `flinkConfiguration` layered on top of its cluster's                                                                                                 | Talking to the running cluster, which must be addressed with the configuration it was actually deployed with |
+| Observe | The same recipe applied to the last reconciled spec and its `flinkConfiguration`, with a session job's own `flinkConfiguration` layered on top of its cluster's, and the runtime configuration layered on top of that                                            | Talking to the running cluster, which must be addressed with the configuration it was actually deployed with |
+| Runtime | The running job itself, read through the JobManager configuration, job execution and checkpoint config REST endpoints                                                                                                                                            | Correcting the observed view wherever the job's effective settings differ from the spec                      |
 
 Deploy and observe are the same derivation applied to different specs: deploy reads the spec being rolled out, observe reads the spec that last reached the cluster. The two differ exactly while an upgrade is in flight, and converge again once the new spec lands.
+
+The runtime configuration exists because a spec is a request, not a record of what the job ended up running with. A job's main method can change settings programmatically, and those take precedence over anything the operator submitted. The job status observer therefore reads them back from the cluster and layers them over the observed configuration, so that decisions such as whether checkpointing is enabled are made against the job's real settings. Its lifecycle differs from the derived configurations above:
+
+- It is fetched once per job, and skipped for jobs in a globally terminal state, whose REST endpoints are already gone.
+- It is cached per resource and job id, under the same cache size and timeout limits as the derived configurations. A new job id, which every redeploy produces, naturally invalidates it.
+- A failed fetch is logged and retried on the next cycle, and the observed configuration stays purely spec-derived until one succeeds.
 
 Three runtime behaviors round out the configuration machinery:
 
@@ -187,7 +194,7 @@ Three runtime behaviors round out the configuration machinery:
 - The watched namespaces come from the same configuration, and with `kubernetes.operator.dynamic.namespaces.enabled`, namespace changes adjust the controllers' informers at runtime.
 
 {{< hint warning >}}
-None of these is the running configuration. The operator derives its view from the spec and its own defaults, while the cluster can pick up settings the operator never sees: a `config.yaml` baked into the image, environment overrides, or properties the job sets programmatically. The configuration a pipeline actually runs with can therefore differ from everything the operator tracks.
+The runtime configuration covers a mapped subset of the job's settings, mainly the default parallelism, object reuse, the job's global parameters, and the checkpointing, state backend and changelog options, and only for as long as the job is running. Whatever falls outside that subset stays invisible to the operator, including a `config.yaml` baked into the image and environment overrides. The configuration a pipeline actually runs with can therefore still differ from what the operator tracks.
 {{< /hint >}}
 
 ### Services

--- a/docs/content/docs/internals/startup.md
+++ b/docs/content/docs/internals/startup.md
@@ -170,15 +170,22 @@ The process installs a shutdown hook honoring `kubernetes.operator.termination.t
 
 ### Configuration
 
-The configuration manager loads the operator's settings at startup and derives every Flink-facing configuration from them. Three configurations matter throughout the operator:
+The configuration manager loads the operator's settings at startup and derives every Flink-facing configuration from them. Four configurations matter throughout the operator:
 
 | Config  | Derived From                                                                                                                                                                                                                                                    | Used For                                                                                                     |
 |---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------|
 | Default | The `flink-operator-config` ConfigMap, refined by per-namespace overrides (`kubernetes.operator.default-configuration.namespace.<namespace>.<key>`) and per-Flink-version overrides (`kubernetes.operator.default-configuration.flink-version.<version>.<key>`) | The operator's own behavior, and the base of everything below                                                |
 | Deploy  | The namespace and Flink version defaults, always merged with the current spec's `flinkConfiguration`, plus operator-managed additions such as the resource generation annotation                                                                                | Submitting and upgrading the Flink cluster                                                                   |
-| Observe | The same recipe applied to the last reconciled spec and its `flinkConfiguration`, with a session job's own `flinkConfiguration` layered on top of its cluster's                                                                                                 | Talking to the running cluster, which must be addressed with the configuration it was actually deployed with |
+| Observe | The same recipe applied to the last reconciled spec and its `flinkConfiguration`, with a session job's own `flinkConfiguration` layered on top of its cluster's, and the runtime configuration layered on top of that                                            | Talking to the running cluster, which must be addressed with the configuration it was actually deployed with |
+| Runtime | The running job itself, read through the JobManager configuration, job execution and checkpoint config REST endpoints                                                                                                                                            | Correcting the observed view wherever the job's effective settings differ from the spec                      |
 
 Deploy and observe are the same derivation applied to different specs: deploy reads the spec being rolled out, observe reads the spec that last reached the cluster. The two differ exactly while an upgrade is in flight, and converge again once the new spec lands.
+
+The runtime configuration exists because a spec is a request, not a record of what the job ended up running with. A job's main method can change settings programmatically, and those take precedence over anything the operator submitted. The job status observer therefore reads them back from the cluster and layers them over the observed configuration, so that decisions such as whether checkpointing is enabled are made against the job's real settings. Its lifecycle differs from the derived configurations above:
+
+- It is fetched once per job, and skipped for jobs in a globally terminal state, whose REST endpoints are already gone.
+- It is cached per resource and job id, under the same cache size and timeout limits as the derived configurations. A new job id, which every redeploy produces, naturally invalidates it.
+- A failed fetch is logged and retried on the next cycle, and the observed configuration stays purely spec-derived until one succeeds.
 
 Three runtime behaviors round out the configuration machinery:
 
@@ -187,7 +194,7 @@ Three runtime behaviors round out the configuration machinery:
 - The watched namespaces come from the same configuration, and with `kubernetes.operator.dynamic.namespaces.enabled`, namespace changes adjust the controllers' informers at runtime.
 
 {{< hint warning >}}
-None of these is the running configuration. The operator derives its view from the spec and its own defaults, while the cluster can pick up settings the operator never sees: a `config.yaml` baked into the image, environment overrides, or properties the job sets programmatically. The configuration a pipeline actually runs with can therefore differ from everything the operator tracks.
+The runtime configuration covers a mapped subset of the job's settings, mainly the default parallelism, object reuse, the job's global parameters, and the checkpointing, state backend and changelog options, and only for as long as the job is running. Whatever falls outside that subset stays invisible to the operator, including a `config.yaml` baked into the image and environment overrides. The configuration a pipeline actually runs with can therefore still differ from what the operator tracks.
 {{< /hint >}}
 
 ### Services

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkRuntimeConfigurationUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/FlinkRuntimeConfigurationUtils.java
@@ -17,11 +17,13 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.configuration.StateChangelogOptions;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.runtime.rest.messages.JobConfigInfo;
 import org.apache.flink.runtime.rest.messages.checkpoints.CheckpointConfigInfo;
 
@@ -131,6 +133,10 @@ public class FlinkRuntimeConfigurationUtils {
     /**
      * Extract execution configuration (parallelism, object-reuse, global job parameters) from a
      * {@link JobConfigInfo} REST response.
+     *
+     * <p>Global job parameters are set by the job itself and are merged over the observed
+     * configuration, so keys belonging to the operator's own namespaces are dropped. Otherwise a
+     * job could change how the operator manages it simply by declaring a matching global parameter.
      */
     public static Map<String, String> mapJobConfiguration(JobConfigInfo configurationInfo) {
         Map<String, String> jobConfig = new HashMap<>();
@@ -141,8 +147,24 @@ public class FlinkRuntimeConfigurationUtils {
         jobConfig.put(
                 CoreOptions.DEFAULT_PARALLELISM.key(), String.valueOf(execInfo.getParallelism()));
         jobConfig.put(PipelineOptions.OBJECT_REUSE.key(), String.valueOf(execInfo.isObjectReuse()));
-        jobConfig.putAll(execInfo.getGlobalJobParameters());
+        execInfo.getGlobalJobParameters()
+                .forEach(
+                        (key, value) -> {
+                            if (!isOperatorControlledKey(key)) {
+                                jobConfig.put(key, value);
+                            }
+                        });
         return jobConfig;
+    }
+
+    /**
+     * Whether the key belongs to a namespace owned by the operator, covering both operator and
+     * autoscaler options, including the autoscaler's legacy {@code kubernetes.operator.} prefixed
+     * form.
+     */
+    private static boolean isOperatorControlledKey(String key) {
+        return key.startsWith(KubernetesOperatorConfigOptions.K8S_OP_CONF_PREFIX)
+                || key.startsWith(AutoScalerOptions.AUTOSCALER_CONF_PREFIX);
     }
 
     /**

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkServiceTest.java
@@ -1612,6 +1612,42 @@ public class AbstractFlinkServiceTest {
     }
 
     @Test
+    void testMapJobConfigurationDropsOperatorControlledGlobalParameters() {
+        JobConfigInfo configInfo =
+                new JobConfigInfo(
+                        new JobID(),
+                        "test-job",
+                        new JobConfigInfo.ExecutionConfigInfo(
+                                "PIPELINED",
+                                "fixedDelay",
+                                4,
+                                true,
+                                Map.of(
+                                        "user.param",
+                                        "value1",
+                                        "kubernetes.operator.job.upgrade.last-state-fallback.enabled",
+                                        "false",
+                                        "job.autoscaler.enabled",
+                                        "false")));
+
+        Map<String, String> result = FlinkRuntimeConfigurationUtils.mapJobConfiguration(configInfo);
+
+        // A job must not be able to change how the operator manages it.
+        assertNull(
+                result.get("kubernetes.operator.job.upgrade.last-state-fallback.enabled"),
+                "operator keys must not be taken from global job parameters");
+        assertNull(
+                result.get("job.autoscaler.enabled"),
+                "autoscaler keys must not be taken from global job parameters");
+
+        // Unrelated parameters and the mapped execution fields are still present.
+        assertEquals("value1", result.get("user.param"));
+        assertEquals("4", result.get("parallelism.default"));
+        assertEquals("true", result.get("pipeline.object-reuse"));
+        assertEquals(3, result.size());
+    }
+
+    @Test
     void testMapJobConfigurationHandlesNullGracefully() {
         assertTrue(FlinkRuntimeConfigurationUtils.mapJobConfiguration(null).isEmpty());
         assertTrue(


### PR DESCRIPTION
## What is the purpose of the change

Follow-up to FLINK-35746, which added runtime configuration observation (reading a job's effective settings from the Flink REST API and layering them over the observed configuration).

Two gaps are addressed. The operator documentation still describes the previous configuration model, to the point of stating the operator cannot observe the running configuration. And the global job parameters taken from the REST response are applied unfiltered, so a job can override operator configuration for its own resource.

## Brief change log

**Documentation** (`docs/content{,.zh}/docs/internals/startup.md`)

- The Configuration section now lists four configurations rather than three, with a Runtime row describing what it is read from (the JobManager configuration, job execution and checkpoint config REST endpoints) and what it is used for.
- The Observe row states that the runtime configuration is layered on top, matching `FlinkResourceContext#getObserveConfig`.
- A short paragraph explains why the runtime configuration exists, since a spec is a request rather than a record of what the job ended up running with, followed by its lifecycle: fetched once per job, skipped for globally terminal jobs, cached per resource and job id, and falling back to spec-derived values while a fetch keeps failing.
- The closing warning previously said "None of these is the running configuration", which FLINK-35746 made untrue. It is replaced rather than removed, since the mapping only covers a subset of settings and only while the job runs, so a `config.yaml` baked into the image is still invisible to the operator.

**Filtering** (`FlinkRuntimeConfigurationUtils`)

- Global job parameters whose key is in the operator's own namespaces (`kubernetes.operator.` and `job.autoscaler.`) are no longer copied into the runtime configuration, and each dropped key is logged at WARN.
- The check uses the existing `KubernetesOperatorConfigOptions.K8S_OP_CONF_PREFIX` and `AutoScalerOptions.AUTOSCALER_CONF_PREFIX` constants so it follows the prefixes if they ever change.

The filter is deliberately limited to those two namespaces. The JobManager configuration endpoint legitimately contributes keys such as `rest.*`, so filtering more broadly by key name would risk dropping genuinely observed settings, whereas operator and autoscaler keys have no reason to arrive from a job's global parameters at all.

## Verifying this change

- `AbstractFlinkServiceTest#testMapJobConfigurationDropsOperatorControlledGlobalParameters` asserts that an operator key and an autoscaler key set as global job parameters are dropped, while an unrelated parameter and the mapped execution fields are kept.
- The existing `testMapJobConfigurationMapsAllExpectedFields` continues to pass, so ordinary parameters are unaffected.
- The full `flink-kubernetes-operator` suite passes (2240 tests).

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
- Core observer or reconciler logic that is regularly executed: yes, the runtime configuration mapping used by the job status observer

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? the Internals startup documentation is corrected to describe the runtime configuration added in FLINK-35746

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
