### PR TITLE
[FLINK-40542] Block session cluster deletion when running jobs cannot be determined

### DIFF
--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/RestApiMetricsCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/RestApiMetricsCollector.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.autoscaler;
 
+import org.apache.flink.autoscaler.config.AutoScalerOptions;
 import org.apache.flink.autoscaler.metrics.FlinkMetric;
 import org.apache.flink.autoscaler.state.AutoScalerStateStore;
 import org.apache.flink.client.program.rest.RestClusterClient;
@@ -42,8 +43,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.autoscaler.metrics.FlinkMetric.HEAP_MEMORY_MAX;
@@ -110,7 +113,11 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
                                     AggregatedSubtaskMetricsHeaders.getInstance(),
                                     parameters,
                                     EmptyRequestBody.getInstance())
-                            .get();
+                            .get(
+                                    ctx.getConfiguration()
+                                            .get(AutoScalerOptions.FLINK_CLIENT_TIMEOUT)
+                                            .toSeconds(),
+                                    TimeUnit.SECONDS);
 
             return aggregateByFlinkMetric(metrics, responseBody);
         }
@@ -124,13 +131,18 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
                         "taskSlotsTotal", FlinkMetric.NUM_TASK_SLOTS_TOTAL,
                         "taskSlotsAvailable", FlinkMetric.NUM_TASK_SLOTS_AVAILABLE);
         try (var restClient = ctx.getRestClusterClient()) {
-            return queryJmMetrics(restClient, metrics);
+            return queryJmMetrics(
+                    restClient,
+                    metrics,
+                    ctx.getConfiguration().get(AutoScalerOptions.FLINK_CLIENT_TIMEOUT));
         }
     }
 
     @SneakyThrows
     protected Map<FlinkMetric, Metric> queryJmMetrics(
-            RestClusterClient<?> restClient, Map<String, FlinkMetric> metrics) {
+            RestClusterClient<?> restClient,
+            Map<String, FlinkMetric> metrics,
+            Duration clientTimeout) {
 
         var parameters = new JobManagerMetricsMessageParameters();
         var queryParamIt = parameters.getQueryParameters().iterator();
@@ -144,7 +156,7 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
                                 JobManagerMetricsHeaders.getInstance(),
                                 parameters,
                                 EmptyRequestBody.getInstance())
-                        .get();
+                        .get(clientTimeout.toSeconds(), TimeUnit.SECONDS);
 
         return responseBody.getMetrics().stream()
                 .collect(Collectors.toMap(m -> metrics.get(m.getId()), m -> m));
