### PR TITLE
[FLINK-40461] Add config option for labels on operator generated events

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -129,6 +129,12 @@
             <td>Maximum number of stack trace lines to include in exception-related Kubernetes event messages.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.events.labels</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>Map</td>
+            <td>Labels to be added to the metadata of every Kubernetes event created by the operator. Keys and values must be valid Kubernetes label keys/values, otherwise event creation will fail. Expected format: labelKey1:labelValue1,labelKey2:labelValue2. Changing this requires an operator restart.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.exception.field.max.length</h5></td>
             <td style="word-wrap: break-word;">2048</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/system_advanced_reconcile_section.html
+++ b/docs/layouts/shortcodes/generated/system_advanced_reconcile_section.html
@@ -21,6 +21,12 @@
             <td>Maximum number of stack trace lines to include in exception-related Kubernetes event messages.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.operator.events.labels</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>Map</td>
+            <td>Labels to be added to the metadata of every Kubernetes event created by the operator. Keys and values must be valid Kubernetes label keys/values, otherwise event creation will fail. Expected format: labelKey1:labelValue1,labelKey2:labelValue2. Changing this requires an operator restart.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.operator.ingress.manage</h5></td>
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/FlinkOperator.java
@@ -118,7 +118,7 @@ public class FlinkOperator {
         this.operator = createOperator();
         this.validators = ValidatorUtils.discoverValidators(configManager, pluginManager);
         this.listeners = ListenerUtils.discoverListeners(configManager, pluginManager);
-        this.eventRecorder = EventRecorder.create(client, listeners);
+        this.eventRecorder = EventRecorder.create(this.client, listeners, baseConfig);
         this.ctxFactory =
                 new FlinkResourceContextFactory(configManager, metricGroup, eventRecorder);
         LOG.info("Initializing file system factories from plugin directory.");

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -761,6 +761,17 @@ public class KubernetesOperatorConfigOptions {
                     .withDescription(
                             "Maximum number of exception-related Kubernetes events emitted per reconciliation cycle.");
 
+    @Documentation.Section(SECTION_ADVANCED)
+    public static final ConfigOption<Map<String, String>> OPERATOR_EVENT_LABELS =
+            operatorConfig("events.labels")
+                    .mapType()
+                    .defaultValue(new HashMap<>())
+                    .withDescription(
+                            "Labels to be added to the metadata of every Kubernetes event created by the operator. "
+                                    + "Keys and values must be valid Kubernetes label keys/values, otherwise event creation will fail. "
+                                    + "Expected format: labelKey1:labelValue1,labelKey2:labelValue2. "
+                                    + "Changing this requires an operator restart.");
+
     @Documentation.Section(SECTION_ADVANCED_RECONCILE)
     public static final ConfigOption<Boolean> OPERATOR_MANAGE_INGRESS =
             operatorConfig("ingress.manage")

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventRecorder.java
@@ -18,19 +18,25 @@
 
 package org.apache.flink.kubernetes.operator.utils;
 
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.operator.api.AbstractFlinkResource;
 import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
 import org.apache.flink.kubernetes.operator.api.FlinkStateSnapshot;
 import org.apache.flink.kubernetes.operator.api.listener.FlinkResourceListener;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
 import org.apache.flink.kubernetes.operator.listener.AuditUtils;
 
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
@@ -38,14 +44,34 @@ import java.util.function.Predicate;
 /** Helper class for creating Kubernetes events for Flink resources. */
 public class EventRecorder {
 
+    private static final Logger LOG = LoggerFactory.getLogger(EventRecorder.class);
+
     private final BiConsumer<AbstractFlinkResource<?, ?>, Event> eventListenerFlinkResource;
     private final BiConsumer<FlinkStateSnapshot, Event> eventListenerFlinkStateSnapshot;
+
+    /**
+     * Labels added to the metadata of every event created by this recorder.
+     *
+     * <p>Paths that do not set any dedupe labels themselves must pass this map as is, never null:
+     * labels are replaced on every update, so passing the (possibly empty) map is what clears the
+     * dedupe labels of a previous update. The autoscaler relies on this to re-emit a scaling report
+     * within the dedupe interval after switching back to scaling enabled mode.
+     */
+    private final Map<String, String> commonLabels;
 
     public EventRecorder(
             BiConsumer<AbstractFlinkResource<?, ?>, Event> eventListenerFlinkResource,
             BiConsumer<FlinkStateSnapshot, Event> eventListenerFlinkStateSnapshot) {
+        this(eventListenerFlinkResource, eventListenerFlinkStateSnapshot, Map.of());
+    }
+
+    public EventRecorder(
+            BiConsumer<AbstractFlinkResource<?, ?>, Event> eventListenerFlinkResource,
+            BiConsumer<FlinkStateSnapshot, Event> eventListenerFlinkStateSnapshot,
+            Map<String, String> commonLabels) {
         this.eventListenerFlinkResource = eventListenerFlinkResource;
         this.eventListenerFlinkStateSnapshot = eventListenerFlinkStateSnapshot;
+        this.commonLabels = Map.copyOf(commonLabels);
     }
 
     public boolean triggerSnapshotEvent(
@@ -64,7 +90,8 @@ public class EventRecorder {
                 component,
                 e -> eventListenerFlinkStateSnapshot.accept(resource, e),
                 null,
-                null);
+                null,
+                commonLabels);
     }
 
     public boolean triggerEvent(
@@ -118,7 +145,8 @@ public class EventRecorder {
                 component,
                 e -> eventListenerFlinkResource.accept(resource, e),
                 messageKey,
-                null);
+                null,
+                commonLabels);
     }
 
     /**
@@ -149,7 +177,8 @@ public class EventRecorder {
                 component,
                 e -> eventListenerFlinkResource.accept(resource, e),
                 messageKey,
-                interval);
+                interval,
+                commonLabels);
     }
 
     public boolean triggerEventOnce(
@@ -168,7 +197,8 @@ public class EventRecorder {
                 message,
                 component,
                 e -> eventListenerFlinkResource.accept(resource, e),
-                messageKey);
+                messageKey,
+                mergeWithCommonLabels(null));
     }
 
     public boolean triggerEventWithAnnotations(
@@ -189,7 +219,8 @@ public class EventRecorder {
                 component,
                 e -> eventListenerFlinkResource.accept(resource, e),
                 messageKey,
-                annotations);
+                annotations,
+                mergeWithCommonLabels(null));
     }
 
     /**
@@ -226,7 +257,47 @@ public class EventRecorder {
                 messageKey,
                 interval,
                 dedupePredicate,
-                labels);
+                mergeWithCommonLabels(labels));
+    }
+
+    /**
+     * Merge the caller provided labels with the globally configured ones. Caller provided labels
+     * take precedence as they may carry functional information such as dedupe state.
+     *
+     * @return the merged labels or null if there is nothing to set.
+     */
+    @Nullable
+    private Map<String, String> mergeWithCommonLabels(@Nullable Map<String, String> labels) {
+        if (commonLabels.isEmpty()) {
+            return labels;
+        }
+        if (labels == null || labels.isEmpty()) {
+            return commonLabels;
+        }
+        var merged = new HashMap<>(commonLabels);
+        merged.putAll(labels);
+        return merged;
+    }
+
+    /**
+     * Drop label entries that Kubernetes would reject. A single invalid entry coming from the
+     * operator config would otherwise fail the creation of every event.
+     */
+    @VisibleForTesting
+    static Map<String, String> validateLabels(Map<String, String> labels) {
+        var valid = new HashMap<String, String>();
+        labels.forEach(
+                (key, value) -> {
+                    // Label keys follow the same syntax as annotation keys
+                    if (!K8sAnnotationsSanitizer.isValidAnnotationKey(key)) {
+                        LOG.warn("Ignoring event label with invalid key: {}", key);
+                    } else if (!K8sAnnotationsSanitizer.isValidLabelValue(value)) {
+                        LOG.warn("Ignoring event label {} with invalid value: {}", key, value);
+                    } else {
+                        valid.put(key, value);
+                    }
+                });
+        return valid;
     }
 
     public boolean triggerEvent(
@@ -241,6 +312,20 @@ public class EventRecorder {
 
     public static EventRecorder create(
             KubernetesClient client, Collection<FlinkResourceListener> listeners) {
+        return create(client, listeners, new Configuration());
+    }
+
+    public static EventRecorder create(
+            KubernetesClient client,
+            Collection<FlinkResourceListener> listeners,
+            Configuration operatorConfig) {
+
+        var commonLabels =
+                validateLabels(
+                        operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_EVENT_LABELS));
+        if (!commonLabels.isEmpty()) {
+            LOG.info("Adding labels {} to all operator generated events", commonLabels);
+        }
 
         BiConsumer<AbstractFlinkResource<?, ?>, Event> biConsumerFlinkResource =
                 (resource, event) -> {
@@ -295,7 +380,8 @@ public class EventRecorder {
                     AuditUtils.logContext(ctx);
                 };
 
-        return new EventRecorder(biConsumerFlinkResource, biConsumerFlinkStateSnapshot);
+        return new EventRecorder(
+                biConsumerFlinkResource, biConsumerFlinkStateSnapshot, commonLabels);
     }
 
     /** The type of the events. */

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/EventUtils.java
@@ -40,6 +40,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -83,6 +84,30 @@ public class EventUtils {
             Consumer<Event> eventListener,
             @Nullable String messageKey,
             @Nullable Duration interval) {
+        return createOrUpdateEventWithInterval(
+                client,
+                target,
+                type,
+                reason,
+                message,
+                component,
+                eventListener,
+                messageKey,
+                interval,
+                Map.of());
+    }
+
+    public static boolean createOrUpdateEventWithInterval(
+            KubernetesClient client,
+            HasMetadata target,
+            EventRecorder.Type type,
+            String reason,
+            String message,
+            EventRecorder.Component component,
+            Consumer<Event> eventListener,
+            @Nullable String messageKey,
+            @Nullable Duration interval,
+            @Nullable Map<String, String> labels) {
         return createOrUpdateEventWithLabels(
                 client,
                 target,
@@ -94,7 +119,7 @@ public class EventUtils {
                 messageKey,
                 interval,
                 null,
-                Map.of());
+                labels);
     }
 
     public static Event findExistingEvent(
@@ -120,6 +145,34 @@ public class EventUtils {
             Consumer<Event> eventListener,
             @Nullable String messageKey,
             @Nullable Map<String, String> annotations) {
+        return createWithAnnotations(
+                client,
+                target,
+                type,
+                reason,
+                message,
+                component,
+                eventListener,
+                messageKey,
+                annotations,
+                null);
+    }
+
+    /**
+     * Create or update an event for the target resource. If the event already exists, it will be
+     * updated with the new annotations, message and the count will be increased.
+     */
+    public static boolean createWithAnnotations(
+            KubernetesClient client,
+            HasMetadata target,
+            EventRecorder.Type type,
+            String reason,
+            String message,
+            EventRecorder.Component component,
+            Consumer<Event> eventListener,
+            @Nullable String messageKey,
+            @Nullable Map<String, String> annotations,
+            @Nullable Map<String, String> labels) {
         String eventName =
                 generateEventName(
                         target, type, reason, messageKey != null ? messageKey : message, component);
@@ -130,11 +183,13 @@ public class EventUtils {
             existing.setCount(existing.getCount() + 1);
             existing.setMessage(message);
             setAnnotations(existing, annotations);
+            setLabels(existing, labels);
             createOrReplaceEvent(client, existing).ifPresent(eventListener);
             return false;
         } else {
             Event event = buildEvent(target, type, reason, message, component, eventName);
             setAnnotations(event, annotations);
+            setLabels(event, labels);
             createOrReplaceEvent(client, event).ifPresent(eventListener);
             return true;
         }
@@ -149,6 +204,20 @@ public class EventUtils {
             EventRecorder.Component component,
             Consumer<Event> eventListener,
             @Nullable String messageKey) {
+        return createIfNotExists(
+                client, target, type, reason, message, component, eventListener, messageKey, null);
+    }
+
+    public static boolean createIfNotExists(
+            KubernetesClient client,
+            HasMetadata target,
+            EventRecorder.Type type,
+            String reason,
+            String message,
+            EventRecorder.Component component,
+            Consumer<Event> eventListener,
+            @Nullable String messageKey,
+            @Nullable Map<String, String> labels) {
 
         String eventName =
                 generateEventName(
@@ -159,6 +228,7 @@ public class EventUtils {
             return false;
         } else {
             Event event = buildEvent(target, type, reason, message, component, eventName);
+            setLabels(event, labels);
             createOrReplaceEvent(client, event).ifPresent(eventListener);
             return true;
         }
@@ -208,14 +278,14 @@ public class EventUtils {
         createOrReplaceEvent(client, existing).ifPresent(eventListener);
     }
 
-    private static void setLabels(Event existing, @Nullable Map<String, String> labels) {
+    private static void setLabels(Event event, @Nullable Map<String, String> labels) {
         if (labels == null) {
             return;
         }
-        if (existing.getMetadata() == null) {
-            existing.setMetadata(new ObjectMeta());
+        if (event.getMetadata() == null) {
+            event.setMetadata(new ObjectMeta());
         }
-        existing.getMetadata().setLabels(labels);
+        event.getMetadata().setLabels(new HashMap<>(labels));
     }
 
     private static void setAnnotations(Event existing, @Nullable Map<String, String> annotations) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/K8sAnnotationsSanitizer.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/utils/K8sAnnotationsSanitizer.java
@@ -111,6 +111,23 @@ public class K8sAnnotationsSanitizer {
     }
 
     /**
+     * Validates a label value according to Kubernetes rules: it must be empty or at most 63
+     * characters, beginning and ending with an alphanumeric character, with dashes, underscores and
+     * dots in between. See <a
+     * href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set">Kubernetes
+     * Labels Syntax and Character Set</a>
+     *
+     * <p>Label keys follow the same syntax as annotation keys, use {@link #isValidAnnotationKey}
+     * for those.
+     */
+    public static boolean isValidLabelValue(String value) {
+        if (value == null) {
+            return false;
+        }
+        return value.isEmpty() || isValidName(value);
+    }
+
+    /**
      * Sanitizes the annotation value by trimming and removing control characters, replacing
      * newlines and tabs with spaces. No length limit.
      */

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventRecorderTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/EventRecorderTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.operator.utils;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.operator.TestUtils;
+import org.apache.flink.kubernetes.operator.api.FlinkDeployment;
+import org.apache.flink.kubernetes.operator.config.KubernetesOperatorConfigOptions;
+
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test for the configurable event labels of {@link EventRecorder}. */
+@EnableKubernetesMockClient(crud = true)
+public class EventRecorderTest {
+
+    private static final Map<String, String> CONFIGURED_LABELS =
+            Map.of("env", "prod", "owner", "flink");
+
+    private KubernetesClient kubernetesClient;
+
+    @Test
+    public void testNoLabelsByDefault() {
+        var recorder = EventRecorder.create(kubernetesClient, List.of(), new Configuration());
+        var flinkApp = TestUtils.buildApplicationCluster();
+
+        recorder.triggerEvent(
+                flinkApp,
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.Cleanup,
+                EventRecorder.Component.Operator,
+                "message",
+                kubernetesClient);
+
+        var labels = getEvent(flinkApp, "message").getMetadata().getLabels();
+        assertTrue(labels == null || labels.isEmpty(), "Unexpected labels: " + labels);
+    }
+
+    @Test
+    public void testConfiguredLabelsAddedToEvents() {
+        var recorder = EventRecorder.create(kubernetesClient, List.of(), configWithLabels());
+        var flinkApp = TestUtils.buildApplicationCluster();
+
+        // Event created via createOrUpdateEventWithInterval
+        recorder.triggerEvent(
+                flinkApp,
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.Cleanup,
+                EventRecorder.Component.Operator,
+                "message",
+                kubernetesClient);
+        assertEquals(CONFIGURED_LABELS, getEvent(flinkApp, "message").getMetadata().getLabels());
+
+        // The labels are kept when the same event is updated
+        recorder.triggerEvent(
+                flinkApp,
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.Cleanup,
+                EventRecorder.Component.Operator,
+                "message",
+                kubernetesClient);
+        var updated = getEvent(flinkApp, "message");
+        assertEquals(2, updated.getCount());
+        assertEquals(CONFIGURED_LABELS, updated.getMetadata().getLabels());
+
+        // Event created via createIfNotExists
+        recorder.triggerEventOnce(
+                flinkApp,
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.Cleanup,
+                "message",
+                EventRecorder.Component.Operator,
+                "once",
+                kubernetesClient);
+        assertEquals(CONFIGURED_LABELS, getEvent(flinkApp, "once").getMetadata().getLabels());
+
+        // Event created via createWithAnnotations
+        recorder.triggerEventWithAnnotations(
+                flinkApp,
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.JobException,
+                "message",
+                EventRecorder.Component.Job,
+                "annotated",
+                kubernetesClient,
+                Map.of("a", "b"));
+        var annotated =
+                getEvent(
+                        flinkApp,
+                        EventRecorder.Type.Warning,
+                        EventRecorder.Reason.JobException.name(),
+                        "annotated",
+                        EventRecorder.Component.Job);
+        assertEquals(CONFIGURED_LABELS, annotated.getMetadata().getLabels());
+        assertEquals(Map.of("a", "b"), annotated.getMetadata().getAnnotations());
+    }
+
+    @Test
+    public void testConfiguredLabelsMergedWithCallerLabels() {
+        var recorder = EventRecorder.create(kubernetesClient, List.of(), configWithLabels());
+        var flinkApp = TestUtils.buildApplicationCluster();
+
+        // Caller labels (used for dedupe) are merged with the configured ones, caller wins on
+        // conflicting keys
+        recorder.triggerEventWithLabels(
+                flinkApp,
+                EventRecorder.Type.Normal,
+                EventRecorder.Reason.ScalingReport.name(),
+                "message",
+                EventRecorder.Component.Operator,
+                "scaling",
+                kubernetesClient,
+                Duration.ofMinutes(30),
+                labels -> false,
+                Map.of("parallelismMap", "hash", "owner", "autoscaler"));
+
+        assertEquals(
+                Map.of("env", "prod", "owner", "autoscaler", "parallelismMap", "hash"),
+                getEvent(
+                                flinkApp,
+                                EventRecorder.Type.Normal,
+                                EventRecorder.Reason.ScalingReport.name(),
+                                "scaling",
+                                EventRecorder.Component.Operator)
+                        .getMetadata()
+                        .getLabels());
+    }
+
+    @Test
+    public void testLabelsNotSetWithoutConfigOnLegacyPaths() {
+        var recorder = EventRecorder.create(kubernetesClient, List.of(), new Configuration());
+        var flinkApp = TestUtils.buildApplicationCluster();
+
+        recorder.triggerEventOnce(
+                flinkApp,
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.Cleanup,
+                "message",
+                EventRecorder.Component.Operator,
+                "once",
+                kubernetesClient);
+
+        var labels = getEvent(flinkApp, "once").getMetadata().getLabels();
+        assertTrue(labels == null || labels.isEmpty(), "Unexpected labels: " + labels);
+    }
+
+    private static Configuration configWithLabels() {
+        var conf = new Configuration();
+        conf.set(KubernetesOperatorConfigOptions.OPERATOR_EVENT_LABELS, CONFIGURED_LABELS);
+        return conf;
+    }
+
+    private Event getEvent(FlinkDeployment flinkApp, String messageKey) {
+        return getEvent(
+                flinkApp,
+                EventRecorder.Type.Warning,
+                EventRecorder.Reason.Cleanup.name(),
+                messageKey,
+                EventRecorder.Component.Operator);
+    }
+
+    private Event getEvent(
+            FlinkDeployment flinkApp,
+            EventRecorder.Type type,
+            String reason,
+            String messageKey,
+            EventRecorder.Component component) {
+        var eventName = EventUtils.generateEventName(flinkApp, type, reason, messageKey, component);
+        return kubernetesClient
+                .v1()
+                .events()
+                .inNamespace(flinkApp.getMetadata().getNamespace())
+                .withName(eventName)
+                .get();
+    }
+}

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/K8sAnnotationsSanitizerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/utils/K8sAnnotationsSanitizerTest.java
@@ -120,4 +120,23 @@ public class K8sAnnotationsSanitizerTest {
         assertThat(sanitized.get("valid-key")).isEqualTo("some value");
         assertThat(sanitized.get("example.com/valid-name")).isEqualTo("value with newlines");
     }
+
+    @Test
+    public void testIsValidLabelValue() {
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("")).isTrue();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("prod")).isTrue();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("a")).isTrue();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("a.b-c_d")).isTrue();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("A1")).isTrue();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("a".repeat(63))).isTrue();
+
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue(null)).isFalse();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("a".repeat(64))).isFalse();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("not valid")).isFalse();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("-lead")).isFalse();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("trail-")).isFalse();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue(".lead")).isFalse();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("foo@bar")).isFalse();
+        assertThat(K8sAnnotationsSanitizer.isValidLabelValue("foo/bar")).isFalse();
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

  This pull request adds a new operator config option `kubernetes.operator.events.labels` that attaches a fixed set of labels to the metadata of every Kubernetes event created by the operator.

  Operator-generated events are currently indistinguishable from other events in a namespace via label selectors. Common labels let cluster tooling (event exporters, alerting, retention policies, dashboards) filter and route
  operator events without parsing their contents.

  ```yaml
  kubernetes.operator.events.labels: env:prod,owner:flink
  ```

  The option is read once at operator startup, so changing it requires an operator restart.

  ## Brief change log
  
    - New `OPERATOR_EVENT_LABELS` map option (default empty) in `KubernetesOperatorConfigOptions`, documented in the advanced section; generated config docs regenerated
    - `EventRecorder` holds the configured labels as `commonLabels` and applies them on all event creation paths; new `EventRecorder.create(client, listeners, operatorConfig)` factory, with the existing two-arg overload
  defaulting to an empty config
    - `EventUtils.createIfNotExists` and `EventUtils.createWithAnnotations` gained a `labels` parameter so labels reach the paths that previously ignored them; the old signatures are kept as overloads that pass no labels
    - Configured labels are merged with caller-provided labels, with the caller winning on conflicting keys, so configuring e.g. `parallelismMap` cannot break autoscaler scaling report dedupe
    - Label entries Kubernetes would reject are dropped with a `WARN` at startup — `setLabels` replaces the whole label map, so a single invalid entry would otherwise fail creation of every event. Keys reuse
  `K8sAnnotationsSanitizer.isValidAnnotationKey` (same syntax as annotation keys); new `isValidLabelValue` covers the value rules (empty, or ≤63 chars, alphanumeric start/end, `-_.` in between)
    - `EventUtils.setLabels` defensively copies the map before setting it; parameter renamed `existing` → `event` since it is now also used on freshly built events
    - `FlinkOperator` passes the initialized `this.client` field (the constructor parameter is null outside of tests) and the base config to `EventRecorder.create`

  Behaviour is unchanged when the option is unset: paths that previously set no labels still set none, and autoscaler dedupe labels are unaffected.

  One deliberate subtlety: paths that do not set their own dedupe labels pass the (possibly empty) common label map rather than `null`. Because labels are replaced on every update, passing the map is what clears a previous
  update's dedupe labels — the autoscaler relies on this to re-emit a scaling report within the dedupe interval after switching back to scaling enabled mode. This is documented on the `commonLabels` field.

  ## Verifying this change

  This change added tests and can be verified as follows:
  
    - Added `EventRecorderTest` (mock Kubernetes client) covering: no labels on events by default; configured labels applied on events created via `createOrUpdateEventWithInterval`, `createIfNotExists` and
  `createWithAnnotations`; labels preserved when an existing event is updated (count incremented); caller labels merged over configured ones with caller precedence; no labels set on the legacy paths when the option is unset
    - Added `K8sAnnotationsSanitizerTest#testIsValidLabelValue` covering empty, max-length and boundary values plus rejection cases (spaces, leading/trailing `-` and `.`, `@`, `/`, >63 chars, null)

  ## Does this pull request potentially affect one of the following parts:

    - Dependencies (does it add or upgrade a dependency): no
    - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
    - Core observer or reconciler logic that is regularly executed: no (event creation is touched, but with no behaviour change when the option is unset)

  ## Documentation

    - Does this pull request introduce a new feature? yes
    - If yes, how is the feature documented? docs (generated config option reference) and JavaDocs

  ---

  ##### Was generative AI tooling used to co-author this PR?
  
  - [X] Yes (please specify the tool below)

  Generated-by: Claude Code (Opus 5)

