### PR TITLE
[FLINK-38290][operator] Keep terminal job state when job is not found

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserver.java
@@ -301,17 +301,23 @@ public class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
     protected void onTargetJobNotFound(FlinkResourceContext<R> ctx) {
         var resource = ctx.getResource();
         var jobStatus = resource.getStatus().getJobStatus();
-
-        eventRecorder.triggerEvent(
-                resource,
-                EventRecorder.Type.Warning,
-                EventRecorder.Reason.Missing,
-                EventRecorder.Component.Job,
-                JOB_NOT_FOUND_ERR,
-                ctx.getKubernetesClient());
+        var alreadyTerminal = ReconciliationUtils.isJobInTerminalState(resource.getStatus());
+        if (alreadyTerminal) {
+            LOG.info(
+                    "Job not found but it was already observed in the {} state, keeping the observed state",
+                    jobStatus.getState());
+        } else {
+            eventRecorder.triggerEvent(
+                    resource,
+                    EventRecorder.Type.Warning,
+                    EventRecorder.Reason.Missing,
+                    EventRecorder.Component.Job,
+                    JOB_NOT_FOUND_ERR,
+                    ctx.getKubernetesClient());
+        }
 
         if (resource instanceof FlinkSessionJob
-                && !ReconciliationUtils.isJobInTerminalState(resource.getStatus())
+                && !alreadyTerminal
                 && resource.getSpec().getJob().getUpgradeMode() == UpgradeMode.STATELESS) {
             // We also mark jobs that were previously not terminated as suspended if
             // stateless upgrade mode is used. In these cases we want to simply restart the job.
@@ -321,8 +327,10 @@ public class JobStatusObserver<R extends AbstractFlinkResource<?, ?>> {
             // upgrading state and retry the upgrade (if possible)
             resource.getStatus().getReconciliationStatus().setState(ReconciliationState.DEPLOYED);
         }
-        jobStatus.setState(org.apache.flink.api.common.JobStatus.RECONCILING);
-        resource.getStatus().setError(JOB_NOT_FOUND_ERR);
+        if (!alreadyTerminal) {
+            jobStatus.setState(org.apache.flink.api.common.JobStatus.RECONCILING);
+            resource.getStatus().setError(JOB_NOT_FOUND_ERR);
+        }
     }
 
     /**

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/observer/JobStatusObserverTest.java
@@ -57,6 +57,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Tests for the {@link JobStatusObserver}. */
@@ -89,9 +90,17 @@ public class JobStatusObserverTest extends OperatorTestBase {
         observer.observe(
                 getResourceContext(
                         job, TestUtils.createContextWithReadyFlinkDeployment(kubernetesClient)));
-        assertEquals(
-                JobStatusObserver.JOB_NOT_FOUND_ERR,
-                flinkResourceEventCollector.events.poll().getMessage());
+        if (fromStatus.isGloballyTerminalState()) {
+            assertTrue(flinkResourceEventCollector.events.isEmpty());
+            assertEquals(fromStatus, jobStatus.getState());
+            assertNull(status.getError());
+        } else {
+            assertEquals(
+                    JobStatusObserver.JOB_NOT_FOUND_ERR,
+                    flinkResourceEventCollector.events.poll().getMessage());
+            assertEquals(JobStatus.RECONCILING, jobStatus.getState());
+            assertEquals(JobStatusObserver.JOB_NOT_FOUND_ERR, status.getError());
+        }
         assertEquals(
                 expectedAfter,
                 status.getReconciliationStatus()
@@ -909,6 +918,80 @@ public class JobStatusObserverTest extends OperatorTestBase {
         assertEquals(
                 now.minus(Duration.ofMinutes(1)).truncatedTo(ChronoUnit.MILLIS),
                 ctx.getExceptionCacheEntry().getLastTimestamp());
+    }
+
+    @Test
+    void testFinishedJobStateSurvivesJobManagerRestart() throws Exception {
+        // A restarted JobManager serves the job overview from an empty in-memory job store, so a
+        // job that already finished reads as missing even though the HA store still considers it
+        // completed and does not resubmit it. The observed terminal state must be kept, otherwise
+        // the deployment is stranded in RECONCILING and the terminal JobManager is never cleaned
+        // up.
+        var deployment = initDeployment();
+        var status = deployment.getStatus();
+        var jobStatus = status.getJobStatus();
+        jobStatus.setState(JobStatus.RUNNING);
+
+        FlinkResourceContext<AbstractFlinkResource<?, ?>> ctx = getResourceContext(deployment);
+        flinkService.submitApplicationCluster(
+                deployment.getSpec().getJob(), ctx.getDeployConfig(deployment.getSpec()), false);
+        var jobId = JobID.fromHexString(jobStatus.getJobId());
+
+        // Let the observer record the terminal state from the cluster
+        flinkService.cancelJob(jobId, true);
+        assertTrue(observer.observe(ctx));
+        assertEquals(JobStatus.FINISHED, jobStatus.getState());
+        flinkResourceEventCollector.events.clear();
+
+        // The JobManager restart drops the finished job from the store it is served from
+        flinkService.clearJobsInTerminalState();
+        assertFalse(observer.observe(ctx));
+
+        assertEquals(JobStatus.FINISHED, jobStatus.getState());
+        assertNull(status.getError());
+        assertTrue(flinkResourceEventCollector.events.isEmpty());
+    }
+
+    @Test
+    void testFailedJobStateSurvivesJobManagerRestart() throws Exception {
+        // Same as the finished case, but a failed job must additionally keep the recorded failure
+        // reason instead of having it replaced by the job not found error.
+        var deployment = initDeployment();
+        var status = deployment.getStatus();
+        var jobStatus = status.getJobStatus();
+        jobStatus.setState(JobStatus.RUNNING);
+
+        FlinkResourceContext<AbstractFlinkResource<?, ?>> ctx = getResourceContext(deployment);
+        flinkService.submitApplicationCluster(
+                deployment.getSpec().getJob(), ctx.getDeployConfig(deployment.getSpec()), false);
+        var jobId = JobID.fromHexString(jobStatus.getJobId());
+
+        flinkService.markApplicationJobFailedWithError(jobId, "job failure");
+        assertTrue(observer.observe(ctx));
+        assertEquals(JobStatus.FAILED, jobStatus.getState());
+        var failureError = status.getError();
+        flinkResourceEventCollector.events.clear();
+
+        flinkService.clearJobsInTerminalState();
+        assertFalse(observer.observe(ctx));
+
+        assertEquals(JobStatus.FAILED, jobStatus.getState());
+        assertEquals(failureError, status.getError());
+        assertTrue(flinkResourceEventCollector.events.isEmpty());
+    }
+
+    @Test
+    void testMissingTerminalJobStillUnblocksPendingUpgrade() throws Exception {
+        // Keeping the terminal job state must not keep a pending upgrade in the UPGRADING state,
+        // the reconciliation state is still reset so the upgrade can be retried.
+        var deployment = initDeployment();
+        var status = deployment.getStatus();
+        status.getJobStatus().setState(JobStatus.FINISHED);
+        status.getReconciliationStatus().setState(ReconciliationState.UPGRADING);
+
+        observer.observe(getResourceContext(deployment));
+
+        assertEquals(ReconciliationState.DEPLOYED, status.getReconciliationStatus().getState());
     }
 
     private static Stream<Arguments> cancellingArgs() {


### PR DESCRIPTION
## What is the purpose of the change

Fixes FLINK-38290, a FlinkDeployment whose job has reached a globallly terminal state falls back to RECONCILING and gets  stuck there when the JM pod is lost and recreated

## Brief change log

* JobStatusObserver#onTargetJobNotFound keeps the observed job state and error when the job is already in a globally terminal state
* The Job Not Found warning event is skipped for terminal jobs and logged instead
* The reconciliation state is still reset to DEPLOYED unconditionally, so a pending upgrade is not blocked

## Verifying this change

This change added tests and can be verified as follows:
  - Extended `testCancellingToMissing` so its 9 globally terminal parameter rows assert the observed state, the error, and the absence of the warning event
- Added `testFinishedJobStateSurvivesJobManagerRestart` and `testFailedJobStateSurvivesJobManagerRestart`: both submit an application cluster, let the observer record the terminal state from the cluster, then drop the job via `clearJobsInTerminalState()` to simulate the JobManager restart. The failed case also asserts the recorded failure reason is not replaced by `Job Not Found`
- Added `testMissingTerminalJobStillUnblocksPendingUpgrade`, which passes with and without the fix by design — it guards the unconditional reconciliation state reset rather than the bug
- Red/green: the 9 parameterized rows and the 2 new tests fail without the fix and pass with it
- No `e2e-tests/` script was added; the scenario needs a JobManager pod restart after job completion, and the unit tests reproduce it through the store-clearing path

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) - no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no) - no
  - Core observer or reconciler logic that is regularly executed: (yes / no) - yes (Reconciller logic)

## Documentation

  - Does this pull request introduce a new feature? (yes / no) -no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude Code
