### PR TITLE
FLINK-40531 Serialize parallelism overrides in a version-portable format

### DIFF
--- a/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStore.java
+++ b/flink-autoscaler-plugin-jdbc/src/main/java/org/apache/flink/autoscaler/jdbc/state/JdbcAutoScalerStateStore.java
@@ -297,7 +297,7 @@ public class JdbcAutoScalerStateStore<KEY, Context extends JobAutoScalerContext<
     }
 
     private static String serializeParallelismOverrides(Map<String, String> overrides) {
-        return ConfigurationUtils.convertValue(overrides, String.class);
+        return ConfigurationUtils.convertValue(overrides, String.class, false);
     }
 
     private static Map<String, String> deserializeParallelismOverrides(String overrides) {

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizer.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizer.java
@@ -168,7 +168,7 @@ public class KubernetesScalingRealizer
     private static String getOverrideString(
             KubernetesJobAutoScalerContext context, Map<String, String> newOverrides) {
         if (context.getResource().getStatus().getReconciliationStatus().isBeforeFirstDeployment()) {
-            return ConfigurationUtils.convertValue(newOverrides, String.class);
+            return serializeOverrides(newOverrides);
         }
 
         var conf = context.getResourceContext().getObserveConfig();
@@ -179,10 +179,29 @@ public class KubernetesScalingRealizer
         // This way we prevent reconciling a NOOP config change which would unnecessarily redeploy
         // the pipeline.
         if (currentOverrides.equals(newOverrides)) {
-            // If overrides are identical, use the previous string as-is.
-            return conf.getValue(PipelineOptions.PARALLELISM_OVERRIDES);
-        } else {
-            return ConfigurationUtils.convertValue(newOverrides, String.class);
+            // If overrides are identical, keep the previous string as-is — but only if every
+            // Flink version can read it (see serializeOverrides).
+            String previous = conf.getValue(PipelineOptions.PARALLELISM_OVERRIDES);
+            if (isLegacyParseable(previous)) {
+                return previous;
+            }
+        }
+        return serializeOverrides(newOverrides);
+    }
+
+    private static String serializeOverrides(Map<String, String> overrides) {
+        return ConfigurationUtils.convertValue(overrides, String.class, false);
+    }
+
+    private static boolean isLegacyParseable(@Nullable String overrideString) {
+        if (overrideString == null) {
+            return false;
+        }
+        try {
+            ConfigurationUtils.convertValue(overrideString, Map.class, false);
+            return true;
+        } catch (Exception e) {
+            return false;
         }
     }
 }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStore.java