@@ -152,6 +164,7 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
 
     @Override
     protected Map<FlinkMetric, AggregatedMetric> queryTmMetrics(Context ctx) throws Exception {
+        var clientTimeout = ctx.getConfiguration().get(AutoScalerOptions.FLINK_CLIENT_TIMEOUT);
         try (var restClient = ctx.getRestClusterClient()) {
             // Unfortunately we cannot simply query for all metric names as Flink doesn't return
             // anything if any of the metric names is missing
@@ -161,7 +174,9 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
                             k -> {
                                 boolean gcMetricsFound =
                                         !queryAggregatedTmMetrics(
-                                                        restClient, TM_METRIC_NAMES_WITH_GC)
+                                                        restClient,
+                                                        TM_METRIC_NAMES_WITH_GC,
+                                                        clientTimeout)
                                                 .isEmpty();
                                 if (!gcMetricsFound) {
                                     LOG.debug("No GC metrics found, using only heap information");
@@ -173,7 +188,8 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
             var tmMetrics =
                     queryAggregatedTmMetrics(
                             restClient,
-                            hasGcMetrics ? TM_METRIC_NAMES_WITH_GC : COMMON_TM_METRIC_NAMES);
+                            hasGcMetrics ? TM_METRIC_NAMES_WITH_GC : COMMON_TM_METRIC_NAMES,
+                            clientTimeout);
             if (!tmMetrics.isEmpty()) {
                 return tmMetrics;
             } else {
@@ -187,7 +203,9 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
 
     @SneakyThrows
     protected Map<FlinkMetric, AggregatedMetric> queryAggregatedTmMetrics(
-            RestClusterClient<?> restClient, Map<String, FlinkMetric> metrics) {
+            RestClusterClient<?> restClient,
+            Map<String, FlinkMetric> metrics,
+            Duration clientTimeout) {
 
         var parameters = new AggregateTaskManagerMetricsParameters();
         var queryParamIt = parameters.getQueryParameters().iterator();
@@ -209,7 +227,7 @@ public class RestApiMetricsCollector<KEY, Context extends JobAutoScalerContext<K
                                 AggregatedTaskManagerMetricsHeaders.getInstance(),
                                 parameters,
                                 EmptyRequestBody.getInstance())
-                        .get();
+                        .get(clientTimeout.toSeconds(), TimeUnit.SECONDS);
 
         return aggregateByFlinkMetric(metrics, responseBody);
     }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/ScalingMetricCollector.java
@@ -304,12 +304,15 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
 
     private void updateKafkaPulsarSourceNumPartitions(
             Context ctx, JobID jobId, JobTopology topology) throws Exception {
+        var clientTimeout = ctx.getConfiguration().get(AutoScalerOptions.FLINK_CLIENT_TIMEOUT);
         try (var restClient = ctx.getRestClusterClient()) {
             for (var vertexInfo : topology.getVertexInfos().values()) {
                 if (topology.isSource(vertexInfo.getId())) {
                     var sourceVertex = vertexInfo.getId();
                     var numPartitions =
-                            queryAggregatedMetricNames(restClient, jobId, sourceVertex).stream()
+                            queryAggregatedMetricNames(
+                                            restClient, jobId, sourceVertex, clientTimeout)
+                                    .stream()
                                     .map(
                                             v -> {
                                                 String key =
@@ -462,6 +465,7 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
     @SneakyThrows
     private Map<JobVertexID, Map<String, FlinkMetric>> queryFilteredMetricNames(
             Context ctx, JobTopology topology, Stream<JobVertexID> vertexStream) {
+        var clientTimeout = ctx.getConfiguration().get(AutoScalerOptions.FLINK_CLIENT_TIMEOUT);
         try (var restClient = ctx.getRestClusterClient()) {
             return vertexStream
                     .filter(v -> !topology.getFinishedVertices().contains(v))
@@ -470,7 +474,11 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                                     v -> v,
                                     v ->
                                             getFilteredVertexMetricNames(
-                                                    restClient, ctx.getJobID(), v, topology)));
+                                                    restClient,
+                                                    ctx.getJobID(),
+                                                    v,
+                                                    topology,
+                                                    clientTimeout)));
         }
     }
 
@@ -479,9 +487,11 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
             RestClusterClient<?> restClient,
             JobID jobID,
             JobVertexID jobVertexID,
-            JobTopology topology) {
+            JobTopology topology,
+            Duration clientTimeout) {
 
-        var allMetricNames = queryAggregatedMetricNames(restClient, jobID, jobVertexID);
+        var allMetricNames =
+                queryAggregatedMetricNames(restClient, jobID, jobVertexID, clientTimeout);
         var filteredMetrics = new HashMap<String, FlinkMetric>();
         var requiredMetrics = new HashSet<FlinkMetric>();
 
@@ -529,7 +539,10 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
     @VisibleForTesting
     @SneakyThrows
     protected Collection<String> queryAggregatedMetricNames(
-            RestClusterClient<?> restClient, JobID jobID, JobVertexID jobVertexID) {
+            RestClusterClient<?> restClient,
+            JobID jobID,
+            JobVertexID jobVertexID,
+            Duration clientTimeout) {
         var parameters = new AggregatedSubtaskMetricsParameters();
         var pathIt = parameters.getPathParameters().iterator();
 
@@ -541,7 +554,7 @@ public abstract class ScalingMetricCollector<KEY, Context extends JobAutoScalerC
                         AggregatedSubtaskMetricsHeaders.getInstance(),
                         parameters,
                         EmptyRequestBody.getInstance())
-                .get()
+                .get(clientTimeout.toSeconds(), TimeUnit.SECONDS)
                 .getMetrics()
                 .stream()
                 .map(AggregatedMetric::getId)

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/JobAutoScalerImplTest.java
@@ -178,7 +178,8 @@ public class JobAutoScalerImplTest {
                             protected Collection<String> queryAggregatedMetricNames(
                                     RestClusterClient<?> restClient,
                                     JobID jobID,
-                                    JobVertexID jobVertexID) {
+                                    JobVertexID jobVertexID,
+                                    Duration timeout) {
                                 throw new NotReadyException(new Exception());
                             }
                         };

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/RestApiMetricsCollectorTest.java
@@ -182,7 +182,8 @@ class RestApiMetricsCollectorTest {
                                                         "taskSlotsTotal",
                                                         FlinkMetric.NUM_TASK_SLOTS_TOTAL,
                                                         "taskSlotsAvailable",
-                                                        FlinkMetric.NUM_TASK_SLOTS_AVAILABLE));
+                                                        FlinkMetric.NUM_TASK_SLOTS_AVAILABLE),
+                                                Duration.ofSeconds(10));
                                 assertThat(flinkMetricMetricMap)
                                         .hasSize(2)
                                         .hasEntrySatisfying(

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/ScalingMetricCollectorTest.java
@@ -45,6 +45,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMap
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -402,7 +403,11 @@ public class ScalingMetricCollectorTest {
                         new InMemoryAutoScalerStateStore<>()) {
                     @Override
                     protected Map<String, FlinkMetric> getFilteredVertexMetricNames(
-                            RestClusterClient<?> rc, JobID id, JobVertexID jvi, JobTopology t) {
+                            RestClusterClient<?> rc,
+                            JobID id,
+                            JobVertexID jvi,
+                            JobTopology t,
+                            Duration timeout) {
                         metricNameQueryCounter.compute(jvi, (j, c) -> c + 1);
                         return Map.of();
                     }
@@ -467,7 +472,10 @@ public class ScalingMetricCollectorTest {
                         new InMemoryAutoScalerStateStore<JobID, JobAutoScalerContext<JobID>>()) {
                     @Override
                     protected Collection<String> queryAggregatedMetricNames(
-                            RestClusterClient<?> restClient, JobID jobID, JobVertexID jobVertexID) {
+                            RestClusterClient<?> restClient,
+                            JobID jobID,
+                            JobVertexID jobVertexID,
+                            Duration timeout) {
                         return metricList;
                     }
                 };
@@ -516,7 +524,8 @@ public class ScalingMetricCollectorTest {
 
         assertEquals(
                 Set.of("a", "b"),
-                testCollector.queryAggregatedMetricNames(client, new JobID(), new JobVertexID()));
+                testCollector.queryAggregatedMetricNames(
+                        client, new JobID(), new JobVertexID(), Duration.ofSeconds(10)));
     }
 
     private void testRequiredMetrics(
@@ -530,7 +539,8 @@ public class ScalingMetricCollectorTest {
             metricList.addAll(requiredMetrics);
             metricList.remove(m);
             try {
-                testCollector.getFilteredVertexMetricNames(null, new JobID(), vertex, topology);
+                testCollector.getFilteredVertexMetricNames(
+                        null, new JobID(), vertex, topology, Duration.ofSeconds(10));
                 fail(m);
             } catch (Exception e) {
                 assertTrue(e.getMessage().startsWith("Could not find required metric "));
@@ -567,6 +577,6 @@ public class ScalingMetricCollectorTest {
                 MetricNotFoundException.class,
                 () ->
                         metricCollector.getFilteredVertexMetricNames(
-                                null, new JobID(), source, topology));
+                                null, new JobID(), source, topology, Duration.ofSeconds(10)));
     }
 }

