### PR TITLE
[FLINK-40452] Cap exception fetching by size instead of line count

### DIFF
--- a/docs/content.zh/docs/operations/events.md
+++ b/docs/content.zh/docs/operations/events.md
@@ -123,10 +123,10 @@ Job status changed to <state>
 
 ```
 <root exception class>: <message>
-<first N lines of the stack trace>
-... (<N> more lines)
+<first N characters of the stack trace>
+... (<N> more characters)
 ```
-The number of stack-trace lines included is controlled by the operator configuration; the trailing `... (<N> more lines)` suffix is only present when the trace was truncated.
+The number of stack-trace characters included is controlled by the `kubernetes.operator.events.exceptions.stacktrace.max.length` operator configuration option; the trailing `... (<N> more characters)` suffix is only present when the trace was truncated.
 
 #### SavepointError
 

--- a/docs/content/docs/operations/events.md
+++ b/docs/content/docs/operations/events.md
@@ -123,10 +123,10 @@ Job status changed to <state>
 
 ```
 <root exception class>: <message>
-<first N lines of the stack trace>
-... (<N> more lines)
+<first N characters of the stack trace>
+... (<N> more characters)
 ```
-The number of stack-trace lines included is controlled by the operator configuration; the trailing `... (<N> more lines)` suffix is only present when the trace was truncated.
+The number of stack-trace characters included is controlled by the `kubernetes.operator.events.exceptions.stacktrace.max.length` operator configuration option; the trailing `... (<N> more characters)` suffix is only present when the trace was truncated.
 
 #### SavepointError
 

--- a/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_operator_config_configuration.html
@@ -123,10 +123,10 @@
             <td>Maximum number of exception-related Kubernetes events emitted per reconciliation cycle.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.events.exceptions.stacktrace-lines</h5></td>
-            <td style="word-wrap: break-word;">5</td>
+            <td><h5>kubernetes.operator.events.exceptions.stacktrace.max.length</h5></td>
+            <td style="word-wrap: break-word;">2048</td>
             <td>Integer</td>
-            <td>Maximum number of stack trace lines to include in exception-related Kubernetes event messages.</td>
+            <td>Maximum number of characters of stack trace text to include in exception-related Kubernetes event messages. The stack trace is truncated once it reaches this size, regardless of how many lines it spans, so a single pathological line with no line breaks cannot bypass the cap.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.exception.field.max.length</h5></td>

--- a/docs/layouts/shortcodes/generated/system_advanced_reconcile_section.html
+++ b/docs/layouts/shortcodes/generated/system_advanced_reconcile_section.html
@@ -15,10 +15,10 @@
             <td>Maximum number of exception-related Kubernetes events emitted per reconciliation cycle.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.events.exceptions.stacktrace-lines</h5></td>
-            <td style="word-wrap: break-word;">5</td>
+            <td><h5>kubernetes.operator.events.exceptions.stacktrace.max.length</h5></td>
+            <td style="word-wrap: break-word;">2048</td>
             <td>Integer</td>
-            <td>Maximum number of stack trace lines to include in exception-related Kubernetes event messages.</td>
+            <td>Maximum number of characters of stack trace text to include in exception-related Kubernetes event messages. The stack trace is truncated once it reaches this size, regardless of how many lines it spans, so a single pathological line with no line breaks cannot bypass the cap.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.operator.ingress.manage</h5></td>

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/FlinkOperatorConfiguration.java
@@ -210,7 +210,8 @@ public class FlinkOperatorConfiguration {
                 operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_EVENT_EXCEPTION_LIMIT);
         int reportedExceptionEventsMaxStackTraceLength =
                 operatorConfig.get(
-                        KubernetesOperatorConfigOptions.OPERATOR_EVENT_EXCEPTION_STACKTRACE_LINES);
+                        KubernetesOperatorConfigOptions
+                                .OPERATOR_EVENT_EXCEPTION_STACKTRACE_MAX_LENGTH);
 
         boolean manageIngress =
                 operatorConfig.get(KubernetesOperatorConfigOptions.OPERATOR_MANAGE_INGRESS);

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/config/KubernetesOperatorConfigOptions.java
@@ -780,12 +780,12 @@ public class KubernetesOperatorConfigOptions {
                             "How often to retrieve Kubernetes cluster resource usage information. This information is used to avoid running out of cluster resources when scaling up resources. Negative values disable the feature.");
 
     @Documentation.Section(SECTION_ADVANCED_RECONCILE)
-    public static final ConfigOption<Integer> OPERATOR_EVENT_EXCEPTION_STACKTRACE_LINES =
-            operatorConfig("events.exceptions.stacktrace-lines")
+    public static final ConfigOption<Integer> OPERATOR_EVENT_EXCEPTION_STACKTRACE_MAX_LENGTH =
+            operatorConfig("events.exceptions.stacktrace.max.length")
                     .intType()