@@ -307,7 +307,7 @@ public class KubernetesAutoScalerStateStore
     }
 
     private static String serializeParallelismOverrides(Map<String, String> overrides) {
-        return ConfigurationUtils.convertValue(overrides, String.class);
+        return ConfigurationUtils.convertValue(overrides, String.class, false);
     }
 
     private static Map<String, String> deserializeParallelismOverrides(String overrides) {

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/KubernetesScalingRealizerTest.java
@@ -63,6 +63,64 @@ public class KubernetesScalingRealizerTest {
     }
 
     @Test
+    public void testOverridesSerializedInLegacyFormatUnderStandardYaml() {
+        // The operator JVM may run in standard-YAML mode (config.yaml based operator conf), but
+        // the override string must stay in the legacy k:v,k:v format: a Flink 1.x JobManager
+        // loading a legacy flink-conf.yaml cannot parse the standard-YAML flow representation
+        // ({k: 'v'}) and crashes on startup.
+        GlobalConfiguration.setStandardYaml(true);
+        try {
+            KubernetesJobAutoScalerContext ctx =
+                    TestingKubernetesAutoscalerUtils.createContext("test", null);
+
+            new KubernetesScalingRealizer()
+                    .realizeParallelismOverrides(ctx, Map.of("a", "1", "b", "2"));
+
+            assertThat(
+                            ctx.getResource()
+                                    .getSpec()
+                                    .getFlinkConfiguration()
+                                    .asFlatMap()
+                                    .get(PipelineOptions.PARALLELISM_OVERRIDES.key()))
+                    .isIn("a:1,b:2", "b:2,a:1");
+        } finally {
+            GlobalConfiguration.setStandardYaml(false);
+        }
+    }
+
+    @Test
+    public void testBrokenStandardYamlOverrideStringIsRewritten() {
+        // A previously deployed flow-format string (produced by a standard-YAML-mode operator)
+        // must be rewritten to the legacy format even when the override map itself is unchanged,
+        // so that a crash-looping legacy-mode job can recover.
+        GlobalConfiguration.setStandardYaml(true);
+        try {
+            KubernetesJobAutoScalerContext ctx =
+                    TestingKubernetesAutoscalerUtils.createContext("test", null);
+            FlinkDeployment resource = (FlinkDeployment) ctx.getResource();
+
+            resource.getSpec()
+                    .getFlinkConfiguration()
+                    .put(PipelineOptions.PARALLELISM_OVERRIDES.key(), "{a: '1', b: '2'}");
+            resource.getStatus()
+                    .getReconciliationStatus()
+                    .serializeAndSetLastReconciledSpec(resource.getSpec(), resource);
+
+            new KubernetesScalingRealizer()
+                    .realizeParallelismOverrides(ctx, Map.of("a", "1", "b", "2"));
+
+            assertThat(
+                            resource.getSpec()
+                                    .getFlinkConfiguration()
+                                    .asFlatMap()
+                                    .get(PipelineOptions.PARALLELISM_OVERRIDES.key()))
+                    .isIn("a:1,b:2", "b:2,a:1");
+        } finally {
+            GlobalConfiguration.setStandardYaml(false);
+        }
+    }
+
+    @Test
     public void testAutoscalerOverridesStringDoesNotChangeUnlessOverridesChange() {
         // Create an overrides map which returns the keys in a deterministic order
         LinkedHashMap<String, String> newOverrides = new LinkedHashMap<>();

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStoreTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/autoscaler/state/KubernetesAutoScalerStateStoreTest.java
@@ -84,6 +84,30 @@ public class KubernetesAutoScalerStateStoreTest
     }
 
     @Test
+    void testParallelismOverridesSerializedInLegacyFormatUnderStandardYaml() throws Exception {
+        // Even when the operator JVM runs in standard-YAML mode, the stored override string must
+        // stay in the legacy k:v,k:v format so it can be read back (and deployed) in a form every
+        // Flink version can parse — the flow representation ({k: 'v'}) breaks legacy-mode parsers.
+        org.apache.flink.configuration.GlobalConfiguration.setStandardYaml(true);
+        try {
+            stateStore.storeParallelismOverrides(ctx, Map.of("a", "1", "b", "2"));
+            stateStore.flush(ctx);
+
+            var serialized =
+                    configMapStore.getSerializedState(
+                            ctx, KubernetesAutoScalerStateStore.PARALLELISM_OVERRIDES_KEY);
+            Assertions.assertTrue(serialized.isPresent());
+            Assertions.assertTrue(
+                    serialized.get().equals("a:1,b:2") || serialized.get().equals("b:2,a:1"),
+                    "Expected legacy map format but got: " + serialized.get());
+            Assertions.assertEquals(
+                    Map.of("a", "1", "b", "2"), stateStore.getParallelismOverrides(ctx));
+        } finally {
+            org.apache.flink.configuration.GlobalConfiguration.setStandardYaml(false);
+        }
+    }
+
+    @Test
     void testCompressionMigration() throws Exception {
         var jobUpdateTs = Instant.now();
         var v1 = new JobVertexID();


### PR DESCRIPTION
Flink can write map-valued config settings in two styles: the old a:1,b:2 and the newer {a: '1', b: '2'}. Every Flink version can read the old style; only newer parsers can read the new one.

The autoscaler lets Flink choose the style automatically, and that choice depends on which config file the operator itself was started with. So if the operator runs with config.yaml, it writes parallelism overrides in the new style into every FlinkDeployment it scales. Any JobManager still reading a legacy flink-conf.yaml then fails to start, because it cannot parse the value. The operator itself reports no problem — only the job breaks.

It also cannot recover by itself: the autoscaler reuses the previous override string whenever the overrides haven't changed, so once a bad string is written it stays there.

Fix: always write the old style, which works on all Flink versions, and rewrite the string if the existing one is unreadable.