### PR TITLE
[FLINK-40389] Source parallelism is not capped at the partition count

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/alignment/BuiltInAlignmentMode.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/alignment/BuiltInAlignmentMode.java
@@ -69,7 +69,12 @@ public enum BuiltInAlignmentMode implements ParallelismAlignmentMode, DescribedE
      */
     private static int alignOrKeepTarget(Context<?> ctx, boolean acceptLoadReducing) {
         int aligned = ParallelismAligner.firstAlignedInRegion(ctx, acceptLoadReducing);
-        return aligned > 0 ? aligned : ctx.getNewParallelism();
+        if (aligned > 0) {
+            return aligned;
+        }
+        // Nothing aligned in the region: keep the target, but never above the cap, since
+        // subtasks past the source partition count are assigned no split.
+        return Math.min(ctx.getNewParallelism(), ParallelismAligner.upperBoundForAlignment(ctx));
     }
 
     private final InlineElement description;

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/alignment/ParallelismAligner.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/alignment/ParallelismAligner.java
@@ -280,6 +280,11 @@ public final class ParallelismAligner {
 
     private static boolean invertsDirection(
             ParallelismAlignmentMode.Context<?> ctx, int candidate) {
+        // Exception to the direction check below: the cap is the most subtasks the vertex can
+        // use, so dropping onto it corrects an over-provisioned vertex rather than inverting it.
+        if (candidate == upperBoundForAlignment(ctx) && candidate < ctx.getCurrentParallelism()) {
+            return false;
+        }
         return (isScaleUp(ctx) && candidate <= ctx.getCurrentParallelism())
                 || (!isScaleUp(ctx) && candidate >= ctx.getCurrentParallelism());
     }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobVertexScalerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.autoscaler;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.autoscaler.JobVertexScaler.ParallelismChange;
+import org.apache.flink.autoscaler.alignment.BuiltInAlignmentMode;
 import org.apache.flink.autoscaler.alignment.KeyGroupOrPartitionsAdjustMode;
 import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.event.TestingEventCollector;
@@ -1208,6 +1209,48 @@ public class JobVertexScalerTest {
                         Map.of(),
                         null,
                         context));