-                    .defaultValue(5)
+                    .defaultValue(2048)
                     .withDescription(
-                            "Maximum number of stack trace lines to include in exception-related Kubernetes event messages.");
+                            "Maximum number of characters of stack trace text to include in exception-related Kubernetes event messages. The stack trace is truncated once it reaches this size, regardless of how many lines it spans, so a single pathological line with no line breaks cannot bypass the cap.");
 
     @Documentation.Section(SECTION_ADVANCED_RECONCILE)
     public static final ConfigOption<Integer> OPERATOR_EVENT_EXCEPTION_LIMIT =

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -217,7 +217,8 @@ public class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
             }
 
             int maxEvents = operatorConfig.getReportedExceptionEventsMaxCount();
-            int maxStackTraceLines = operatorConfig.getReportedExceptionEventsMaxStackTraceLength();
+            int maxStackTraceLength =
+                    operatorConfig.getReportedExceptionEventsMaxStackTraceLength();
 
             int count = 0;
             for (var exception : exceptions) {
@@ -226,7 +227,7 @@ public class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
                 if (!exceptionTime.isAfter(lastRecorded) || count++ >= maxEvents) {
                     break;
                 }
-                emitJobManagerExceptionEvent(ctx, exception, exceptionTime, maxStackTraceLines);
+                emitJobManagerExceptionEvent(ctx, exception, exceptionTime, maxStackTraceLength);
             }
 
             if (count > maxEvents) {
@@ -244,7 +245,7 @@ public class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
             FlinkResourceContext<R> ctx,
             JobExceptionsInfoWithHistory.RootExceptionInfo exception,
             Instant exceptionTime,
-            int maxStackTraceLines) {
+            int maxStackTraceLength) {
         Map<String, String> annotations = new HashMap<>();
         if (exceptionTime != null) {
             annotations.put(EXCEPTION_TIMESTAMP, exceptionTime.toString());
@@ -267,15 +268,14 @@ public class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
         StringBuilder eventMessage = new StringBuilder();
         String stacktrace = exception.getStacktrace();
         if (stacktrace != null && !stacktrace.isBlank()) {
-            String[] lines = stacktrace.split("\n");
-            for (int i = 0; i < Math.min(maxStackTraceLines, lines.length); i++) {
-                eventMessage.append(lines[i]).append("\n");
-            }
-            if (lines.length > maxStackTraceLines) {
+            if (stacktrace.length() > maxStackTraceLength) {
                 eventMessage
+                        .append(stacktrace, 0, maxStackTraceLength)
                         .append("... (")
-                        .append(lines.length - maxStackTraceLines)
-                        .append(" more lines)");
+                        .append(stacktrace.length() - maxStackTraceLength)
+                        .append(" more characters)");
+            } else {
+                eventMessage.append(stacktrace);
             }
         }
 

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
@@ -471,8 +471,9 @@ public class JobStatusObserverTest extends OperatorTestBase {
         jobStatus.setState(JobStatus.RUNNING);
         Map<String, String> configuration = new HashMap<>();
         configuration.put(
-                KubernetesOperatorConfigOptions.OPERATOR_EVENT_EXCEPTION_STACKTRACE_LINES.key(),
-                "2");
+                KubernetesOperatorConfigOptions.OPERATOR_EVENT_EXCEPTION_STACKTRACE_MAX_LENGTH
+                        .key(),
+                "12");
         Configuration operatorConfig = Configuration.fromMap(configuration);
         FlinkResourceContext<AbstractFlinkResource<?, ?>> ctx =
                 getResourceContext(deployment, operatorConfig);
@@ -486,7 +487,9 @@ public class JobStatusObserverTest extends OperatorTestBase {
         ctx.getExceptionCacheEntry().setLastTimestamp(Instant.ofEpochMilli(3000L));
 
         long exceptionTime = 4000L;
-        String longTrace = "line1\nline2\nline3\nline4";
+        String longTrace =
+                "line1\nline2\nline3\nline4"; // 23 characters total, ("line1\nline2\n") fit within
+        // the cap
         flinkService.addExceptionHistory(jobId, "StackTraceCheck", longTrace, exceptionTime);
 
         // Ensure jobFailedErr is null before the observe call
@@ -505,7 +508,51 @@ public class JobStatusObserverTest extends OperatorTestBase {
         assertTrue(msg.contains("line1"));
         assertTrue(msg.contains("line2"));
         assertFalse(msg.contains("line3"));
-        assertTrue(msg.contains("... (2 more lines)"));
+        assertTrue(msg.contains("... (11 more characters)"));
+    }
+
+    @Test
+    public void testStackTraceTruncationBySizeNotLineCount() throws Exception {
+        var deployment = initDeployment();
+        var status = deployment.getStatus();
+        var jobStatus = status.getJobStatus();
+        jobStatus.setState(JobStatus.RUNNING);
+        Map<String, String> configuration = new HashMap<>();
+        configuration.put(
+                KubernetesOperatorConfigOptions.OPERATOR_EVENT_EXCEPTION_STACKTRACE_MAX_LENGTH
+                        .key(),
+                "100");
+        Configuration operatorConfig = Configuration.fromMap(configuration);
+        FlinkResourceContext<AbstractFlinkResource<?, ?>> ctx =
+                getResourceContext(deployment, operatorConfig);
+
+        var jobId = JobID.fromHexString(deployment.getStatus().getJobStatus().getJobId());
+        flinkService.submitApplicationCluster(
+                deployment.getSpec().getJob(), ctx.getDeployConfig(deployment.getSpec()), false);
+        ReconciliationUtils.updateStatusForDeployedSpec(deployment, new Configuration());
+        ctx.getExceptionCacheEntry().setInitialized(true);
+        ctx.getExceptionCacheEntry().setJobId(jobId.toHexString());
+        ctx.getExceptionCacheEntry().setLastTimestamp(Instant.ofEpochMilli(3000L));
+
+        long exceptionTime = 4000L;
+        // A single unbroken line of 5000 characters, assess that it gets truncated
+        String singleHugeLine = "x".repeat(5000);
+        flinkService.addExceptionHistory(jobId, "HugeSingleLine", singleHugeLine, exceptionTime);
+
+        flinkService.setJobFailedErr(null);
+        observer.observe(ctx);
+
+        var events =
+                kubernetesClient
+                        .v1()
+                        .events()
+                        .inNamespace(deployment.getMetadata().getNamespace())
+                        .list()
+                        .getItems();
+        assertEquals(1, events.size());
+        String msg = events.get(0).getMessage();
+        assertTrue(msg.length() < singleHugeLine.length());
+        assertTrue(msg.contains("... (4900 more characters)"));
     }
 
     @Test
@@ -755,8 +802,9 @@ public class JobStatusObserverTest extends OperatorTestBase {
         jobStatus.setState(JobStatus.RUNNING);
         Map<String, String> configuration = new HashMap<>();
         configuration.put(
-                KubernetesOperatorConfigOptions.OPERATOR_EVENT_EXCEPTION_STACKTRACE_LINES.key(),
-                "2");
+                KubernetesOperatorConfigOptions.OPERATOR_EVENT_EXCEPTION_STACKTRACE_MAX_LENGTH
+                        .key(),
+                "12");
         Configuration operatorConfig = Configuration.fromMap(configuration);
         FlinkResourceContext<AbstractFlinkResource<?, ?>> ctx =
                 getResourceContext(
@@ -797,7 +845,7 @@ public class JobStatusObserverTest extends OperatorTestBase {
         assertTrue(msg.contains("line1"));
         assertTrue(msg.contains("line2"));
         assertFalse(msg.contains("line3"));
-        assertTrue(msg.contains("... (2 more lines)"));
+        assertTrue(msg.contains("... (11 more characters)"));
     }
 
     @Test


### PR DESCRIPTION
JobStatusObserver capped JobManager exception text in K8s events byline count (stacktrace.split("\n"), keep first N lines). A single unbroken line of any size produces one array element, so it bypassed the cap entirely and could fill the operator heap.

 # Approach

  - Replaced `events.exceptions.stacktrace-lines` (line count, default 5)
  with `events.exceptions.stacktrace.max.length` (character count, default
  2048 — matches the two existing sibling options
  `exception.stacktrace.max.length` / `exception.field.max.length`; no
  config in the repo defaults to 4096, so 2048 was kept rather than
  raised).
  - Replaced the truncation itself: stacktrace.length() > 
  maxStackTraceLength + bounded substring, instead of splitting on \n.
  Also removes an unbounded 3-4x string-copy chain downstream of the old
  cap.
  - Old option removed outright (no value-preserving migration exists
  between line-count and character-count semantics).
  - Added a regression test (5000-char single line, no newlines) and
  updated existing tests, generated config docs, and hand-written
  event-format docs (both locales).

  # Testing

Updated existing unit test and added a new test to explicitly cover the bug scenario reported in FlINK-40452.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed. See
AGENTS.md for the full guidance.
-->

- [X] Yes (please specify the tool below)

Generated-by: Claude Code (Opus 5)
