### PR TITLE
[FLINK-40413] Autoscaling example classes leak into the operator javadoc site

### DIFF
--- a/examples/autoscaling/autoscaling-dynamic.yaml
+++ b/examples/autoscaling/autoscaling-dynamic.yaml
@@ -49,7 +49,7 @@ spec:
         - name: flink-main-container
   job:
     jarURI: local:///opt/flink/usrlib/autoscaling.jar
-    entryClass: autoscaling.LoadSimulationPipeline
+    entryClass: org.apache.flink.examples.autoscaling.LoadSimulationPipeline
     parallelism: 1
     upgradeMode: stateless
     args:

--- a/examples/autoscaling/pom.xml
+++ b/examples/autoscaling/pom.xml
@@ -133,7 +133,7 @@ under the License.
                             <transformers>
                                 <transformer
                                         implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>autoscaling.AutoscalingExample</mainClass>
+                                    <mainClass>org.apache.flink.examples.autoscaling.AutoscalingExample</mainClass>
                                 </transformer>
                             </transformers>
                         </configuration>

--- a/examples/autoscaling/src/main/java/org/apache/flink/examples/autoscaling/AutoscalingExample.java
+++ b/examples/autoscaling/src/main/java/org/apache/flink/examples/autoscaling/AutoscalingExample.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package autoscaling;
+package org.apache.flink.examples.autoscaling;
 
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;

--- a/examples/autoscaling/src/main/java/org/apache/flink/examples/autoscaling/LoadSimulationPipeline.java
+++ b/examples/autoscaling/src/main/java/org/apache/flink/examples/autoscaling/LoadSimulationPipeline.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package autoscaling;
+package org.apache.flink.examples.autoscaling;
 
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;


### PR DESCRIPTION
## What is the purpose of the change

The nightly docs build publishes an `autoscaling` package on the operator javadoc site (https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/api/java/autoscaling/package-summary.html). The site is built with `mvn javadoc:aggregate` and filters examples out via `-DexcludePackageNames="org.apache.flink.examples"`, but the autoscaling example declares the bare package `autoscaling`, so it escapes the filter. This PR moves the example under `org.apache.flink.examples.autoscaling` so the existing exclusion applies and the site only hosts operator and autoscaler packages.

## Brief change log

  - Moved `AutoscalingExample` and `LoadSimulationPipeline` from the bare `autoscaling` package to `org.apache.flink.examples.autoscaling`
  - Updated the shade plugin `mainClass` in `examples/autoscaling/pom.xml` to the new fully qualified name
  - Updated `spec.job.entryClass` in `examples/autoscaling/autoscaling-dynamic.yaml` accordingly

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

Manually verified:

  - `mvn clean package` on the module succeeds, and the shaded jar manifest reads `Main-Class: org.apache.flink.examples.autoscaling.AutoscalingExample`
  - `mvn javadoc:javadoc -DexcludePackageNames="org.apache.flink.examples"` (the flag used by `docs.yaml`) generates no docs for the module, confirming the exclusion now covers it

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
