### PR TITLE
[FLINK-40384][snapshot] Only clean up terminal snapshots

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserver.java
@@ -26,6 +26,7 @@ import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
 import org.apache.flink.kubernetes.operator.api.status.Checkpoint;
 import org.apache.flink.kubernetes.operator.api.status.CheckpointInfo;
 import org.apache.flink.kubernetes.operator.api.status.CommonStatus;
+import org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus;
 import org.apache.flink.kubernetes.operator.api.status.Savepoint;
 import org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType;
 import org.apache.flink.kubernetes.operator.config.FlinkOperatorConfiguration;
@@ -53,7 +54,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.configuration.CheckpointingOptions.MAX_RETAINED_CHECKPOINTS;
+import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.ABANDONED;
 import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.COMPLETED;
+import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.FAILED;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_CLEANUP_ENABLED;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_AGE;
 import static org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions.OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT;
@@ -70,6 +73,8 @@ public class SnapshotObserver<
             s -> DateTimeUtils.parseKubernetes(s.getMetadata().getCreationTimestamp());
     private static final Set<SnapshotTriggerType> CLEAN_UP_SNAPSHOT_TRIGGER_TYPES =
             Set.of(SnapshotTriggerType.PERIODIC, SnapshotTriggerType.UPGRADE);
+    private static final Set<FlinkStateSnapshotStatus.State> CLEAN_UP_SNAPSHOT_STATES =
+            Set.of(COMPLETED, FAILED, ABANDONED);
 
     private final EventRecorder eventRecorder;
 
@@ -278,6 +283,12 @@ public class SnapshotObserver<
         var snapshotList =
                 snapshots.stream()
                         .filter(s -> !s.isMarkedForDeletion())
+                        .filter(
+                                s ->
+                                        s.getStatus() != null
+                                                && s.getStatus().getState() != null
+                                                && CLEAN_UP_SNAPSHOT_STATES.contains(
+                                                        s.getStatus().getState()))
                         .filter(
                                 s ->
                                         CLEAN_UP_SNAPSHOT_TRIGGER_TYPES.contains(

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/SnapshotObserverTest.java
@@ -51,6 +51,7 @@ import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshot
 import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.COMPLETED;
 import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.FAILED;
 import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.IN_PROGRESS;
+import static org.apache.flink.kubernetes.operator.api.status.FlinkStateSnapshotStatus.State.TRIGGER_PENDING;
 import static org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType.MANUAL;
 import static org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType.PERIODIC;
 import static org.apache.flink.kubernetes.operator.api.status.SnapshotTriggerType.UPGRADE;
@@ -163,10 +164,10 @@ public class SnapshotObserverTest extends OperatorTestBase {
 
         var testDataSavepoints =
                 List.of(
-                        createSnapshot(SAVEPOINT, 0, PERIODIC, IN_PROGRESS),
-                        createSnapshot(SAVEPOINT, 1, PERIODIC, IN_PROGRESS),
-                        createSnapshot(SAVEPOINT, 2, PERIODIC, IN_PROGRESS),
-                        createSnapshot(SAVEPOINT, 3, PERIODIC, IN_PROGRESS));
+                        createSnapshot(SAVEPOINT, 0, PERIODIC, ABANDONED),
+                        createSnapshot(SAVEPOINT, 1, PERIODIC, ABANDONED),
+                        createSnapshot(SAVEPOINT, 2, PERIODIC, ABANDONED),
+                        createSnapshot(SAVEPOINT, 3, PERIODIC, ABANDONED));
 
         var removedSavepoints =
                 observer.getFlinkStateSnapshotsToCleanUp(
@@ -176,6 +177,41 @@ public class SnapshotObserverTest extends OperatorTestBase {
                         testDataSavepoints.get(0),
                         testDataSavepoints.get(1),
                         testDataSavepoints.get(2));
+    }
+
+    @Test
+    public void testSnapshotWithoutStatusIsNotCleanedUp() {
+        var conf = new Configuration().set(OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT, 1);
+        var operatorConfig = FlinkOperatorConfiguration.fromConfiguration(conf);
+
+        var completedSnapshot = createSnapshot(SAVEPOINT, 0, PERIODIC, COMPLETED);
+        var snapshotWithoutStatus = createSnapshot(SAVEPOINT, 1, PERIODIC, IN_PROGRESS);
+        snapshotWithoutStatus.setStatus(null);
+
+        var removedSavepoints =
+                observer.getFlinkStateSnapshotsToCleanUp(
+                        List.of(completedSnapshot, snapshotWithoutStatus),
+                        conf,
+                        operatorConfig,
+                        SAVEPOINT);
+        assertThat(removedSavepoints).isEmpty();
+    }
+
+    @Test
+    public void testActiveSnapshotsAreNotCleanedUp() {
+        var conf = new Configuration().set(OPERATOR_SAVEPOINT_HISTORY_MAX_COUNT, 1);
+        var operatorConfig = FlinkOperatorConfiguration.fromConfiguration(conf);
+
+        var snapshots =
+                List.of(
+                        createSnapshot(SAVEPOINT, 0, PERIODIC, COMPLETED),
+                        createSnapshot(SAVEPOINT, 1, PERIODIC, TRIGGER_PENDING),
+                        createSnapshot(SAVEPOINT, 2, PERIODIC, IN_PROGRESS));
+
+        var removedSavepoints =
+                observer.getFlinkStateSnapshotsToCleanUp(
+                        snapshots, conf, operatorConfig, SAVEPOINT);
+        assertThat(removedSavepoints).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes [FLINK-40384](https://issues.apache.org/jira/browse/FLINK-40384) by preventing periodic `FlinkStateSnapshot` history cleanup from deleting snapshot resources that are still active or have not initialized their status yet.

Previously, snapshots with a null status or in `TRIGGER_PENDING` / `IN_PROGRESS` state could be selected for cleanup. Deleting such snapshots can race with status reconciliation, resulting in Kubernetes `409 Conflict` errors and repeated `SavepointError` events. With this change, only snapshots in terminal states are eligible for cleanup.

## Brief change log

- Restrict `FlinkStateSnapshot` cleanup to the terminal states `COMPLETED`, `FAILED`, and `ABANDONED`.
- Preserve snapshots with a null status or an active `TRIGGER_PENDING` / `IN_PROGRESS` state.
- Add regression tests covering snapshots without status and active snapshots.

## Verifying this change

This change added tests and was verified as follows:

- Ran `SnapshotObserverTest`; all 11 tests passed:
  `mvn -pl flink-kubernetes-operator -am -Dtest=SnapshotObserverTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Verified Spotless and Checkstyle checks pass.
- Verified `git diff --check` passes.
- Manually verified the change on a Kubernetes cluster.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
- Core observer or reconciler logic that is regularly executed: yes

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex  Reviewed by human and verified on k8s cluster. 