+    }
+
+    @Test
+    public void testSourceCappedAtPartitionCountWhenOverProvisioned() {
+        final var vertex = new JobVertexID();
+        // 15 partitions, running at 100: both a requested scale-up and scale-down land on 15.
+        // setup() pins the legacy EVENLY_SPREAD, so that one is covered first.
+        assertEquals(15, scaleOverProvisionedSource(vertex, 1.8));
+        assertEquals(15, scaleOverProvisionedSource(vertex, 0.5));
+
+        conf.set(
+                AutoScalerOptions.SCALING_KEY_GROUP_PARTITIONS_ADJUST_MODE,
+                KeyGroupOrPartitionsAdjustMode.MAXIMIZE_UTILISATION);
+        assertEquals(15, scaleOverProvisionedSource(vertex, 1.8));
+        assertEquals(15, scaleOverProvisionedSource(vertex, 0.5));
+
+        // The new key takes precedence over the deprecated one set above.
+        for (var mode :
+                List.of(BuiltInAlignmentMode.BALANCED, BuiltInAlignmentMode.EVENLY_SPREAD)) {
+            conf.set(AutoScalerOptions.ALIGNMENT_MODE, mode.name());
+            assertEquals(15, scaleOverProvisionedSource(vertex, 1.8), mode.name());
+            assertEquals(15, scaleOverProvisionedSource(vertex, 0.5), mode.name());
+        }
+
+        // OFF opts out of alignment, so the computed target is used as-is.
+        conf.set(AutoScalerOptions.ALIGNMENT_MODE, BuiltInAlignmentMode.OFF.name());
+        assertEquals(180, scaleOverProvisionedSource(vertex, 1.8));
+    }
+
+    private int scaleOverProvisionedSource(JobVertexID vertex, double scaleFactor) {
+        return vertexScaler.scale(
+                vertex,
+                100,
+                List.of(),
+                15,
+                180,
+                scaleFactor,
+                1,
+                Integer.MAX_VALUE,
+                Map.of(),
+                null,
+                context);
     }
 
     @Test

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/alignment/AlignmentModeTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/alignment/AlignmentModeTest.java
@@ -23,14 +23,19 @@ import org.apache.flink.autoscaler.topology.ShipStrategy;
 import org.apache.flink.configuration.Configuration;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static org.apache.flink.autoscaler.TestingAutoscalerUtils.createDefaultJobAutoScalerContext;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
  * Tests for the built-in and legacy {@link ParallelismAlignmentMode}s and {@link
@@ -120,6 +125,100 @@ class AlignmentModeTest {
         var blocked = ctx(22, 25, 35, 128, 20, 30, List.of(ShipStrategy.HASH));
         assertThat(KeyGroupOrPartitionsAdjustMode.EVENLY_SPREAD.alignParallelism(blocked, emitter))
                 .isEqualTo(22);
+        assertThat(emitted).hasValue(1);
+    }
+
+    @SuppressWarnings("deprecation")
+    static Stream<ParallelismAlignmentMode> aligningModes() {
+        return Stream.of(
+                BuiltInAlignmentMode.BALANCED,
+                BuiltInAlignmentMode.EVENLY_SPREAD,
+                KeyGroupOrPartitionsAdjustMode.EVENLY_SPREAD,
+                KeyGroupOrPartitionsAdjustMode.MAXIMIZE_UTILISATION);
+    }
+
+    @SuppressWarnings("deprecation")
+    static Stream<KeyGroupOrPartitionsAdjustMode> legacyModes() {
+        return Stream.of(
+                KeyGroupOrPartitionsAdjustMode.EVENLY_SPREAD,
+                KeyGroupOrPartitionsAdjustMode.MAXIMIZE_UTILISATION);
+    }
+
+    /** Every aligning mode against a target above the cap, on both sides of the current value. */
+    static Stream<Arguments> cappedTargets() {
+        return aligningModes()
+                .flatMap(mode -> Stream.of(180, 50, 16, 15).map(target -> arguments(mode, target)));
+    }
+
+    @ParameterizedTest(name = "{0}, target {1}")
+    @MethodSource("cappedTargets")
+    void targetAbovePartitionCountIsCappedInEitherDirection(
+            ParallelismAlignmentMode mode, int target) {
+        // 15 partitions, running at 100: 15 is the ceiling whether the target is above it (180),
+        // below it (50, 16), or already on it (15).
+        assertThat(mode.alignParallelism(ctx(100, target, 15, 180))).isEqualTo(15);
+    }
+
+    @Test
+    void offKeepsTheTargetAbovePartitionCount() {
+        // OFF opts out of alignment altogether, so the over-provisioning is the user's choice.
+        assertThat(BuiltInAlignmentMode.OFF.alignParallelism(ctx(100, 180, 15, 180)))
+                .isEqualTo(180);
+        assertThat(BuiltInAlignmentMode.OFF.alignParallelism(ctx(100, 50, 15, 180))).isEqualTo(50);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("aligningModes")
+    void keyedVertexIsCappedAtItsKeyGroupCount(ParallelismAlignmentMode mode) {
+        // Without source partitions the cap is the key group count. scale() already clamps the
+        // target to maxParallelism, so only sources reach this in practice.
+        assertThat(mode.alignParallelism(ctx(20, 18, 0, 12))).isEqualTo(12);
+    }
+
+    /** Legacy modes only, and only targets that deviate from the cap, so an event is expected. */
+    static Stream<Arguments> legacyCappedTargets() {
+        return legacyModes()
+                .flatMap(mode -> Stream.of(180, 50, 16).map(target -> arguments(mode, target)));
+    }
+
+    @ParameterizedTest(name = "{0}, target {1}")
+    @MethodSource("legacyCappedTargets")
+    @SuppressWarnings("deprecation")
+    void legacyEmitsWheneverCappedAtPartitionCount(
+            KeyGroupOrPartitionsAdjustMode mode, int target) {
+        // Capping is not an inversion, but it still deviates from the target, so the event stays.
+        assertThat(mode.alignParallelism(ctx(100, target, 15, 180), emitter)).isEqualTo(15);
+        assertThat(emitted).hasValue(1);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("legacyModes")
+    @SuppressWarnings("deprecation")
+    void alreadyAtThePartitionCountBlocksAScaleUp(KeyGroupOrPartitionsAdjustMode mode) {
+        // Already on the cap: the candidate is not below current, so the scale-up stays blocked.
+        assertThat(mode.alignParallelism(ctx(15, 20, 15, 180), emitter)).isEqualTo(15);
+        assertThat(emitted).hasValue(1);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void movingUpToTheCapOnAScaleDownIsStillAnInversion() {
+        // The lower limit clamps the fallback up onto the cap (12), above the current 10, so
+        // taking it would invert the scale-down.
+        var c = ctx(10, 8, 12, 128, 12, 12, List.of(ShipStrategy.HASH));
+        assertThat(KeyGroupOrPartitionsAdjustMode.EVENLY_SPREAD.alignParallelism(c, emitter))
+                .isEqualTo(10);
+        assertThat(emitted).hasValue(1);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void lowerLimitClampAboveCurrentStillBlocksAScaleDown() {
+        // The same inversion, but below the cap (candidate 11, cap 30): the exemption must not
+        // reach it.
+        var c = ctx(10, 8, 35, 128, 11, 30, List.of(ShipStrategy.HASH));
+        assertThat(KeyGroupOrPartitionsAdjustMode.EVENLY_SPREAD.alignParallelism(c, emitter))
+                .isEqualTo(10);
         assertThat(emitted).hasValue(1);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

A source vertex can be scaled far beyond its partition count. Every subtask above that count is assigned no split and stays idle, together with anything chained onto the source, so the slots are paid for and do no work.

Reproduction: Kafka source with 15 partitions, current parallelism 100, operator max parallelism 180. Values are what `JobVertexScaler#scale` returns.

| raw target | new default (BALANCED) | legacy default (EVENLY_SPREAD) | correct |
|---|---|---|---|
| 180 (scale up) | 180 | 100 (scale blocked) | 15 |
| 50 (scale down) | 50 | 15 | 15 |
| 10 (scale down) | 15 | 15 | 15 |

Only the third row, where the target already sits at or below the partition count, is handled correctly by either.

## Brief change log

Two defects, one fix each, both inside the alignment package.

**The built-in modes cap the search region but not the result.** `firstAlignedInRegion` scans `[target, regionEnd]` derived from `upperBoundForAlignment = min(N, maxParallelism, parallelismUpperLimit)`. When the target is already above that region the loop body never runs and the search returns 0, and `alignOrKeepTarget` then keeps the unaligned target. It now bounds that kept target by the cap.

**The legacy modes reach the right value and then discard it.** `relaxedDownwardFallback` correctly arrives at 15, but `invertsDirection` (added in FLINK-39299 to stop the search drifting past `currentParallelism` and silently inverting a scale) cannot tell that apart from a candidate that is legitimately far below current because the partition count is a hard ceiling. Landing exactly on the cap is no longer treated as an inversion. Only downwards though, since `relaxedDownwardFallback` clamps up to `parallelismLowerLimit` and can land on a cap above the current parallelism, which would turn a requested scale-down into a scale-up.

The cap is a no-op for keyed vertices. `scale()` clamps the target to `min(maxParallelism, parallelismUpperLimit)` before calling the aligner, so `target > upperBoundForAlignment` is only reachable when `N` is the binding term, and for a keyed vertex `N == maxParallelism`. Sources are the only case where `N` is independent of that clamp. The second fix also only affects scale-ups: on a scale-down the candidate already sits below the current parallelism, so it was never read as an inversion, which is why the legacy modes got the scale-down rows right to begin with.

`OFF` overrides `alignParallelism` directly and is untouched, so explicitly disabling alignment still uses the computed target as-is.

An earlier attempt clamped the target in `JobVertexScaler#scale` instead. It produced the same parallelism but suppressed the `SCALING_LIMITED` event, because alignment then saw a target already equal to the cap and reported no deviation, regressing `JobVertexScalerTest#testSendingScalingLimitedEvents`. Fixing this inside the aligner keeps that event intact for the legacy modes.

## Verifying this change

Coverage is a mode × direction matrix over all four aligning modes (`BALANCED`, `EVENLY_SPREAD`, and both legacy modes), each combination a separate parameterized invocation so no leg is masked by an earlier failing assertion in the same method.

Added to `AlignmentModeTest`:

- `targetAbovePartitionCountIsCappedInEitherDirection`, every mode against a target above the cap on a scale-up (180) and on a scale-down (50, 16), plus a target already on the cap (15) that has to be left alone
- `offKeepsTheTargetAbovePartitionCount`, `OFF` opts out in both directions
- `keyedVertexIsCappedAtItsKeyGroupCount`, the `numSourcePartitions == 0` path where `N` falls back to `maxParallelism`
- `legacyEmitsWheneverCappedAtPartitionCount`, `SCALING_LIMITED` for every capped target
- `alreadyAtThePartitionCountBlocksAScaleUp`, running exactly on the cap
- `movingUpToTheCapOnAScaleDownIsStillAnInversion` and `lowerLimitClampAboveCurrentStillBlocksAScaleDown`, the scale-down inversions the exemption must leave alone, one landing on the cap and one below it

Added to `JobVertexScalerTest`: `testSourceCappedAtPartitionCountWhenOverProvisioned`, the reproduction end-to-end through `scale()`, under both legacy modes, both built-in modes, and `OFF`. This is the level the table above is stated at, and the module's other alignment tests all run with the legacy mode pinned in `setup()`, so the new default had no end-to-end coverage.

Each fix was reverted in isolation to confirm the tests catch it:

| reverted | failing tests |
|---|---|
| built-in clamp | the end-to-end case under `BALANCED`, plus 8 aligner cases covering both built-in modes at targets 180, 50 and 16 |
| inversion exemption | the end-to-end case under the legacy mode, plus 4 aligner cases covering both legacy modes on the scale-up |

`legacyModesBlockAndEmit` covers the FLINK-39299 scale-up inversion and still blocks at 22. Full `flink-autoscaler` suite passes: 289 tests, 257 pre-existing plus 32 added.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- Core observer or reconciler logic that is regularly executed: yes, the autoscaler alignment path

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)

Generated-by: [Claude Opus]

