### PR TITLE
[FLINK-40408] Fix NOTICE files to match dependencies

### DIFF
--- a/flink-autoscaler-standalone/src/main/resources/META-INF/NOTICE
+++ b/flink-autoscaler-standalone/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- com.google.errorprone:error_prone_annotations:jar:2.36.0
+- com.google.guava:failureaccess:jar:1.0.2
+- com.google.guava:guava:jar:33.4.0-jre
+- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava
+- com.google.j2objc:j2objc-annotations:jar:3.0.0
 - com.squareup.okhttp3:okhttp:jar:4.12.0
 - com.squareup.okio:okio-jvm:jar:3.6.0
 - com.squareup.okio:okio:jar:3.6.0
@@ -38,3 +43,8 @@ See bundled license files for details.
 
 - com.esotericsoftware.kryo:kryo:2.24.0
 - com.esotericsoftware.minlog:minlog:1.2
+
+This project bundles the following dependencies under the MIT License.
+See bundled license files for details.
+
+- org.checkerframework:checker-qual:jar:3.43.0

--- a/flink-autoscaler-standalone/src/main/resources/META-INF/licenses/LICENSE.checker-qual
+++ b/flink-autoscaler-standalone/src/main/resources/META-INF/licenses/LICENSE.checker-qual
@@ -1,0 +1,22 @@
+Checker Framework qualifiers
+Copyright 2004-present by the Checker Framework developers
+
+MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/flink-kubernetes-operator-api/pom.xml
+++ b/flink-kubernetes-operator-api/pom.xml
@@ -84,7 +84,6 @@ under the License.
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
 
         <dependency>

--- a/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-operator/src/main/resources/META-INF/NOTICE
@@ -53,7 +53,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.fabric8:kubernetes-model-resource:jar:7.8.0
 - io.fabric8:kubernetes-model-scheduling:jar:7.8.0
 - io.fabric8:kubernetes-model-storageclass:jar:7.8.0
+- io.fabric8:kubernetes-httpclient-jdk:7.8.0
 - io.fabric8:zjsonpatch:jar:7.8.0
+- io.github.java-diff-utils:java-diff-utils:4.17
 - io.javaoperatorsdk:operator-framework-core:jar:5.5.0
 - io.javaoperatorsdk:operator-framework:jar:5.5.0
 - org.apache.commons:commons-compress:jar:1.26.0
@@ -63,7 +65,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.logging.log4j:log4j-1.2-api:jar:2.25.4
 - org.apache.logging.log4j:log4j-api:jar:2.25.4
 - org.apache.logging.log4j:log4j-core:jar:2.25.4
-- org.checkerframework:checker-qual:jar:3.43.0
 - org.javassist:javassist:jar:3.24.0-GA
 - org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.8.21
 - org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.8.21
@@ -77,11 +78,14 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.xerial.snappy:snappy-java:jar:1.1.10.4
 - org.yaml:snakeyaml:jar:2.5
 - tools.profiler:async-profiler:jar:2.9
-- io.github.java-diff-utils:java-diff-utils:4.15
-- io.fabric8:kubernetes-httpclient-jdk:7.8.0
 
 This project bundles the following dependencies under the BSD License.
 See bundled license files for details.
 
 - com.esotericsoftware.kryo:kryo:jar:2.24.0
 - com.esotericsoftware.minlog:minlog:jar:1.2
+
+This project bundles the following dependencies under the MIT License.
+See bundled license files for details.
+
+- org.checkerframework:checker-qual:jar:3.43.0

--- a/flink-kubernetes-webhook/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes-webhook/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.javaoperatorsdk:kubernetes-webhooks-framework-core:jar:1.1.1
+- io.javaoperatorsdk:kubernetes-webhooks-framework-core:jar:3.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@ under the License.
                 <version>2.21.5</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>5.9.3</version>


### PR DESCRIPTION
## What is the purpose of the change

Some NOTICE file entries are currently out of date, this PR aims to fix all issues I could find.

## Brief change log


  - `flink-kubernetes-webhook`
    - `kubernetes-webhooks-framework-core` updated to 3.0.0
  - `flink-autoscaler-standalone`
    - added `LICENSE.checker-qual`
    - added previously missing Guava dependencies
  - `flink-kubernetes-operator`
    - `java-diff-utils` updated to 4.17
    - moved `checker-qual` from the Apache-2.0 to MIT section
    - moved two entries into alphabetical order
  - pinned `commons-lang3` in dependencyManagement and fixed NOTICE files accordingly

## Verifying this change

Manual verification of bundled dependencies.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