--- a/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/TestingMetricsCollector.java
+++ b/flink-autoscaler/src/test/java/org/apache/flink/autoscaler/TestingMetricsCollector.java
@@ -101,7 +101,10 @@ public class TestingMetricsCollector<KEY, Context extends JobAutoScalerContext<K
 
     @Override
     protected Collection<String> queryAggregatedMetricNames(
-            RestClusterClient<?> restClient, JobID jobID, JobVertexID jobVertexID) {
+            RestClusterClient<?> restClient,
+            JobID jobID,
+            JobVertexID jobVertexID,
+            Duration timeout) {
         return metricNames.getOrDefault(jobVertexID, Collections.emptyList());
     }
 

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconciler.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -143,39 +144,55 @@ public class SessionReconciler
 
     // Detects jobs which are not in globally terminated states
     @VisibleForTesting
-    Set<JobID> getNonTerminalJobs(FlinkResourceContext<FlinkDeployment> ctx) {
+    Optional<Set<JobID>> getNonTerminalJobs(FlinkResourceContext<FlinkDeployment> ctx) {
         LOG.debug("Starting nonTerminal jobs detection for session cluster");
-        try {
-            // Get all jobs running in the Flink cluster
-            var flinkService = ctx.getFlinkService();
-            var clusterClient = flinkService.getClusterClient(ctx.getObserveConfig());
+        var flinkService = ctx.getFlinkService();
+        try (var clusterClient = flinkService.getClusterClient(ctx.getObserveConfig())) {
             var allJobs =
                     clusterClient
                             .sendRequest(
                                     JobsOverviewHeaders.getInstance(),
                                     EmptyMessageParameters.getInstance(),
                                     EmptyRequestBody.getInstance())
-                            .get()
+                            .get(
+                                    ctx.getOperatorConfig().getFlinkClientTimeout().toMillis(),
+                                    TimeUnit.MILLISECONDS)
                             .getJobs();
 
-            // running job Ids
+            if (allJobs == null) {
+                return Optional.of(Set.of());
+            }
+
             Set<JobID> nonTerminalJobIds =
                     allJobs.stream()
                             .filter(job -> !job.getStatus().isGloballyTerminalState())
                             .map(JobDetails::getJobId)
                             .collect(Collectors.toSet());
 
-            return nonTerminalJobIds;
+            return Optional.of(nonTerminalJobIds);
         } catch (Exception e) {
             LOG.warn("Failed to detect nonTerminal jobs in session cluster", e);
-            return Set.of();
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return Optional.empty();
         }
     }
 
     @Override
     public DeleteControl cleanupInternal(FlinkResourceContext<FlinkDeployment> ctx) {
-        var sessionJobs = ctx.getJosdkContext().getSecondaryResources(FlinkSessionJob.class);
         var deployment = ctx.getResource();
+        var status = deployment.getStatus();
+
+        if (status.getReconciliationStatus().isBeforeFirstDeployment()) {
+            LOG.info("Session cluster was never deployed, deleting immediately");
+            var conf = ctx.getDeployConfig(deployment.getSpec());
+            ctx.getFlinkService()
+                    .deleteClusterDeployment(deployment.getMetadata(), status, conf, true);
+            return DeleteControl.defaultDelete();
+        }
+
+        var sessionJobs = ctx.getJosdkContext().getSecondaryResources(FlinkSessionJob.class);
 
         boolean blockOnSessionJobs =
                 ctx.getObserveConfig()
@@ -207,21 +224,39 @@ public class SessionReconciler
                 ctx.getObserveConfig()
                         .getBoolean(KubernetesOperatorConfigOptions.BLOCK_ON_UNMANAGED_JOBS);
         if (blockOnSessionJobs && blockOnUnmanagedJobs) {
-            Set<JobID> nonTerminalJobs = getNonTerminalJobs(ctx);
-            if (!nonTerminalJobs.isEmpty()) {
+            Optional<Set<JobID>> nonTerminalJobs = getNonTerminalJobs(ctx);
+            if (nonTerminalJobs.isEmpty()) {
                 var error =
-                        String.format(
-                                "The session cluster has non terminated jobs %s that should be cancelled first",
-                                nonTerminalJobs.stream()
-                                        .map(JobID::toHexString)
-                                        .collect(Collectors.toList()));
-                eventRecorder.triggerEvent(
+                        "Could not determine whether the session cluster has running jobs; blocking deletion to avoid stopping unmanaged jobs without a checkpoint";
+                if (eventRecorder.triggerEvent(
                         deployment,
                         EventRecorder.Type.Warning,
                         EventRecorder.Reason.CleanupFailed,
                         EventRecorder.Component.Operator,
                         error,
-                        ctx.getKubernetesClient());
+                        ctx.getKubernetesClient())) {
+                    LOG.warn(error);
+                }
+                return DeleteControl.noFinalizerRemoval()
+                        .rescheduleAfter(ctx.getOperatorConfig().getReconcileInterval().toMillis());
+            }
+            var runningJobs = nonTerminalJobs.get();
+            if (!runningJobs.isEmpty()) {
+                var error =
+                        String.format(
+                                "The session cluster has non terminated jobs %s that should be cancelled first",
+                                runningJobs.stream()
+                                        .map(JobID::toHexString)
+                                        .collect(Collectors.toList()));
+                if (eventRecorder.triggerEvent(
+                        deployment,
+                        EventRecorder.Type.Warning,
+                        EventRecorder.Reason.CleanupFailed,
+                        EventRecorder.Component.Operator,
+                        error,
+                        ctx.getKubernetesClient())) {
+                    LOG.warn(error);
+                }
                 return DeleteControl.noFinalizerRemoval()
                         .rescheduleAfter(ctx.getOperatorConfig().getReconcileInterval().toMillis());
             }

--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/service/AbstractFlinkService.java
@@ -687,22 +687,26 @@ public abstract class AbstractFlinkService implements FlinkService {
                             savepointStatusMessageParameters,
                             EmptyRequestBody.getInstance());
 
-            if (response.get() == null || response.get().resource() == null) {
+            AsynchronousOperationResult<SavepointInfo> result =
+                    response.get(
+                            operatorConfig.getFlinkClientTimeout().toSeconds(), TimeUnit.SECONDS);
+
+            if (result == null || result.resource() == null) {
                 return SavepointFetchResult.pending();
             }
 
-            if (response.get().resource().getLocation() == null) {
-                if (response.get().resource().getFailureCause() != null) {
+            if (result.resource().getLocation() == null) {
+                if (result.resource().getFailureCause() != null) {
                     LOG.error(
                             "Failure occurred while fetching the savepoint result",
-                            response.get().resource().getFailureCause());
+                            result.resource().getFailureCause());
                     return SavepointFetchResult.error(
-                            response.get().resource().getFailureCause().toString());
+                            result.resource().getFailureCause().toString());
                 } else {
                     return SavepointFetchResult.pending();
                 }
             }
-            String location = response.get().resource().getLocation();
+            String location = result.resource().getLocation();
             LOG.info("Savepoint result: {}", location);
             return SavepointFetchResult.completed(location);
         } catch (Exception e) {
@@ -729,19 +733,22 @@ public abstract class AbstractFlinkService implements FlinkService {
                             checkpointStatusMessageParameters,
                             EmptyRequestBody.getInstance());
 
-            if (response.get() == null || response.get().resource() == null) {
+            AsynchronousOperationResult<CheckpointInfo> result =
+                    response.get(
+                            operatorConfig.getFlinkClientTimeout().toSeconds(), TimeUnit.SECONDS);
+
+            if (result == null || result.resource() == null) {
                 return CheckpointFetchResult.pending();
             }
 
-            if (response.get().resource().getFailureCause() != null) {
+            if (result.resource().getFailureCause() != null) {
                 LOG.error(
                         "Failure occurred while fetching the checkpoint result",
-                        response.get().resource().getFailureCause());
-                return CheckpointFetchResult.error(
-                        response.get().resource().getFailureCause().toString());
+                        result.resource().getFailureCause());
+                return CheckpointFetchResult.error(result.resource().getFailureCause().toString());
             }
 
-            QueueStatus.Id operationStatus = response.get().queueStatus().getId();
+            QueueStatus.Id operationStatus = result.queueStatus().getId();
             switch (operationStatus) {
                 case IN_PROGRESS:
                     return CheckpointFetchResult.pending();
@@ -750,8 +757,7 @@ public abstract class AbstractFlinkService implements FlinkService {
                             "Checkpoint {} triggered by the operator for job {} completed:",
                             triggerId,
                             jobId);
-                    return CheckpointFetchResult.completed(
-                            response.get().resource().getCheckpointId());
+                    return CheckpointFetchResult.completed(result.resource().getCheckpointId());
                 default:
                     throw new IllegalStateException(
                             String.format(
@@ -781,7 +787,9 @@ public abstract class AbstractFlinkService implements FlinkService {
                     clusterClient.sendRequest(
                             checkpointStatusHeaders, parameters, EmptyRequestBody.getInstance());
 
-            var stats = response.get();
+            var stats =
+                    response.get(
+                            operatorConfig.getFlinkClientTimeout().toSeconds(), TimeUnit.SECONDS);
             if (stats == null) {
                 throw new IllegalStateException(
                         String.format(
@@ -866,7 +874,9 @@ public abstract class AbstractFlinkService implements FlinkService {
                                         checkpointingStatisticsHeaders,
                                         parameters,
                                         EmptyRequestBody.getInstance())
-                                .get();
+                                .get(
+                                        operatorConfig.getFlinkClientTimeout().toSeconds(),
+                                        TimeUnit.SECONDS);
                 CheckpointStatistics.CompletedCheckpointStatistics completedCheckpointStatistics =
                         checkpointingStatistics
                                 .getLatestCheckpoints()

--- a/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
+++ b/flink-kubernetes-operator/src/test/java/org/apache/flink/kubernetes/operator/reconciler/deployment/SessionReconcilerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.reconciler.deployment;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.operator.OperatorTestBase;
@@ -303,7 +304,8 @@ public class SessionReconcilerTest extends OperatorTestBase {
         var resourceContext = getResourceContext(deployment, context);
 
         var sessionReconciler = (SessionReconciler) reconciler.getReconciler();
-        Set<JobID> nonTerminalJobs = sessionReconciler.getNonTerminalJobs(resourceContext);
+        Set<JobID> nonTerminalJobs =
+                sessionReconciler.getNonTerminalJobs(resourceContext).orElseThrow();
 
         // Verify all non-terminal jobs are identified - should be 4 (2 managed + 2 unmanaged
         // running)
@@ -330,7 +332,7 @@ public class SessionReconcilerTest extends OperatorTestBase {
                                         || job.f1.getJobId().equals(managedJobId2));
 
         Set<JobID> nonTerminalJobsAfterSessionJobsRemoval =
-                sessionReconciler.getNonTerminalJobs(resourceContext);
+                sessionReconciler.getNonTerminalJobs(resourceContext).orElseThrow();
 
         assertEquals(
                 2,
@@ -346,12 +348,111 @@ public class SessionReconcilerTest extends OperatorTestBase {
                                         || job.f1.getJobId().equals(unmanagedRunningJobId2));
 
         Set<JobID> nonTerminalJobsAfterRemoval =
-                sessionReconciler.getNonTerminalJobs(resourceContext);
+                sessionReconciler.getNonTerminalJobs(resourceContext).orElseThrow();
 
         assertEquals(
                 0,
                 nonTerminalJobsAfterRemoval.size(),
                 "Should have no non-terminal jobs when only terminated jobs exist");
+    }
+
+    @Test
+    public void testCleanupBlocksWhenNonTerminalJobsCannotBeDetermined() throws Exception {
+        flinkService =
+                new TestingFlinkService(kubernetesClient) {
+                    @Override
+                    public RestClusterClient<String> getClusterClient(Configuration config)
+                            throws Exception {
+                        throw new Exception("JobManager unreachable");
+                    }
+                };
+
+        FlinkDeployment deployment = TestUtils.buildSessionCluster();
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(KubernetesOperatorConfigOptions.BLOCK_ON_SESSION_JOBS.key(), "true");
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(KubernetesOperatorConfigOptions.BLOCK_ON_UNMANAGED_JOBS.key(), "true");
+
+        reconciler.reconcile(deployment, flinkService.getContext());
+
+        var context =
+                new TestUtils.TestingContext<FlinkDeployment>() {
+                    @Override
+                    public Optional<FlinkDeployment> getSecondaryResource(
+                            Class expectedType, String eventSourceName) {
+                        var session = TestUtils.buildSessionCluster();
+                        session.getStatus()
+                                .setJobManagerDeploymentStatus(JobManagerDeploymentStatus.READY);
+                        session.getStatus()
+                                .getReconciliationStatus()
+                                .serializeAndSetLastReconciledSpec(session.getSpec(), session);
+                        return Optional.of(session);
+                    }
+
+                    @Override
+                    public <T1> Set<T1> getSecondaryResources(Class<T1> aClass) {
+                        return Set.of();
+                    }
+
+                    @Override
+                    public KubernetesClient getClient() {
+                        return kubernetesClient;
+                    }
+                };
+        var resourceContext = getResourceContext(deployment, context);
+        var sessionReconciler = (SessionReconciler) reconciler.getReconciler();
+
+        assertTrue(
+                sessionReconciler.getNonTerminalJobs(resourceContext).isEmpty(),
+                "Job detection must be indeterminate when the cluster cannot be queried");
+
+        DeleteControl deleteControl = sessionReconciler.cleanupInternal(resourceContext);
+
+        assertFalse(
+                deleteControl.isRemoveFinalizer(),
+                "Deletion must be blocked when running jobs cannot be determined");
+    }
+
+    @Test
+    public void testCleanupDeletesImmediatelyWhenNeverDeployed() throws Exception {
+        flinkService =
+                new TestingFlinkService(kubernetesClient) {
+                    @Override
+                    public RestClusterClient<String> getClusterClient(Configuration config)
+                            throws Exception {
+                        throw new Exception("JobManager unreachable");
+                    }
+                };
+
+        FlinkDeployment deployment = TestUtils.buildSessionCluster();
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(KubernetesOperatorConfigOptions.BLOCK_ON_SESSION_JOBS.key(), "true");
+        deployment
+                .getSpec()
+                .getFlinkConfiguration()
+                .put(KubernetesOperatorConfigOptions.BLOCK_ON_UNMANAGED_JOBS.key(), "true");
+
+        assertTrue(
+                deployment.getStatus().getReconciliationStatus().isBeforeFirstDeployment(),
+                "Precondition: deployment must never have been reconciled");
+
+        var context =
+                TestUtils.<FlinkDeployment>createContextWithReadyFlinkDeployment(kubernetesClient);
+        var resourceContext = getResourceContext(deployment, context);
+        var sessionReconciler = (SessionReconciler) reconciler.getReconciler();
+
+        DeleteControl deleteControl = sessionReconciler.cleanupInternal(resourceContext);
+
+        assertTrue(
+                deleteControl.isRemoveFinalizer(),
+                "Deletion must proceed immediately for a session cluster that never deployed, "
+                        + "even though the JobManager cannot be reached and blocking is enabled");
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

`SessionReconciler.getNonTerminalJobs` returned `Set.of()` on any query failure, and `cleanupInternal` treats an empty set as "safe to delete". So a session `FlinkDeployment` with an unreachable JobManager got deleted anyway during cleanup, stopping unmanaged jobs without a checkpoint.

This makes the guard fail closed: an indeterminate result blocks deletion instead of assuming the cluster is empty. Per review feedback, it also bounds this and several other unbounded blocking REST calls in the operator and autoscaler with their configured client timeouts, so a hung JobManager can't stall them indefinitely.

## Brief change log

  - `getNonTerminalJobs` now returns `Optional<Set<JobID>>`; empty means "could not determine", distinct from a present empty set ("no jobs").
  - `cleanupInternal` blocks deletion and emits `CleanupFailed` on the indeterminate case, rescheduling until the JobManager is reachable — mirroring the block-on-session-jobs branch. Also closes the `RestClusterClient` via try-with-resources and bounds the query with the Flink client timeout.
  - A session cluster that never deployed is deleted immediately instead of blocking forever, mirroring `ApplicationReconciler`/`SessionJobReconciler`. Also null-guards the jobs list and restores the interrupt flag on `InterruptedException`.
  - Same bounded-timeout fix applied to `AbstractFlinkService#fetchSavepointInfo/#fetchCheckpointInfo/#fetchCheckpointStats/#populateStateSize` (`kubernetes.operator.flink.client.timeout`) and `ScalingMetricCollector#queryAggregatedMetricNames`, `RestApiMetricsCollector#queryAggregatedVertexMetrics/#queryJmMetrics/#queryAggregatedTmMetrics` (`job.autoscaler.flink.rest-client.timeout`).

Related: fail-open was introduced with block-on-unmanaged-jobs (FLINK-28648); the new block lifts automatically so it doesn't reintroduce the deadlock fixed in FLINK-39618. The existing opt-out (`block-on-unmanaged-jobs`/`block-on-session-jobs` = false, FLINK-39432) still allows force-deleting a permanently unreachable cluster.

## Verifying this change

  - `SessionReconcilerTest`: `testCleanupBlocksWhenNonTerminalJobsCannotBeDetermined` and `testCleanupDeletesImmediatelyWhenNeverDeployed`.
  - Manually verified on minikube: deleting a session cluster with the JobManager down is blocked with a `CleanupFailed` event and completes once reachable.
  - The additional timeout-bounding changes are mechanical (no happy-path behavior change) and covered by the existing `AbstractFlinkServiceTest`, `ScalingMetricCollectorTest`, `RestApiMetricsCollectorTest`, `JobAutoScalerImplTest` suites.

## Does this pull request potentially affect one of the following parts:

  - Dependencies: no
  - Public API / `CustomResourceDescriptors`: no
  - Core observer or reconciler logic: yes (session cleanup, checkpoint/savepoint fetch, autoscaler metric collection)

## Documentation

  - New feature? no

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (Claude Code)

Generated-by: Claude Code (Claude Opus 4.8)
